### PR TITLE
fix: write trace level logs to stdout

### DIFF
--- a/cmd/cmd/log.go
+++ b/cmd/cmd/log.go
@@ -71,6 +71,7 @@ func InitLogging() {
 		LogLevels: []logrus.Level{
 			logrus.InfoLevel,
 			logrus.DebugLevel,
+			logrus.TraceLevel,
 		},
 	})
 }


### PR DESCRIPTION
Trace level logs don't show up when running the agent/principal with `--log-level=trace`