### PR TITLE
fix: Namespace displayed on startup logs

### DIFF
--- a/internal/informer/application/appinformer.go
+++ b/internal/informer/application/appinformer.go
@@ -225,7 +225,11 @@ func NewAppInformer(ctx context.Context, client appclientset.Interface, namespac
 }
 
 func (i *AppInformer) Start(stopch <-chan struct{}) {
-	log().Infof("Starting app informer (namespaces: %s)", strings.Join(append([]string{i.options.namespace}, i.options.namespaces...), ","))
+	ns := ""
+	if i.options.namespace != "" {
+		ns = i.options.namespace + ","
+	}
+	log().Infof("Starting app informer (namespaces: %s)", strings.TrimSuffix(ns+strings.Join(i.options.namespaces, ","), ","))
 	i.appInformer.Run(stopch)
 	log().Infof("App informer has shutdown")
 }

--- a/principal/server.go
+++ b/principal/server.go
@@ -165,7 +165,13 @@ func NewServer(ctx context.Context, kubeClient *kube.KubernetesClient, namespace
 // error during startup, before the go routines are running, will be returned
 // immediately. Errors during the runtime will be propagated via errch.
 func (s *Server) Start(ctx context.Context, errch chan error) error {
-	log().Infof("Starting %s (server) v%s (ns=%s, allowed_namespaces=%v)", s.version.Name(), s.version.Version(), s.namespace, s.options.namespaces)
+
+	if s.namespace != "" {
+		log().Infof("Starting %s (server) v%s (ns=%s, allowed_namespaces=%v)", s.version.Name(), s.version.Version(), s.namespace, s.options.namespaces)
+	} else {
+		log().Infof("Starting %s (server) v%s (allowed_namespaces=%v)", s.version.Name(), s.version.Version(), s.options.namespaces)
+	}
+
 	if s.options.serveGRPC {
 		if err := s.serveGRPC(ctx, errch); err != nil {
 			return err


### PR DESCRIPTION
This PR is to modify log statement printed while starting `Server` and `AppInformer`

- Now logs in `principal` will look something like this

`time="2024-09-20T17:35:59+05:30" level=info msg="Starting argocd-agent (server) v99.9.9-unreleased (allowed_namespaces=[*])" module=server`

`time="2024-09-20T17:35:59+05:30" level=info msg="Starting app informer (namespaces: *)" module=AppInformer`

- And logs in `agent` will look like this

`time="2024-09-20T17:36:12+05:30" level=info msg="Starting argocd-agent (agent) v99.9.9-unreleased (ns=agent-managed, allowed_namespaces=[], mode=managed)" module=Agent`

`time="2024-09-20T17:36:12+05:30" level=info msg="Starting app informer (namespaces: agent-managed)" module=AppInformer`

Fixes: https://github.com/argoproj-labs/argocd-agent/issues/158