### PR TITLE
refactor: reduce visibility of appManager/informer fields, rename application field of ApplicationManager

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,10 @@ test:
 	mkdir -p test/out
 	./hack/test.sh
 
+.PHONY: test-e2e
+test-e2e:
+	go test -race -timeout 60s github.com/argoproj-labs/argocd-agent/test/e2e
+
 .PHONY: mod-vendor
 mod-vendor:
 	go mod vendor

--- a/agent/inbound_test.go
+++ b/agent/inbound_test.go
@@ -90,8 +90,7 @@ func Test_UpdateApplication(t *testing.T) {
 
 	t.Run("Update application using patch in managed mode", func(t *testing.T) {
 		a.mode = types.AgentModeManaged
-		a.appManager.Role = manager.ManagerRoleAgent
-		a.appManager.Mode = manager.ManagerModeManaged
+		a.appManager, err = application.NewApplicationManager(be, "argocd", application.WithAllowUpsert(true), application.WithMode(manager.ManagerModeManaged), application.WithRole(manager.ManagerRoleAgent))
 		getEvent := be.On("Get", mock.Anything, mock.Anything, mock.Anything).Return(&v1alpha1.Application{}, nil)
 		defer getEvent.Unset()
 		supportsPatchEvent := be.On("SupportsPatch").Return(true)
@@ -105,8 +104,7 @@ func Test_UpdateApplication(t *testing.T) {
 
 	t.Run("Update application using update in managed mode", func(t *testing.T) {
 		a.mode = types.AgentModeManaged
-		a.appManager.Role = manager.ManagerRoleAgent
-		a.appManager.Mode = manager.ManagerModeManaged
+		a.appManager, err = application.NewApplicationManager(be, "argocd", application.WithAllowUpsert(true), application.WithMode(manager.ManagerModeManaged), application.WithRole(manager.ManagerRoleAgent))
 		getEvent := be.On("Get", mock.Anything, mock.Anything, mock.Anything).Return(&v1alpha1.Application{}, nil)
 		defer getEvent.Unset()
 		supportsPatchEvent := be.On("SupportsPatch").Return(false)
@@ -120,8 +118,8 @@ func Test_UpdateApplication(t *testing.T) {
 
 	t.Run("Update application using patch in autonomous mode", func(t *testing.T) {
 		a.mode = types.AgentModeAutonomous
-		a.appManager.Role = manager.ManagerRoleAgent
-		a.appManager.Mode = manager.ManagerModeAutonomous
+		a.appManager, err = application.NewApplicationManager(be, "argocd", application.WithAllowUpsert(true), application.WithMode(manager.ManagerModeAutonomous), application.WithRole(manager.ManagerRoleAgent))
+
 		getEvent := be.On("Get", mock.Anything, mock.Anything, mock.Anything).Return(&v1alpha1.Application{}, nil)
 		defer getEvent.Unset()
 		supportsPatchEvent := be.On("SupportsPatch").Return(true)
@@ -135,8 +133,8 @@ func Test_UpdateApplication(t *testing.T) {
 
 	t.Run("Update application using update in autonomous mode", func(t *testing.T) {
 		a.mode = types.AgentModeAutonomous
-		a.appManager.Role = manager.ManagerRoleAgent
-		a.appManager.Mode = manager.ManagerModeAutonomous
+		a.appManager, err = application.NewApplicationManager(be, "argocd", application.WithAllowUpsert(true), application.WithMode(manager.ManagerModeAutonomous), application.WithRole(manager.ManagerRoleAgent))
+
 		getEvent := be.On("Get", mock.Anything, mock.Anything, mock.Anything).Return(&v1alpha1.Application{}, nil)
 		defer getEvent.Unset()
 		supportsPatchEvent := be.On("SupportsPatch").Return(false)

--- a/internal/informer/application/appinformer.go
+++ b/internal/informer/application/appinformer.go
@@ -46,8 +46,8 @@ type AppInformer struct {
 	appClient appclientset.Interface
 	options   *AppInformerOptions
 
-	AppInformer cache.SharedIndexInformer
-	AppLister   applisters.ApplicationLister
+	appInformer cache.SharedIndexInformer
+	appLister   applisters.ApplicationLister
 
 	// lock should be acquired when reading/writing from callbacks defined in 'options' field
 	lock sync.RWMutex
@@ -75,7 +75,7 @@ func NewAppInformer(ctx context.Context, client appclientset.Interface, namespac
 
 	i := &AppInformer{options: o, appClient: client}
 
-	i.AppInformer = cache.NewSharedIndexInformer(
+	i.appInformer = cache.NewSharedIndexInformer(
 		&cache.ListWatch{
 			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
 				logCtx := log().WithField("component", "ListWatch")
@@ -129,7 +129,7 @@ func NewAppInformer(ctx context.Context, client appclientset.Interface, namespac
 			},
 		},
 	)
-	_, _ = i.AppInformer.AddEventHandler(
+	_, _ = i.appInformer.AddEventHandler(
 		cache.ResourceEventHandlerFuncs{
 			AddFunc: func(obj interface{}) {
 				app, ok := obj.(*v1alpha1.Application)
@@ -217,16 +217,16 @@ func NewAppInformer(ctx context.Context, client appclientset.Interface, namespac
 			},
 		},
 	)
-	i.AppLister = applisters.NewApplicationLister(i.AppInformer.GetIndexer())
+	i.appLister = applisters.NewApplicationLister(i.appInformer.GetIndexer())
 	// SetWatchErrorHandler only returns error when informer already started,
 	// so it should be safe to not handle the error.
-	_ = i.AppInformer.SetWatchErrorHandler(cache.DefaultWatchErrorHandler)
+	_ = i.appInformer.SetWatchErrorHandler(cache.DefaultWatchErrorHandler)
 	return i
 }
 
 func (i *AppInformer) Start(stopch <-chan struct{}) {
 	log().Infof("Starting app informer (namespaces: %s)", strings.Join(append([]string{i.options.namespace}, i.options.namespaces...), ","))
-	i.AppInformer.Run(stopch)
+	i.appInformer.Run(stopch)
 	log().Infof("App informer has shutdown")
 }
 

--- a/internal/informer/application/appinformer_test.go
+++ b/internal/informer/application/appinformer_test.go
@@ -59,7 +59,7 @@ func Test_AppInformer(t *testing.T) {
 		}))
 		stopCh := make(chan struct{})
 		go func() {
-			inf.AppInformer.Run(stopCh)
+			inf.appInformer.Run(stopCh)
 		}()
 		ticker := time.NewTicker(1 * time.Second)
 		running := true
@@ -74,7 +74,7 @@ func Test_AppInformer(t *testing.T) {
 				time.Sleep(100 * time.Millisecond)
 			}
 		}
-		apps, err := inf.AppLister.Applications(inf.options.namespace).List(labels.Everything())
+		apps, err := inf.appLister.Applications(inf.options.namespace).List(labels.Everything())
 		assert.NoError(t, err)
 		assert.Len(t, apps, 2)
 	})
@@ -88,7 +88,7 @@ func Test_AppInformer(t *testing.T) {
 		}))
 		stopCh := make(chan struct{})
 		go func() {
-			inf.AppInformer.Run(stopCh)
+			inf.appInformer.Run(stopCh)
 		}()
 		ticker := time.NewTicker(1 * time.Second)
 		running := true
@@ -103,13 +103,13 @@ func Test_AppInformer(t *testing.T) {
 				time.Sleep(100 * time.Millisecond)
 			}
 		}
-		apps, err := inf.AppLister.Applications(inf.options.namespace).List(labels.Everything())
+		apps, err := inf.appLister.Applications(inf.options.namespace).List(labels.Everything())
 		assert.NoError(t, err)
 		assert.Len(t, apps, 1)
-		app, err := inf.AppLister.Applications(inf.options.namespace).Get("test1")
+		app, err := inf.appLister.Applications(inf.options.namespace).Get("test1")
 		assert.NoError(t, err)
 		assert.NotNil(t, app)
-		app, err = inf.AppLister.Applications(inf.options.namespace).Get("test2")
+		app, err = inf.appLister.Applications(inf.options.namespace).Get("test2")
 		assert.ErrorContains(t, err, "not found")
 		assert.Nil(t, app)
 	})
@@ -122,7 +122,7 @@ func Test_AppInformer(t *testing.T) {
 		}))
 		stopCh := make(chan struct{})
 		go func() {
-			inf.AppInformer.Run(stopCh)
+			inf.appInformer.Run(stopCh)
 		}()
 		ticker := time.NewTicker(1 * time.Second)
 		running := true
@@ -138,13 +138,13 @@ func Test_AppInformer(t *testing.T) {
 				time.Sleep(100 * time.Millisecond)
 			}
 		}
-		apps, err := inf.AppLister.Applications(inf.options.namespace).List(labels.Everything())
+		apps, err := inf.appLister.Applications(inf.options.namespace).List(labels.Everything())
 		assert.NoError(t, err)
 		assert.Len(t, apps, 1)
-		app, err := inf.AppLister.Applications(inf.options.namespace).Get("test1")
+		app, err := inf.appLister.Applications(inf.options.namespace).Get("test1")
 		assert.NoError(t, err)
 		assert.NotNil(t, app)
-		app, err = inf.AppLister.Applications(inf.options.namespace).Get("test2")
+		app, err = inf.appLister.Applications(inf.options.namespace).Get("test2")
 		assert.ErrorContains(t, err, "not found")
 		assert.Nil(t, app)
 	})
@@ -157,7 +157,7 @@ func Test_AppInformer(t *testing.T) {
 		}))
 		stopCh := make(chan struct{})
 		go func() {
-			inf.AppInformer.Run(stopCh)
+			inf.appInformer.Run(stopCh)
 		}()
 		ticker := time.NewTicker(2 * time.Second)
 		running := true
