### PR TITLE
chore(demo-env): Use local argo-cd manifests for speeding up kustomize

### DIFF
--- a/hack/demo-env/agent-autonomous/kustomization.yaml
+++ b/hack/demo-env/agent-autonomous/kustomization.yaml
@@ -1,10 +1,10 @@
 resources:
-- https://github.com/argoproj/argo-cd/manifests/crds?ref=stable
-- https://github.com/argoproj/argo-cd/manifests/base/config?ref=stable
-- https://github.com/argoproj/argo-cd/manifests/base/redis?ref=stable
-- https://github.com/argoproj/argo-cd/manifests/base/repo-server?ref=stable
-- https://github.com/argoproj/argo-cd/manifests/base/application-controller?ref=stable
-- https://github.com/argoproj/argo-cd/manifests/cluster-rbac/application-controller?ref=stable
+- ../argo-cd/manifests/crds
+- ../argo-cd/manifests/base/config
+- ../argo-cd/manifests/base/redis
+- ../argo-cd/manifests/base/repo-server
+- ../argo-cd/manifests/base/application-controller
+- ../argo-cd/manifests/cluster-rbac/application-controller
 - ../common
 
 images:

--- a/hack/demo-env/agent-managed/kustomization.yaml
+++ b/hack/demo-env/agent-managed/kustomization.yaml
@@ -1,10 +1,10 @@
 resources:
-- https://github.com/argoproj/argo-cd/manifests/crds?ref=stable
-- https://github.com/argoproj/argo-cd/manifests/base/config?ref=stable
-- https://github.com/argoproj/argo-cd/manifests/base/redis?ref=stable
-- https://github.com/argoproj/argo-cd/manifests/base/repo-server?ref=stable
-- https://github.com/argoproj/argo-cd/manifests/base/application-controller?ref=stable
-- https://github.com/argoproj/argo-cd/manifests/cluster-rbac/application-controller?ref=stable
+- ../argo-cd/manifests/crds
+- ../argo-cd/manifests/base/config
+- ../argo-cd/manifests/base/redis
+- ../argo-cd/manifests/base/repo-server
+- ../argo-cd/manifests/base/application-controller
+- ../argo-cd/manifests/cluster-rbac/application-controller
 - ../common
 
 images:

--- a/hack/demo-env/control-plane/kustomization.yaml
+++ b/hack/demo-env/control-plane/kustomization.yaml
@@ -1,12 +1,12 @@
 resources:
-- https://github.com/argoproj/argo-cd/manifests/crds?ref=stable
-- https://github.com/argoproj/argo-cd/manifests/base/config?ref=stable
-- https://github.com/argoproj/argo-cd/manifests/base/dex?ref=stable
-- https://github.com/argoproj/argo-cd/manifests/base/redis?ref=stable
-- https://github.com/argoproj/argo-cd/manifests/base/repo-server?ref=stable
-- https://github.com/argoproj/argo-cd/manifests/base/server?ref=stable
-- https://github.com/argoproj/argo-cd/manifests/cluster-rbac/server?ref=stable
-- https://github.com/argoproj/argo-cd/examples/k8s-rbac/argocd-server-applications?ref=stable
+- ../argo-cd/manifests/crds
+- ../argo-cd/manifests/base/config
+- ../argo-cd/manifests/base/dex
+- ../argo-cd/manifests/base/redis
+- ../argo-cd/manifests/base/repo-server
+- ../argo-cd/manifests/base/server
+- ../argo-cd/manifests/cluster-rbac/server
+- ../argo-cd/examples/k8s-rbac/argocd-server-applications
 - ../common
 
 images:

--- a/hack/demo-env/setup-vcluster-env.sh
+++ b/hack/demo-env/setup-vcluster-env.sh
@@ -91,7 +91,15 @@ apply() {
 	echo "-> TMP_DIR is $TMP_DIR"
 	cp -r ${SCRIPTPATH}/* $TMP_DIR
 
-  # Comment out 'loadBalancerIP:' lines on OpenShift
+	mkdir -p ${TMP_DIR}/argo-cd
+	cd ${TMP_DIR}/argo-cd
+	git init
+	git remote add origin https://github.com/argoproj/argo-cd
+	git fetch --depth=1 origin stable
+	git checkout FETCH_HEAD
+	cd -
+
+    # Comment out 'loadBalancerIP:' lines on OpenShift
 	if [[ "$OPENSHIFT" != "" ]]; then
 		sed -i.bak -e '/loadBalancerIP/s/^/#/' $TMP_DIR/control-plane/redis-service.yaml
 		sed -i.bak -e '/loadBalancerIP/s/^/#/' $TMP_DIR/control-plane/repo-server-service.yaml


### PR DESCRIPTION
This change shallow clones the Argo CD repository to a temp path and points the kustomize bases to use those, instead of always pulling from github.com.