### PR TITLE
feat: handle UID mismatch between incoming and existing resources

### DIFF
--- a/agent/inbound.go
+++ b/agent/inbound.go
@@ -65,7 +65,7 @@ func (a *Agent) processIncomingApplication(ev *event.Event) error {
 		if !sourceUIDMatch {
 			logCtx.Debug("An app already exists with a different source UID. Deleting the existing app")
 			if err := a.deleteApplication(incomingApp); err != nil {
-				return err
+				return fmt.Errorf("could not delete existing app prior to creation: %w", err)
 			}
 		}
 
@@ -77,12 +77,14 @@ func (a *Agent) processIncomingApplication(ev *event.Event) error {
 		if !sourceUIDMatch {
 			logCtx.Debug("Source UID mismatch between the incoming app and existing app. Deleting the existing app")
 			if err := a.deleteApplication(incomingApp); err != nil {
-				return err
+				return fmt.Errorf("could not delete existing app prior to creation: %w", err)
 			}
 
 			logCtx.Debug("Creating the incoming app after deleting the existing app")
-			_, err := a.createApplication(incomingApp)
-			return err
+			if _, err := a.createApplication(incomingApp); err != nil {
+				return fmt.Errorf("could not create incoming app after deleting existing app: %w", err)
+			}
+			return nil
 		}
 
 		_, err = a.updateApplication(incomingApp)
@@ -120,7 +122,7 @@ func (a *Agent) processIncomingAppProject(ev *event.Event) error {
 		if !sourceUIDMatch {
 			logCtx.Debug("An appProject already exists with a different source UID. Deleting the existing appProject")
 			if err := a.deleteAppProject(incomingAppProject); err != nil {
-				return err
+				return fmt.Errorf("could not delete existing appProject prior to creation: %w", err)
 			}
 		}
 
@@ -132,12 +134,14 @@ func (a *Agent) processIncomingAppProject(ev *event.Event) error {
 		if !sourceUIDMatch {
 			logCtx.Debug("Source UID mismatch between the incoming and existing appProject. Deleting the existing appProject")
 			if err := a.deleteAppProject(incomingAppProject); err != nil {
-				return err
+				return fmt.Errorf("could not delete existing appProject prior to creation: %w", err)
 			}
 
 			logCtx.Debug("Creating the incoming appProject after deleting the existing appProject")
-			_, err := a.createAppProject(incomingAppProject)
-			return err
+			if _, err := a.createAppProject(incomingAppProject); err != nil {
+				return fmt.Errorf("could not create incoming appProject after deleting existing appProject: %w", err)
+			}
+			return nil
 		}
 
 		_, err = a.updateAppProject(incomingAppProject)

--- a/internal/manager/manager.go
+++ b/internal/manager/manager.go
@@ -29,6 +29,12 @@ const (
 	ManagerModeManaged
 )
 
+const (
+	// SourceUIDAnnotation is an annotation that represents the UID of the source resource.
+	// It is added to the resources managed on the target.
+	SourceUIDAnnotation = "argocd.argoproj.io/source-uid"
+)
+
 type Manager interface {
 	SetRole(role ManagerRole)
 	SetMode(role ManagerRole)


### PR DESCRIPTION
**What does this PR do / why we need it**:

Currently, we don't handle a case where the incoming app/app project could have a different source UID than the resource on the cluster with the same name and namespace. This indicates that the existing resource in the agent was created from a different resource in principal which no longer exists. We annotate the resources in the agent with the source UID to track their source of truth.
For more details: https://github.com/argoproj-labs/argocd-agent/pull/225#discussion_r1851965152
1. An app is present on both the principal and the agent
2. Principal process stops
3. User deletes the app 
4. Principal starts again and the user creates a new app
5. The agent couldn't differentiate between the new and old apps.


**Which issue(s) this PR fixes**:

Fixes https://github.com/argoproj-labs/argocd-agent/pull/225#discussion_r1851965152

**How to test changes / Special notes to the reviewer**:


**Checklist**

* [x] Documentation update is required by this PR (and has been updated) OR no documentation update is required.

