### PR TITLE
feat: support periodic ping to principal for keeping connection alive

### DIFF
--- a/hack/dev-env/start-agent-autonomous.sh
+++ b/hack/dev-env/start-agent-autonomous.sh
@@ -20,4 +20,14 @@ if ! kubectl config get-contexts | tail -n +2 | awk '{ print $2 }' | grep -qE '^
     exit 1
 fi
 SCRIPTPATH="$( cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
-go run github.com/argoproj-labs/argocd-agent/cmd/agent --agent-mode autonomous --creds userpass:${SCRIPTPATH}/creds/creds.agent-autonomous --server-address 127.0.0.1 --server-port 8443 --insecure-tls --kubecontext vcluster-agent-autonomous --namespace argocd --log-level trace $ARGS --metrics-port 8182
+go run github.com/argoproj-labs/argocd-agent/cmd/agent \
+    --agent-mode autonomous \
+    --creds userpass:${SCRIPTPATH}/creds/creds.agent-autonomous \
+    --server-address 127.0.0.1 \
+    --server-port 8443 \
+    --insecure-tls \
+    --kubecontext vcluster-agent-autonomous \
+    --namespace argocd \
+    --log-level trace $ARGS \
+    --metrics-port 8182 \
+    #--keep-alive-ping-interval 15m

--- a/hack/dev-env/start-agent-managed.sh
+++ b/hack/dev-env/start-agent-managed.sh
@@ -20,4 +20,13 @@ if ! kubectl config get-contexts | tail -n +2 | awk '{ print $2 }' | grep -qE '^
     exit 1
 fi
 SCRIPTPATH="$( cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
-go run github.com/argoproj-labs/argocd-agent/cmd/agent --agent-mode managed --creds userpass:${SCRIPTPATH}/creds/creds.agent-managed --server-address 127.0.0.1 --server-port 8443 --insecure-tls --kubecontext vcluster-agent-managed --namespace agent-managed --log-level trace $ARGS
+go run github.com/argoproj-labs/argocd-agent/cmd/agent \
+    --agent-mode managed \
+    --creds userpass:${SCRIPTPATH}/creds/creds.agent-managed \
+    --server-address 127.0.0.1 \
+    --server-port 8443 \
+    --insecure-tls \
+    --kubecontext vcluster-agent-managed \
+    --namespace agent-managed \
+    --log-level trace $ARGS \
+    #--keep-alive-ping-interval 15m

--- a/principal/listen.go
+++ b/principal/listen.go
@@ -27,6 +27,7 @@ import (
 	"golang.org/x/net/http2/h2c"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/keepalive"
 	"k8s.io/apimachinery/pkg/util/wait"
 
 	"github.com/argoproj-labs/argocd-agent/internal/metrics"
@@ -152,6 +153,11 @@ func (s *Server) serveGRPC(ctx context.Context, metrics *metrics.PrincipalMetric
 		),
 		// TLS credentials
 		grpc.Creds(credentials.NewTLS(s.tlsConfig)),
+	}
+
+	if s.keepAliveMinimumInterval != 0 {
+		log().Debugf("Agent ping to principal is enabled, agent should wait at least %s before sending next ping event to principal", s.keepAliveMinimumInterval)
+		grpcOpts = append(grpcOpts, grpc.KeepaliveEnforcementPolicy(keepalive.EnforcementPolicy{MinTime: s.keepAliveMinimumInterval}))
 	}
 
 	// Instantiate server with given opts

--- a/principal/options.go
+++ b/principal/options.go
@@ -377,3 +377,10 @@ func WithResourceProxyTLS(tlsConfig *tls.Config) ServerOption {
 		return nil
 	}
 }
+
+func WithKeepAliveMinimumInterval(interval time.Duration) ServerOption {
+	return func(o *Server) error {
+		o.keepAliveMinimumInterval = interval
+		return nil
+	}
+}

--- a/principal/server.go
+++ b/principal/server.go
@@ -115,6 +115,10 @@ type Server struct {
 
 	// metrics holds principal side metrics
 	metrics *metrics.PrincipalMetrics
+
+	// Minimum time duration for agent to wait before sending next keepalive ping to principal
+	// if agent sends ping more often than specified interval then connection will be dropped
+	keepAliveMinimumInterval time.Duration
 }
 
 // noAuthEndpoints is a list of endpoints that are available without the need


### PR DESCRIPTION
This PR is to introduce a configurable periodic ping to keep connection alive between agent and principal using [grpc keepalive feature](https://grpc.io/docs/guides/keepalive/). 

By default it is disabled and to enable it you need to set value of `keep-alive-ping-interval` in startup script or set env variable `KEEP_ALIVE_PING_INTERVAL`  at agent side and at principal side you have to set value of `wait-duration-for-agent-ping` in startup script or set value of env variable `WAIT_DURATION_FOR_AGENT_PING` .

Fixes https://github.com/argoproj-labs/argocd-agent/issues/171