### PR TITLE
fix: update the existing resources when the principal restarts

### DIFF
--- a/internal/manager/application/application.go
+++ b/internal/manager/application/application.go
@@ -268,22 +268,22 @@ func (m *ApplicationManager) UpdateManagedApp(ctx context.Context, incoming *v1a
 }
 
 // CompareSourceUID checks for an existing app with the same name/namespace and compare its source UID with the incoming app.
-func (m *ApplicationManager) CompareSourceUID(ctx context.Context, incoming *v1alpha1.Application) (bool, error) {
+func (m *ApplicationManager) CompareSourceUID(ctx context.Context, incoming *v1alpha1.Application) (bool, bool, error) {
 	existing, err := m.applicationBackend.Get(ctx, incoming.Name, incoming.Namespace)
 	if err != nil {
 		if errors.IsNotFound(err) {
-			return true, nil
+			return false, false, nil
 		}
-		return false, err
+		return false, false, err
 	}
 
 	// If there is an existing app with the same name/namespace, compare its source UID with the incoming app.
 	sourceUID, exists := existing.Annotations[manager.SourceUIDAnnotation]
 	if !exists {
-		return false, fmt.Errorf("source UID Annotation is not found for app: %s", incoming.Name)
+		return true, false, fmt.Errorf("source UID Annotation is not found for app: %s", incoming.Name)
 	}
 
-	return string(incoming.UID) == sourceUID, nil
+	return true, string(incoming.UID) == sourceUID, nil
 }
 
 // UpdateAutonomousApp updates the Application resource on the control plane side

--- a/internal/manager/appproject/appproject.go
+++ b/internal/manager/appproject/appproject.go
@@ -378,22 +378,22 @@ func (m *AppProjectManager) EnsureSynced(duration time.Duration) error {
 }
 
 // CompareSourceUID checks for an existing appProject with the same name/namespace and compare its source UID with the incoming appProject.
-func (m *AppProjectManager) CompareSourceUID(ctx context.Context, incoming *v1alpha1.AppProject) (bool, error) {
+func (m *AppProjectManager) CompareSourceUID(ctx context.Context, incoming *v1alpha1.AppProject) (bool, bool, error) {
 	existing, err := m.appprojectBackend.Get(ctx, incoming.Name, incoming.Namespace)
 	if err != nil {
 		if errors.IsNotFound(err) {
-			return true, nil
+			return false, false, nil
 		}
-		return false, err
+		return false, false, err
 	}
 
 	// If there is an existing appProject with the same name/namespace, compare its source UID with the incoming appProject.
 	sourceUID, ok := existing.Annotations[manager.SourceUIDAnnotation]
 	if !ok {
-		return false, fmt.Errorf("source UID Annotation is not found for appProject: %s", incoming.Name)
+		return true, false, fmt.Errorf("source UID Annotation is not found for appProject: %s", incoming.Name)
 	}
 
-	return string(incoming.UID) == sourceUID, nil
+	return true, string(incoming.UID) == sourceUID, nil
 }
 
 func log() *logrus.Entry {


### PR DESCRIPTION
**What does this PR do / why we need it**:

When the principal restarts, the informer reconciles the existing resources and they are sent to the agent as `Create` events.  However, the agent may drop these `Create` events if the resource exists. The agent may miss updates by dropping these events. Consider the following scenario:
1. The principal and the agent are in sync
2. Principal process stops
3. The user updates the app
4. The principal restarts and sends the latest resources as `Create` events.
5. The agent will drop the `Create` events since the resource already exists.
6. Now the agent is out of sync with the principal until the next update event.

This PR updates the logic to handle create events. The agent now checks if the resource already exists and updates the resources instead of dropping the events.

**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:


**Checklist**

* [ ] Documentation update is required by this PR (and has been updated) OR no documentation update is required.