@@ -175,10 +175,10 @@ func Test_AppInformer(t *testing.T) {
 				_, _ = fac.ArgoprojV1alpha1().Applications(inf.options.namespace).Update(context.TODO(), appc, v1.UpdateOptions{})
 			}
 		}
-		apps, err := inf.AppLister.Applications(inf.options.namespace).List(labels.Everything())
+		apps, err := inf.appLister.Applications(inf.options.namespace).List(labels.Everything())
 		assert.NoError(t, err)
 		assert.Len(t, apps, 1)
-		napp, err := inf.AppLister.Applications(inf.options.namespace).Get("test1")
+		napp, err := inf.appLister.Applications(inf.options.namespace).Get("test1")
 		assert.NoError(t, err)
 		assert.NotNil(t, napp)
 		assert.Equal(t, "hello", napp.Spec.Project)
@@ -192,7 +192,7 @@ func Test_AppInformer(t *testing.T) {
 		}))
 		stopCh := make(chan struct{})
 		go func() {
-			inf.AppInformer.Run(stopCh)
+			inf.appInformer.Run(stopCh)
 		}()
 		ticker := time.NewTicker(2 * time.Second)
 		running := true
@@ -208,10 +208,10 @@ func Test_AppInformer(t *testing.T) {
 				_ = fac.ArgoprojV1alpha1().Applications(inf.options.namespace).Delete(context.TODO(), "test1", v1.DeleteOptions{})
 			}
 		}
