### PR TITLE
fix: create the resource if it doesn't exist while handling update events

### DIFF
--- a/agent/inbound.go
+++ b/agent/inbound.go
@@ -84,6 +84,14 @@ func (a *Agent) processIncomingApplication(ev *event.Event) error {
 			logCtx.Errorf("Error creating application: %v", err)
 		}
 	case event.SpecUpdate:
+		if !exists {
+			logCtx.Debug("Received an Update event for an app that doesn't exist. Creating the incoming app")
+			if _, err := a.createApplication(incomingApp); err != nil {
+				return fmt.Errorf("could not create incoming app: %w", err)
+			}
+			return nil
+		}
+
 		if !sourceUIDMatch {
 			logCtx.Debug("Source UID mismatch between the incoming app and existing app. Deleting the existing app")
 			if err := a.deleteApplication(incomingApp); err != nil {
@@ -150,6 +158,14 @@ func (a *Agent) processIncomingAppProject(ev *event.Event) error {
 			logCtx.Errorf("Error creating appproject: %v", err)
 		}
 	case event.SpecUpdate:
+		if !exists {
+			logCtx.Debug("Received an Update event for an appProject that doesn't exist. Creating the incoming appProject")
+			if _, err := a.createAppProject(incomingAppProject); err != nil {
+				return fmt.Errorf("could not create incoming appProject: %w", err)
+			}
+			return nil
+		}
+
 		if !sourceUIDMatch {
 			logCtx.Debug("Source UID mismatch between the incoming and existing appProject. Deleting the existing appProject")
 			if err := a.deleteAppProject(incomingAppProject); err != nil {


### PR DESCRIPTION
**What does this PR do / why we need it**:

In https://github.com/argoproj-labs/argocd-agent/pull/266 we update the resource if it already exists while handling create events. However, since the principal will send the latest event for a resource the agent may sometimes receive an update event for a resource that doesn't exist yet. For example:

1. The user creates an app on the control plane and updates it immediately before the create event is sent to the agent. 
2. Sometimes the principal may send the update event since it is the latest one.
3. The agent must create the incoming app since it doesn't exist

**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:


**Checklist**

* [ ] Documentation update is required by this PR (and has been updated) OR no documentation update is required.

