### PR TITLE
fix: principal agent not starting up with the default autoNamespaceLabels config

### DIFF
--- a/cmd/principal/main.go
+++ b/cmd/principal/main.go
@@ -86,7 +86,8 @@ func NewPrincipalRunCommand() *cobra.Command {
 			opts = append(opts, principal.WithListenerPort(listenPort))
 			opts = append(opts, principal.WithGRPC(true))
 			nsLabels := make(map[string]string)
-			if len(autoNamespaceLabels) > 0 {
+			if len(autoNamespaceLabels) > 0 &&
+				!(len(autoNamespaceLabels) == 1 && autoNamespaceLabels[0] == "") {
 				nsLabels, err = labels.StringsToMap(autoNamespaceLabels)
 				if err != nil {
 					cmd.Fatal("Could not parse auto namespace labels: %v", err)

--- a/internal/informer/appproject/projectinformer.go
+++ b/internal/informer/appproject/projectinformer.go
@@ -116,7 +116,7 @@ func NewAppProjectInformer(ctx context.Context, client appclientset.Interface, n
 	}
 	i, err := informer.NewGenericInformer(&v1alpha1.AppProject{},
 		informer.WithListCallback(func(options v1.ListOptions, namespace string) (runtime.Object, error) {
-			log().Infof("Listing AppProjects %v", client.ArgoprojV1alpha1().AppProjects(namespace))
+			log().Infof("Listing AppProjects in namespace %s", namespace)
 			projects, err := client.ArgoprojV1alpha1().AppProjects(namespace).List(ctx, options)
 			log().Infof("Lister returned %d AppProjects", len(projects.Items))
 			if pi.filterFunc != nil {


### PR DESCRIPTION
The principal agent pod kept crashlooping with the error:

```
[FATAL]: Could not parse auto namespace labels: invalid label '': has no value
```

I am using the default values so the auto namespace labels is an empty string.
This fix is to ensure that the principal can properly start with the default case.

Also contains a minor logging fix to address the following:
```
level=info msg="Listing AppProjects &{0xc0002579a0 }" module=AppProjectInformer
```