### PR TITLE
fix: Fix trace log level output

### DIFF
--- a/cmd/cmd/log.go
+++ b/cmd/cmd/log.go
@@ -71,6 +71,7 @@ func InitLogging() {
 		LogLevels: []logrus.Level{
 			logrus.InfoLevel,
 			logrus.DebugLevel,
+			logrus.TraceLevel,
 		},
 	})
 }


### PR DESCRIPTION
This PR fixes log output when the log level is trace. Prior to this fix, trace messages would disappear in the nirvana.