### PR TITLE
feat: Remove hard requirements for HTTP/2

### DIFF
--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -35,21 +35,22 @@ import (
 
 func NewAgentRunCommand() *cobra.Command {
 	var (
-		serverAddress string
-		serverPort    int
-		logLevel      string
-		logFormat     string
-		insecure      bool
-		rootCAPath    string
-		kubeConfig    string
-		kubeContext   string
-		namespace     string
-		agentMode     string
-		creds         string
-		showVersion   bool
-		versionFormat string
-		tlsClientCrt  string
-		tlsClientKey  string
+		serverAddress   string
+		serverPort      int
+		logLevel        string
+		logFormat       string
+		insecure        bool
+		rootCAPath      string
+		kubeConfig      string
+		kubeContext     string
+		namespace       string
+		agentMode       string
+		creds           string
+		showVersion     bool
+		versionFormat   string
+		tlsClientCrt    string
+		tlsClientKey    string
+		enableWebSocket bool
 	)
 	command := &cobra.Command{
 		Short: "Run the argocd-agent agent component",
@@ -96,6 +97,7 @@ func NewAgentRunCommand() *cobra.Command {
 			if tlsClientCrt != "" && tlsClientKey != "" {
 				remoteOpts = append(remoteOpts, client.WithTLSClientCertFromFile(tlsClientCrt, tlsClientKey))
 			}
+			remoteOpts = append(remoteOpts, client.WithWebSocket(enableWebSocket))
 			remoteOpts = append(remoteOpts, client.WithClientMode(types.AgentModeFromString(agentMode)))
 			if serverAddress != "" && serverPort > 0 && serverPort < 65536 {
 				remote, err = client.NewRemote(serverAddress, serverPort, remoteOpts...)
@@ -161,6 +163,9 @@ func NewAgentRunCommand() *cobra.Command {
 	command.Flags().StringVar(&tlsClientKey, "tls-client-key",
 		env.StringWithDefault("ARGOCD_AGENT_TLS_CLIENT_KEY_PATH", nil, ""),
 		"Path to TLS client key")
+	command.Flags().BoolVar(&enableWebSocket, "enable-websocket",
+		env.BoolWithDefault("ARGOCD_AGENT_ENABLE_WEBSOCKET", false),
+		"Agent will rely on gRPC over WebSocket to stream events to the Principal")
 
 	command.Flags().StringVar(&kubeConfig, "kubeconfig", "", "Path to a kubeconfig file to use")
 	command.Flags().StringVar(&kubeContext, "kubecontext", "", "Override the default kube context")

--- a/cmd/principal/main.go
+++ b/cmd/principal/main.go
@@ -55,6 +55,7 @@ func NewPrincipalRunCommand() *cobra.Command {
 		autoNamespaceAllow     bool
 		autoNamespacePattern   string
 		autoNamespaceLabels    []string
+		enableWebSocket        bool
 	)
 	var command = &cobra.Command{
 		Short: "Run the argocd-agent principal component",
@@ -146,6 +147,8 @@ func NewPrincipalRunCommand() *cobra.Command {
 				observer(10 * time.Second)
 			}
 
+			opts = append(opts, principal.WithWebSocket(enableWebSocket))
+
 			s, err := principal.NewServer(ctx, kubeConfig, namespace, opts...)
 			if err != nil {
 				cmd.Fatal("Could not create new server instance: %v", err)
@@ -224,6 +227,10 @@ func NewPrincipalRunCommand() *cobra.Command {
 	command.Flags().StringVar(&userDB, "passwd",
 		env.StringWithDefault("ARGOCD_PRINCIPAL_USER_DB_PATH", nil, ""),
 		"Path to userpass passwd file")
+
+	command.Flags().BoolVar(&enableWebSocket, "enable-websocket",
+		env.BoolWithDefault("ARGOCD_PRINCIPAL_ENABLE_WEBSOCKET", false),
+		"Principal will rely on gRPC over WebSocket to stream events to the Agent")
 
 	command.Flags().StringVar(&kubeConfig, "kubeconfig", "", "Path to a kubeconfig file to use")
 	command.Flags().StringVar(&kubeContext, "kubecontext", "", "Override the default kube context")

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,9 @@ require (
 	github.com/stretchr/testify v1.9.0
 	github.com/wI2L/jsondiff v0.6.0
 	golang.org/x/crypto v0.27.0
+	golang.org/x/net v0.29.0
 	golang.org/x/sync v0.8.0
+	golang.stackrox.io/grpc-http1 v0.3.13
 	google.golang.org/genproto/googleapis/api v0.0.0-20240814211410-ddb44dafa142
 	google.golang.org/grpc v1.67.0
 	google.golang.org/protobuf v1.34.2
@@ -45,6 +47,7 @@ require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/chai2010/gettext-go v1.0.2 // indirect
 	github.com/cloudflare/circl v1.3.7 // indirect
+	github.com/coder/websocket v1.8.12 // indirect
 	github.com/cyphar/filepath-securejoin v0.2.4 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
@@ -68,6 +71,7 @@ require (
 	github.com/gobwas/glob v0.2.3 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang-jwt/jwt/v4 v4.5.0 // indirect
+	github.com/golang/glog v1.2.2 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/google/btree v1.1.2 // indirect
@@ -128,7 +132,6 @@ require (
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.26.0 // indirect
 	golang.org/x/mod v0.17.0 // indirect
-	golang.org/x/net v0.28.0 // indirect
 	golang.org/x/oauth2 v0.22.0 // indirect
 	golang.org/x/sys v0.25.0 // indirect
 	golang.org/x/term v0.24.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -696,6 +696,8 @@ github.com/cncf/xds/go v0.0.0-20211011173535-cb28da3451f1/go.mod h1:eXthEFrGJvWH
 github.com/cncf/xds/go v0.0.0-20220314180256-7f1daf1720fc/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cncf/xds/go v0.0.0-20230105202645-06c439db220b/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cncf/xds/go v0.0.0-20230310173818-32f1caf87195/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
+github.com/coder/websocket v1.8.12 h1:5bUXkEPPIbewrnkU8LTCLVaxi4N4J8ahufH2vlo4NAo=
+github.com/coder/websocket v1.8.12/go.mod h1:LNVeNrXQZfe5qhS9ALED3uA+l5pPqvwXg3CKoDBB2gs=
 github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/cpuguy83/go-md2man/v2 v2.0.4/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
@@ -815,6 +817,8 @@ github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0/go.mod h1:E/TSTwGw
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/glog v1.0.0/go.mod h1:EWib/APOK0SL3dFbYqvxE3UYd8E6s1ouQ7iEp/0LWV4=
 github.com/golang/glog v1.1.0/go.mod h1:pfYeQZ3JWZoXTV5sFc986z3HTpwQs9At6P4ImfuP3NQ=
+github.com/golang/glog v1.2.2 h1:1+mZ9upx1Dh6FmUTFR1naJ77miKiXgALjWOZ3NVFPmY=
+github.com/golang/glog v1.2.2/go.mod h1:6AhwSGph0fcJtXVM/PEHPqZlFeoLxhs7/t5UDAwmO+w=
 github.com/golang/groupcache v0.0.0-20190129154638-5b532d6fd5ef/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20191227052852-215e87163ea7/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
@@ -1386,8 +1390,8 @@ golang.org/x/net v0.17.0/go.mod h1:NxSsAGuq816PNPmqtQdLE42eU2Fs7NoRIZrHJAlaCOE=
 golang.org/x/net v0.19.0/go.mod h1:CfAk/cbD4CthTvqiEl8NpboMuiuOYsAr/7NOjZJtv1U=
 golang.org/x/net v0.21.0/go.mod h1:bIjVDfnllIU7BJ2DNgfnXvpSvtn8VRwhlsaeUTyUS44=
 golang.org/x/net v0.23.0/go.mod h1:JKghWKKOSdJwpW2GEx0Ja7fmaKnMsbu+MWVZTokSYmg=
-golang.org/x/net v0.28.0 h1:a9JDOJc5GMUJ0+UDqmLT86WiEy7iWyIhz8gz8E4e5hE=
-golang.org/x/net v0.28.0/go.mod h1:yqtgsTWOOnlGLG9GFRrK3++bGOUEkNBoHZc8MEDWPNg=
+golang.org/x/net v0.29.0 h1:5ORfpBpCs4HzDYoodCDBbwHzdR5UrLBZ3sOnUJmFoHo=
+golang.org/x/net v0.29.0/go.mod h1:gLkgy8jTGERgjzMic6DS9+SP0ajcu6Xu3Orq/SpETg0=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
@@ -1678,6 +1682,8 @@ golang.org/x/xerrors v0.0.0-20220411194840-2f41105eb62f/go.mod h1:I/5z698sn9Ka8T
 golang.org/x/xerrors v0.0.0-20220517211312-f3a8303e98df/go.mod h1:K8+ghG5WaK9qNqU5K3HdILfMLy1f3aNYFI/wnl100a8=
 golang.org/x/xerrors v0.0.0-20220609144429-65e65417b02f/go.mod h1:K8+ghG5WaK9qNqU5K3HdILfMLy1f3aNYFI/wnl100a8=
 golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2/go.mod h1:K8+ghG5WaK9qNqU5K3HdILfMLy1f3aNYFI/wnl100a8=
+golang.stackrox.io/grpc-http1 v0.3.13 h1:Fu54UK9A2Q4IcAzAGR2jLOn5/rwZzu5DizP/2SCj4Tk=
+golang.stackrox.io/grpc-http1 v0.3.13/go.mod h1:3WeU1sdO5IjWYgr0pYEPLIU6GULfYADtIq7Zseyy30Q=
 gonum.org/v1/gonum v0.0.0-20180816165407-929014505bf4/go.mod h1:Y+Yx5eoAFn32cQvJDxZx5Dpnq+c3wtXuadVZAcxbbBo=
 gonum.org/v1/gonum v0.8.2/go.mod h1:oe/vMfY3deqTw+1EZJhuvEW2iwGF1bW9wwu7XCu0+v0=
 gonum.org/v1/gonum v0.9.3/go.mod h1:TZumC3NeyVQskjXqmyWt4S3bINhy7B4eYwW69EbyX+0=

--- a/principal/options.go
+++ b/principal/options.go
@@ -356,3 +356,10 @@ func WithAutoNamespaceCreate(enabled bool, pattern string, labels map[string]str
 		return nil
 	}
 }
+
+func WithWebSocket(enableWebSocket bool) ServerOption {
+	return func(o *Server) error {
+		o.enableWebSocket = enableWebSocket
+		return nil
+	}
+}

--- a/principal/server.go
+++ b/principal/server.go
@@ -82,6 +82,10 @@ type Server struct {
 	autoNamespaceAllow   bool
 	autoNamespacePattern *regexp.Regexp
 	autoNamespaceLabels  map[string]string
+
+	// The Principal will rely on gRPC over WebSocket for bi-directional streaming. This option could be enabled
+	// when there is an intermediate component that is HTTP/2 incompatible and downgrades the incoming request to HTTP/1.1
+	enableWebSocket bool
 }
 
 // noAuthEndpoints is a list of endpoints that are available without the need

--- a/test/proxy/proxy.go
+++ b/test/proxy/proxy.go
@@ -1,0 +1,84 @@
+package proxy
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"log"
+	"math/big"
+	"net"
+	"net/http"
+	"net/http/httputil"
+	"path"
+	"testing"
+
+	"github.com/argoproj-labs/argocd-agent/test/fake/testcerts"
+)
+
+// Start a reverse proxy that downgrades the incoming HTTP/2 requests to HTTP/1.1
+func StartHTTP2DowngradingProxy(t *testing.T, addr string, target string) *http.Server {
+	tempDir := t.TempDir()
+	basePath := path.Join(tempDir, "certs")
+	testcerts.WriteSelfSignedCert(t, "rsa", basePath, x509.Certificate{SerialNumber: big.NewInt(1)})
+
+	lis, err := net.Listen("tcp", addr)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	server := &http.Server{
+		TLSConfig: &tls.Config{
+			InsecureSkipVerify: true,
+		},
+		Handler: downgradeToHTTP1Handler(target),
+		Addr:    lis.Addr().String(),
+	}
+
+	go server.ServeTLS(lis, basePath+".crt", basePath+".key")
+
+	return server
+}
+
+func downgradeToHTTP1Handler(target string) http.Handler {
+	printHeaders := func(header http.Header) {
+		for name, values := range header {
+			for _, value := range values {
+				fmt.Printf("%s: %s\n", name, value)
+			}
+		}
+	}
+	return &httputil.ReverseProxy{
+		Director: func(req *http.Request) {
+			fmt.Println("Intercepting a request")
+			req.URL.Host = target
+			if req.URL.Scheme == "" {
+				req.URL.Scheme = "https"
+			}
+
+			// Request is downgraded to HTTP/1.1
+			req.ProtoMajor, req.ProtoMinor, req.Proto = 1, 1, "HTTP/1.1"
+
+			// Log headers for debugging
+			fmt.Println("Request Headers:")
+			printHeaders(req.Header)
+		},
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{
+				InsecureSkipVerify: true,
+			},
+			ForceAttemptHTTP2: false,
+		},
+		ModifyResponse: func(res *http.Response) error {
+			// Ensure the response is sent as HTTP/1.1
+			res.ProtoMajor = 1
+			res.ProtoMinor = 1
+			res.Proto = "HTTP/1.1"
+
+			// Log response headers for debugging
+			fmt.Println("Response Headers:")
+			printHeaders(res.Header)
+
+			return nil
+		},
+	}
+}

--- a/test/proxy/proxy.go
+++ b/test/proxy/proxy.go
@@ -34,6 +34,7 @@ func StartHTTP2DowngradingProxy(t *testing.T, addr string, target string) *http.
 		Addr:    lis.Addr().String(),
 	}
 
+    //nolint:errcheck
 	go server.ServeTLS(lis, basePath+".crt", basePath+".key")
 
 	return server

--- a/test/proxy/proxy.go
+++ b/test/proxy/proxy.go
@@ -34,7 +34,7 @@ func StartHTTP2DowngradingProxy(t *testing.T, addr string, target string) *http.
 		Addr:    lis.Addr().String(),
 	}
 
-    //nolint:errcheck
+	//nolint:errcheck
 	go server.ServeTLS(lis, basePath+".crt", basePath+".key")
 
 	return server


### PR DESCRIPTION
 gRPC relies on HTTP/2 for multiplexing requests and is required for bi-directional streaming. However, intermediate infra components (load balancers, proxy, etc.) could be incompatible with HTTP/2 and may downgrade to HTTP/1.1. For these cases, we provide an option to use gRPC over WebSocket for bi-directional streaming that doesn't require HTTP/2. https://github.com/stackrox/go-grpc-http1 handles the translation between gRPC and WebSocket.

* Flags to enable WebSocket
* Update the principal and the agent code to use the go-grpc-http1 client if the flag is enabled
* e2e tests with a HTTP/2 incompatible reverse proxy