-		apps, err := inf.AppLister.Applications(inf.options.namespace).List(labels.Everything())
+		apps, err := inf.appLister.Applications(inf.options.namespace).List(labels.Everything())
 		assert.NoError(t, err)
 		assert.Len(t, apps, 0)
-		napp, err := inf.AppLister.Applications(inf.options.namespace).Get("test1")
+		napp, err := inf.appLister.Applications(inf.options.namespace).Get("test1")
 		assert.ErrorContains(t, err, "not found")
 		assert.Nil(t, napp)
 	})
@@ -225,7 +225,7 @@ func Test_AppInformer(t *testing.T) {
 		}), WithNamespaces("kube-system"))
 		stopCh := make(chan struct{})
 		go func() {
-			inf.AppInformer.Run(stopCh)
+			inf.appInformer.Run(stopCh)
 		}()
 		ticker := time.NewTicker(2 * time.Second)
 		running := true
@@ -240,10 +240,10 @@ func Test_AppInformer(t *testing.T) {
 				time.Sleep(100 * time.Millisecond)
 			}
 		}
-		apps, err := inf.AppLister.Applications("").List(labels.Everything())
+		apps, err := inf.appLister.Applications("").List(labels.Everything())
 		assert.NoError(t, err)
 		assert.Len(t, apps, 0)
