### PR TITLE
feat: store the informer events even if the agent is not connected

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -224,6 +224,12 @@ func (a *Agent) Start(ctx context.Context) error {
 		}
 	}()
 
+	// Wait for the app informer to be synced
+	err := a.appManager.EnsureSynced(waitForSyncedDuration)
+	if err != nil {
+		return fmt.Errorf("failed to sync applications: %w", err)
+	}
+
 	if a.remote != nil {
 		a.remote.SetClientMode(a.mode)
 		// TODO: Right now, maintainConnection always returns nil. Revisit
@@ -232,12 +238,6 @@ func (a *Agent) Start(ctx context.Context) error {
 	}
 
 	a.emitter = event.NewEventSource(fmt.Sprintf("agent://%s", "agent-managed"))
-
-	// Wait for the app informer to be synced
-	err := a.appManager.EnsureSynced(waitForSyncedDuration)
-	if err != nil {
-		return fmt.Errorf("failed to sync applications: %w", err)
-	}
 
 	return err
 }

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -23,8 +23,10 @@ import (
 
 	kubeapp "github.com/argoproj-labs/argocd-agent/internal/backend/kubernetes/application"
 	kubeappproject "github.com/argoproj-labs/argocd-agent/internal/backend/kubernetes/appproject"
+	kubenamespace "github.com/argoproj-labs/argocd-agent/internal/backend/kubernetes/namespace"
 	"github.com/argoproj-labs/argocd-agent/internal/event"
 	"github.com/argoproj-labs/argocd-agent/internal/informer"
+	"github.com/argoproj-labs/argocd-agent/internal/kube"
 	"github.com/argoproj-labs/argocd-agent/internal/manager"
 	"github.com/argoproj-labs/argocd-agent/internal/manager/application"
 	"github.com/argoproj-labs/argocd-agent/internal/manager/appproject"
@@ -33,12 +35,12 @@ import (
 	"github.com/argoproj-labs/argocd-agent/pkg/client"
 	"github.com/argoproj-labs/argocd-agent/pkg/types"
 	"github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/watch"
 
 	"github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
-	appclientset "github.com/argoproj/argo-cd/v2/pkg/client/clientset/versioned"
 )
 
 const waitForSyncedDuration = 10 * time.Second
@@ -56,11 +58,12 @@ type Agent struct {
 	infStopCh chan struct{}
 	connected atomic.Bool
 	// syncCh is not currently used
-	syncCh         chan bool
-	remote         *client.Remote
-	appManager     *application.ApplicationManager
-	projectManager *appproject.AppProjectManager
-	mode           types.AgentMode
+	syncCh           chan bool
+	remote           *client.Remote
+	appManager       *application.ApplicationManager
+	projectManager   *appproject.AppProjectManager
+	namespaceManager *kubenamespace.KubernetesBackend
+	mode             types.AgentMode
 	// queues is a queue of create/update/delete events to send to the principal
 	queues  *queue.SendRecvQueues
 	emitter *event.EventSource
@@ -86,7 +89,7 @@ type AgentOption func(*Agent) error
 
 // NewAgent creates a new agent instance, using the given client interfaces and
 // options.
-func NewAgent(ctx context.Context, appclient appclientset.Interface, namespace string, opts ...AgentOption) (*Agent, error) {
+func NewAgent(ctx context.Context, client *kube.KubernetesClient, namespace string, opts ...AgentOption) (*Agent, error) {
 	a := &Agent{
 		version: version.New("argocd-agent", "agent"),
 	}
@@ -100,6 +103,8 @@ func NewAgent(ctx context.Context, appclient appclientset.Interface, namespace s
 			return nil, err
 		}
 	}
+
+	appclient := client.ApplicationsClientset
 
 	if a.remote == nil {
 		return nil, fmt.Errorf("remote not defined")
@@ -196,6 +201,22 @@ func NewAgent(ctx context.Context, appclient appclientset.Interface, namespace s
 		return nil, err
 	}
 
+	nsInformerOpts := []informer.InformerOption[*corev1.Namespace]{
+		informer.WithListHandler[*corev1.Namespace](func(ctx context.Context, opts v1.ListOptions) (runtime.Object, error) {
+			return client.Clientset.CoreV1().Namespaces().List(ctx, opts)
+		}),
+		informer.WithWatchHandler[*corev1.Namespace](func(ctx context.Context, opts v1.ListOptions) (watch.Interface, error) {
+			return client.Clientset.CoreV1().Namespaces().Watch(ctx, opts)
+		}),
+		informer.WithDeleteHandler[*corev1.Namespace](a.deleteNamespaceCallback),
+	}
+
+	nsInformer, err := informer.NewInformer(ctx, nsInformerOpts...)
+	if err != nil {
+		return nil, err
+	}
+	a.namespaceManager = kubenamespace.NewKubernetesBackend(nsInformer)
+
 	a.syncCh = make(chan bool, 1)
 	return a, nil
 }
@@ -229,6 +250,20 @@ func (a *Agent) Start(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("failed to sync applications: %w", err)
 	}
+
+	// The namespace informer lives in its own go routine
+	go func() {
+		if err := a.namespaceManager.StartInformer(a.context); err != nil {
+			log().WithError(err).Error("Namespace informer has exited non-successfully")
+		} else {
+			log().Info("Namespace informer has exited")
+		}
+	}()
+
+	if err := a.namespaceManager.EnsureSynced(waitForSyncedDuration); err != nil {
+		return fmt.Errorf("unable to sync Namespace informer: %w", err)
+	}
+	log().Infof("Namespace informer synced and ready")
 
 	if a.remote != nil {
 		a.remote.SetClientMode(a.mode)

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -18,26 +18,26 @@ import (
 	"context"
 	"testing"
 
-	fakeappclient "github.com/argoproj/argo-cd/v2/pkg/client/clientset/versioned/fake"
 	"github.com/sirupsen/logrus"
 
 	"github.com/argoproj-labs/argocd-agent/pkg/client"
+	"github.com/argoproj-labs/argocd-agent/test/fake/kube"
 	"github.com/stretchr/testify/require"
 )
 
 func newAgent(t *testing.T) *Agent {
 	t.Helper()
-	appc := fakeappclient.NewSimpleClientset()
+	kubec := kube.NewKubernetesFakeClient()
 	remote, err := client.NewRemote("127.0.0.1", 8080)
 	require.NoError(t, err)
-	agent, err := NewAgent(context.TODO(), appc, "argocd", WithRemote(remote))
+	agent, err := NewAgent(context.TODO(), kubec, "argocd", WithRemote(remote))
 	require.NoError(t, err)
 	return agent
 }
 
 func Test_NewAgent(t *testing.T) {
-	appc := fakeappclient.NewSimpleClientset()
-	agent, err := NewAgent(context.TODO(), appc, "agent", WithRemote(&client.Remote{}))
+	kubec := kube.NewKubernetesFakeClient()
+	agent, err := NewAgent(context.TODO(), kubec, "agent", WithRemote(&client.Remote{}))
 	require.NotNil(t, agent)
 	require.NoError(t, err)
 }

--- a/agent/connection.go
+++ b/agent/connection.go
@@ -36,12 +36,14 @@ func (a *Agent) maintainConnection() error {
 				if err != nil {
 					log().Warnf("Could not connect to %s: %v", a.remote.Addr(), err)
 				} else {
-					err = a.queues.Create(a.remote.ClientID())
-					if err != nil {
-						log().Warnf("Could not create agent queue pair: %v", err)
-					} else {
-						a.SetConnected(true)
+					if !a.queues.HasQueuePair(a.remote.ClientID()) {
+						err = a.queues.Create(a.remote.ClientID())
+						if err != nil {
+							log().Warnf("Could not create agent queue pair: %v", err)
+							continue
+						}
 					}
+					a.SetConnected(true)
 				}
 			} else {
 				err = a.handleStreamEvents()
@@ -214,10 +216,6 @@ func (a *Agent) handleStreamEvents() error {
 	}
 
 	log().WithField("component", "EventHandler").Info("Stream closed")
-	err = a.queues.Delete(a.remote.ClientID(), true)
-	if err != nil {
-		log().Errorf("Could not remove agent queue: %v", err)
-	}
 
 	return nil
 }

--- a/agent/outbound.go
+++ b/agent/outbound.go
@@ -26,13 +26,6 @@ func (a *Agent) addAppCreationToQueue(app *v1alpha1.Application) {
 	logCtx := log().WithField("event", "NewApp").WithField("application", app.QualifiedName())
 	logCtx.Debugf("New app event")
 
-	// If the agent is not connected, we ignore this event. It just makes no
-	// sense to fill up the send queue when we can't send.
-	if !a.IsConnected() {
-		logCtx.Trace("Agent is not connected, ignoring this event")
-		return
-	}
-
 	// Update events trigger a new event sometimes, too. If we've already seen
 	// the app, we just ignore the request then.
 	if a.appManager.IsManaged(app.QualifiedName()) {
@@ -63,13 +56,6 @@ func (a *Agent) addAppUpdateToQueue(old *v1alpha1.Application, new *v1alpha1.App
 	defer a.watchLock.Unlock()
 	if a.appManager.IsChangeIgnored(new.QualifiedName(), new.ResourceVersion) {
 		logCtx.Debugf("Ignoring this change for resource version %s", new.ResourceVersion)
-		return
-	}
-
-	// If the agent is not connected, we ignore this event. It just makes no
-	// sense to fill up the send queue when we can't send.
-	if !a.IsConnected() {
-		logCtx.Trace("Agent is not connected, ignoring this event")
 		return
 	}
 
@@ -108,13 +94,6 @@ func (a *Agent) addAppUpdateToQueue(old *v1alpha1.Application, new *v1alpha1.App
 func (a *Agent) addAppDeletionToQueue(app *v1alpha1.Application) {
 	logCtx := log().WithField("event", "DeleteApp").WithField("application", app.QualifiedName())
 	logCtx.Debugf("Delete app event")
-
-	// If the agent is not connected, we ignore this event. It just makes no
-	// sense to fill up the send queue when we can't send.
-	if !a.IsConnected() {
-		logCtx.Trace("Agent is not connected, ignoring this event")
-		return
-	}
 
 	if !a.appManager.IsManaged(app.QualifiedName()) {
 		logCtx.Tracef("App is not managed")

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -119,7 +119,7 @@ func NewAgentRunCommand() *cobra.Command {
 			}
 			agentOpts = append(agentOpts, agent.WithRemote(remote))
 			agentOpts = append(agentOpts, agent.WithMode(agentMode))
-			ag, err := agent.NewAgent(ctx, kubeConfig.ApplicationsClientset, namespace, agentOpts...)
+			ag, err := agent.NewAgent(ctx, kubeConfig, namespace, agentOpts...)
 			if err != nil {
 				cmd.Fatal("Could not create a new agent instance: %v", err)
 			}

--- a/internal/backend/interface.go
+++ b/internal/backend/interface.go
@@ -94,3 +94,9 @@ type AppProject interface {
 	StartInformer(ctx context.Context) error
 	EnsureSynced(duration time.Duration) error
 }
+
+// Namespace defines a generic interface to track agent namespaces.
+type Namespace interface {
+	StartInformer(ctx context.Context) error
+	EnsureSynced(duration time.Duration) error
+}

--- a/internal/backend/kubernetes/namespace/kubernetes.go
+++ b/internal/backend/kubernetes/namespace/kubernetes.go
@@ -1,0 +1,48 @@
+// Copyright 2024 The argocd-agent Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package namespace
+
+import (
+	"context"
+	"time"
+
+	"github.com/argoproj-labs/argocd-agent/internal/backend"
+	"github.com/argoproj-labs/argocd-agent/internal/informer"
+)
+
+var _ backend.Namespace = &KubernetesBackend{}
+
+// KubernetesBackend is an implementation of the backend.Namespace interface, which is used to track the state of namespaces
+// local to the agent/principal. KubernetesBackend is used by both the principal and agent components.
+type KubernetesBackend struct {
+	// informer is used to watch for changes to the namespaces.
+	informer informer.InformerInterface
+}
+
+func NewKubernetesBackend(nsInformer informer.InformerInterface) *KubernetesBackend {
+	return &KubernetesBackend{
+		informer: nsInformer,
+	}
+}
+
+func (be *KubernetesBackend) StartInformer(ctx context.Context) error {
+	return be.informer.Start(ctx)
+}
+
+func (be *KubernetesBackend) EnsureSynced(timeout time.Duration) error {
+	ctx, cancelFunc := context.WithTimeout(context.Background(), timeout)
+	defer cancelFunc()
+	return be.informer.WaitForSync(ctx)
+}

--- a/internal/queue/queue.go
+++ b/internal/queue/queue.go
@@ -59,12 +59,10 @@ func newBoundedQueue(maxSize int) *boundedQueue {
 }
 
 func (bq *boundedQueue) Add(item *event.Event) {
-	// We empty the queue if the size is going to exceed maxSize.
+	// We pop the oldest item if the size is going to exceed maxSize.
 	if bq.Len() == bq.maxSize {
-		for bq.Len() != 0 {
-			old, _ := bq.Get()
-			bq.Done(old)
-		}
+		old, _ := bq.Get()
+		bq.Done(old)
 	}
 
 	bq.TypedRateLimitingInterface.Add(item)

--- a/internal/queue/queue.go
+++ b/internal/queue/queue.go
@@ -59,7 +59,7 @@ func newBoundedQueue(maxSize int) *boundedQueue {
 }
 
 func (bq *boundedQueue) Add(item *event.Event) {
-	// We empty the queue if the size is going to exceeded maxSize.
+	// We empty the queue if the size is going to exceed maxSize.
 	if bq.Len() == bq.maxSize {
 		for bq.Len() != 0 {
 			old, _ := bq.Get()

--- a/internal/queue/queue.go
+++ b/internal/queue/queue.go
@@ -35,9 +35,39 @@ type QueuePair interface {
 	Delete(name string, shutdown bool) error
 }
 
+const (
+	// defaultMaxQueueSize is the max number of items that the workqueue can hold.
+	defaultMaxQueueSize int = 1000
+)
+
 type queuepair struct {
-	recvq workqueue.TypedRateLimitingInterface[*event.Event]
-	sendq workqueue.TypedRateLimitingInterface[*event.Event]
+	recvq *boundedQueue
+	sendq *boundedQueue
+}
+
+type boundedQueue struct {
+	workqueue.TypedRateLimitingInterface[*event.Event]
+	maxSize int
+}
+
+func newBoundedQueue(maxSize int) *boundedQueue {
+	rateLimiter := workqueue.DefaultTypedControllerRateLimiter[*event.Event]()
+	return &boundedQueue{
+		TypedRateLimitingInterface: workqueue.NewTypedRateLimitingQueue(rateLimiter),
+		maxSize:                    maxSize,
+	}
+}
+
+func (bq *boundedQueue) Add(item *event.Event) {
+	// We empty the queue if the size is going to exceeded maxSize.
+	if bq.Len() == bq.maxSize {
+		for bq.Len() != 0 {
+			old, _ := bq.Get()
+			bq.Done(old)
+		}
+	}
+
+	bq.TypedRateLimitingInterface.Add(item)
 }
 
 type SendRecvQueues struct {
@@ -115,8 +145,8 @@ func (q *SendRecvQueues) Create(name string) error {
 		return fmt.Errorf("cannot initialize queue for %s: queue already exists", name)
 	}
 	qp := &queuepair{}
-	qp.sendq = workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[*event.Event]())
-	qp.recvq = workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[*event.Event]())
+	qp.sendq = newBoundedQueue(defaultMaxQueueSize)
+	qp.recvq = newBoundedQueue(defaultMaxQueueSize)
 	q.queues[name] = qp
 
 	return nil

--- a/internal/queue/queue_test.go
+++ b/internal/queue/queue_test.go
@@ -15,6 +15,7 @@
 package queue
 
 import (
+	"strconv"
 	"testing"
 
 	"github.com/cloudevents/sdk-go/v2/event"
@@ -66,11 +67,16 @@ func Test_Queue(t *testing.T) {
 
 		for i := 1; i <= defaultMaxQueueSize; i++ {
 			ev := event.New()
+			ev.SetID(strconv.Itoa(i))
 			queue.Add(&ev)
 		}
 
-		// Since the queue is full, check if it is emptied before adding a new item.
-		queue.Add(&event.Event{})
-		assert.Equal(t, 1, queue.Len())
+		// Since the queue is full, check if the oldest item is popped before adding a new item.
+		ev := event.New()
+		ev.SetID("1001")
+		queue.Add(&ev)
+		assert.Equal(t, defaultMaxQueueSize, queue.Len())
+		front, _ := queue.Get()
+		assert.Equal(t, "2", front.ID())
 	})
 }

--- a/internal/queue/queue_test.go
+++ b/internal/queue/queue_test.go
@@ -17,6 +17,7 @@ package queue
 import (
 	"testing"
 
+	"github.com/cloudevents/sdk-go/v2/event"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -55,5 +56,19 @@ func Test_Queue(t *testing.T) {
 		assert.NoError(t, err)
 		err = q.Delete("agent1", true)
 		assert.Error(t, err)
+	})
+
+	t.Run("Ensure that the max queue size is respected", func(t *testing.T) {
+		q := NewSendRecvQueues()
+		err := q.Create("agent1")
+		assert.NoError(t, err)
+		queue := q.RecvQ("agent1")
+
+		for i := 1; i <= defaultMaxQueueSize+1; i++ {
+			ev := event.New()
+			queue.Add(&ev)
+		}
+
+		assert.Equal(t, 1, queue.Len())
 	})
 }

--- a/internal/queue/queue_test.go
+++ b/internal/queue/queue_test.go
@@ -64,11 +64,13 @@ func Test_Queue(t *testing.T) {
 		assert.NoError(t, err)
 		queue := q.RecvQ("agent1")
 
-		for i := 1; i <= defaultMaxQueueSize+1; i++ {
+		for i := 1; i <= defaultMaxQueueSize; i++ {
 			ev := event.New()
 			queue.Add(&ev)
 		}
 
+		// Since the queue is full, check if it is emptied before adding a new item.
+		queue.Add(&event.Event{})
 		assert.Equal(t, 1, queue.Len())
 	})
 }

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -42,9 +42,21 @@ func ClientIdFromContext(ctx context.Context) (string, error) {
 	return clientId, nil
 }
 
-// ClientIdToContext returns a copy of context ctx with the clientId stored
-func ClientIdToContext(ctx context.Context, clientId string) context.Context {
-	return context.WithValue(ctx, types.ContextAgentIdentifier, clientId)
+// ClientModeFromContext returns the client mode stored in context ctx. Returns an
+// error if there is no client mode in the ctx.
+func ClientModeFromContext(ctx context.Context) (string, error) {
+	val := ctx.Value(types.ContextAgentMode)
+	clientMode, ok := val.(string)
+	if !ok {
+		return "", fmt.Errorf("no client mode found in context")
+	}
+	return clientMode, nil
+}
+
+// ClientInfoToContext returns a copy of context ctx with the clientId and clientMode stored
+func ClientInfoToContext(ctx context.Context, clientId, clientMode string) context.Context {
+	clientCtx := context.WithValue(ctx, types.ContextAgentIdentifier, clientId)
+	return context.WithValue(clientCtx, types.ContextAgentMode, clientMode)
 }
 
 // IsValidClientId returns true if the string s is considered a valid client

--- a/internal/session/session_test.go
+++ b/internal/session/session_test.go
@@ -7,20 +7,28 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func Test_ClientIdFromContext(t *testing.T) {
-	t.Run("Successfully extract client ID", func(t *testing.T) {
-		ctx := ClientIdToContext(context.Background(), "agent")
+func Test_ClientInfoInContext(t *testing.T) {
+	t.Run("Successfully extract client ID and mode", func(t *testing.T) {
+		ctx := ClientInfoToContext(context.Background(), "agent", "managed")
 		a, err := ClientIdFromContext(ctx)
 		assert.NoError(t, err)
 		assert.Equal(t, "agent", a)
+		m, err := ClientModeFromContext(ctx)
+		assert.NoError(t, err)
+		assert.Equal(t, "managed", m)
 	})
 	t.Run("No client ID in context", func(t *testing.T) {
 		a, err := ClientIdFromContext(context.Background())
 		assert.ErrorContains(t, err, "no client identifier")
 		assert.Empty(t, a)
 	})
+	t.Run("No client mode in context", func(t *testing.T) {
+		a, err := ClientModeFromContext(context.Background())
+		assert.ErrorContains(t, err, "no client mode found in context")
+		assert.Empty(t, a)
+	})
 	t.Run("Invalid client ID in context", func(t *testing.T) {
-		ctx := ClientIdToContext(context.Background(), "ag_ent")
+		ctx := ClientInfoToContext(context.Background(), "ag_ent", "managed")
 		a, err := ClientIdFromContext(ctx)
 		assert.ErrorContains(t, err, "invalid client identifier")
 		assert.Empty(t, a)

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -66,4 +66,7 @@ func (k EventContextKey) String() string {
 	return string(k)
 }
 
-const ContextAgentIdentifier EventContextKey = "agent_name"
+const (
+	ContextAgentIdentifier EventContextKey = "agent_name"
+	ContextAgentMode       EventContextKey = "agent_mode"
+)

--- a/principal/apis/eventstream/eventstream.go
+++ b/principal/apis/eventstream/eventstream.go
@@ -161,17 +161,6 @@ func (s *Server) newClientConnection(ctx context.Context, timeout time.Duration)
 	return c, nil
 }
 
-// agentMode gets the agent mode from the context ctx. Returns an error
-// if no agent mode is found in the context
-func agentMode(ctx context.Context) (string, error) {
-	agentMode, ok := ctx.Value(types.ContextAgentMode).(string)
-	if !ok {
-		return "", fmt.Errorf("invalid context: no agent mode")
-	}
-
-	return agentMode, nil
-}
-
 // onDisconnect must be called whenever client c disconnects from the stream
 func (s *Server) onDisconnect(c *client) {
 	c.lock.Lock()
@@ -283,9 +272,9 @@ func (s *Server) sendFunc(c *client, subs eventstreamapi.EventStream_SubscribeSe
 		return fmt.Errorf("panic: nil item in queue")
 	}
 
-	mode, err := agentMode(c.ctx)
+	mode, err := session.ClientModeFromContext(c.ctx)
 	if err != nil {
-		return fmt.Errorf("unable to extract the agent mode from context")
+		return fmt.Errorf("unable to determine agent mode: %w", err)
 	}
 
 	if types.AgentModeFromString(mode) != types.AgentModeManaged {

--- a/principal/apis/eventstream/mock/mock.go
+++ b/principal/apis/eventstream/mock/mock.go
@@ -38,6 +38,7 @@ type MockEventServer struct {
 	grpc.ServerStream
 
 	AgentName   string
+	AgentMode   string
 	NumSent     atomic.Uint32
 	NumRecv     atomic.Uint32
 	Application v1alpha1.Application
@@ -58,11 +59,17 @@ func (s *MockEventServer) AddRecvHook(hook RecvHook) {
 }
 
 func (s *MockEventServer) Context() context.Context {
+	ctx := context.TODO()
+
 	if s.AgentName != "" {
-		return context.WithValue(context.TODO(), types.ContextAgentIdentifier, s.AgentName)
-	} else {
-		return context.TODO()
+		ctx = context.WithValue(ctx, types.ContextAgentIdentifier, s.AgentName)
 	}
+
+	if s.AgentMode != "" {
+		ctx = context.WithValue(ctx, types.ContextAgentMode, s.AgentMode)
+	}
+
+	return ctx
 }
 
 func (s *MockEventServer) Send(sub *eventstreamapi.Event) error {

--- a/principal/auth.go
+++ b/principal/auth.go
@@ -118,7 +118,8 @@ func (s *Server) authenticate(ctx context.Context) (context.Context, error) {
 
 	// claims at this point is validated and we can propagate values to the
 	// context.
-	authCtx := session.ClientIdToContext(ctx, agentInfo.ClientID)
+	authCtx := context.WithValue(session.ClientIdToContext(ctx, agentInfo.ClientID),
+		types.ContextAgentMode, agentInfo.Mode)
 	if !s.queues.HasQueuePair(agentInfo.ClientID) {
 		logCtx.Tracef("Creating a new queue pair for client %s", agentInfo.ClientID)
 		if err := s.queues.Create(agentInfo.ClientID); err != nil {

--- a/principal/auth.go
+++ b/principal/auth.go
@@ -118,8 +118,8 @@ func (s *Server) authenticate(ctx context.Context) (context.Context, error) {
 
 	// claims at this point is validated and we can propagate values to the
 	// context.
-	authCtx := context.WithValue(session.ClientIdToContext(ctx, agentInfo.ClientID),
-		types.ContextAgentMode, agentInfo.Mode)
+	authCtx := session.ClientInfoToContext(ctx, agentInfo.ClientID, agentInfo.Mode)
+
 	if !s.queues.HasQueuePair(agentInfo.ClientID) {
 		logCtx.Tracef("Creating a new queue pair for client %s", agentInfo.ClientID)
 		if err := s.queues.Create(agentInfo.ClientID); err != nil {

--- a/principal/callbacks.go
+++ b/principal/callbacks.go
@@ -32,17 +32,12 @@ func (s *Server) newAppCallback(outbound *v1alpha1.Application) {
 		"application_name": outbound.Name,
 	})
 
-	// Return early if no interested agent is connected
 	if !s.queues.HasQueuePair(outbound.Namespace) {
-		logCtx.Debug("No agent is connected to this queue, discarding event")
-		return
-	}
-
-	// New app events are only relevant for managed agents
-	mode := s.agentMode(outbound.Namespace)
-	if mode != types.AgentModeManaged {
-		logCtx.Tracef("Discarding event for unmanaged agent")
-		return
+		if err := s.queues.Create(outbound.Namespace); err != nil {
+			logCtx.WithError(err).Error("failed to create a queue pair for an existing agent namespace")
+			return
+		}
+		logCtx.Trace("Created a new queue pair for the existing namespace")
 	}
 	q := s.queues.SendQ(outbound.Namespace)
 	if q == nil {
@@ -77,8 +72,11 @@ func (s *Server) updateAppCallback(old *v1alpha1.Application, new *v1alpha1.Appl
 		return
 	}
 	if !s.queues.HasQueuePair(old.Namespace) {
-		logCtx.Tracef("No agent is connected to this queue, discarding event")
-		return
+		if err := s.queues.Create(old.Namespace); err != nil {
+			logCtx.WithError(err).Error("failed to create a queue pair for an existing agent namespace")
+			return
+		}
+		logCtx.Trace("Created a new queue pair for the existing agent namespace")
 	}
 	q := s.queues.SendQ(old.Namespace)
 	if q == nil {
@@ -98,13 +96,11 @@ func (s *Server) deleteAppCallback(outbound *v1alpha1.Application) {
 		"application_name": outbound.Name,
 	})
 	if !s.queues.HasQueuePair(outbound.Namespace) {
-		logCtx.Tracef("No agent is connected to this queue, discarding event")
-		return
-	}
-	mode := s.agentMode(outbound.Namespace)
-	if !mode.IsManaged() {
-		logCtx.Tracef("Discarding event for unmanaged agent")
-		return
+		if err := s.queues.Create(outbound.Namespace); err != nil {
+			logCtx.WithError(err).Error("failed to create a queue pair for an existing agent namespace")
+			return
+		}
+		logCtx.Trace("Created a new queue pair for the existing agent namespace")
 	}
 	q := s.queues.SendQ(outbound.Namespace)
 	if q == nil {
@@ -129,8 +125,11 @@ func (s *Server) newAppProjectCallback(outbound *v1alpha1.AppProject) {
 
 	// Return early if no interested agent is connected
 	if !s.queues.HasQueuePair(outbound.Namespace) {
-		logCtx.Debug("No agent is connected to this queue, discarding event")
-		return
+		if err := s.queues.Create(outbound.Namespace); err != nil {
+			logCtx.WithError(err).Error("failed to create a queue pair for an existing agent namespace")
+			return
+		}
+		logCtx.Trace("Created a new queue pair for the existing namespace")
 	}
 
 	// New appproject events are only relevant for managed agents
@@ -172,8 +171,11 @@ func (s *Server) updateAppProjectCallback(old *v1alpha1.AppProject, new *v1alpha
 		return
 	}
 	if !s.queues.HasQueuePair(old.Namespace) {
-		logCtx.Tracef("No agent is connected to this queue, discarding event")
-		return
+		if err := s.queues.Create(old.Namespace); err != nil {
+			logCtx.WithError(err).Error("failed to create a queue pair for an existing agent namespace")
+			return
+		}
+		logCtx.Trace("Created a new queue pair for the existing agent namespace")
 	}
 	q := s.queues.SendQ(old.Namespace)
 	if q == nil {
@@ -193,13 +195,11 @@ func (s *Server) deleteAppProjectCallback(outbound *v1alpha1.AppProject) {
 		"appproject_name": outbound.Name,
 	})
 	if !s.queues.HasQueuePair(outbound.Namespace) {
-		logCtx.Tracef("No agent is connected to this queue, discarding event")
-		return
-	}
-	mode := s.agentMode(outbound.Namespace)
-	if !mode.IsManaged() {
-		logCtx.Tracef("Discarding event for unmanaged agent")
-		return
+		if err := s.queues.Create(outbound.Namespace); err != nil {
+			logCtx.WithError(err).Error("failed to create a queue pair for an existing agent namespace")
+			return
+		}
+		logCtx.Trace("Created a new queue pair for the existing agent namespace")
 	}
 	q := s.queues.SendQ(outbound.Namespace)
 	if q == nil {

--- a/principal/server_test.go
+++ b/principal/server_test.go
@@ -28,8 +28,6 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 var certTempl = x509.Certificate{
@@ -94,44 +92,6 @@ func Test_NewServer(t *testing.T) {
 		s, err := NewServer(context.TODO(), kube.NewKubernetesFakeClient(), testNamespace, WithListenerPort(-1), WithGeneratedTokenSigningKey())
 		assert.Error(t, err)
 		assert.Nil(t, s)
-	})
-}
-
-func TestRemoveQueueIfUnused(t *testing.T) {
-	t.Run("should remove the queue if the namespace is not found", func(t *testing.T) {
-		ctx := context.Background()
-		fakeClient := kube.NewKubernetesFakeClient()
-
-		s, err := NewServer(context.TODO(), fakeClient, testNamespace, WithGeneratedTokenSigningKey())
-		assert.Nil(t, err)
-
-		err = s.queues.Create(testNamespace)
-		assert.Nil(t, err)
-
-		s.removeQueueIfUnused(ctx, testNamespace)
-		assert.False(t, s.queues.HasQueuePair(testNamespace))
-	})
-
-	t.Run("shouldn't remove the queue if the namespace is found", func(t *testing.T) {
-		ns := &corev1.Namespace{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: testNamespace,
-			},
-		}
-
-		ctx := context.Background()
-		fakeClient := kube.NewKubernetesFakeClient()
-		_, err := fakeClient.Clientset.CoreV1().Namespaces().Create(ctx, ns, metav1.CreateOptions{})
-		assert.Nil(t, err)
-
-		s, err := NewServer(context.TODO(), fakeClient, testNamespace, WithGeneratedTokenSigningKey())
-		assert.Nil(t, err)
-
-		err = s.queues.Create(testNamespace)
-		assert.Nil(t, err)
-
-		s.removeQueueIfUnused(ctx, testNamespace)
-		assert.True(t, s.queues.HasQueuePair(testNamespace))
 	})
 }
 

--- a/principal/server_test.go
+++ b/principal/server_test.go
@@ -28,6 +28,8 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 var certTempl = x509.Certificate{
@@ -92,6 +94,44 @@ func Test_NewServer(t *testing.T) {
 		s, err := NewServer(context.TODO(), kube.NewKubernetesFakeClient(), testNamespace, WithListenerPort(-1), WithGeneratedTokenSigningKey())
 		assert.Error(t, err)
 		assert.Nil(t, s)
+	})
+}
+
+func TestRemoveQueueIfUnused(t *testing.T) {
+	t.Run("should remove the queue if the namespace is not found", func(t *testing.T) {
+		ctx := context.Background()
+		fakeClient := kube.NewKubernetesFakeClient()
+
+		s, err := NewServer(context.TODO(), fakeClient, testNamespace, WithGeneratedTokenSigningKey())
+		assert.Nil(t, err)
+
+		err = s.queues.Create(testNamespace)
+		assert.Nil(t, err)
+
+		s.removeQueueIfUnused(ctx, testNamespace)
+		assert.False(t, s.queues.HasQueuePair(testNamespace))
+	})
+
+	t.Run("shouldn't remove the queue if the namespace is found", func(t *testing.T) {
+		ns := &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: testNamespace,
+			},
+		}
+
+		ctx := context.Background()
+		fakeClient := kube.NewKubernetesFakeClient()
+		_, err := fakeClient.Clientset.CoreV1().Namespaces().Create(ctx, ns, metav1.CreateOptions{})
+		assert.Nil(t, err)
+
+		s, err := NewServer(context.TODO(), fakeClient, testNamespace, WithGeneratedTokenSigningKey())
+		assert.Nil(t, err)
+
+		err = s.queues.Create(testNamespace)
+		assert.Nil(t, err)
+
+		s.removeQueueIfUnused(ctx, testNamespace)
+		assert.True(t, s.queues.HasQueuePair(testNamespace))
 	})
 }
 

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -267,8 +267,8 @@ func Test_AgentServer(t *testing.T) {
 		client.WithAuth("userpass", auth.Credentials{userpass.ClientIDField: "client", userpass.ClientSecretField: "insecure"}),
 	)
 	require.NoError(t, err)
-	fakeAppcAgent := fakeappclient.NewSimpleClientset()
-	a, err := agent.NewAgent(actx, fakeAppcAgent, "client",
+	fakeKubeClient := fakekube.NewKubernetesFakeClient()
+	a, err := agent.NewAgent(actx, fakeKubeClient, "client",
 		agent.WithRemote(remote),
 		agent.WithMode(types.AgentModeManaged.String()),
 	)
@@ -363,8 +363,8 @@ func Test_WithHTTP1WebSocket(t *testing.T) {
 	startAgent := func(t *testing.T, ctx context.Context, remote *client.Remote) (*client.Remote, *agent.Agent) {
 		t.Helper()
 
-		fakeAppcAgent := fakeappclient.NewSimpleClientset()
-		a, err := agent.NewAgent(ctx, fakeAppcAgent, "client",
+		fakeKubeClient := fakekube.NewKubernetesFakeClient()
+		a, err := agent.NewAgent(ctx, fakeKubeClient, "client",
 			agent.WithRemote(remote),
 			agent.WithMode(types.AgentModeManaged.String()),
 		)


### PR DESCRIPTION
**What does this PR do / why we need it**:

See https://github.com/argoproj-labs/argocd-agent/pull/225#discussion_r1851955435 for more details.

Currently, the principal removes the queue when the agent disconnects and drops all the incoming events from the informer. When the agent connects back it may miss the updates and be out of sync from the principal.  For example:

1. The principal and the agent are in sync
2. Agent disconnects
3. The user updates the application. But the principal discards them since there is no agent
4. The agent connects back and is now out of sync with the principal.

There are two solutions to this problem:
1. The principal shouldn't remove the queue and reuse it when the agent connects again. The principal will just send the events from the queue when the agent reconnects.
2. The principal could list all the latest resources from the cluster and send them to the agent.

This PR explores solution 1. However, it doesn't handle orphaned resources. For example, if a resource is deleted when the principal is down it cannot transmit this event to the agent and the resource on the agent will be orphaned.

Changes introduced in this PR:
1. Keep the queue open even if the agent is not connected and store the informer events
2. Since the namespace name matches the agent ID, we remove the queue when the namespace associated with the agent is deleted.

**Which issue(s) this PR fixes**:

Fixes https://github.com/argoproj-labs/argocd-agent/pull/225#discussion_r1851955435

**How to test changes / Special notes to the reviewer**:


**Checklist**

* [ ] Documentation update is required by this PR (and has been updated) OR no documentation update is required.

