### PR TITLE
fix: casing for Dockerfiles and default make image repo url

### DIFF
--- a/Dockerfile.agent
+++ b/Dockerfile.agent
@@ -1,4 +1,4 @@
-FROM docker.io/library/golang:1.22 as builder
+FROM docker.io/library/golang:1.22 AS builder
 WORKDIR /src
 COPY . .
 RUN make agent

--- a/Dockerfile.principal
+++ b/Dockerfile.principal
@@ -1,4 +1,4 @@
-FROM docker.io/library/golang:1.22 as builder
+FROM docker.io/library/golang:1.22 AS builder
 WORKDIR /src
 COPY . .
 RUN make principal

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 DOCKER_BIN?=docker
 
 # Image names
-IMAGE_REPOSITORY?=quay.io/jannfis
+IMAGE_REPOSITORY?=ghcr.io/argoproj-labs/argocd-agent
 IMAGE_NAME_AGENT=argocd-agent-agent
 IMAGE_NAME_PRINCIPAL=argocd-agent-principal
 IMAGE_PLATFORMS?=linux/amd64


### PR DESCRIPTION
Small fix to Dockerfiles to avoid getting a warning when running `make image-...`

```                                                                                                                                                                                                                                          
 1 warning found (use docker --debug to expand):
 - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 1)
```

Adjust the default image repo from a personal repo to the default deployment repo.