### PR TITLE
refactor: AppInformer now uses GenericInformer as foundation

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -120,20 +120,21 @@ func NewAgent(ctx context.Context, appclient appclientset.Interface, namespace s
 		return nil, fmt.Errorf("unexpected agent mode: %v", a.mode)
 	}
 
-	appInformer := appinformer.NewAppInformer(ctx, appclient, a.namespace,
-		appinformer.WithListAppCallback(a.listAppCallback),
+	appInformer, err := appinformer.NewAppInformer(ctx, appclient, a.namespace,
+		// appinformer.WithListAppCallback(a.listAppCallback),
 		appinformer.WithNewAppCallback(a.addAppCreationToQueue),
 		appinformer.WithUpdateAppCallback(a.addAppUpdateToQueue),
 		appinformer.WithDeleteAppCallback(a.addAppDeletionToQueue),
 		appinformer.WithFilterChain(a.DefaultFilterChain()),
 	)
+	if err != nil {
+		return nil, err
+	}
 
 	allowUpsert := false
 	if a.mode == types.AgentModeManaged {
 		allowUpsert = true
 	}
-
-	var err error
 
 	appProjectManagerOption := []appproject.AppProjectManagerOption{
 		appproject.WithAllowUpsert(true),

--- a/internal/backend/kubernetes/application/kubernetes.go
+++ b/internal/backend/kubernetes/application/kubernetes.go
@@ -125,7 +125,7 @@ func (be *KubernetesBackend) SupportsPatch() bool {
 }
 
 func (be *KubernetesBackend) StartInformer(ctx context.Context) {
-	be.appInformer.Start(ctx.Done())
+	be.appInformer.Start(ctx)
 }
 
 func (be *KubernetesBackend) EnsureSynced(duration time.Duration) error {

--- a/internal/informer/application/callbacks.go
+++ b/internal/informer/application/callbacks.go
@@ -52,40 +52,40 @@ type ErrorCallback func(err error, fmt string, args ...string)
 func (i *AppInformer) NewAppCallback() NewAppCallback {
 	i.lock.RLock()
 	defer i.lock.RUnlock()
-	return i.options.newCb
+	return i.addFunc
 }
 
 // SetNewAppCallback sets the new application callback for the AppInformer
 func (i *AppInformer) SetNewAppCallback(cb NewAppCallback) {
 	i.lock.Lock()
 	defer i.lock.Unlock()
-	i.options.newCb = cb
+	i.addFunc = cb
 }
 
 // UpdateAppCallback returns the update application callback of the AppInformer
 func (i *AppInformer) UpdateAppCallback() UpdateAppCallback {
 	i.lock.RLock()
 	defer i.lock.RUnlock()
-	return i.options.updateCb
+	return i.updateFunc
 }
 
 // SetUpdateAppCallback sets the update application callback for the AppInformer
 func (i *AppInformer) SetUpdateAppCallback(cb UpdateAppCallback) {
 	i.lock.Lock()
 	defer i.lock.Unlock()
-	i.options.updateCb = cb
+	i.updateFunc = cb
 }
 
 // DeleteAppCallback returns the delete application callback of the AppInformer
 func (i *AppInformer) DeleteAppCallback() DeleteAppCallback {
 	i.lock.RLock()
 	defer i.lock.RUnlock()
-	return i.options.deleteCb
+	return i.deleteFunc
 }
 
 // SetDeleteAppCallback sets the delete application callback for the AppInformer
 func (i *AppInformer) SetDeleteAppCallback(cb DeleteAppCallback) {
 	i.lock.Lock()
 	defer i.lock.Unlock()
-	i.options.deleteCb = cb
+	i.deleteFunc = cb
 }

--- a/internal/informer/application/options.go
+++ b/internal/informer/application/options.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/argoproj-labs/argocd-agent/internal/filter"
 	"github.com/argoproj-labs/argocd-agent/internal/metrics"
+	"github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
 )
 
 // AppInformerOptions is a set of options for the AppInformer.
@@ -39,67 +40,67 @@ type AppInformerOptions struct {
 	errorCb    ErrorCallback
 }
 
-type AppInformerOption func(o *AppInformerOptions)
+type AppInformerOption func(ai *AppInformer)
 
 // WithMetrics sets the ApplicationMetrics instance to be used by the AppInformer
 func WithMetrics(m *metrics.ApplicationWatcherMetrics) AppInformerOption {
-	return func(o *AppInformerOptions) {
-		o.appMetrics = m
+	return func(o *AppInformer) {
+		o.metrics = m
 	}
 }
 
 // WithNamespaces sets additional namespaces to be watched by the AppInformer
 func WithNamespaces(namespaces ...string) AppInformerOption {
-	return func(o *AppInformerOptions) {
+	return func(o *AppInformer) {
 		o.namespaces = namespaces
 	}
 }
 
 // WithFilterChain sets the FilterChain to be used by the AppInformer
 func WithFilterChain(fc *filter.Chain) AppInformerOption {
-	return func(o *AppInformerOptions) {
+	return func(o *AppInformer) {
 		o.filters = fc
 	}
 }
 
 // WithListAppCallback sets the ListAppsCallback to be called by the AppInformer
-func WithListAppCallback(cb ListAppsCallback) AppInformerOption {
-	return func(o *AppInformerOptions) {
-		o.listCb = cb
+func WithListAppCallback(cb func(app *v1alpha1.Application) bool) AppInformerOption {
+	return func(o *AppInformer) {
+		o.filterFunc = cb
 	}
 }
 
 // WithNewAppCallback sets the NewAppCallback to be executed by the AppInformer
 func WithNewAppCallback(cb NewAppCallback) AppInformerOption {
-	return func(o *AppInformerOptions) {
-		o.newCb = cb
+	return func(o *AppInformer) {
+		o.addFunc = cb
 	}
 }
 
 // WithUpdateAppCallback sets the UpdateAppCallback to be executed by the AppInformer
 func WithUpdateAppCallback(cb UpdateAppCallback) AppInformerOption {
-	return func(o *AppInformerOptions) {
-		o.updateCb = cb
+	return func(o *AppInformer) {
+		o.updateFunc = cb
 	}
 }
 
 // WithDeleteAppCallback sets the DeleteAppCallback to be executed by the AppInformer
 func WithDeleteAppCallback(cb DeleteAppCallback) AppInformerOption {
-	return func(o *AppInformerOptions) {
-		o.deleteCb = cb
+	return func(o *AppInformer) {
+		o.deleteFunc = cb
 	}
 }
 
-// WithErrorCallback sets the ErrorCallback to be executed by the AppInformer
-func WithErrorCallback(cb ErrorCallback) AppInformerOption {
-	return func(o *AppInformerOptions) {
-		o.errorCb = cb
-	}
-}
+// // WithErrorCallback sets the ErrorCallback to be executed by the AppInformer
+// func WithErrorCallback(cb ErrorCallback) AppInformerOption {
+// 	return func(o *AppInformerOptions) {
+// 		o.errorCb = cb
+// 	}
+// }
 
-// WithResyncDuration sets the resync duration to be used by the AppInformer's lister
-func WithResyncDuration(d time.Duration) AppInformerOption {
-	return func(o *AppInformerOptions) {
-		o.resync = d
-	}
-}
+// // WithResyncDuration sets the resync duration to be used by the AppInformer's lister
+// func WithResyncDuration(d time.Duration) AppInformerOption {
+// 	return func(o *AppInformerOptions) {
+// 		o.resync = d
+// 	}
+// }

--- a/internal/manager/application/application_test.go
+++ b/internal/manager/application/application_test.go
@@ -44,8 +44,10 @@ var appExistsError = errors.NewAlreadyExists(schema.GroupResource{Group: "argopr
 var appNotFoundError = errors.NewNotFound(schema.GroupResource{Group: "argoproj.io", Resource: "application"}, "existing")
 
 func fakeAppManager(t *testing.T, objects ...runtime.Object) (*fakeappclient.Clientset, *ApplicationManager) {
+	t.Helper()
 	appC := fakeappclient.NewSimpleClientset(objects...)
-	informer := appinformer.NewAppInformer(context.Background(), appC, "argocd")
+	informer, err := appinformer.NewAppInformer(context.Background(), appC, "argocd")
+	require.NoError(t, err)
 	be := application.NewKubernetesBackend(appC, "", informer, true)
 
 	am, err := NewApplicationManager(be, "argocd")
@@ -186,8 +188,9 @@ func Test_ManagerUpdateManaged(t *testing.T) {
 
 		// We are on the agent
 		appC := fakeappclient.NewSimpleClientset(existing)
-		informer := appinformer.NewAppInformer(context.Background(), appC, "argocd")
-		be := application.NewKubernetesBackend(appC, "", informer, true)
+		ai, err := appinformer.NewAppInformer(context.Background(), appC, "argocd")
+		require.NoError(t, err)
+		be := application.NewKubernetesBackend(appC, "", ai, true)
 		mgr, err := NewApplicationManager(be, "argocd", WithMode(manager.ManagerModeManaged), WithRole(manager.ManagerRoleAgent))
 		require.NoError(t, err)
 
@@ -273,8 +276,9 @@ func Test_ManagerUpdateStatus(t *testing.T) {
 		}
 
 		appC := fakeappclient.NewSimpleClientset(existing)
-		informer := appinformer.NewAppInformer(context.Background(), appC, "argocd")
-		be := application.NewKubernetesBackend(appC, "", informer, true)
+		ai, err := appinformer.NewAppInformer(context.Background(), appC, "argocd")
+		require.NoError(t, err)
+		be := application.NewKubernetesBackend(appC, "", ai, true)
 		mgr, err := NewApplicationManager(be, "argocd")
 		require.NoError(t, err)
 		mgr.mode = manager.ManagerModeManaged
@@ -349,8 +353,9 @@ func Test_ManagerUpdateAutonomous(t *testing.T) {
 		}
 
 		appC := fakeappclient.NewSimpleClientset(existing)
-		informer := appinformer.NewAppInformer(context.Background(), appC, "argocd")
-		be := application.NewKubernetesBackend(appC, "", informer, true)
+		ai, err := appinformer.NewAppInformer(context.Background(), appC, "argocd")
+		require.NoError(t, err)
+		be := application.NewKubernetesBackend(appC, "", ai, true)
 		mgr, err := NewApplicationManager(be, "argocd")
 		require.NoError(t, err)
 		mgr.role = manager.ManagerRolePrincipal

--- a/pkg/client/remote_test.go
+++ b/pkg/client/remote_test.go
@@ -36,6 +36,7 @@ func Test_Connect(t *testing.T) {
 	tempDir := t.TempDir()
 	basePath := path.Join(tempDir, "certs")
 	testcerts.WriteSelfSignedCert(t, "rsa", basePath, x509.Certificate{SerialNumber: big.NewInt(1)})
+
 	s, err := principal.NewServer(context.TODO(), kube.NewKubernetesFakeClient(), "default",
 		principal.WithGRPC(true),
 		principal.WithListenerPort(0),
@@ -46,7 +47,6 @@ func Test_Connect(t *testing.T) {
 	am := userpass.NewUserPassAuthentication("")
 	am.UpsertUser("default", "password")
 	s.AuthMethodsForE2EOnly().RegisterMethod("userpass", am)
-
 	require.NoError(t, err)
 	errch := make(chan error)
 	err = s.Start(context.Background(), errch)

--- a/principal/server.go
+++ b/principal/server.go
@@ -161,10 +161,13 @@ func NewServer(ctx context.Context, kubeClient *kube.KubernetesClient, namespace
 		appProjectManagerOption = append(appProjectManagerOption, appproject.WithMetrics(metrics.NewAppProjectClientMetrics()))
 	}
 
-	appInformer := appinformer.NewAppInformer(s.ctx, kubeClient.ApplicationsClientset,
+	appInformer, err := appinformer.NewAppInformer(s.ctx, kubeClient.ApplicationsClientset,
 		s.namespace,
 		appInformerOptions...,
 	)
+	if err != nil {
+		return nil, err
+	}
 
 	s.appManager, err = application.NewApplicationManager(kubeapp.NewKubernetesBackend(kubeClient.ApplicationsClientset, s.namespace, appInformer, true), s.namespace,
 		managerOpts...,


### PR DESCRIPTION
This refactor makes the AppInformer use GenericInformer instead of rolling its own.