### PR TITLE
docs: demo/dev guide - add running argocd agent components in clusters using open cluster management

### DIFF
--- a/hack/demo-env/README.md
+++ b/hack/demo-env/README.md
@@ -27,7 +27,7 @@ The author uses [microk8s](https://microk8s.io/) as the host Kubernetes cluster.
 After installing microk8s, you want to enable metallb and hostpath storage in that cluster. metallb gives your cluster load balancer capabilities, and the hostpath storage will allow vcluster to persist its configuration:  
 
 ```shell
-sudo microk8s.enable metallb
+sudo microk8s.enable metallb:192.168.56.200-192.168.56.254 # Adjust the range as needed. Currently set to values used in the steps below
 sudo microk8s.enable hostpath-storage
 ```
 
@@ -109,3 +109,8 @@ There is a vscode launch configuration to assist with debugging components in `h
 ### Running in a cluster
 
 To be written.
+
+### Running in a cluster using Open Cluster Management
+
+For running in a cluster using [Open Cluster Management (OCM)](https://open-cluster-management.io/),
+see the [demo environment with OCM](./ocm/README.md) for more information.

--- a/hack/demo-env/apps/autonomous-guestbook.yaml
+++ b/hack/demo-env/apps/autonomous-guestbook.yaml
@@ -3,8 +3,6 @@ kind: Application
 metadata:
   name: guestbook
   namespace: argocd
-  finalizers:
-  - resources-finalizer.argocd.argoproj.io
 spec:
   project: default
   source:
@@ -16,4 +14,4 @@ spec:
     namespace: guestbook
   syncPolicy:
     syncOptions:
-      - "CreateNamespace=true"
+    - CreateNamespace=true

--- a/hack/demo-env/apps/managed-guestbook.yaml
+++ b/hack/demo-env/apps/managed-guestbook.yaml
@@ -14,4 +14,4 @@ spec:
     namespace: guestbook
   syncPolicy:
     syncOptions:
-      - "CreateNamespace=true"
+    - CreateNamespace=true

--- a/hack/demo-env/ocm/README.md
+++ b/hack/demo-env/ocm/README.md
@@ -1,0 +1,112 @@
+## Running the agent components in clusters using the Open Cluster Management (OCM) setup
+
+[Open Cluster Management (OCM)](https://open-cluster-management.io/) is a robust, modular,
+and extensible platform for orchestrating multiple Kubernetes clusters.
+It features an addon framework that allows other projects to develop extensions for managing clusters in custom scenarios.
+
+The following instructions will setup the `vcluster-control-plane` as the OCM hub cluster,
+with the `vcluster-agent-managed` and `vcluster-agent-autonomous` clusters joining as managed clusters.
+
+The Argo CD agent principal component will be installed on the hub cluster directly,
+while the Argo CD agent agents will be deployed to the managed clusters as OCM addons.
+
+## Set up OCM
+
+### Install clusteradm CLI tool
+
+Run the following command to download and install the latest OCM `clusteradm` tool:
+
+```shell
+curl -L https://raw.githubusercontent.com/open-cluster-management-io/clusteradm/main/install.sh | bash
+```
+### Setup the hub cluster
+
+Setup the `vcluster-control-plane` as the OCM hub cluster:
+
+```shell
+kubectl config use-context vcluster-control-plane
+joincmd=$(clusteradm init --wait | grep clusteradm)
+```
+
+### Request to join as managed clusters
+
+Request `vcluster-agent-managed` and `vcluster-agent-autonomous` to join the hub as managed clusters:
+
+```shell
+kubectl config use-context vcluster-agent-managed
+$(echo ${joincmd} --wait | sed "s/<cluster_name>/agent-managed/g")
+
+kubectl config use-context vcluster-agent-autonomous
+$(echo ${joincmd} --wait | sed "s/<cluster_name>/agent-autonomous/g")
+```
+
+### Accept the managed clusters join requests
+
+Accept the join requests on the hub cluster:
+
+```shell
+kubectl config use-context vcluster-control-plane
+clusteradm accept --clusters agent-managed
+clusteradm accept --clusters agent-autonomous
+```
+
+### Verify
+
+Verify that the managed clusters have successfully joined the hub cluster:
+
+```shell
+kubectl get managedclusters
+NAME               HUB ACCEPTED   MANAGED CLUSTER URLS   JOINED   AVAILABLE   AGE
+agent-autonomous   true                                  True     True        2m57s
+agent-managed      true                                  True     True        2m57s
+```
+
+## Deploy the Argo CD agent components
+
+### Deploy and verify the Argo CD agent principal component
+
+Deploy the principal component:
+
+```shell
+kubectl config use-context vcluster-control-plane
+kubectl create -n argocd secret generic argocd-agent-principal-userpass --from-literal=passwd="$(cat hack/demo-env/creds/users.control-plane)"
+kubectl apply -n argocd -k hack/demo-env/ocm/principal
+```
+
+Verify the principal deployment:
+
+```shell
+kubectl -n argocd get deploy argocd-agent-principal
+NAME                     READY   UP-TO-DATE   AVAILABLE   AGE
+argocd-agent-principal   1/1     1            1           46s
+```
+
+### Deploy and verify the Argo CD agent agent component
+
+Deploy the agent component:
+
+```shell
+kubectl config use-context vcluster-agent-managed
+kubectl create -n agent-managed  secret generic argocd-agent-managed-userpass --from-literal=credentials="$(cat hack/demo-env/creds/creds.agent-managed)"
+kubectl config use-context vcluster-control-plane
+kubectl apply -k hack/demo-env/ocm/agent-managed
+
+kubectl config use-context vcluster-agent-autonomous
+kubectl create ns agent-autonomous
+kubectl create -n agent-autonomous  secret generic argocd-agent-auto-userpass --from-literal=credentials="$(cat hack/demo-env/creds/creds.agent-autonomous)"
+kubectl config use-context vcluster-control-plane
+kubectl apply -k hack/demo-env/ocm/agent-autonomous
+```
+
+Verify the agents deployment:
+
+```shell
+kubectl config use-context vcluster-control-plane
+kubectl -n agent-managed get managedclusteraddon
+NAME                   AVAILABLE   DEGRADED   PROGRESSING
+argocd-agent-managed   True                   False
+
+kubectl -n agent-autonomous get managedclusteraddon
+NAME                AVAILABLE   DEGRADED   PROGRESSING
+argocd-agent-auto   True                   False
+```

--- a/hack/demo-env/ocm/agent-autonomous/kustomization.yaml
+++ b/hack/demo-env/ocm/agent-autonomous/kustomization.yaml
@@ -1,0 +1,4 @@
+resources:
+- ocm-agent-auto-addontemplate.yaml
+- ocm-agent-auto-cmaddon.yaml
+- ocm-agent-auto-maddon.yaml

--- a/hack/demo-env/ocm/agent-autonomous/ocm-agent-auto-addontemplate.yaml
+++ b/hack/demo-env/ocm/agent-autonomous/ocm-agent-auto-addontemplate.yaml
@@ -1,0 +1,173 @@
+apiVersion: addon.open-cluster-management.io/v1alpha1
+kind: AddOnTemplate
+metadata:
+  name: argocd-agent-auto-template
+spec:
+  addonName: argocd-agent-auto
+  agentSpec:
+    workload:
+      manifests:
+        - kind: ServiceAccount
+          apiVersion: v1
+          metadata:
+            labels:
+              app.kubernetes.io/name: argocd-agent-auto
+              app.kubernetes.io/part-of: argocd-agent
+              app.kubernetes.io/component: agent
+            name: argocd-agent-auto
+            namespace: argocd
+        - kind: ClusterRole
+          apiVersion: rbac.authorization.k8s.io/v1
+          metadata:
+            labels:
+              app.kubernetes.io/name: argocd-agent-auto
+              app.kubernetes.io/part-of: argocd-agent
+              app.kubernetes.io/component: agent
+            name: argocd-agent-auto
+          rules:
+            - apiGroups: [argoproj.io]
+              resources: [applications, appprojects, applicationsets]
+              verbs: [create, get, list, watch, update, delete, patch]
+            - apiGroups: [""]
+              resources: [secrets, configmaps]
+              verbs: [create, get, list, watch, update, patch, delete]
+            - apiGroups: [""]
+              resources: [events]
+              verbs: [create, list]
+        - kind: ClusterRoleBinding
+          apiVersion: rbac.authorization.k8s.io/v1
+          metadata:
+            labels:
+              app.kubernetes.io/name: argocd-agent-auto
+              app.kubernetes.io/part-of: argocd-agent
+              app.kubernetes.io/component: agent
+            name: argocd-agent-auto-binding
+          subjects:
+            - kind: ServiceAccount
+              name: argocd-agent-auto
+              namespace: argocd
+          roleRef:
+            kind: ClusterRole
+            name: argocd-agent-auto
+            apiGroup: rbac.authorization.k8s.io
+        - kind: Deployment
+          apiVersion: apps/v1
+          metadata:
+            labels:
+              app.kubernetes.io/name: argocd-agent-auto
+            name: argocd-agent-auto
+            namespace: argocd
+          spec:
+            selector:
+              matchLabels:
+                app.kubernetes.io/name: argocd-agent-auto
+                app.kubernetes.io/part-of: argocd-agent
+                app.kubernetes.io/component: agent
+            template:
+              metadata:
+                labels:
+                  app.kubernetes.io/name: argocd-agent-auto
+                  app.kubernetes.io/part-of: argocd-agent
+                  app.kubernetes.io/component: agent
+              spec:
+                serviceAccountName: argocd-agent-auto
+                containers:
+                  - name: argocd-agent-auto
+                    image: ghcr.io/argoproj-labs/argocd-agent/argocd-agent-agent:latest
+                    imagePullPolicy: Always
+                    args: [/usr/local/bin/argocd-agent-agent]
+                    env:
+                      - name: ARGOCD_AGENT_REMOTE_SERVER
+                        valueFrom:
+                          configMapKeyRef:
+                            name: argocd-agent-params
+                            key: agent.server.address
+                            optional: true
+                      - name: ARGOCD_AGENT_REMOTE_PORT
+                        valueFrom:
+                          configMapKeyRef:
+                            name: argocd-agent-params
+                            key: agent.server.port
+                            optional: true
+                      - name: ARGOCD_AGENT_LOG_LEVEL
+                        valueFrom:
+                          configMapKeyRef:
+                            name: argocd-agent-params
+                            key: agent.log.level
+                            optional: true
+                      - name: ARGOCD_AGENT_NAMESPACE
+                        valueFrom:
+                          configMapKeyRef:
+                            name: argocd-agent-params
+                            key: agent.namespace
+                            optional: true
+                      - name: ARGOCD_AGENT_TLS_CLIENT_CERT_PATH
+                        valueFrom:
+                          configMapKeyRef:
+                            name: argocd-agent-params
+                            key: agent.tls.client.cert-path
+                            optional: true
+                      - name: ARGOCD_AGENT_TLS_CLIENT_KEY_PATH
+                        valueFrom:
+                          configMapKeyRef:
+                            name: argocd-agent-params
+                            key: agent.tls.client.key-path
+                            optional: true
+                      - name: ARGOCD_AGENT_TLS_INSECURE
+                        valueFrom:
+                          configMapKeyRef:
+                            name: argocd-agent-params
+                            key: agent.tls.client.insecure
+                            optional: true
+                      - name: ARGOCD_AGENT_TLS_ROOT_CA_PATH
+                        valueFrom:
+                          configMapKeyRef:
+                            name: argocd-agent-params
+                            key: agent.tls.root-ca-path
+                            optional: true
+                      - name: ARGOCD_AGENT_MODE
+                        valueFrom:
+                          configMapKeyRef:
+                            name: argocd-agent-params
+                            key: agent.mode
+                            optional: true
+                      - name: ARGOCD_AGENT_CREDS
+                        valueFrom:
+                          configMapKeyRef:
+                            name: argocd-agent-params
+                            key: agent.creds.userpass.path
+                            optional: true
+                    ports:
+                      - containerPort: 8000
+                        name: metrics
+                    securityContext:
+                      capabilities:
+                        drop: [ALL]
+                      allowPrivilegeEscalation: false
+                      readOnlyRootFilesystem: true
+                      runAsNonRoot: true
+                      seccompProfile:
+                        type: RuntimeDefault
+                    volumeMounts:
+                      - name: userpass-passwd
+                        mountPath: /app/config/creds
+                volumes:
+                  - name: userpass-passwd
+                    secret:
+                      secretName: argocd-agent-auto-userpass
+                      items:
+                        - key: credentials
+                          path: userpass.creds
+        - kind: ConfigMap
+          apiVersion: v1
+          metadata:
+            name: argocd-agent-params
+            namespace: argocd
+          data:
+            agent.mode: "autonomous"
+            agent.creds.userpass.path: "userpass:/app/config/creds/userpass.creds"
+            agent.tls.client.insecure: "true"
+            agent.log.level: "trace"
+            agent.namespace: "argocd"
+            agent.server.address: "192.168.56.103"
+            agent.server.port: "443"

--- a/hack/demo-env/ocm/agent-autonomous/ocm-agent-auto-cmaddon.yaml
+++ b/hack/demo-env/ocm/agent-autonomous/ocm-agent-auto-cmaddon.yaml
@@ -1,0 +1,15 @@
+apiVersion: addon.open-cluster-management.io/v1alpha1
+kind: ClusterManagementAddOn
+metadata:
+  name: argocd-agent-auto
+  annotations:
+    addon.open-cluster-management.io/lifecycle: "addon-manager"
+spec:
+  addOnMeta:
+    description: argocd-agent-auto is an OCM-io for ArgoCD agent autonomous mode
+    displayName: ArgoCD Agent Autonomous
+  supportedConfigs:
+    - group: addon.open-cluster-management.io
+      resource: addontemplates
+      defaultConfig:
+        name: argocd-agent-auto-template

--- a/hack/demo-env/ocm/agent-autonomous/ocm-agent-auto-maddon.yaml
+++ b/hack/demo-env/ocm/agent-autonomous/ocm-agent-auto-maddon.yaml
@@ -1,0 +1,7 @@
+apiVersion: addon.open-cluster-management.io/v1alpha1
+kind: ManagedClusterAddOn
+metadata:
+  name: argocd-agent-auto
+  namespace: agent-autonomous
+spec:
+  installNamespace: argocd

--- a/hack/demo-env/ocm/agent-managed/kustomization.yaml
+++ b/hack/demo-env/ocm/agent-managed/kustomization.yaml
@@ -1,0 +1,4 @@
+resources:
+- ocm-agent-managed-addontemplate.yaml
+- ocm-agent-managed-cmaddon.yaml
+- ocm-agent-managed-maddon.yaml

--- a/hack/demo-env/ocm/agent-managed/ocm-agent-managed-addontemplate.yaml
+++ b/hack/demo-env/ocm/agent-managed/ocm-agent-managed-addontemplate.yaml
@@ -1,0 +1,203 @@
+apiVersion: addon.open-cluster-management.io/v1alpha1
+kind: AddOnTemplate
+metadata:
+  name: argocd-agent-managed-template
+spec:
+  addonName: argocd-agent-managed
+  agentSpec:
+    workload:
+      manifests:
+        - kind: ServiceAccount
+          apiVersion: v1
+          metadata:
+            labels:
+              app.kubernetes.io/name: argocd-agent-managed
+              app.kubernetes.io/part-of: argocd-agent
+              app.kubernetes.io/component: agent
+            name: argocd-agent-managed
+            namespace: agent-managed
+        - kind: Role
+          apiVersion: rbac.authorization.k8s.io/v1
+          metadata:
+            labels:
+              app.kubernetes.io/name: argocd-agent-managed
+              app.kubernetes.io/part-of: argocd-agent
+              app.kubernetes.io/component: agent
+            name: argocd-agent-managed
+            namespace: agent-managed
+          rules:
+            - apiGroups: [argoproj.io]
+              resources: [applications, appprojects, applicationsets]
+              verbs: [create, get, list, watch, update, delete, patch]
+            - apiGroups: [""]
+              resources: [secrets, configmaps]
+              verbs: [create, get, list, watch, update, patch, delete]
+            - apiGroups: [""]
+              resources: [events]
+              verbs: [create, list]
+        - kind: ClusterRole
+          apiVersion: rbac.authorization.k8s.io/v1
+          metadata:
+            labels:
+              app.kubernetes.io/name: argocd-agent-managed
+              app.kubernetes.io/part-of: argocd-agent
+              app.kubernetes.io/component: agent
+            name: argocd-agent-managed
+          rules:
+            - apiGroups: [argoproj.io]
+              resources: [appprojects]
+              verbs: [get, list, watch]
+        - kind: RoleBinding
+          apiVersion: rbac.authorization.k8s.io/v1
+          metadata:
+            labels:
+              app.kubernetes.io/name: argocd-agent-managed
+              app.kubernetes.io/part-of: argocd-agent
+              app.kubernetes.io/component: agent
+            name: argocd-agent-managed
+            namespace: agent-managed
+          roleRef:
+            apiGroup: rbac.authorization.k8s.io
+            kind: Role
+            name: argocd-agent-managed
+          subjects:
+            - kind: ServiceAccount
+              name: argocd-agent-managed
+              namespace: agent-managed
+        - kind: ClusterRoleBinding
+          apiVersion: rbac.authorization.k8s.io/v1
+          metadata:
+            labels:
+              app.kubernetes.io/name: argocd-agent-managed
+              app.kubernetes.io/part-of: argocd-agent
+              app.kubernetes.io/component: agent
+            name: argocd-agent-managed
+          roleRef:
+            apiGroup: rbac.authorization.k8s.io
+            kind: ClusterRole
+            name: argocd-agent-managed
+          subjects:
+            - kind: ServiceAccount
+              name: argocd-agent-managed
+              namespace: agent-managed
+        - kind: Deployment
+          apiVersion: apps/v1
+          metadata:
+            labels:
+              app.kubernetes.io/name: argocd-agent-managed
+            name: argocd-agent-managed
+            namespace: agent-managed
+          spec:
+            selector:
+              matchLabels:
+                app.kubernetes.io/name: argocd-agent-managed
+                app.kubernetes.io/part-of: argocd-agent
+                app.kubernetes.io/component: agent
+            template:
+              metadata:
+                labels:
+                  app.kubernetes.io/name: argocd-agent-managed
+                  app.kubernetes.io/part-of: argocd-agent
+                  app.kubernetes.io/component: agent
+              spec:
+                serviceAccountName: argocd-agent-managed
+                containers:
+                  - name: argocd-agent-managed
+                    image: ghcr.io/argoproj-labs/argocd-agent/argocd-agent-agent:latest
+                    imagePullPolicy: Always
+                    args: [/usr/local/bin/argocd-agent-agent]
+                    env:
+                      - name: ARGOCD_AGENT_REMOTE_SERVER
+                        valueFrom:
+                          configMapKeyRef:
+                            name: argocd-agent-params
+                            key: agent.server.address
+                            optional: true
+                      - name: ARGOCD_AGENT_REMOTE_PORT
+                        valueFrom:
+                          configMapKeyRef:
+                            name: argocd-agent-params
+                            key: agent.server.port
+                            optional: true
+                      - name: ARGOCD_AGENT_LOG_LEVEL
+                        valueFrom:
+                          configMapKeyRef:
+                            name: argocd-agent-params
+                            key: agent.log.level
+                            optional: true
+                      - name: ARGOCD_AGENT_NAMESPACE
+                        valueFrom:
+                          configMapKeyRef:
+                            name: argocd-agent-params
+                            key: agent.namespace
+                            optional: true
+                      - name: ARGOCD_AGENT_TLS_CLIENT_CERT_PATH
+                        valueFrom:
+                          configMapKeyRef:
+                            name: argocd-agent-params
+                            key: agent.tls.client.cert-path
+                            optional: true
+                      - name: ARGOCD_AGENT_TLS_CLIENT_KEY_PATH
+                        valueFrom:
+                          configMapKeyRef:
+                            name: argocd-agent-params
+                            key: agent.tls.client.key-path
+                            optional: true
+                      - name: ARGOCD_AGENT_TLS_INSECURE
+                        valueFrom:
+                          configMapKeyRef:
+                            name: argocd-agent-params
+                            key: agent.tls.client.insecure
+                            optional: true
+                      - name: ARGOCD_AGENT_TLS_ROOT_CA_PATH
+                        valueFrom:
+                          configMapKeyRef:
+                            name: argocd-agent-params
+                            key: agent.tls.root-ca-path
+                            optional: true
+                      - name: ARGOCD_AGENT_MODE
+                        valueFrom:
+                          configMapKeyRef:
+                            name: argocd-agent-params
+                            key: agent.mode
+                            optional: true
+                      - name: ARGOCD_AGENT_CREDS
+                        valueFrom:
+                          configMapKeyRef:
+                            name: argocd-agent-params
+                            key: agent.creds.userpass.path
+                            optional: true
+                    ports:
+                      - containerPort: 8000
+                        name: metrics
+                    securityContext:
+                      capabilities:
+                        drop: [ALL]
+                      allowPrivilegeEscalation: false
+                      readOnlyRootFilesystem: true
+                      runAsNonRoot: true
+                      seccompProfile:
+                        type: RuntimeDefault
+                    volumeMounts:
+                      - name: userpass-passwd
+                        mountPath: /app/config/creds
+                volumes:
+                  - name: userpass-passwd
+                    secret:
+                      secretName: argocd-agent-managed-userpass
+                      items:
+                        - key: credentials
+                          path: userpass.creds
+        - kind: ConfigMap
+          apiVersion: v1
+          metadata:
+            name: argocd-agent-params
+            namespace: agent-managed
+          data:
+            agent.mode: "managed"
+            agent.creds.userpass.path: "userpass:/app/config/creds/userpass.creds"
+            agent.tls.client.insecure: "true"
+            agent.log.level: "trace"
+            agent.namespace: "agent-managed"
+            agent.server.address: "192.168.56.103"
+            agent.server.port: "443"

--- a/hack/demo-env/ocm/agent-managed/ocm-agent-managed-cmaddon.yaml
+++ b/hack/demo-env/ocm/agent-managed/ocm-agent-managed-cmaddon.yaml
@@ -1,0 +1,15 @@
+apiVersion: addon.open-cluster-management.io/v1alpha1
+kind: ClusterManagementAddOn
+metadata:
+  name: argocd-agent-managed
+  annotations:
+    addon.open-cluster-management.io/lifecycle: "addon-manager"
+spec:
+  addOnMeta:
+    description: argocd-agent-managed is an OCM-io for ArgoCD agent managed mode
+    displayName: ArgoCD Agent Managed
+  supportedConfigs:
+    - group: addon.open-cluster-management.io
+      resource: addontemplates
+      defaultConfig:
+        name: argocd-agent-managed-template

--- a/hack/demo-env/ocm/agent-managed/ocm-agent-managed-maddon.yaml
+++ b/hack/demo-env/ocm/agent-managed/ocm-agent-managed-maddon.yaml
@@ -1,0 +1,7 @@
+apiVersion: addon.open-cluster-management.io/v1alpha1
+kind: ManagedClusterAddOn
+metadata:
+  name: argocd-agent-managed
+  namespace: agent-managed
+spec:
+  installNamespace: agent-managed

--- a/hack/demo-env/ocm/principal/kustomization.yaml
+++ b/hack/demo-env/ocm/principal/kustomization.yaml
@@ -1,0 +1,9 @@
+resources:
+- principal-sa.yaml
+- principal-role.yaml
+- principal-clusterrole.yaml
+- principal-rolebinding.yaml
+- principal-clusterrolebinding.yaml
+- principal-deployment.yaml
+- principal-service.yaml
+- principal-params-cm.yaml

--- a/hack/demo-env/ocm/principal/principal-clusterrole.yaml
+++ b/hack/demo-env/ocm/principal/principal-clusterrole.yaml
@@ -1,0 +1,23 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/name: argocd-agent-principal
+    app.kubernetes.io/part-of: argocd-agent
+    app.kubernetes.io/component: principal
+  name: argocd-agent-principal
+rules:
+- apiGroups:
+  - argoproj.io
+  resources:
+  - applications
+  - appprojects
+  - applicationsets
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+  - delete
+  - patch

--- a/hack/demo-env/ocm/principal/principal-clusterrolebinding.yaml
+++ b/hack/demo-env/ocm/principal/principal-clusterrolebinding.yaml
@@ -1,0 +1,16 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/name: argocd-agent-principal
+    app.kubernetes.io/part-of: argocd-agent
+    app.kubernetes.io/component: principal
+  name: argocd-agent-principal
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: argocd-agent-principal
+subjects:
+- kind: ServiceAccount
+  name: argocd-agent-principal
+  namespace: argocd

--- a/hack/demo-env/ocm/principal/principal-deployment.yaml
+++ b/hack/demo-env/ocm/principal/principal-deployment.yaml
@@ -1,0 +1,159 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/name: argocd-agent-principal
+  name: argocd-agent-principal
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: argocd-agent-principal
+      app.kubernetes.io/part-of: argocd-agent
+      app.kubernetes.io/component: principal
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: argocd-agent-principal
+        app.kubernetes.io/part-of: argocd-agent
+        app.kubernetes.io/component: principal
+    spec:
+      containers:
+        - args:
+            - /usr/local/bin/argocd-agent-principal
+          env:
+          - name: ARGOCD_PRINCIPAL_LISTEN_HOST
+            valueFrom:
+              configMapKeyRef:
+                name: argocd-agent-params
+                key: principal.listen.host
+                optional: true
+          - name: ARGOCD_PRINCIPAL_LISTEN_PORT
+            valueFrom:
+              configMapKeyRef:
+                name: argocd-agent-params
+                key: principal.listen.port
+                optional: true
+          - name: ARGOCD_PRINCIPAL_LOG_LEVEL
+            valueFrom:
+              configMapKeyRef:
+                name: argocd-agent-params
+                key: principal.log.level
+                optional: true
+          - name: ARGOCD_PRINCIPAL_METRICS_PORT
+            valueFrom:
+              configMapKeyRef:
+                name: argocd-agent-params
+                key: principal.metrics.port
+                optional: true
+          - name: ARGOCD_PRINCIPAL_METRICS_ENABLED
+            valueFrom:
+              configMapKeyRef:
+                name: argocd-agent-params
+                key: principal.metrics.enabled
+                optional: true
+          - name: ARGOCD_PRINCIPAL_NAMESPACE
+            valueFrom:
+              configMapKeyRef:
+                name: argocd-agent-params
+                key: principal.namespace
+                optional: true
+          - name: ARGOCD_PRINCIPAL_ALLOWED_NAMESPACES
+            valueFrom:
+              configMapKeyRef:
+                name: argocd-agent-params
+                key: principal.allowed-namespaces
+                optional: true
+          - name: ARGOCD_PRINCIPAL_NAMESPACE_CREATE_ENABLE
+            valueFrom:
+              configMapKeyRef:
+                name: argocd-agent-params
+                key: principal.namespace-create.enable
+                optional: true
+          - name: ARGOCD_PRINCIPAL_NAMESPACE_CREATE_PATTERN
+            valueFrom:
+              configMapKeyRef:
+                name: argocd-agent-params
+                key: principal.namespace-create.pattern
+                optional: true
+          - name: ARGOCD_PRINCIPAL_NAMESPACE_CREATE_LABELS
+            valueFrom:
+              configMapKeyRef:
+                name: argocd-agent-params
+                key: principal.namespace-create.labels
+                optional: true
+          - name: ARGOCD_PRINCIPAL_TLS_SERVER_CERT_PATH
+            valueFrom:
+              configMapKeyRef:
+                name: argocd-agent-params
+                key: principal.tls.server.cert-path
+                optional: true
+          - name: ARGOCD_PRINCIPAL_TLS_SERVER_KEY_PATH
+            valueFrom:
+              configMapKeyRef:
+                name: argocd-agent-params
+                key: principal.tls.server.key-path
+                optional: true
+          - name: ARGOCD_PRINCIPAL_TLS_SERVER_ALLOW_GENERATE
+            valueFrom:
+              configMapKeyRef:
+                name: argocd-agent-params
+                key: principal.tls.server.allow-generate
+                optional: true
+          - name: ARGOCD_PRINCIPAL_TLS_CLIENT_CERT_REQUIRE
+            valueFrom:
+              configMapKeyRef:
+                name: argocd-agent-params
+                key: principal.tls.client-cert.match-subject
+                optional: true
+          - name: ARGOCD_PRINCIPAL_TLS_CLIENT_CERT_MATCH_SUBJECT
+            valueFrom:
+              configMapKeyRef:
+                name: argocd-agent-params
+                key: principal.tls.client-cert.match-subject
+                optional: true
+          - name: ARGOCD_PRINCIPAL_JWT_ALLOW_GENERATE
+            valueFrom:
+              configMapKeyRef:
+                name: argocd-agent-params
+                key: principal.jwt.allow-generate
+                optional: true
+          - name: ARGOCD_PRINCIPAL_JWT_KEY_PATH
+            valueFrom:
+              configMapKeyRef:
+                name: argocd-agent-params
+                key: principal.jwt.key-path
+                optional: true
+          - name: ARGOCD_PRINCIPAL_USER_DB_PATH
+            valueFrom:
+              configMapKeyRef:
+                name: argocd-agent-params
+                key: principal.user-db.path
+                optional: true
+          image: ghcr.io/argoproj-labs/argocd-agent/argocd-agent-principal:latest
+          imagePullPolicy: Always
+          name: argocd-agent-principal
+          ports:
+            - containerPort: 8443
+              name: principal
+            - containerPort: 8000
+              name: metrics
+          securityContext:
+            capabilities:
+              drop:
+                - ALL
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
+          volumeMounts:
+            - name: userpass-passwd
+              mountPath: /app/config/userpass
+      serviceAccountName: argocd-agent-principal
+      volumes:
+      - name: userpass-passwd
+        secret:
+          secretName: argocd-agent-principal-userpass
+          items:
+          - key: passwd
+            path: passwd

--- a/hack/demo-env/ocm/principal/principal-params-cm.yaml
+++ b/hack/demo-env/ocm/principal/principal-params-cm.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: argocd-agent-params
+data:
+  principal.log.level: trace
+  principal.allowed-namespaces: "*"
+  principal.tls.server.allow-generate: "true"
+  principal.jwt.allow-generate: "true"
+  principal.user-db.path: "/app/config/userpass/passwd"

--- a/hack/demo-env/ocm/principal/principal-role.yaml
+++ b/hack/demo-env/ocm/principal/principal-role.yaml
@@ -1,0 +1,29 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app.kubernetes.io/name: argocd-agent-principal
+    app.kubernetes.io/part-of: argocd-agent
+    app.kubernetes.io/component: principal
+  name: argocd-agent-principal
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  - configmaps
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - list

--- a/hack/demo-env/ocm/principal/principal-rolebinding.yaml
+++ b/hack/demo-env/ocm/principal/principal-rolebinding.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/name: argocd-agent-principal
+    app.kubernetes.io/part-of: argocd-agent
+    app.kubernetes.io/component: principal
+  name: argocd-agent-principal
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: argocd-agent-principal
+subjects:
+- kind: ServiceAccount
+  name: argocd-agent-principal

--- a/hack/demo-env/ocm/principal/principal-sa.yaml
+++ b/hack/demo-env/ocm/principal/principal-sa.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/name: argocd-agent-principal
+    app.kubernetes.io/part-of: argocd-agent
+    app.kubernetes.io/component: principal
+  name: argocd-agent-principal

--- a/hack/demo-env/ocm/principal/principal-service.yaml
+++ b/hack/demo-env/ocm/principal/principal-service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/name: argocd-agent-principal
+    app.kubernetes.io/part-of: argocd-agent
+    app.kubernetes.io/component: principal
+  name: argocd-agent-principal
+spec:
+  type: LoadBalancer
+  ports:
+  - name: https
+    protocol: TCP
+    port: 443
+    targetPort: 8443
+  selector:
+    app.kubernetes.io/name: argocd-agent-principal
+  externalIPs:
+    - 192.168.56.103


### PR DESCRIPTION
Enhance the demo/dev guide docs with steps to run the agent components using [Open Cluster Management](https://open-cluster-management.io/) and it's [addon framework](https://open-cluster-management.io/docs/concepts/addon/).