### PR TITLE
fix: Allow resource proxy to proxy /api and /apis requests

### DIFF
--- a/principal/resource.go
+++ b/principal/resource.go
@@ -28,7 +28,7 @@ import (
 // resourceRequestRegexp is the regexp used to match requests for retrieving a
 // resource or a list of resources from the server. It makes use of named
 // capture groups.
-const resourceRequestRegexp = `^/(?:api|apis/(?P<group>[^\/]+))/(?P<version>v[^\/]+)(?:/(?:namespaces/(?P<namespace>[^\/]+)/)?)?(?:(?P<resource>[^\/]+)(?:/(?P<name>[^\/]+))?)?$`
+const resourceRequestRegexp = `^/(?:api|apis|(?:api|apis/(?P<group>[^\/]+))/(?P<version>v[^\/]+)(?:/(?:namespaces/(?P<namespace>[^\/]+)/)?)?(?:(?P<resource>[^\/]+)(?:/(?P<name>[^\/]+))?)?)$`
 
 // requestTimeout is the timeout that's being applied to requests for any live
 // resource.


### PR DESCRIPTION
**What does this PR do / why we need it**:

Small fix in the regular expression used by the resource proxy to also allow requests for `/api` and `/apis` without any further qualifications, to get a list of available APIs (i.e. `kubectl api-resources`).

Also adds some unit tests for the regexp itself.

**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:


**Checklist**

* [ ] Documentation update is required by this PR (and has been updated) OR no documentation update is required.

