### PR TITLE
feat: resend events with exponential backoff and wait for ACK

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -67,6 +67,8 @@ type Agent struct {
 	// At present, 'watchLock' is only acquired on calls to 'addAppUpdateToQueue'. This behaviour was added as a short-term attempt to preserve update event ordering. However, this is known to be problematic due to the potential for race conditions, both within itself, and between other event processors like deleteAppCallback.
 	watchLock sync.RWMutex
 	version   *version.Version
+
+	eventWriter *event.EventWriter
 }
 
 const defaultQueueName = "default"

--- a/agent/connection.go
+++ b/agent/connection.go
@@ -79,7 +79,7 @@ func (a *Agent) sender(stream eventstreamapi.EventStream_SubscribeClient) error 
 		return nil
 	}
 
-	logCtx.Trace("Adding an item to the event writer", "resourceID", event.ResourceID(ev), "eventID", event.EventID(ev))
+	logCtx.Tracef("Adding an item to the event writer: resourceID %s eventID %s", event.ResourceID(ev), event.EventID(ev))
 	a.eventWriter.Add(ev)
 
 	return nil
@@ -110,13 +110,13 @@ func (a *Agent) receiver(stream eventstreamapi.EventStream_SubscribeClient) erro
 	logCtx.Debugf("Received a new event from stream")
 
 	if ev.Target() == event.TargetEventAck {
-		logCtx.Trace("Received an ACK for an event", "resourceID", ev.ResourceID(), "eventID", ev.EventID())
+		logCtx.Tracef("Received an ACK for an event: resourceID %s eventID %s", ev.ResourceID(), ev.EventID())
 		rawEvent, err := format.FromProto(rcvd.Event)
 		if err != nil {
 			return err
 		}
 		a.eventWriter.Remove(rawEvent)
-		logCtx.Trace("Removed an event from the EventWriter", "resourceID", ev.ResourceID(), "eventID", ev.EventID())
+		logCtx.Tracef("Removed an event from the EventWriter: resourceID %s eventID %s", ev.ResourceID(), ev.EventID())
 		return nil
 	}
 
@@ -130,7 +130,7 @@ func (a *Agent) receiver(stream eventstreamapi.EventStream_SubscribeClient) erro
 			return fmt.Errorf("no send queue found for the remote principal")
 		}
 		sendQ.Add(a.emitter.ProcessedEvent(event.EventProcessed, ev))
-		logCtx.Info("Sent an ACK for an event", "resourceID", ev.ResourceID(), "eventID", ev.EventID())
+		logCtx.Tracef("Sent an ACK for an event: resourceID %s eventID %s", ev.ResourceID(), ev.EventID())
 	}
 	return nil
 }

--- a/agent/connection.go
+++ b/agent/connection.go
@@ -79,23 +79,8 @@ func (a *Agent) sender(stream eventstreamapi.EventStream_SubscribeClient) error 
 		return nil
 	}
 
-	logCtx.Tracef("Sending an item to the event stream")
-
-	pev, err := format.ToProto(ev)
-	if err != nil {
-		logCtx.Warnf("Could not wire event: %v", err)
-		return nil
-	}
-
-	err = stream.Send(&eventstreamapi.Event{Event: pev})
-	if err != nil {
-		if grpcutil.NeedReconnectOnError(err) {
-			return err
-		} else {
-			logCtx.Errorf("Error while sending: %v", err)
-			return nil
-		}
-	}
+	logCtx.Trace("Adding an item to the event writer", "resourceID", event.ResourceID(ev), "eventID", event.EventID(ev))
+	a.eventWriter.Add(ev)
 
 	return nil
 }
@@ -123,9 +108,29 @@ func (a *Agent) receiver(stream eventstreamapi.EventStream_SubscribeClient) erro
 		return nil
 	}
 	logCtx.Debugf("Received a new event from stream")
+
+	if ev.Target() == event.TargetEventAck {
+		logCtx.Trace("Received an ACK for an event", "resourceID", ev.ResourceID(), "eventID", ev.EventID())
+		rawEvent, err := format.FromProto(rcvd.Event)
+		if err != nil {
+			return err
+		}
+		a.eventWriter.Remove(rawEvent)
+		logCtx.Trace("Removed an event from the EventWriter", "resourceID", ev.ResourceID(), "eventID", ev.EventID())
+		return nil
+	}
+
 	err = a.processIncomingEvent(ev)
