### PR TITLE
chore: use goreman to start principal and agent

### DIFF
--- a/hack/demo-env/Makefile
+++ b/hack/demo-env/Makefile
@@ -1,0 +1,10 @@
+AUTONOMOUS_MODE?=false
+GOBIN=$(shell go env GOPATH)/bin
+
+.PHONY: start-local
+start-local:
+	AUTONOMOUS_MODE=$(AUTONOMOUS_MODE) $(GOBIN)/goreman -set-ports=false -f Procfile start
+
+.PHONY: help
+help:
+	@echo "Not yet, sorry."

--- a/hack/demo-env/Procfile
+++ b/hack/demo-env/Procfile
@@ -1,0 +1,2 @@
+principal: ./start-principal.sh
+agent: sleep 15s && if [ "$AUTONOMOUS_MODE" = "true" ]; then ./start-agent-autonomous.sh; else ./start-agent-managed.sh; fi


### PR DESCRIPTION
This PR is to make use of `goreman` to run principal and agent in same console, this would make debugging easy as logs of both components would be printed in same console, also it would help to understand the order of execution of agent and principal code blocks. 