### PR TITLE
fix: fix gen-creds.sh

### DIFF
--- a/hack/demo-env/gen-creds.sh
+++ b/hack/demo-env/gen-creds.sh
@@ -39,7 +39,7 @@ fi
 touch "${creds_path}/users.control-plane"
 
 for ag in agent-managed agent-autonomous; do
-	password=$(pwmake 56)
-	htpasswd -b -B "${creds_path}/users.control-plane" "${ag}" "${password}"
+	password=$($pwmake 56)
+	$htpasswd -b -B "${creds_path}/users.control-plane" "${ag}" "${password}"
 	echo "${ag}:${password}" > "${creds_path}/creds.${ag}"
 done


### PR DESCRIPTION
The gen-creds.sh script sets up an environment variable alias for pwmake in case the system has pwgen instead, but then doesn't use it.