-	if err != nil {
+	if err != nil && !event.IsEventDiscarded(err) && !event.IsEventNotAllowed(err) {
 		logCtx.WithError(err).Errorf("Unable to process incoming event")
+	} else {
+		// Send an ACK if the event is processed successfully.
+		sendQ := a.queues.SendQ(a.remote.ClientID())
+		if sendQ == nil {
+			return fmt.Errorf("no send queue found for the remote principal")
+		}
+		sendQ.Add(a.emitter.ProcessedEvent(event.EventProcessed, ev))
+		logCtx.Info("Sent an ACK for an event", "resourceID", ev.ResourceID(), "eventID", ev.EventID())
 	}
 	return nil
 }
@@ -137,6 +142,10 @@ func (a *Agent) handleStreamEvents() error {
 	if err != nil {
 		return err
 	}
+
+	a.eventWriter = event.NewEventWriter(stream)
+	go a.eventWriter.SendWaitingEvents(a.context)
+
 	logCtx := log().WithFields(logrus.Fields{
 		"module":      "StreamEvent",
 		"server_addr": grpcutil.AddressFromContext(stream.Context()),

--- a/internal/event/event.go
+++ b/internal/event/event.go
@@ -341,7 +341,11 @@ func (ew *EventWriter) Remove(ev *cloudevents.Event) {
 		return
 	}
 
-	if EventID(latestEvent.event) == EventID(ev) {
+	latestEvent.mu.RLock()
+	latestEventID := EventID(latestEvent.event)
+	latestEvent.mu.RUnlock()
+
+	if latestEventID == EventID(ev) {
 		delete(ew.latestEvents, resourceID)
 	}
 }

--- a/internal/event/event.go
+++ b/internal/event/event.go
@@ -346,6 +346,9 @@ func (ew *EventWriter) Remove(ev *cloudevents.Event) {
 	}
 }
 
+// SendWaitingEvents will periodically send the events waiting in the EventWriter.
+// Note: This function will never return unless the context is done, and therefore
+// should be started in a separate goroutine.
 func (ew *EventWriter) SendWaitingEvents(ctx context.Context) {
 	ew.log.Info("Starting event writer")
 	for {
@@ -406,6 +409,7 @@ func (ew *EventWriter) sendEvent(resID string) {
 		return
 	}
 
+	// A Send() on the stream is actually not blocking.
 	err = ew.target.Send(&eventstreamapi.Event{Event: pev})
 	if err != nil {
 		logCtx.Errorf("Error while sending: %v\n", err)

--- a/internal/event/event.go
+++ b/internal/event/event.go
@@ -15,10 +15,18 @@
 package event
 
 import (
+	"context"
 	"errors"
 	"fmt"
+	"sync"
+	"time"
 
+	"github.com/argoproj-labs/argocd-agent/internal/grpcutil"
+	"github.com/argoproj-labs/argocd-agent/pkg/api/grpc/eventstreamapi"
 	"github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
+	"github.com/sirupsen/logrus"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
 
 	_ "github.com/cloudevents/sdk-go/binding/format/protobuf/v2"
 	format "github.com/cloudevents/sdk-go/binding/format/protobuf/v2"
@@ -43,12 +51,19 @@ const (
 	SpecUpdate      EventType = TypePrefix + ".spec-update"
 	StatusUpdate    EventType = TypePrefix + ".status-update"
 	OperationUpdate EventType = TypePrefix + ".operation-update"
+	EventProcessed  EventType = TypePrefix + ".processed"
 )
 
 const (
 	TargetUnknown     EventTarget = "unknown"
 	TargetApplication EventTarget = "application"
 	TargetAppProject  EventTarget = "appproject"
+	TargetEventAck    EventTarget = "eventProcessed"
+)
+
+const (
+	resourceID string = "resourceid"
+	eventID    string = "eventid"
 )
 
 var (
@@ -75,6 +90,13 @@ type Event struct {
 	target EventTarget
 }
 
+func New(ev *cloudevents.Event, target EventTarget) *Event {
+	return &Event{
+		event:  ev,
+		target: target,
+	}
+}
+
 func NewEventSource(source string) *EventSource {
 	ev := &EventSource{}
 	ev.source = source
@@ -85,15 +107,37 @@ func IsEventDiscarded(err error) bool {
 	return errors.Is(err, ErrEventDiscarded)
 }
 
+func IsEventNotAllowed(err error) bool {
+	return errors.Is(err, ErrEventNotAllowed)
+}
+
+func NewEventNotAllowedErr(format string, a ...any) error {
+	return fmt.Errorf("%w: %w", ErrEventNotAllowed, fmt.Errorf(format, a...))
+}
+
+func NewEventDiscardedErr(format string, a ...any) error {
+	return fmt.Errorf("%w: %w", ErrEventDiscarded, fmt.Errorf(format, a...))
+}
+
 func (evs EventSource) ApplicationEvent(evType EventType, app *v1alpha1.Application) *cloudevents.Event {
 	cev := cloudevents.NewEvent()
 	cev.SetSource(evs.source)
 	cev.SetSpecVersion(cloudEventSpecVersion)
 	cev.SetType(evType.String())
+	cev.SetExtension(eventID, createEventID(app.ObjectMeta))
+	cev.SetExtension(resourceID, createResourceID(app.ObjectMeta))
 	cev.SetDataSchema(TargetApplication.String())
 	// TODO: Handle this error situation?
 	_ = cev.SetData(cloudevents.ApplicationJSON, app)
 	return &cev
+}
+
+func createResourceID(res v1.ObjectMeta) string {
+	return fmt.Sprintf("%s_%s", res.Name, res.UID)
+}
+
+func createEventID(res v1.ObjectMeta) string {
+	return fmt.Sprintf("%s_%s_%s", res.Name, res.UID, res.ResourceVersion)
 }
 
 func (evs EventSource) AppProjectEvent(evType EventType, appProject *v1alpha1.AppProject) *cloudevents.Event {
@@ -101,9 +145,25 @@ func (evs EventSource) AppProjectEvent(evType EventType, appProject *v1alpha1.Ap
 	cev.SetSource(evs.source)
 	cev.SetSpecVersion(cloudEventSpecVersion)
 	cev.SetType(evType.String())
+	cev.SetExtension(eventID, createEventID(appProject.ObjectMeta))
+	cev.SetExtension(resourceID, createResourceID(appProject.ObjectMeta))
 	cev.SetDataSchema(TargetAppProject.String())
 	// TODO: Handle this error situation?
 	_ = cev.SetData(cloudevents.ApplicationJSON, appProject)
+	return &cev
+}
+
+func (evs EventSource) ProcessedEvent(evType EventType, ev *Event) *cloudevents.Event {
+	cev := cloudevents.NewEvent()
+	cev.SetSource(evs.source)
+	cev.SetSpecVersion(cloudEventSpecVersion)
+	cev.SetType(evType.String())
+
+	for k, v := range ev.event.Extensions() {
+		cev.SetExtension(k, v)
+	}
+
+	cev.SetDataSchema(TargetEventAck.String())
 	return &cev
 }
 
@@ -130,6 +190,8 @@ func Target(raw *cloudevents.Event) EventTarget {
 		return TargetApplication
 	case TargetAppProject.String():
 		return TargetAppProject
+	case TargetEventAck.String():
+		return TargetEventAck
 	}
 	return ""
 }
@@ -148,8 +210,199 @@ func (ev Event) Application() (*v1alpha1.Application, error) {
 	return app, err
 }
 
+func (ev Event) ResourceID() string {
+	return ResourceID(ev.event)
+}
+
+func (ev Event) EventID() string {
+	return EventID(ev.event)
+}
+
+func ResourceID(ev *cloudevents.Event) string {
+	id, ok := ev.Extensions()[resourceID].(string)
+	if ok {
+		return id
+	}
+
+	return ""
+}
+
+func EventID(ev *cloudevents.Event) string {
+	id, ok := ev.Extensions()[eventID].(string)
+	if ok {
+		return id
+	}
+
+	return ""
+}
+
 func (ev Event) AppProject() (*v1alpha1.AppProject, error) {
 	proj := &v1alpha1.AppProject{}
 	err := ev.event.DataAs(proj)
 	return proj, err
+}
+
+type streamWriter interface {
+	Send(*eventstreamapi.Event) error
+	Context() context.Context
+}
+
+// EventWriter keeps track of the latest event for resources and sends them on a given gRPC stream.
+// It resends the event with exponential backoff until the event is ACK'd and removed from its list.
+type EventWriter struct {
+	mu sync.RWMutex
+
+	// key: resource name + UID
+	// value: latest event for a resource
+	// - acquire 'lock' before accessing
+	latestEvents map[string]*eventMessage
+
+	// target refers to the specified gRPC stream.
+	target streamWriter
+
+	log *logrus.Entry
+}
+
+type eventMessage struct {
+	mu sync.RWMutex
+
+	// latest event for a resource
+	// - acquire 'lock' before accessing
+	event *cloudevents.Event
+
+	// retry sending the event after this time
+	retryAfter *time.Time
+
+	// config for exponential backoff
+	backoff *wait.Backoff
+}
+
+func NewEventWriter(target streamWriter) *EventWriter {
+	return &EventWriter{
+		latestEvents: map[string]*eventMessage{},
+		target:       target,
+		log: logrus.WithFields(logrus.Fields{
+			"module":      "EventWriter",
+			"client_addr": grpcutil.AddressFromContext(target.Context()),
+		}),
+	}
+}
+
+func (ew *EventWriter) Add(ev *cloudevents.Event) {
+	resID := ResourceID(ev)
+
+	ew.mu.Lock()
+	defer ew.mu.Unlock()
+
+	defaultBackoff := wait.Backoff{
+		Steps:    5,
+		Duration: 5 * time.Second,
+		Factor:   2.0,
+		Jitter:   0.1,
+	}
+
+	eventMsg, exists := ew.latestEvents[resID]
+	if !exists {
+		ew.latestEvents[resID] = &eventMessage{
+			event:   ev,
+			backoff: &defaultBackoff,
+		}
+		return
+	}
+
+	// Replace the old event and reset the backoff.
+	eventMsg.mu.Lock()
+	eventMsg.event = ev
+	eventMsg.backoff = &defaultBackoff
+	eventMsg.retryAfter = nil
+	eventMsg.mu.Unlock()
+}
+
+func (ew *EventWriter) Get(resID string) *eventMessage {
+	ew.mu.RLock()
+	defer ew.mu.RUnlock()
+	return ew.latestEvents[resID]
+}
+
+func (ew *EventWriter) Remove(ev *cloudevents.Event) {
+	ew.mu.Lock()
+	defer ew.mu.Unlock()
+
+	// Remove the event only if it matches both the resourceID and eventID.
+	resourceID := ResourceID(ev)
+	latestEvent, exists := ew.latestEvents[resourceID]
+	if !exists {
+		return
+	}
+
+	if EventID(latestEvent.event) == EventID(ev) {
+		delete(ew.latestEvents, resourceID)
+	}
+}
+
+func (ew *EventWriter) SendWaitingEvents(ctx context.Context) {
+	ew.log.Info("Starting event writer")
+	for {
+		select {
+		case <-ctx.Done():
+			ew.log.Info("Shutting down event writer")
+			return
+		default:
+			ew.mu.RLock()
+			resourceIDs := make([]string, 0, len(ew.latestEvents))
+			for resID := range ew.latestEvents {
+				resourceIDs = append(resourceIDs, resID)
+			}
+			ew.mu.RUnlock()
+
+			for _, resourceID := range resourceIDs {
+				ew.sendEvent(resourceID)
+			}
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+}
+
+func (ew *EventWriter) sendEvent(resID string) {
+	// Check if the event is already ACK'd.
+	eventMsg := ew.Get(resID)
+	if eventMsg == nil {
+		ew.log.Trace("event is not found, perhaps it is already ACK'd", "resourceID", resID)
+		return
+	}
+
+	eventMsg.mu.Lock()
+	defer eventMsg.mu.Unlock()
+
+	// Check if it is time to resend the event.
+	if eventMsg.retryAfter != nil && eventMsg.retryAfter.After(time.Now()) {
+		return
+	}
+
+	defer func() {
+		// Update the retryAfter for resending the event again
+		retryAfter := time.Now().Add(eventMsg.backoff.Step())
+		eventMsg.retryAfter = &retryAfter
+	}()
+
+	// Resend the event since it is not ACK'd.
+	pev, err := format.ToProto(eventMsg.event)
+	if err != nil {
+		ew.log.Errorf("Could not wire event: %v\n", err)
+		return
+	}
+
+	err = ew.target.Send(&eventstreamapi.Event{Event: pev})
+	if err != nil {
+		ew.log.Errorf("Error while sending: %v\n", err)
+		return
+	}
+
+	ew.log.Trace("event sent to target", "resourceID", resID, "type", eventMsg.event.Type())
+
+	// We don't have to wait for an ACK if the current event is ACK. So, remove it from the EventWriter.
+	if Target(eventMsg.event) == TargetEventAck {
+		ew.Remove(eventMsg.event)
+		ew.log.Trace("ACK is removed from the EventWriter", "resourceID", resID, "eventID", EventID(eventMsg.event))
+	}
 }

--- a/internal/event/event_test.go
+++ b/internal/event/event_test.go
@@ -13,3 +13,159 @@
 // limitations under the License.
 
 package event
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/argoproj-labs/argocd-agent/pkg/api/grpc/eventstreamapi"
+	"github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestEventWriter(t *testing.T) {
+	es := NewEventSource("test")
+
+	app1 := &v1alpha1.Application{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "app1",
+			Namespace:       "test",
+			ResourceVersion: "1",
+			UID:             "1234",
+		},
+	}
+
+	app2 := &v1alpha1.Application{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "app2",
+			Namespace:       "test",
+			ResourceVersion: "1",
+			UID:             "1234",
+		},
+	}
+
+	t.Run("should add/update/remove events from the queue", func(t *testing.T) {
+		fs := &fakeStream{}
+		evSender := NewEventWriter(fs)
+
+		ev := es.ApplicationEvent(Create, app1)
+		evSender.Add(ev)
+
+		latestEvent := evSender.Get(ResourceID(ev))
+		require.NotNil(t, latestEvent)
+		require.Equal(t, latestEvent.event, ev)
+		require.Nil(t, latestEvent.retryAfter)
+		now := time.Now()
+		latestEvent.retryAfter = &now
+
+		// Add an Update event for the same resource
+		app1.ResourceVersion = "2"
+		ev = es.ApplicationEvent(Update, app1)
+		evSender.Add(ev)
+
+		latestEvent = evSender.Get(ResourceID(ev))
+		require.NotNil(t, latestEvent)
+		require.Equal(t, latestEvent.event, ev)
+		require.Nil(t, latestEvent.retryAfter)
+
+		// Try removing an event with the same resourceID but different eventID.
+		app1.ResourceVersion = "3"
+		newEv := es.ApplicationEvent(Update, app1)
+		evSender.Remove(newEv)
+
+		// The old event should not removed from the queue.
+		latestEvent = evSender.Get(ResourceID(newEv))
+		require.NotNil(t, latestEvent)
+		require.Equal(t, latestEvent.event, ev)
+
+		// The event will be removed only if both the resourceID and eventID matches.
+		evSender.Remove(ev)
+		latestEvent = evSender.Get(ResourceID(ev))
+		require.Nil(t, latestEvent)
+	})
+
+	t.Run("should handle events from multiple resources", func(t *testing.T) {
+		fs := &fakeStream{}
+		evSender := NewEventWriter(fs)
+
+		app1Events := []EventType{Create, Update, Delete}
+		app2Events := []EventType{Create, Update, Update, Delete}
+
+		for v, e := range app2Events {
+			app2.ResourceVersion = fmt.Sprintf("%d", v)
+			evSender.Add(es.ApplicationEvent(e, app2))
+		}
+
+		for v, e := range app1Events {
+			app1.ResourceVersion = fmt.Sprintf("%d", v)
+			evSender.Add(es.ApplicationEvent(e, app1))
+		}
+
+		require.Len(t, evSender.latestEvents, 2)
+		latestApp1Event := evSender.Get(createResourceID(app1.ObjectMeta))
+		require.NotNil(t, latestApp1Event)
+		require.Equal(t, createEventID(app1.ObjectMeta), EventID(latestApp1Event.event))
+
+		latestApp2Event := evSender.Get(createResourceID(app2.ObjectMeta))
+		require.NotNil(t, latestApp2Event)
+		require.Equal(t, createEventID(app2.ObjectMeta), EventID(latestApp2Event.event))
+	})
+
+	t.Run("should send waiting events to the stream", func(t *testing.T) {
+		fs := &fakeStream{}
+		evSender := NewEventWriter(fs)
+
+		ev := es.ApplicationEvent(Create, app1)
+		resID := createResourceID(app1.ObjectMeta)
+		evSender.Add(ev)
+
+		// shouldn't send an event that is not being tracked
+		evSender.sendEvent("random-id")
+		require.Len(t, fs.events, 0)
+
+		// shouldn't send an event that isn't past the retryAfter time.
+		latestEvent := evSender.Get(resID)
+		require.NotNil(t, latestEvent)
+		retryAfter := time.Now().Add(1 * time.Hour)
+		latestEvent.retryAfter = &retryAfter
+
+		evSender.sendEvent(resID)
+		require.Len(t, fs.events, 0)
+
+		// should send a valid event to the stream
+		retryAfter = time.Now().Add(-10 * time.Second)
+		latestEvent.retryAfter = &retryAfter
+		evSender.sendEvent(resID)
+		require.Len(t, fs.events, 1)
+		require.Equal(t, []string{createEventID(app1.ObjectMeta)}, fs.events[resID])
+	})
+}
+
+type fakeStream struct {
+	mu     sync.RWMutex
+	events map[string][]string
+}
+
+func (fs *fakeStream) Send(event *eventstreamapi.Event) error {
+	fs.mu.Lock()
+	defer fs.mu.Unlock()
+	ev, err := FromWire(event.Event)
+	if err != nil {
+		return err
+	}
+
+	if fs.events == nil {
+		fs.events = map[string][]string{}
+	}
+
+	fs.events[ResourceID(ev.event)] = append(fs.events[ResourceID(ev.event)], EventID(ev.event))
+	return nil
+}
+
+func (fs *fakeStream) Context() context.Context {
+	return context.Background()
+}

--- a/principal/apis/eventstream/eventstream.go
+++ b/principal/apis/eventstream/eventstream.go
@@ -192,7 +192,7 @@ func (s *Server) recvFunc(c *client, subs eventstreamapi.EventStream_SubscribeSe
 	}
 
 	if event.Target(incomingEvent) == event.TargetEventAck {
-		logCtx.Trace("Received an ACK event", "resourceID", event.ResourceID(incomingEvent), "eventID", event.EventID(incomingEvent))
+		logCtx.Tracef("Received an ACK: resourceID %s eventID %s", event.ResourceID(incomingEvent), event.EventID(incomingEvent))
 		s.eventWriter.Remove(incomingEvent)
 		logCtx.Trace("Removed the ACK from the EventWriter")
 		return nil
@@ -229,7 +229,7 @@ func (s *Server) sendFunc(c *client, subs eventstreamapi.EventStream_SubscribeSe
 		return fmt.Errorf("panic: nil item in queue")
 	}
 
-	logCtx.Trace("Adding an item to the event writer", "resourceID", event.ResourceID(ev), "eventID", event.EventID(ev))
+	logCtx.Tracef("Adding an item to the event writer: resourceID %s eventID %s", event.ResourceID(ev), event.EventID(ev))
 	s.eventWriter.Add(ev)
 
 	q.Done(ev)

--- a/principal/event.go
+++ b/principal/event.go
@@ -272,7 +272,7 @@ func (s *Server) eventProcessor(ctx context.Context) error {
 						logCtx.Debugf("Queue disappeared -- client probably has disconnected")
 						return
 					}
-					logCtx.Trace("sending an ACK", "resourceID", event.ResourceID(ev), "eventID", event.EventID(ev))
+					logCtx.Tracef("sending an ACK: resourceID %s eventID %s", event.ResourceID(ev), event.EventID(ev))
 					sendQ.Add(s.events.ProcessedEvent(event.EventProcessed, event.New(ev, event.TargetEventAck)))
 				}(queueName, q)
 			}

--- a/principal/event.go
+++ b/principal/event.go
@@ -72,11 +72,13 @@ func (s *Server) processApplicationEvent(ctx context.Context, agentName string, 
 	agentMode := s.agentMode(agentName)
 
 	logCtx := log().WithFields(logrus.Fields{
-		"module":   "QueueProcessor",
-		"client":   agentName,
-		"mode":     agentMode.String(),
-		"event":    ev.Type(),
-		"incoming": incoming.QualifiedName(),
+		"module":      "QueueProcessor",
+		"client":      agentName,
+		"mode":        agentMode.String(),
+		"event":       ev.Type(),
+		"incoming":    incoming.QualifiedName(),
+		"resource_id": event.ResourceID(ev),
+		"event_id":    event.EventID(ev),
 	})
 
 	// For autonomous agents, we may have to create the appropriate namespace
@@ -159,11 +161,13 @@ func (s *Server) processAppProjectEvent(ctx context.Context, agentName string, e
 	agentMode := s.agentMode(agentName)
 
 	logCtx := log().WithFields(logrus.Fields{
-		"module":   "QueueProcessor",
-		"client":   agentName,
-		"mode":     agentMode.String(),
-		"event":    ev.Type(),
-		"incoming": incoming.Name,
+		"module":      "QueueProcessor",
+		"client":      agentName,
+		"mode":        agentMode.String(),
+		"event":       ev.Type(),
+		"incoming":    incoming.Name,
+		"resource_id": event.ResourceID(ev),
+		"event_id":    event.EventID(ev),
 	})
 
 	switch ev.Type() {
@@ -272,7 +276,7 @@ func (s *Server) eventProcessor(ctx context.Context) error {
 						logCtx.Debugf("Queue disappeared -- client probably has disconnected")
 						return
 					}
-					logCtx.Tracef("sending an ACK: resourceID %s eventID %s", event.ResourceID(ev), event.EventID(ev))
+					logCtx.WithField("resource_id", event.ResourceID(ev)).WithField("event_id", event.EventID(ev)).Trace("sending an ACK for an event")
 					sendQ.Add(s.events.ProcessedEvent(event.EventProcessed, event.New(ev, event.TargetEventAck)))
 				}(queueName, q)
 			}


### PR DESCRIPTION
* Added a new event type `ACK` that is sent by the principal/agent when an event is processed successfully.
* `EventWriter` keeps track of the latest events and sends them on the gRPC stream. Both the agent and the principal will add events to the `EventWriter` instead of directly sending them to the gRPC stream. The `EventWriter` will send the events with exponential backoff until we receive an ACK from the other side. It continuously loops over the waiting events and sends them to the other side with minimal delay. The goal was to propagate the events as soon as possible with minimal delay and without blocking the other events.
* Added `UID` (resourceID) and `resourceVersion` (eventID) to the cloudevent as extensions. We do this to map an event to a particular state of a resource. For example, when we receive an ACK for an event we want to know if the ACK is for the latest version of a resource. 

**Note**: I think there are multiple ways of designing this and I'm happy to update the approach based on the feedback.

Other choices that were considered:

1. We send events on a stream and immediately wait for an ACK. Use apimachinery's wait.ExponentialBackOff to resend events until we receive an ACK. However, the events from other resources will be blocked until the current event is processed.
2. We can improvise the above approach by running the wait.ExponentialBackOff in a separate goroutine for each app. However, each goroutine is shortlived (they only exist until we receive an ACK) and there might be a scenario where the runtime spends more time context switching if there are a large number of apps.
3. We could potentially solve this using a pool of goroutines (like a boss-worker pattern). But I still went with the current approach (continuously loop and resend) since there is minimal delay and we don't have to wait for the ACK sequentially.


Fixes: https://github.com/argoproj-labs/argocd-agent/issues/117