### PR TITLE
chore(scripts): fix argocd deploy release version

### DIFF
--- a/hack/demo-env/agent-autonomous/kustomization.yaml
+++ b/hack/demo-env/agent-autonomous/kustomization.yaml
@@ -7,5 +7,9 @@ resources:
 - https://github.com/argoproj/argo-cd/manifests/cluster-rbac/application-controller?ref=stable
 - ../common
 
+images:
+- name: quay.io/argoproj/argocd
+  newTag: LatestReleaseTag
+
 patches:
 - path: argocd-secret.yaml

--- a/hack/demo-env/agent-managed/kustomization.yaml
+++ b/hack/demo-env/agent-managed/kustomization.yaml
@@ -7,6 +7,10 @@ resources:
 - https://github.com/argoproj/argo-cd/manifests/cluster-rbac/application-controller?ref=stable
 - ../common
 
+images:
+- name: quay.io/argoproj/argocd
+  newTag: LatestReleaseTag
+
 patches:
 - path: argocd-cmd-params-cm.yaml
 - path: argocd-secret.yaml

--- a/hack/demo-env/control-plane/kustomization.yaml
+++ b/hack/demo-env/control-plane/kustomization.yaml
@@ -9,6 +9,10 @@ resources:
 - https://github.com/argoproj/argo-cd/examples/k8s-rbac/argocd-server-applications?ref=stable
 - ../common
 
+images:
+- name: quay.io/argoproj/argocd
+  newTag: LatestReleaseTag
+
 patches:
 - path: argocd-cmd-params-cm.yaml
 - path: argocd-secret.yaml

--- a/hack/demo-env/setup-vcluster-env.sh
+++ b/hack/demo-env/setup-vcluster-env.sh
@@ -98,6 +98,11 @@ apply() {
 		sed -i.bak -e '/loadBalancerIP/s/^/#/' $TMP_DIR/control-plane/server-service.yaml
 	fi
 
+	LATEST_RELEASE_TAG=`curl -s "https://api.github.com/repos/argoproj/argo-cd/releases/latest" | jq -r .tag_name`
+	sed -i.bak -e "s/LatestReleaseTag/${LATEST_RELEASE_TAG}/" $TMP_DIR/control-plane/kustomization.yaml
+	sed -i.bak -e "s/LatestReleaseTag/${LATEST_RELEASE_TAG}/" $TMP_DIR/agent-autonomous/kustomization.yaml
+	sed -i.bak -e "s/LatestReleaseTag/${LATEST_RELEASE_TAG}/" $TMP_DIR/agent-managed/kustomization.yaml
+
 	echo "-> Create Argo CD on control plane"
 
 	cluster=control-plane


### PR DESCRIPTION
For the demo/dev env script, the ArgoCD deployments installed on the hub and spoke are using the `latest` tag instead of the release tag. This is due to the kustomization yamls are all using `?ref=stable` but the argocd github repo still references latest (bug with argocd repo?). For example, https://github.com/argoproj/argo-cd/blob/stable/manifests/base/server/argocd-server-deployment.yaml#L21

This fix is to replace the latest tag with the latest stable release tag.