### PR TITLE
chore: add additional comments to code/structs,  and sanity tests to verify functions are called within the expected context

### DIFF
--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -40,7 +40,7 @@ func newAgent(t *testing.T) *Agent {
 func Test_NewAgent(t *testing.T) {
 	fakec := fakekube.NewFakeClientsetWithResources()
 	appc := fakeappclient.NewSimpleClientset()
-	agent, err := NewAgent(context.TODO(), fakec, appc, "agent")
+	agent, err := NewAgent(context.TODO(), fakec, appc, "agent", WithRemote(&client.Remote{}))
 	require.NotNil(t, agent)
 	require.NoError(t, err)
 }

--- a/agent/inbound_test.go
+++ b/agent/inbound_test.go
@@ -24,6 +24,7 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	backend_mocks "github.com/argoproj-labs/argocd-agent/internal/backend/mocks"
+	"github.com/argoproj-labs/argocd-agent/internal/manager"
 	"github.com/argoproj-labs/argocd-agent/internal/manager/application"
 	"github.com/argoproj-labs/argocd-agent/pkg/types"
 )
@@ -31,7 +32,9 @@ import (
 func Test_CreateApplication(t *testing.T) {
 	a := newAgent(t)
 	be := backend_mocks.NewApplication(t)
-	a.appManager = application.NewApplicationManager(be, "argocd", application.WithAllowUpsert(true))
+	var err error
+	a.appManager, err = application.NewApplicationManager(be, "argocd", application.WithAllowUpsert(true))
+	require.NoError(t, err)
 	require.NotNil(t, a)
 	app := &v1alpha1.Application{ObjectMeta: v1.ObjectMeta{
 		Name:      "test",
@@ -67,7 +70,9 @@ func Test_CreateApplication(t *testing.T) {
 func Test_UpdateApplication(t *testing.T) {
 	a := newAgent(t)
 	be := backend_mocks.NewApplication(t)
-	a.appManager = application.NewApplicationManager(be, "argocd", application.WithAllowUpsert(true))
+	var err error
+	a.appManager, err = application.NewApplicationManager(be, "argocd", application.WithAllowUpsert(true))
+	require.NoError(t, err)
 	require.NotNil(t, a)
 	app := &v1alpha1.Application{
 		ObjectMeta: v1.ObjectMeta{
@@ -85,6 +90,8 @@ func Test_UpdateApplication(t *testing.T) {
 
 	t.Run("Update application using patch in managed mode", func(t *testing.T) {
 		a.mode = types.AgentModeManaged
+		a.appManager.Role = manager.ManagerRoleAgent
+		a.appManager.Mode = manager.ManagerModeManaged
 		getEvent := be.On("Get", mock.Anything, mock.Anything, mock.Anything).Return(&v1alpha1.Application{}, nil)
 		defer getEvent.Unset()
 		supportsPatchEvent := be.On("SupportsPatch").Return(true)
@@ -98,6 +105,8 @@ func Test_UpdateApplication(t *testing.T) {
 
 	t.Run("Update application using update in managed mode", func(t *testing.T) {
 		a.mode = types.AgentModeManaged
+		a.appManager.Role = manager.ManagerRoleAgent
+		a.appManager.Mode = manager.ManagerModeManaged
 		getEvent := be.On("Get", mock.Anything, mock.Anything, mock.Anything).Return(&v1alpha1.Application{}, nil)
 		defer getEvent.Unset()
 		supportsPatchEvent := be.On("SupportsPatch").Return(false)
@@ -111,6 +120,8 @@ func Test_UpdateApplication(t *testing.T) {
 
 	t.Run("Update application using patch in autonomous mode", func(t *testing.T) {
 		a.mode = types.AgentModeAutonomous
+		a.appManager.Role = manager.ManagerRoleAgent
+		a.appManager.Mode = manager.ManagerModeAutonomous
 		getEvent := be.On("Get", mock.Anything, mock.Anything, mock.Anything).Return(&v1alpha1.Application{}, nil)
 		defer getEvent.Unset()
 		supportsPatchEvent := be.On("SupportsPatch").Return(true)
@@ -124,6 +135,8 @@ func Test_UpdateApplication(t *testing.T) {
 
 	t.Run("Update application using update in autonomous mode", func(t *testing.T) {
 		a.mode = types.AgentModeAutonomous
+		a.appManager.Role = manager.ManagerRoleAgent
+		a.appManager.Mode = manager.ManagerModeAutonomous
 		getEvent := be.On("Get", mock.Anything, mock.Anything, mock.Anything).Return(&v1alpha1.Application{}, nil)
 		defer getEvent.Unset()
 		supportsPatchEvent := be.On("SupportsPatch").Return(false)

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -107,6 +107,10 @@ func NewAgentRunCommand() *cobra.Command {
 				cmd.Fatal("No remote specified")
 			}
 
+			if namespace == "" {
+				cmd.Fatal("namespace value is empty and must be specified")
+			}
+
 			kubeConfig, err := cmd.GetKubeConfig(ctx, namespace, kubeConfig, kubeContext)
 			if err != nil {
 				cmd.Fatal("Could not load Kubernetes config: %v", err)

--- a/internal/auth/userpass/userpass.go
+++ b/internal/auth/userpass/userpass.go
@@ -53,11 +53,17 @@ type UserPassAuthentication struct {
 	dbpath string
 	lock   sync.RWMutex
 	userdb map[string]string
-	dummy  []byte
+
+	// dummy is not a password itself, but rather is used to make timing attacks
+	// a little more complex: in the case where an invalid username is sent, we
+	// will hash the dummy password instead (to prevent attackers from
+	// determining whether a username exists by timing response times)
+	dummy []byte
 }
 
 // NewUserPassAuthentication creates a new instance of UserPassAuthentication
 func NewUserPassAuthentication(path string) *UserPassAuthentication {
+	// see 'dummy' field of UserPassAuthentication for explanation of this value
 	dummy, _ := bcrypt.GenerateFromPassword([]byte("bdf3fdc6da5b5029e83f3024858c3c1e6aa3d1e71fa09e4691212f7571b5a3e3"), bcrypt.DefaultCost)
 	return &UserPassAuthentication{
 		userdb: make(map[string]string),

--- a/internal/backend/interface.go
+++ b/internal/backend/interface.go
@@ -24,12 +24,23 @@ import (
 )
 
 type ApplicationSelector struct {
-	Labels     map[string]string
-	Names      []string
+
+	// Labels is not currently implemented.
+	Labels map[string]string
+
+	// Names is not currently implemented.
+	Names []string
+
+	// Namespaces is used by the 'List' Application interface function to restrict the list of Applications returned to a specific set of Namespaces.
 	Namespaces []string
-	Projects   []string
+
+	// Projects is not currently implemented.
+	Projects []string
 }
 
+// Application defines a generic interface to store/track Argo CD Application state, via ApplicationManager.
+//
+// As of this writing (August 2024), the only implementation is a Kubernetes-based backend (KubernetesBackend in 'internal/backend/kubernetes/application') but other backends (e.g. RDBMS-backed) could be implemented in the future.
 type Application interface {
 	List(ctx context.Context, selector ApplicationSelector) ([]v1alpha1.Application, error)
 	Create(ctx context.Context, app *v1alpha1.Application) (*v1alpha1.Application, error)

--- a/internal/backend/kubernetes/application/kubernetes.go
+++ b/internal/backend/kubernetes/application/kubernetes.go
@@ -32,9 +32,16 @@ import (
 
 var _ backend.Application = &KubernetesBackend{}
 
+// KubernetesBackend is an implementation of the backend.Application interface, which is used by ApplicationManager to track/update the state of Argo CD Applications.
+// KubernetesBackend stores/retrieves all data from Argo CD Application CRs on the cluster that is local to the agent/principal.
+//
+// KubernetesBackend is used by both the principal and agent components.
 type KubernetesBackend struct {
+	// appClient is used to interfact with Argo CD Application resources on the cluster on which agent/principal is installed.
 	appClient appclientset.Interface
-	informer  *appinformer.AppInformer
+	// informer is used to watch for change events for Argo CD Application resources on the cluster
+	informer *appinformer.AppInformer
+	// namespace is not currently read, is not guaranteed to be non-empty, and is not guaranteed to contain the source of Argo CD Application CRs in all cases
 	namespace string
 	usePatch  bool
 }

--- a/internal/event/event.go
+++ b/internal/event/event.go
@@ -33,6 +33,7 @@ type EventTarget string
 
 const TypePrefix = "io.argoproj.argocd-agent.event"
 
+// Supported EventTypes that are sent agent <-> principal
 const (
 	Ping            EventType = TypePrefix + ".ping"
 	Pong            EventType = TypePrefix + ".pong"
@@ -63,10 +64,12 @@ func (t EventTarget) String() string {
 	return string(t)
 }
 
+// EventSource is a utility to construct new 'cloudevents.Event' events for a given 'source'
 type EventSource struct {
 	source string
 }
 
+// Event is the 'on the wire' representation of an event, and is parsed by from protobuf via FromWire
 type Event struct {
 	event  *cloudevents.Event
 	target EventTarget

--- a/internal/informer/application/appinformer.go
+++ b/internal/informer/application/appinformer.go
@@ -40,7 +40,7 @@ const defaultResyncPeriod = 1 * time.Minute
 // AppInformer is a filtering and customizable SharedIndexInformer for Argo CD
 // Application resources in a cluster. It works across a configurable set of
 // namespaces, lets you define a list of filters to indicate interest in the
-// resource of a particular even and allows you to set up callbacks to handle
+// resource of a particular event and allows you to set up callbacks to handle
 // the events.
 type AppInformer struct {
 	appClient appclientset.Interface
@@ -49,6 +49,7 @@ type AppInformer struct {
 	AppInformer cache.SharedIndexInformer
 	AppLister   applisters.ApplicationLister
 
+	// lock should be acquired when reading/writing from callbacks defined in 'options' field
 	lock sync.RWMutex
 
 	// synced indicates whether the informer is synced and the watch is set up

--- a/internal/informer/application/options.go
+++ b/internal/informer/application/options.go
@@ -26,6 +26,7 @@ import (
 // Options should not be modified concurrently, they are not implemented in a
 // thread-safe way.
 type AppInformerOptions struct {
+	// namespace will be set to "", if len(namespaces) > 0
 	namespace  string
 	namespaces []string
 	appMetrics *metrics.ApplicationWatcherMetrics

--- a/internal/informer/informer.go
+++ b/internal/informer/informer.go
@@ -30,22 +30,26 @@ import (
 )
 
 type GenericInformer struct {
-	listFunc      ListFunc
-	watchFunc     WatchFunc
-	addFunc       AddFunc
-	updateFunc    UpdateFunc
-	deleteFunc    DeleteFunc
-	filterFunc    FilterFunc
-	synced        atomic.Bool
-	running       atomic.Bool
-	resyncPeriod  time.Duration
-	informer      cache.SharedIndexInformer
-	runch         chan struct{}
-	logger        *logrus.Entry
-	mutex         sync.RWMutex
+	listFunc     ListFunc
+	watchFunc    WatchFunc
+	addFunc      AddFunc
+	updateFunc   UpdateFunc
+	deleteFunc   DeleteFunc
+	filterFunc   FilterFunc
+	synced       atomic.Bool
+	running      atomic.Bool
+	resyncPeriod time.Duration
+	informer     cache.SharedIndexInformer
+	runch        chan struct{}
+	logger       *logrus.Entry
+	// mutex prevents unsynchronized access to namespaces, and ensures that Start/Stop logic is only called once.
+	mutex sync.RWMutex
+	// labelSelector is not currently implemented
 	labelSelector string
+	// fieldSelector is not currently implemented
 	fieldSelector string
-	namespaces    map[string]interface{}
+	// mutex should be owned before accessing namespaces
+	namespaces map[string]interface{}
 }
 
 type InformerOption func(i *GenericInformer) error

--- a/internal/queue/queue.go
+++ b/internal/queue/queue.go
@@ -23,6 +23,7 @@ import (
 
 var _ QueuePair = &SendRecvQueues{}
 
+// QueuePair maintains a map (indexed by name) of send/receive queue pairs
 type QueuePair interface {
 	Names() []string
 	HasQueuePair(name string) bool
@@ -63,7 +64,7 @@ func (q *SendRecvQueues) Names() []string {
 	return names
 }
 
-// HasQueuePair retruns true if a queue pair with name currently exists
+// HasQueuePair returns true if a queue pair with name currently exists
 func (q *SendRecvQueues) HasQueuePair(name string) bool {
 	q.queuelock.RLock()
 	defer q.queuelock.RUnlock()
@@ -78,7 +79,7 @@ func (q *SendRecvQueues) Len() int {
 	return len(q.queues)
 }
 
-// RecvQ will return the send queue from the queue pair named name. If no such
+// SendQ will return the send queue from the queue pair named name. If no such
 // queue pair exists, returns nil
 func (q *SendRecvQueues) SendQ(name string) workqueue.RateLimitingInterface {
 	q.queuelock.RLock()

--- a/pkg/client/remote.go
+++ b/pkg/client/remote.go
@@ -62,7 +62,7 @@ func NewToken(tok string) (*token, error) {
 	return r, nil
 }
 
-// Remote represents a remote argocd-agent server component
+// Remote represents a remote argocd-agent server component. Remote is used only by the agent component, and not by principal.
 type Remote struct {
 	hostname     string
 	port         int

--- a/pkg/client/remote_test.go
+++ b/pkg/client/remote_test.go
@@ -46,7 +46,7 @@ func Test_Connect(t *testing.T) {
 
 	am := userpass.NewUserPassAuthentication("")
 	am.UpsertUser("default", "password")
-	s.AuthMethods().RegisterMethod("userpass", am)
+	s.AuthMethodsForE2EOnly().RegisterMethod("userpass", am)
 
 	require.NoError(t, err)
 	errch := make(chan error)
@@ -54,7 +54,7 @@ func Test_Connect(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("Connect to a server", func(t *testing.T) {
-		r, err := NewRemote("127.0.0.1", s.Listener().Port(),
+		r, err := NewRemote("127.0.0.1", s.ListenerForE2EOnly().Port(),
 			WithInsecureSkipTLSVerify(),
 			WithAuth("userpass", auth.Credentials{userpass.ClientIDField: "default", userpass.ClientSecretField: "password"}),
 			WithClientMode(types.AgentModeManaged),
@@ -76,7 +76,7 @@ func Test_Connect(t *testing.T) {
 	})
 
 	t.Run("Invalid auth and context deadline reached", func(t *testing.T) {
-		r, err := NewRemote("127.0.0.1", s.Listener().Port(),
+		r, err := NewRemote("127.0.0.1", s.ListenerForE2EOnly().Port(),
 			WithInsecureSkipTLSVerify(),
 			WithAuth("userpass", auth.Credentials{userpass.ClientIDField: "default", userpass.ClientSecretField: "passwor"}),
 		)

--- a/principal/listen.go
+++ b/principal/listen.go
@@ -43,6 +43,7 @@ var listenerBackoff = wait.Backoff{
 	Jitter:   0.1,
 }
 
+// Listener is a utility wrapper around net.Listener and associated data
 type Listener struct {
 	host   string
 	port   int

--- a/principal/options.go
+++ b/principal/options.go
@@ -40,22 +40,27 @@ var supportedTLSVersion map[string]int = map[string]int{
 }
 
 type ServerOptions struct {
-	serverName             string
-	port                   int
-	address                string
-	tlsCertPath            string
-	tlsKeyPath             string
-	tlsCert                *x509.Certificate
-	tlsKey                 crypto.PrivateKey
-	tlsCiphers             *tls.CipherSuite
-	tlsMinVersion          int
-	gracePeriod            time.Duration
-	namespaces             []string
-	signingKey             crypto.PrivateKey
-	unauthMethods          map[string]bool
-	serveGRPC              bool
-	serveREST              bool
-	eventProcessors        int64
+	serverName  string
+	port        int
+	address     string
+	tlsCertPath string
+	tlsKeyPath  string
+	tlsCert     *x509.Certificate
+	tlsKey      crypto.PrivateKey
+	// tlsCiphers is not currently read
+	tlsCiphers *tls.CipherSuite
+	// tlsMinVersion is not currently read
+	tlsMinVersion int
+	gracePeriod   time.Duration
+	namespaces    []string
+	signingKey    crypto.PrivateKey
+	// unauthMethods is not currently implemented
+	unauthMethods map[string]bool
+	serveGRPC     bool
+	// serveREST is not currently implemented
+	serveREST       bool
+	eventProcessors int64
+	// metricsEnabled is not currently read
 	metricsEnabled         bool
 	metricsPort            int
 	requireClientCerts     bool


### PR DESCRIPTION
This PR:
- Adds comments to important structs/fields within the code.
    - Comments describe the behaviour as it currently exists, but I'm happy to revert/modify any items that are expected to have a different future behaviour.
- Adds some sanity tests to code to ensure that agent-only code is only run in agent-only context, and vice versa for principal.
- We don't have E2E tests setup for this repo yet (see issue #137), so I manually verified I've not broken anything by  setting up the demo-env and ensuring the basic workflow still works.