### PR TITLE
refactor: Reduce dependence on client-go API outside of k8s backend

### DIFF
--- a/agent/inbound.go
+++ b/agent/inbound.go
@@ -17,6 +17,7 @@ package agent
 import (
 	"fmt"
 
+	"github.com/argoproj-labs/argocd-agent/internal/backend"
 	"github.com/argoproj-labs/argocd-agent/internal/event"
 	"github.com/argoproj-labs/argocd-agent/pkg/types"
 	"github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
@@ -160,7 +161,8 @@ func (a *Agent) deleteApplication(app *v1alpha1.Application) error {
 
 	logCtx.Infof("Deleting application")
 
-	err := a.appManager.Delete(a.context, a.namespace, app, true)
+	deletionPropagation := backend.DeletePropagationBackground
+	err := a.appManager.Delete(a.context, a.namespace, app, &deletionPropagation)
 	if err != nil {
 		return err
 	}

--- a/agent/inbound.go
+++ b/agent/inbound.go
@@ -21,7 +21,6 @@ import (
 	"github.com/argoproj-labs/argocd-agent/pkg/types"
 	"github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
 	"github.com/sirupsen/logrus"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 /*
@@ -161,8 +160,7 @@ func (a *Agent) deleteApplication(app *v1alpha1.Application) error {
 
 	logCtx.Infof("Deleting application")
 
-	delPol := v1.DeletePropagationBackground
-	err := a.appclient.ArgoprojV1alpha1().Applications(a.namespace).Delete(a.context, app.Name, v1.DeleteOptions{PropagationPolicy: &delPol})
+	err := a.appManager.Delete(a.context, a.namespace, app, true)
 	if err != nil {
 		return err
 	}

--- a/internal/backend/interface.go
+++ b/internal/backend/interface.go
@@ -39,6 +39,21 @@ type ApplicationSelector struct {
 	Projects []string
 }
 
+// DeletionPropagation is based on the kubernetes DeletionPropagation API, and follows its behaviours for deletion propagation,
+// specifically that it controls how deletion will propagate to the dependents of the object (and corresponding GC behaviour)
+type DeletionPropagation string
+
+const (
+	// Orphans the dependents: the object is deleted, the dependents are not.
+	DeletePropagationOrphan DeletionPropagation = "Orphan"
+
+	// The object is deleted, and any dependent objects are deleted in the background.
+	DeletePropagationBackground DeletionPropagation = "Background"
+
+	// The object continues to exist until all dependents are deleted. This same behaviour cascades to dependent objects.
+	DeletePropagationForeground DeletionPropagation = "Foreground"
+)
+
 // Application defines a generic interface to store/track Argo CD Application state, via ApplicationManager.
 //
 // As of this writing (August 2024), the only implementation is a Kubernetes-based backend (KubernetesBackend in 'internal/backend/kubernetes/application') but other backends (e.g. RDBMS-backed) could be implemented in the future.
@@ -46,7 +61,7 @@ type Application interface {
 	List(ctx context.Context, selector ApplicationSelector) ([]v1alpha1.Application, error)
 	Create(ctx context.Context, app *v1alpha1.Application) (*v1alpha1.Application, error)
 	Get(ctx context.Context, name string, namespace string) (*v1alpha1.Application, error)
-	Delete(ctx context.Context, name string, namespace string, deletionPropagationBackground bool) error
+	Delete(ctx context.Context, name string, namespace string, deletionPropagation *DeletionPropagation) error
 	Update(ctx context.Context, app *v1alpha1.Application) (*v1alpha1.Application, error)
 	Patch(ctx context.Context, name string, namespace string, patch []byte) (*v1alpha1.Application, error)
 	SupportsPatch() bool

--- a/internal/backend/interface.go
+++ b/internal/backend/interface.go
@@ -19,6 +19,7 @@ package backend
 
 import (
 	"context"
+	"time"
 
 	"github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
 )
@@ -45,9 +46,10 @@ type Application interface {
 	List(ctx context.Context, selector ApplicationSelector) ([]v1alpha1.Application, error)
 	Create(ctx context.Context, app *v1alpha1.Application) (*v1alpha1.Application, error)
 	Get(ctx context.Context, name string, namespace string) (*v1alpha1.Application, error)
-	Delete(ctx context.Context, name string, namespace string) error
+	Delete(ctx context.Context, name string, namespace string, deletionPropagationBackground bool) error
 	Update(ctx context.Context, app *v1alpha1.Application) (*v1alpha1.Application, error)
 	Patch(ctx context.Context, name string, namespace string, patch []byte) (*v1alpha1.Application, error)
 	SupportsPatch() bool
 	StartInformer(ctx context.Context)
+	EnsureSynced(duration time.Duration) error
 }

--- a/internal/backend/kubernetes/application/kubernetes_test.go
+++ b/internal/backend/kubernetes/application/kubernetes_test.go
@@ -20,9 +20,9 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/argoproj-labs/argocd-agent/internal/backend"
 	"github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
 	fakeappclient "github.com/argoproj/argo-cd/v2/pkg/client/clientset/versioned/fake"
-	"github.com/argoproj-labs/argocd-agent/internal/backend"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/wI2L/jsondiff"
@@ -131,13 +131,13 @@ func Test_Delete(t *testing.T) {
 	t.Run("Delete existing app", func(t *testing.T) {
 		fakeAppC := fakeappclient.NewSimpleClientset(apps...)
 		k := NewKubernetesBackend(fakeAppC, "", nil, true)
-		err := k.Delete(context.TODO(), "app", "ns1")
+		err := k.Delete(context.TODO(), "app", "ns1", false)
 		assert.NoError(t, err)
 	})
 	t.Run("Delete non-existing app", func(t *testing.T) {
 		fakeAppC := fakeappclient.NewSimpleClientset(apps...)
 		k := NewKubernetesBackend(fakeAppC, "", nil, true)
-		err := k.Delete(context.TODO(), "app", "ns10")
+		err := k.Delete(context.TODO(), "app", "ns10", false)
 		assert.ErrorContains(t, err, "not found")
 	})
 }

--- a/internal/backend/kubernetes/application/kubernetes_test.go
+++ b/internal/backend/kubernetes/application/kubernetes_test.go
@@ -131,13 +131,15 @@ func Test_Delete(t *testing.T) {
 	t.Run("Delete existing app", func(t *testing.T) {
 		fakeAppC := fakeappclient.NewSimpleClientset(apps...)
 		k := NewKubernetesBackend(fakeAppC, "", nil, true)
-		err := k.Delete(context.TODO(), "app", "ns1", false)
+		deletionPropagation := backend.DeletePropagationForeground
+		err := k.Delete(context.TODO(), "app", "ns1", &deletionPropagation)
 		assert.NoError(t, err)
 	})
 	t.Run("Delete non-existing app", func(t *testing.T) {
 		fakeAppC := fakeappclient.NewSimpleClientset(apps...)
 		k := NewKubernetesBackend(fakeAppC, "", nil, true)
-		err := k.Delete(context.TODO(), "app", "ns10", false)
+		deletionPropagation := backend.DeletePropagationForeground
+		err := k.Delete(context.TODO(), "app", "ns10", &deletionPropagation)
 		assert.ErrorContains(t, err, "not found")
 	})
 }

--- a/internal/backend/mocks/Application.go
+++ b/internal/backend/mocks/Application.go
@@ -9,6 +9,8 @@ import (
 
 	mock "github.com/stretchr/testify/mock"
 
+	time "time"
+
 	v1alpha1 "github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
 )
 
@@ -84,17 +86,17 @@ func (_c *Application_Create_Call) RunAndReturn(run func(context.Context, *v1alp
 	return _c
 }
 
-// Delete provides a mock function with given fields: ctx, name, namespace
-func (_m *Application) Delete(ctx context.Context, name string, namespace string) error {
-	ret := _m.Called(ctx, name, namespace)
+// Delete provides a mock function with given fields: ctx, name, namespace, deletionPropagationBackground
+func (_m *Application) Delete(ctx context.Context, name string, namespace string, deletionPropagationBackground bool) error {
+	ret := _m.Called(ctx, name, namespace, deletionPropagationBackground)
 
 	if len(ret) == 0 {
 		panic("no return value specified for Delete")
 	}
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, string, string) error); ok {
-		r0 = rf(ctx, name, namespace)
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, bool) error); ok {
+		r0 = rf(ctx, name, namespace, deletionPropagationBackground)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -111,13 +113,14 @@ type Application_Delete_Call struct {
 //   - ctx context.Context
 //   - name string
 //   - namespace string
-func (_e *Application_Expecter) Delete(ctx interface{}, name interface{}, namespace interface{}) *Application_Delete_Call {
-	return &Application_Delete_Call{Call: _e.mock.On("Delete", ctx, name, namespace)}
+//   - deletionPropagationBackground bool
+func (_e *Application_Expecter) Delete(ctx interface{}, name interface{}, namespace interface{}, deletionPropagationBackground interface{}) *Application_Delete_Call {
+	return &Application_Delete_Call{Call: _e.mock.On("Delete", ctx, name, namespace, deletionPropagationBackground)}
 }
 
-func (_c *Application_Delete_Call) Run(run func(ctx context.Context, name string, namespace string)) *Application_Delete_Call {
+func (_c *Application_Delete_Call) Run(run func(ctx context.Context, name string, namespace string, deletionPropagationBackground bool)) *Application_Delete_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(string), args[2].(string))
+		run(args[0].(context.Context), args[1].(string), args[2].(string), args[3].(bool))
 	})
 	return _c
 }
@@ -127,7 +130,53 @@ func (_c *Application_Delete_Call) Return(_a0 error) *Application_Delete_Call {
 	return _c
 }
 
-func (_c *Application_Delete_Call) RunAndReturn(run func(context.Context, string, string) error) *Application_Delete_Call {
+func (_c *Application_Delete_Call) RunAndReturn(run func(context.Context, string, string, bool) error) *Application_Delete_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// EnsureSynced provides a mock function with given fields: duration
+func (_m *Application) EnsureSynced(duration time.Duration) error {
+	ret := _m.Called(duration)
+
+	if len(ret) == 0 {
+		panic("no return value specified for EnsureSynced")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(time.Duration) error); ok {
+		r0 = rf(duration)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// Application_EnsureSynced_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'EnsureSynced'
+type Application_EnsureSynced_Call struct {
+	*mock.Call
+}
+
+// EnsureSynced is a helper method to define mock.On call
+//   - duration time.Duration
+func (_e *Application_Expecter) EnsureSynced(duration interface{}) *Application_EnsureSynced_Call {
+	return &Application_EnsureSynced_Call{Call: _e.mock.On("EnsureSynced", duration)}
+}
+
+func (_c *Application_EnsureSynced_Call) Run(run func(duration time.Duration)) *Application_EnsureSynced_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(time.Duration))
+	})
+	return _c
+}
+
+func (_c *Application_EnsureSynced_Call) Return(_a0 error) *Application_EnsureSynced_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *Application_EnsureSynced_Call) RunAndReturn(run func(time.Duration) error) *Application_EnsureSynced_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/backend/mocks/Application.go
+++ b/internal/backend/mocks/Application.go
@@ -86,17 +86,17 @@ func (_c *Application_Create_Call) RunAndReturn(run func(context.Context, *v1alp
 	return _c
 }
 
-// Delete provides a mock function with given fields: ctx, name, namespace, deletionPropagationBackground
-func (_m *Application) Delete(ctx context.Context, name string, namespace string, deletionPropagationBackground bool) error {
-	ret := _m.Called(ctx, name, namespace, deletionPropagationBackground)
+// Delete provides a mock function with given fields: ctx, name, namespace, deletionPropagation
+func (_m *Application) Delete(ctx context.Context, name string, namespace string, deletionPropagation *backend.DeletionPropagation) error {
+	ret := _m.Called(ctx, name, namespace, deletionPropagation)
 
 	if len(ret) == 0 {
 		panic("no return value specified for Delete")
 	}
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, string, string, bool) error); ok {
-		r0 = rf(ctx, name, namespace, deletionPropagationBackground)
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, *backend.DeletionPropagation) error); ok {
+		r0 = rf(ctx, name, namespace, deletionPropagation)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -113,14 +113,14 @@ type Application_Delete_Call struct {
 //   - ctx context.Context
 //   - name string
 //   - namespace string
-//   - deletionPropagationBackground bool
-func (_e *Application_Expecter) Delete(ctx interface{}, name interface{}, namespace interface{}, deletionPropagationBackground interface{}) *Application_Delete_Call {
-	return &Application_Delete_Call{Call: _e.mock.On("Delete", ctx, name, namespace, deletionPropagationBackground)}
+//   - deletionPropagation *backend.DeletionPropagation
+func (_e *Application_Expecter) Delete(ctx interface{}, name interface{}, namespace interface{}, deletionPropagation interface{}) *Application_Delete_Call {
+	return &Application_Delete_Call{Call: _e.mock.On("Delete", ctx, name, namespace, deletionPropagation)}
 }
 
-func (_c *Application_Delete_Call) Run(run func(ctx context.Context, name string, namespace string, deletionPropagationBackground bool)) *Application_Delete_Call {
+func (_c *Application_Delete_Call) Run(run func(ctx context.Context, name string, namespace string, deletionPropagation *backend.DeletionPropagation)) *Application_Delete_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(string), args[2].(string), args[3].(bool))
+		run(args[0].(context.Context), args[1].(string), args[2].(string), args[3].(*backend.DeletionPropagation))
 	})
 	return _c
 }
@@ -130,7 +130,7 @@ func (_c *Application_Delete_Call) Return(_a0 error) *Application_Delete_Call {
 	return _c
 }
 
-func (_c *Application_Delete_Call) RunAndReturn(run func(context.Context, string, string, bool) error) *Application_Delete_Call {
+func (_c *Application_Delete_Call) RunAndReturn(run func(context.Context, string, string, *backend.DeletionPropagation) error) *Application_Delete_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/manager/application/application.go
+++ b/internal/manager/application/application.go
@@ -114,8 +114,16 @@ func NewApplicationManager(be backend.Application, namespace string, opts ...App
 	return m, nil
 }
 
+// StartBackend informs the backend to run startup logic, which usually means beginning to listen for events.
+// For example, in the case of the Kubernetes backend, the shared informer is started, which will listen for Application events from the watch api of the K8s cluster.
 func (m *ApplicationManager) StartBackend(ctx context.Context) {
 	m.applicationBackend.StartInformer(ctx)
+}
+
+// EnsureSynced waits until either the backend indicates it has fully synced, or the
+// timeout has been reached (which will return an error)
+func (m *ApplicationManager) EnsureSynced(duration time.Duration) error {
+	return m.applicationBackend.EnsureSynced(duration)
 }
 
 // stampLastUpdated "stamps" an application with the last updated label
@@ -473,7 +481,8 @@ func (m *ApplicationManager) UpdateOperation(ctx context.Context, incoming *v1al
 // Delete will delete an application resource. If Delete is called by the
 // principal, any existing finalizers will be removed before deletion is
 // attempted.
-func (m *ApplicationManager) Delete(ctx context.Context, namespace string, incoming *v1alpha1.Application) error {
+// if 'deletionPropagationBackground' is true, the deletion operation will return once the owner object is deleted, but before child objects are deleted.
+func (m *ApplicationManager) Delete(ctx context.Context, namespace string, incoming *v1alpha1.Application, deletionPropagationBackground bool) error {
 	removeFinalizer := false
 	logCtx := log().WithFields(logrus.Fields{
 		"component":       "DeleteOperation",
@@ -496,7 +505,7 @@ func (m *ApplicationManager) Delete(ctx context.Context, namespace string, incom
 		}
 	}
 
-	err = m.applicationBackend.Delete(ctx, incoming.Name, incoming.Namespace)
+	err = m.applicationBackend.Delete(ctx, incoming.Name, incoming.Namespace, deletionPropagationBackground)
 
 	return err
 }

--- a/internal/manager/application/application.go
+++ b/internal/manager/application/application.go
@@ -481,8 +481,8 @@ func (m *ApplicationManager) UpdateOperation(ctx context.Context, incoming *v1al
 // Delete will delete an application resource. If Delete is called by the
 // principal, any existing finalizers will be removed before deletion is
 // attempted.
-// if 'deletionPropagationBackground' is true, the deletion operation will return once the owner object is deleted, but before child objects are deleted.
-func (m *ApplicationManager) Delete(ctx context.Context, namespace string, incoming *v1alpha1.Application, deletionPropagationBackground bool) error {
+// 'deletionPropagation' follows the corresponding K8s behaviour, defaulting to Foreground if nil.
+func (m *ApplicationManager) Delete(ctx context.Context, namespace string, incoming *v1alpha1.Application, deletionPropagation *backend.DeletionPropagation) error {
 	removeFinalizer := false
 	logCtx := log().WithFields(logrus.Fields{
 		"component":       "DeleteOperation",
@@ -505,7 +505,7 @@ func (m *ApplicationManager) Delete(ctx context.Context, namespace string, incom
 		}
 	}
 
-	err = m.applicationBackend.Delete(ctx, incoming.Name, incoming.Namespace, deletionPropagationBackground)
+	err = m.applicationBackend.Delete(ctx, incoming.Name, incoming.Namespace, deletionPropagation)
 
 	return err
 }

--- a/internal/manager/application/application_test.go
+++ b/internal/manager/application/application_test.go
@@ -459,7 +459,7 @@ func Test_DeleteApp(t *testing.T) {
 		app, err := appC.ArgoprojV1alpha1().Applications("argocd").Get(context.TODO(), "foobar", v1.GetOptions{})
 		assert.NoError(t, err)
 		assert.NotNil(t, app)
-		err = mgr.Delete(context.TODO(), "argocd", existing)
+		err = mgr.Delete(context.TODO(), "argocd", existing, false)
 		assert.NoError(t, err)
 		app, err = appC.ArgoprojV1alpha1().Applications("argocd").Get(context.TODO(), "foobar", v1.GetOptions{})
 		assert.True(t, errors.IsNotFound(err))

--- a/internal/manager/application/application_test.go
+++ b/internal/manager/application/application_test.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/argoproj-labs/argocd-agent/internal/backend"
 	"github.com/argoproj-labs/argocd-agent/internal/backend/kubernetes/application"
 	appmock "github.com/argoproj-labs/argocd-agent/internal/backend/mocks"
 	appinformer "github.com/argoproj-labs/argocd-agent/internal/informer/application"
@@ -459,7 +460,8 @@ func Test_DeleteApp(t *testing.T) {
 		app, err := appC.ArgoprojV1alpha1().Applications("argocd").Get(context.TODO(), "foobar", v1.GetOptions{})
 		assert.NoError(t, err)
 		assert.NotNil(t, app)
-		err = mgr.Delete(context.TODO(), "argocd", existing, false)
+		deletionPropagation := backend.DeletePropagationForeground
+		err = mgr.Delete(context.TODO(), "argocd", existing, &deletionPropagation)
 		assert.NoError(t, err)
 		app, err = appC.ArgoprojV1alpha1().Applications("argocd").Get(context.TODO(), "foobar", v1.GetOptions{})
 		assert.True(t, errors.IsNotFound(err))

--- a/pkg/client/remote_test.go
+++ b/pkg/client/remote_test.go
@@ -66,6 +66,7 @@ func Test_Connect(t *testing.T) {
 		err = r.Connect(ctx, false)
 		assert.NoError(t, err)
 		assert.NotNil(t, r.conn)
+		require.NotNil(t, r.accessToken)
 		require.NotNil(t, r.accessToken.Claims)
 		sub, err := r.accessToken.Claims.GetSubject()
 		assert.NoError(t, err)

--- a/principal/event.go
+++ b/principal/event.go
@@ -126,7 +126,7 @@ func (s *Server) processApplicationEvent(ctx context.Context, agentName string, 
 		if agentMode.IsManaged() {
 			err = errors.New("event type not allowed when mode is not autonomous")
 		} else {
-			err = s.appManager.Delete(ctx, agentName, incoming)
+			err = s.appManager.Delete(ctx, agentName, incoming, false)
 		}
 		if err != nil {
 			return fmt.Errorf("could not delete application %s: %w", incoming.QualifiedName(), err)

--- a/principal/event.go
+++ b/principal/event.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/argoproj-labs/argocd-agent/internal/backend"
 	"github.com/argoproj-labs/argocd-agent/internal/event"
 	"github.com/argoproj-labs/argocd-agent/internal/namedlock"
 	"github.com/argoproj-labs/argocd-agent/pkg/types"
@@ -126,7 +127,8 @@ func (s *Server) processApplicationEvent(ctx context.Context, agentName string, 
 		if agentMode.IsManaged() {
 			err = errors.New("event type not allowed when mode is not autonomous")
 		} else {
-			err = s.appManager.Delete(ctx, agentName, incoming, false)
+			deletionPropagation := backend.DeletePropagationForeground
+			err = s.appManager.Delete(ctx, agentName, incoming, &deletionPropagation)
 		}
 		if err != nil {
 			return fmt.Errorf("could not delete application %s: %w", incoming.QualifiedName(), err)


### PR DESCRIPTION
My understanding of the Application backend abstraction is that it is designed to be agnostic to the particular implementation [1]. And on top of that exists the `ApplicationManager`, which is a generic mechanism for interacting with any backend implementation.

At present we only have the Kubernetes backend, and Kubernetes is our primary interface, so naturally some of the implementation details of that backend will leak out. 

This PR seeks to make a fairly minor change to slightly unleak some of those, as a way to pick some low hanging fruit in this area.

[1] But note that agent role code explicitly states that it requires the Kubernetes-based backend.

**This PR:**

- Agent role code changes:
    - Remove direct kubernetes API objects (k8s client-go, argo application client-go, app informer APIs) from Agent. These should be accessed via ApplicationManager.
        - While it's true that agent role code DOES require K8s backend, IMHO agent code should still access that backend via ApplicationManager, rather than via direct k8s client-go calls.
        - Likewise switches `deleteApplication` in `agent/inbound.go` to call `Delete` from `ApplicationManager`, rather than calling `Delete` on client-go K8s API directly.

- Principal role code changes:
    - Remove appinformer from `Server` struct, `ApplicationManager` should be used instead

- Add `EnsureSynced`, and `deletionPropagationBackground` param to `Delete`, to `Application` backend interface
    - To some extent this might seem like it is INCREASING the abstraction leak, rather than decreasing :)
    - However, my expectation is the concept of 'blocking until initial sync', and 'delete child objects in background' are universal enough that they will be useful for other potential backends (or in the worse case, would be a no-op in those backends)
    - At some point in the future, when we have other backends, we can tweak the specific API names to be more generic