### PR TITLE
chore(build): Bump actions/cache to v4.2.0 due to deprecation

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -171,7 +171,7 @@ jobs:
           sudo chmod go-r $HOME/.kube/config
           kubectl version
       - name: Restore go build cache
-        uses: actions/cache@13aacd865c20de90d75de3b17ebe84f7a17d57d2 # v4.0.0
+        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         with:
           path: ~/.cache/go-build
           key: ${{ runner.os }}-go-build-v1-${{ github.run_id }}


### PR DESCRIPTION
**What does this PR do / why we need it**:

See https://github.com/actions/cache/discussions/1510

Our builds fail currently because we're using a deprecated version of `actions/cache`

**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:


**Checklist**

* [ ] Documentation update is required by this PR (and has been updated) OR no documentation update is required.

