### PR TITLE
chore(scripts): Fix OpenShift detection in setup-vcluster-env.sh

### DIFF
--- a/hack/demo-env/setup-vcluster-env.sh
+++ b/hack/demo-env/setup-vcluster-env.sh
@@ -51,7 +51,7 @@ trap on_error ERR
 check_for_openshift() {
 
 	OPENSHIFT=
-	if kubectl api-resources | grep -q "openshift.io"; then 
+	if (kubectl api-resources || true) | grep -q "openshift.io"; then
 		OPENSHIFT=true
 	fi
 


### PR DESCRIPTION
The test to detect OpenShift in the `setup-vcluster-env.sh` script
```
	if kubectl api-resources | grep -q "openshift.io"; then
		OPENSHIFT=true
	fi
```
 is not working.  `grep -q` will return success as soon as it detects the first match. This will close the pipe between the `kubectl` command and the `grep` command. The `kubectl` command will then try to write its next result to the closed pipe, causing it to error out.  Since the script has set `set -o pipefail`, the entire pipeline will then error out, resulting in the `OPENSHIFT` variable not being set.

This PR fixes this by forcing the `kubectl` step to always exit successfully.