### PR TITLE
fix-demo: misc demo related fixes

### DIFF
--- a/hack/demo-env/README.md
+++ b/hack/demo-env/README.md
@@ -40,7 +40,7 @@ sudo microk8s.config > ~/.kube/config
 
 What's left is to install the metallb configuration. You should be good now.
 
-```
+```shell
 kubectl apply -n metallb-system -f hack/demo-env/resources/metallb-ipaddresspool.yaml
 ```
 
@@ -50,7 +50,7 @@ Make sure you have administrative access to a cluster and [vcluster](https://git
 
 To setup all required virtual clusters, run
 
-```
+```shell
 ./hack/demo-env/setup-vcluster-env.sh create
 ```
 
@@ -78,7 +78,11 @@ This is a local development environment. It comes with pre-configured credential
 
 You can authenticate to the the Argo CD UI or API server with user `admin` and password `adminadmin`. Creative, isn't it.
 
-You will need to generate credentials for the agents. Run the `gen-creds.sh` script before you start any of the agent or principal components.
+You will need to generate credentials for the agents. Before you start any of the agent or principal components run:
+
+```shell
+gen-creds.sh
+```
 
 ## Starting the components
 

--- a/hack/demo-env/setup-vcluster-env.sh
+++ b/hack/demo-env/setup-vcluster-env.sh
@@ -205,7 +205,7 @@ create)
 	for c in $VCLUSTERS; do
 		cluster=$(cluster $c)
  		echo "  --> Creating vcluster $cluster"
-		vcluster create --context=${initial_context} ${EXTRA_VCLUSTER_PARAMS} --switch-context=false -n vcluster-${cluster} --expose --kube-config-context-name vcluster-${cluster} vcluster-${cluster}
+		vcluster create --context=${initial_context} ${EXTRA_VCLUSTER_PARAMS} -n vcluster-${cluster} --expose --kube-config-context-name vcluster-${cluster} vcluster-${cluster}
 
 		# I found a sleep statement here was beneficial to allow time for the load balancer to become available. If we find this is not required, these commented out lines should be removed.
 		# if [[ "$OPENSHIFT" != "" ]]; then

--- a/hack/demo-env/start-agent-autonomous.sh
+++ b/hack/demo-env/start-agent-autonomous.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # Copyright 2024 The argocd-agent Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set -e -o pipefail
+set -ex -o pipefail
 ARGS=$*
 if ! kubectl config get-contexts | tail -n +2 | awk '{ print $2 }' | grep -qE '^vcluster-agent-autonomous$'; then
     echo "kube context vcluster-agent-autonomous is not configured; missing setup?" >&2

--- a/hack/demo-env/start-agent-managed.sh
+++ b/hack/demo-env/start-agent-managed.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # Copyright 2024 The argocd-agent Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/hack/demo-env/start-principal.sh
+++ b/hack/demo-env/start-principal.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # Copyright 2024 The argocd-agent Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
I've tried to setup the demo/dev env and encountered a few issues. This PR is to address those issues:

1) When I ran the `setup-vcluster-env.sh` script, got the following error:
```
  --> Creating vcluster control-plane
18:40:36 fatal unknown flag: --switch-context
ERROR: Error occurred, terminating.
```
`switch-context` is no longer a valid flag for `vcluster create` in vcluster version 0.20.1 stable and there are no similar replacement flags. After I removed the flag, the script ran fine and ultimately the demo/dev env setup was successful so for now I think it's safe to remove this flag.

2) When I ran the `start-*` scripts, I got the following error:
```
set: Illegal option -o pipefail
```
The pipefail option seems to be a [bash specific feature](https://www.gnu.org/software/bash/manual/html_node/The-Set-Builtin.html). I've added the bash shebang in this PR.
Also added the set x to `start-agent-autonomous.sh` to be consistent with the other start scripts.

3) misc demo README fixes for consistency.