### PR TITLE
fix: fix panic in principal on autonomous app deletion

### DIFF
--- a/principal/callbacks.go
+++ b/principal/callbacks.go
@@ -64,12 +64,12 @@ func (s *Server) updateAppCallback(old *v1alpha1.Application, new *v1alpha1.Appl
 		"application_name": old.Name,
 	})
 	if len(new.Finalizers) > 0 && len(new.Finalizers) != len(old.Finalizers) {
-		var err error
-		new, err = s.appManager.RemoveFinalizers(s.ctx, new)
+		tmp, err := s.appManager.RemoveFinalizers(s.ctx, new)
 		if err != nil {
 			logCtx.WithError(err).Warnf("Could not remove finalizer")
 		} else {
 			logCtx.Debug("Removed finalizer")
+			new = tmp
 		}
 	}
 	if s.appManager.IsChangeIgnored(new.QualifiedName(), new.ResourceVersion) {


### PR DESCRIPTION
I'm seeing a panic in the principal when an autonomous app is deleted:
```
time="2024-10-03T14:52:26-04:00" level=debug msg="Processing event" client=agent-autonomous event=io.argoproj.argocd-agent.event.delete incoming= mode=autonomous module=QueueProcessor
time="2024-10-03T14:52:27-04:00" level=debug msg="Removed finalizer for app agent-autonomous/guestbook" application=argocd/guestbook component=DeleteOperation resourceVersion=853
time="2024-10-03T14:52:27-04:00" level=info msg="Deleted application agent-autonomous/guestbook" client=agent-autonomous event=io.argoproj.argocd-agent.event.delete incoming=argocd/guestbook mode=autonomous module=QueueProcessor
time="2024-10-03T14:52:27-04:00" level=warning msg="Could not remove finalizer" application_name=guestbook component=EventCallback error="error updating application agent-autonomous/guestbook: applications.argoproj.io \"guestbook\" not found" event=application_update module=server queue=agent-autonomous
E1003 14:52:27.127757   54912 runtime.go:79] Observed a panic: "invalid memory address or nil pointer dereference" (runtime error: invalid memory address or nil pointer dereference)
goroutine 28 [running]:
k8s.io/apimachinery/pkg/util/runtime.logPanic({0x102a7f380, 0x1042104b0})
	/Users/jpitman/go/pkg/mod/k8s.io/apimachinery@v0.29.6/pkg/util/runtime/runtime.go:75 +0x85
k8s.io/apimachinery/pkg/util/runtime.HandleCrash({0x0, 0x0, 0xc000272f28?})
	/Users/jpitman/go/pkg/mod/k8s.io/apimachinery@v0.29.6/pkg/util/runtime/runtime.go:49 +0x6b
panic({0x102a7f380?, 0x1042104b0?})
	/usr/local/Cellar/go/1.23.1/libexec/src/runtime/panic.go:785 +0x132
github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1.(*Application).QualifiedName(...)
	/Users/jpitman/go/pkg/mod/github.com/argoproj/argo-cd/v2@v2.12.3/pkg/apis/application/v1alpha1/types.go:3142
github.com/argoproj-labs/argocd-agent/principal.(*Server).updateAppCallback(0xc000272ea0, 0xc0008a7808, 0xc0008a7c08)
	/Users/jpitman/go/src/github.com/argoproj/argoproj-labs/argocd-agent/principal/callbacks.go:75 +0x492
github.com/argoproj-labs/argocd-agent/internal/informer/application.NewAppInformer.func5({0x102de23c0?, 0xc0008a7808?}, {0x102de23c0?, 0xc0008a7c08?})
	/Users/jpitman/go/src/github.com/argoproj/argoproj-labs/argocd-agent/internal/informer/application/appinformer.go:190 +0x2ca
```