### PR TITLE
fix: principal install missing argocd-agent-principal-userpass secret

### DIFF
--- a/install/kubernetes/principal/kustomization.yaml
+++ b/install/kubernetes/principal/kustomization.yaml
@@ -7,3 +7,4 @@ resources:
 - principal-deployment.yaml
 - principal-service.yaml
 - principal-params-cm.yaml
+- principal-userpass-secret.yaml


### PR DESCRIPTION
I am following the [quickstart](https://github.com/argoproj-labs/argocd-agent/blob/main/docs/hack/quickstart.md) and after the step `kubectl apply -n argocd -k install/kubernetes/principal`, the principal agent pod is not coming up.

The error was:
```
MountVolume.SetUp failed for volume "userpass-passwd" : secret "argocd-agent-principal-userpass" not found
```

This fix is to ensure the kustomization.yaml properly contains the required secret for install.