### PR TITLE
refactor: Provide additional kubernetes client to servers

### DIFF
--- a/cmd/principal/main.go
+++ b/cmd/principal/main.go
@@ -134,7 +134,7 @@ func NewPrincipalRunCommand() *cobra.Command {
 				observer(10 * time.Second)
 			}
 
-			s, err := principal.NewServer(ctx, kubeConfig.ApplicationsClientset, namespace, opts...)
+			s, err := principal.NewServer(ctx, kubeConfig, namespace, opts...)
 			if err != nil {
 				cmd.Fatal("Could not create new server instance: %v", err)
 			}

--- a/pkg/client/remote_test.go
+++ b/pkg/client/remote_test.go
@@ -22,12 +22,11 @@ import (
 	"testing"
 	"time"
 
-	fakeappclient "github.com/argoproj/argo-cd/v2/pkg/client/clientset/versioned/fake"
-
 	"github.com/argoproj-labs/argocd-agent/internal/auth"
 	"github.com/argoproj-labs/argocd-agent/internal/auth/userpass"
 	"github.com/argoproj-labs/argocd-agent/pkg/types"
 	"github.com/argoproj-labs/argocd-agent/principal"
+	"github.com/argoproj-labs/argocd-agent/test/fake/kube"
 	"github.com/argoproj-labs/argocd-agent/test/fake/testcerts"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -37,7 +36,7 @@ func Test_Connect(t *testing.T) {
 	tempDir := t.TempDir()
 	basePath := path.Join(tempDir, "certs")
 	testcerts.WriteSelfSignedCert(t, "rsa", basePath, x509.Certificate{SerialNumber: big.NewInt(1)})
-	s, err := principal.NewServer(context.TODO(), fakeappclient.NewSimpleClientset(), "default",
+	s, err := principal.NewServer(context.TODO(), kube.NewKubernetesFakeClient(), "default",
 		principal.WithGRPC(true),
 		principal.WithListenerPort(0),
 		principal.WithTLSKeyPairFromPath(basePath+".crt", basePath+".key"),

--- a/principal/apis/eventstream/eventstream.go
+++ b/principal/apis/eventstream/eventstream.go
@@ -87,7 +87,7 @@ func NewServer(queues queue.QueuePair, opts ...ServerOption) *Server {
 
 // newClientConnection returns a new client object to be used to read from and
 // send to the subscription stream.
-func newClientConnection(ctx context.Context, timeout time.Duration) (*client, error) {
+func (s *Server) newClientConnection(ctx context.Context, timeout time.Duration) (*client, error) {
 	c := &client{}
 	c.wg = &sync.WaitGroup{}
 
@@ -122,6 +122,7 @@ func agentName(ctx context.Context) (string, error) {
 	if !ok {
 		return "", fmt.Errorf("invalid context: no agent name")
 	}
+	// TODO: check agentName for validity
 	return agentName, nil
 }
 
@@ -256,7 +257,7 @@ func (s *Server) sendFunc(c *client, subs eventstreamapi.EventStream_SubscribeSe
 //
 // Subscribe is called by GRPC machinery.
 func (s *Server) Subscribe(subs eventstreamapi.EventStream_SubscribeServer) error {
-	c, err := newClientConnection(subs.Context(), s.options.MaxStreamDuration)
+	c, err := s.newClientConnection(subs.Context(), s.options.MaxStreamDuration)
 	if err != nil {
 		return err
 	}

--- a/principal/listen_test.go
+++ b/principal/listen_test.go
@@ -22,12 +22,12 @@ import (
 	"testing"
 	"time"
 
-	fakeappclient "github.com/argoproj/argo-cd/v2/pkg/client/clientset/versioned/fake"
 	"github.com/argoproj-labs/argocd-agent/internal/auth"
 	"github.com/argoproj-labs/argocd-agent/internal/auth/userpass"
 	"github.com/argoproj-labs/argocd-agent/pkg/api/grpc/authapi"
 	"github.com/argoproj-labs/argocd-agent/pkg/api/grpc/versionapi"
 	"github.com/argoproj-labs/argocd-agent/pkg/types"
+	"github.com/argoproj-labs/argocd-agent/test/fake/kube"
 	fakecerts "github.com/argoproj-labs/argocd-agent/test/fake/testcerts"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -79,7 +79,7 @@ func Test_Listen(t *testing.T) {
 	templ := certTempl
 	fakecerts.WriteSelfSignedCert(t, "rsa", path.Join(tempDir, "test-cert"), templ)
 	t.Run("Auto-select port for listener", func(t *testing.T) {
-		s, err := NewServer(context.TODO(), fakeappclient.NewSimpleClientset(), testNamespace,
+		s, err := NewServer(context.TODO(), kube.NewKubernetesFakeClient(), testNamespace,
 			WithTLSKeyPairFromPath(path.Join(tempDir, "test-cert.crt"), path.Join(tempDir, "test-cert.key")),
 			WithListenerPort(0),
 			WithGeneratedTokenSigningKey(),
@@ -94,7 +94,7 @@ func Test_Listen(t *testing.T) {
 	})
 
 	t.Run("Listen on privileged port", func(t *testing.T) {
-		s, err := NewServer(context.TODO(), fakeappclient.NewSimpleClientset(), testNamespace,
+		s, err := NewServer(context.TODO(), kube.NewKubernetesFakeClient(), testNamespace,
 			WithTLSKeyPairFromPath(path.Join(tempDir, "test-cert.crt"), path.Join(tempDir, "test-cert.key")),
 			WithGeneratedTokenSigningKey(),
 			WithListenerPort(443),
@@ -145,7 +145,7 @@ func Test_Serve(t *testing.T) {
 	fakecerts.WriteSelfSignedCert(t, "rsa", path.Join(tempDir, "test-cert"), templ)
 
 	// We start a real (non-mocked) server
-	s, err := NewServer(context.TODO(), fakeappclient.NewSimpleClientset(), testNamespace,
+	s, err := NewServer(context.TODO(), kube.NewKubernetesFakeClient(), testNamespace,
 		WithTLSKeyPairFromPath(path.Join(tempDir, "test-cert.crt"), path.Join(tempDir, "test-cert.key")),
 		WithGeneratedTokenSigningKey(),
 		WithListenerPort(0),

--- a/principal/server_test.go
+++ b/principal/server_test.go
@@ -23,7 +23,7 @@ import (
 	"testing"
 	"time"
 
-	fakeappclient "github.com/argoproj/argo-cd/v2/pkg/client/clientset/versioned/fake"
+	"github.com/argoproj-labs/argocd-agent/test/fake/kube"
 	fakecerts "github.com/argoproj-labs/argocd-agent/test/fake/testcerts"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
@@ -46,7 +46,7 @@ func Test_ServerWithTLSConfig(t *testing.T) {
 	t.Run("Valid TLS key pair", func(t *testing.T) {
 		templ := certTempl
 		fakecerts.WriteSelfSignedCert(t, "rsa", path.Join(tempDir, "test-cert"), templ)
-		s, err := NewServer(context.TODO(), fakeappclient.NewSimpleClientset(), testNamespace,
+		s, err := NewServer(context.TODO(), kube.NewKubernetesFakeClient(), testNamespace,
 			WithTLSKeyPairFromPath(path.Join(tempDir, "test-cert.crt"), path.Join(tempDir, "test-cert.key")),
 			WithGeneratedTokenSigningKey(),
 		)
@@ -56,7 +56,7 @@ func Test_ServerWithTLSConfig(t *testing.T) {
 		assert.NotNil(t, tlsConfig)
 	})
 	t.Run("Non-existing TLS key pair", func(t *testing.T) {
-		s, err := NewServer(context.TODO(), fakeappclient.NewSimpleClientset(), testNamespace,
+		s, err := NewServer(context.TODO(), kube.NewKubernetesFakeClient(), testNamespace,
 			WithTLSKeyPairFromPath(path.Join(tempDir, "other-cert.crt"), path.Join(tempDir, "other-cert.key")),
 			WithGeneratedTokenSigningKey(),
 		)
@@ -67,7 +67,7 @@ func Test_ServerWithTLSConfig(t *testing.T) {
 	})
 
 	t.Run("Invalid TLS certificate", func(t *testing.T) {
-		s, err := NewServer(context.TODO(), fakeappclient.NewSimpleClientset(), testNamespace,
+		s, err := NewServer(context.TODO(), kube.NewKubernetesFakeClient(), testNamespace,
 			WithTLSKeyPairFromPath("server_test.go", "server_test.go"),
 			WithGeneratedTokenSigningKey(),
 		)
@@ -81,7 +81,7 @@ func Test_ServerWithTLSConfig(t *testing.T) {
 
 func Test_NewServer(t *testing.T) {
 	t.Run("Instantiate new server object with non-default options", func(t *testing.T) {
-		s, err := NewServer(context.TODO(), fakeappclient.NewSimpleClientset(), testNamespace, WithListenerAddress("0.0.0.0"), WithGeneratedTokenSigningKey())
+		s, err := NewServer(context.TODO(), kube.NewKubernetesFakeClient(), testNamespace, WithListenerAddress("0.0.0.0"), WithGeneratedTokenSigningKey())
 		assert.NoError(t, err)
 		assert.NotNil(t, s)
 		assert.NotEqual(t, defaultOptions(), s.options)
@@ -89,7 +89,7 @@ func Test_NewServer(t *testing.T) {
 	})
 
 	t.Run("Instantiate new server object with invalid option", func(t *testing.T) {
-		s, err := NewServer(context.TODO(), fakeappclient.NewSimpleClientset(), testNamespace, WithListenerPort(-1), WithGeneratedTokenSigningKey())
+		s, err := NewServer(context.TODO(), kube.NewKubernetesFakeClient(), testNamespace, WithListenerPort(-1), WithGeneratedTokenSigningKey())
 		assert.Error(t, err)
 		assert.Nil(t, s)
 	})

--- a/test/fake/kube/kubernetes.go
+++ b/test/fake/kube/kubernetes.go
@@ -15,6 +15,8 @@
 package kube
 
 import (
+	"github.com/argoproj-labs/argocd-agent/internal/kube"
+	fakeappclient "github.com/argoproj/argo-cd/v2/pkg/client/clientset/versioned/fake"
 	"k8s.io/apimachinery/pkg/runtime"
 	kubefake "k8s.io/client-go/kubernetes/fake"
 )
@@ -27,4 +29,11 @@ func NewFakeKubeClient() *kubefake.Clientset {
 func NewFakeClientsetWithResources(objects ...runtime.Object) *kubefake.Clientset {
 	clientset := kubefake.NewSimpleClientset(objects...)
 	return clientset
+}
+
+func NewKubernetesFakeClient(objects ...runtime.Object) *kube.KubernetesClient {
+	c := &kube.KubernetesClient{}
+	c.Clientset = NewFakeClientsetWithResources()
+	c.ApplicationsClientset = fakeappclient.NewSimpleClientset(objects...)
+	return c
 }


### PR DESCRIPTION
This is a small refactor so that the agent and principal both will have access to a generic Kubernetes API client in addition to the versioned Application client.

It is a prerequisite for some changes to come.