### PR TITLE
fix: agent pod is not starting because the image is running as root

### DIFF
--- a/Dockerfile.agent
+++ b/Dockerfile.agent
@@ -6,5 +6,5 @@ RUN make agent
 FROM docker.io/library/alpine:latest
 
 COPY --from=builder /src/dist/argocd-agent-agent /bin/argocd-agent-agent
-
+USER 999
 ENTRYPOINT ["/bin/argocd-agent-agent"]


### PR DESCRIPTION
I am trying to start the agent but the agent pod is failing with the error

```
Error: container has runAsNonRoot and image will run as root (pod: "argocd-agent-agent-74b8b74b5b-9vlbj_argocd(b547aa02-a3ca-4b8c-b26b-fe1aa1aaeb4c)", container: argocd-agent-agent)
```

This fix is to make sure the image is building with a non-root user. I copied the user ID from the principal Dockerfile.