-		napp, err := inf.AppLister.Applications("").Get("test1")
+		napp, err := inf.appLister.Applications("").Get("test1")
 		assert.ErrorContains(t, err, "not found")
 		assert.Nil(t, napp)
 	})
@@ -257,7 +257,7 @@ func Test_AppInformer(t *testing.T) {
 		}), WithNamespaces("test"))
 		stopCh := make(chan struct{})
 		go func() {
-			inf.AppInformer.Run(stopCh)
+			inf.appInformer.Run(stopCh)
 		}()
 		ticker := time.NewTicker(2 * time.Second)
 		running := true
@@ -272,10 +272,10 @@ func Test_AppInformer(t *testing.T) {
 				time.Sleep(100 * time.Millisecond)
 			}
 		}
-		apps, err := inf.AppLister.Applications("").List(labels.Everything())
+		apps, err := inf.appLister.Applications("").List(labels.Everything())
 		assert.NoError(t, err)
 		assert.Len(t, apps, 1)
-		napp, err := inf.AppLister.Applications("test").Get("test1")
+		napp, err := inf.appLister.Applications("test").Get("test1")
 		assert.NoError(t, err)
 		assert.NotNil(t, napp)
 	})

--- a/internal/manager/application/application_test.go
+++ b/internal/manager/application/application_test.go
@@ -57,20 +57,20 @@ func Test_ManagerOptions(t *testing.T) {
 	t.Run("NewManager with default options", func(t *testing.T) {
 		m, err := NewApplicationManager(nil, "")
 		require.NoError(t, err)
-		assert.Equal(t, false, m.AllowUpsert)
-		assert.Nil(t, m.Metrics)
+		assert.Equal(t, false, m.allowUpsert)
+		assert.Nil(t, m.metrics)
 	})
 
 	t.Run("NewManager with metrics", func(t *testing.T) {
 		m, err := NewApplicationManager(nil, "", WithMetrics(metrics.NewApplicationClientMetrics()))
 		require.NoError(t, err)
-		assert.NotNil(t, m.Metrics)
+		assert.NotNil(t, m.metrics)
 	})
 
 	t.Run("NewManager with upsert enabled", func(t *testing.T) {
 		m, err := NewApplicationManager(nil, "", WithAllowUpsert(true))
 		require.NoError(t, err)
-		assert.True(t, m.AllowUpsert)
+		assert.True(t, m.allowUpsert)
 	})
 }
 
