### PR TITLE
fix: use project manager to process incoming AppProjects

### DIFF
--- a/agent/inbound.go
+++ b/agent/inbound.go
@@ -319,7 +319,7 @@ func (a *Agent) createAppProject(incoming *v1alpha1.AppProject) (*v1alpha1.AppPr
 
 	// If we receive a new AppProject event for an AppProject we already manage, it usually
 	// means that we're out-of-sync from the control plane.
-	if a.appManager.IsManaged(incoming.Name) {
+	if a.projectManager.IsManaged(incoming.Name) {
 		logCtx.Trace("Discarding this event, because AppProject is already managed on this agent")
 		return nil, event.NewEventDiscardedErr("appproject %s is already managed", incoming.Name)
 	}
@@ -348,7 +348,7 @@ func (a *Agent) updateAppProject(incoming *v1alpha1.AppProject) (*v1alpha1.AppPr
 		"resourceVersion": incoming.ResourceVersion,
 	})
 
-	if a.appManager.IsChangeIgnored(incoming.Name, incoming.ResourceVersion) {
+	if a.projectManager.IsChangeIgnored(incoming.Name, incoming.ResourceVersion) {
 		logCtx.Tracef("Discarding this event, because agent has seen this version %s already", incoming.ResourceVersion)
 		return nil, event.NewEventDiscardedErr("the version %s has already been seen by this agent", incoming.ResourceVersion)
 	} else {

--- a/agent/inbound_test.go
+++ b/agent/inbound_test.go
@@ -587,16 +587,16 @@ func Test_CreateAppProject(t *testing.T) {
 	})
 
 	t.Run("Discard event because appproject is already managed", func(t *testing.T) {
-		defer a.appManager.Unmanage(project.Name)
+		defer a.projectManager.Unmanage(project.Name)
 		a.mode = types.AgentModeManaged
-		a.appManager.Manage(project.Name)
+		a.projectManager.Manage(project.Name)
 		napp, err := a.createAppProject(project)
 		require.ErrorContains(t, err, "is already managed")
 		require.Nil(t, napp)
 	})
 
 	t.Run("Create appproject", func(t *testing.T) {
-		defer a.appManager.Unmanage(project.Name)
+		defer a.projectManager.Unmanage(project.Name)
 		a.mode = types.AgentModeManaged
 		createMock := be.On("Create", mock.Anything, mock.Anything).Return(&v1alpha1.AppProject{}, nil)
 		defer createMock.Unset()


### PR DESCRIPTION
**What does this PR do / why we need it**:

Use projectManager instead of appManager when handling AppProject events from the informer.

**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:


**Checklist**

* [ ] Documentation update is required by this PR (and has been updated) OR no documentation update is required.