@@ -276,8 +276,8 @@ func Test_ManagerUpdateStatus(t *testing.T) {
 		be := application.NewKubernetesBackend(appC, "", informer, true)
 		mgr, err := NewApplicationManager(be, "argocd")
 		require.NoError(t, err)
-		mgr.Mode = manager.ManagerModeManaged
-		mgr.Role = manager.ManagerRolePrincipal
+		mgr.mode = manager.ManagerModeManaged
+		mgr.role = manager.ManagerRolePrincipal
 		updated, err := mgr.UpdateStatus(context.Background(), "cluster-1", incoming)
 		require.NoError(t, err)
 		b, err := json.MarshalIndent(updated, "", " ")
@@ -352,7 +352,7 @@ func Test_ManagerUpdateAutonomous(t *testing.T) {
 		be := application.NewKubernetesBackend(appC, "", informer, true)
 		mgr, err := NewApplicationManager(be, "argocd")
 		require.NoError(t, err)
-		mgr.Role = manager.ManagerRolePrincipal
+		mgr.role = manager.ManagerRolePrincipal
 		updated, err := mgr.UpdateAutonomousApp(context.TODO(), "cluster-1", incoming)
 		require.NoError(t, err)
 		require.NotNil(t, updated)
@@ -420,8 +420,8 @@ func Test_ManagerUpdateOperation(t *testing.T) {
 		// be := kubernetes.NewKubernetesBackend(appC, "", informer, true)
 		// mgr := NewApplicationManager(be, "argocd")
 		_, mgr := fakeAppManager(t, existing)
-		mgr.Mode = manager.ManagerModeAutonomous
-		mgr.Role = manager.ManagerRoleAgent
+		mgr.mode = manager.ManagerModeAutonomous
+		mgr.role = manager.ManagerRoleAgent
 		updated, err := mgr.UpdateOperation(context.TODO(), incoming)
 		require.NoError(t, err)
 		require.NotNil(t, updated)

--- a/principal/server.go
+++ b/principal/server.go
@@ -177,7 +177,7 @@ func (s *Server) Start(ctx context.Context, errch chan error) error {
 
 	// The application informer lives in its own go routine
 	go func() {
-		s.appManager.Application.StartInformer(ctx)
+		s.appManager.StartBackend(s.ctx)
 	}()
 
 	s.events = event.NewEventSource(s.options.serverName)
@@ -274,11 +274,6 @@ func (s *Server) AuthMethodsForE2EOnly() *auth.Methods {
 
 func (s *Server) QueuesForE2EOnly() *queue.SendRecvQueues {
 	return s.queues
-}
-
-// AppManagerForE2EOnly should only be used for E2E tests
-func (s *Server) AppManagerForE2EOnly() *application.ApplicationManager {
-	return s.appManager
 }
 
 func (s *Server) agentMode(namespace string) types.AgentMode {

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -25,13 +25,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
-	fakeappclient "github.com/argoproj/argo-cd/v2/pkg/client/clientset/versioned/fake"
-	format "github.com/cloudevents/sdk-go/binding/format/protobuf/v2"
 	"github.com/argoproj-labs/argocd-agent/agent"
 	"github.com/argoproj-labs/argocd-agent/internal/auth"
 	"github.com/argoproj-labs/argocd-agent/internal/auth/userpass"
-	"github.com/argoproj-labs/argocd-agent/internal/backend"
 	"github.com/argoproj-labs/argocd-agent/internal/event"
 	"github.com/argoproj-labs/argocd-agent/pkg/api/grpc/authapi"
 	"github.com/argoproj-labs/argocd-agent/pkg/api/grpc/eventstreamapi"
@@ -39,6 +35,9 @@ import (
 	"github.com/argoproj-labs/argocd-agent/pkg/types"
 	"github.com/argoproj-labs/argocd-agent/principal"
 	fakecerts "github.com/argoproj-labs/argocd-agent/test/fake/testcerts"
+	"github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
+	fakeappclient "github.com/argoproj/argo-cd/v2/pkg/client/clientset/versioned/fake"
+	format "github.com/cloudevents/sdk-go/binding/format/protobuf/v2"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -225,9 +224,9 @@ func Test_EndToEnd_Push(t *testing.T) {
 	assert.Equal(t, 0, q.RecvQ("default").Len())
 
 	// All applications should have been created by now on the server
-	apps, err := s.AppManagerForE2EOnly().Application.List(context.Background(), backend.ApplicationSelector{})
+	apps, err := appC.ArgoprojV1alpha1().Applications("default").List(context.Background(), v1.ListOptions{})
 	assert.NoError(t, err)
-	assert.Len(t, apps, 10)
+	assert.Len(t, apps.Items, 10)
 }
 
 func Test_AgentServer(t *testing.T) {


### PR DESCRIPTION
This PR:
- Reduces the visibility of fields that are not currently used by other packages
    - As always, happy to revert any changes for cases where there are expected uses for these fields, or some grander vision
- In `ApplicationManager`, renamed `application` field -> `applicationBackend`, to clarify it is a backend for storing applications, and not a specific application itself (which was already pretty obvious from the context, but still IMHO worth renaming)
- Add an initial makefile target for running the E2E tests in `test/e2e` folder
