### PR TITLE
fix: Unmanage app on agent on deletion event

### DIFF
--- a/agent/outbound.go
+++ b/agent/outbound.go
@@ -97,7 +97,9 @@ func (a *Agent) addAppDeletionToQueue(app *v1alpha1.Application) {
 	logCtx.Debugf("Delete app event")
 
 	if !a.appManager.IsManaged(app.QualifiedName()) {
-		logCtx.Tracef("App is not managed")
+		logCtx.Tracef("App is not managed, proceeding anyways")
+	} else {
+		_ = a.appManager.Unmanage(app.QualifiedName())
 	}
 
 	q := a.queues.SendQ(a.remote.ClientID())

--- a/agent/outbound_test.go
+++ b/agent/outbound_test.go
@@ -1,0 +1,150 @@
+package agent
+
+import (
+	"testing"
+
+	"github.com/argoproj-labs/argocd-agent/internal/event"
+	"github.com/argoproj-labs/argocd-agent/pkg/types"
+	"github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func Test_addAppCreationToQueue(t *testing.T) {
+	a := newAgent(t)
+	a.remote.SetClientID("agent")
+	a.emitter = event.NewEventSource("principal")
+	err := a.queues.Create("agent")
+	require.NoError(t, err)
+
+	t.Run("Add some application", func(t *testing.T) {
+		app := &v1alpha1.Application{ObjectMeta: v1.ObjectMeta{Name: "guestbook", Namespace: "agent"}}
+		a.addAppCreationToQueue(app)
+
+		// Should have an event in queue
+		ev, _ := a.queues.SendQ("agent").Get()
+		assert.NotNil(t, ev)
+		// Queue should be empty after get
+		assert.Equal(t, 0, a.queues.SendQ("agent").Len())
+
+		// App should be managed by now
+		assert.True(t, a.appManager.IsManaged("agent/guestbook"))
+	})
+
+	t.Run("Add some application that is already managed", func(t *testing.T) {
+		a.appManager.Manage("agent/guestbook")
+		app := &v1alpha1.Application{ObjectMeta: v1.ObjectMeta{Name: "guestbook", Namespace: "agent"}}
+		a.addAppCreationToQueue(app)
+
+		// Should not have an event in queue
+		items := a.queues.SendQ("agent").Len()
+		assert.Equal(t, 0, items)
+
+		// App should be managed by now
+		assert.True(t, a.appManager.IsManaged("agent/guestbook"))
+	})
+
+	t.Run("Missing queue", func(t *testing.T) {
+		a.remote.SetClientID("notexisting")
+		app := &v1alpha1.Application{ObjectMeta: v1.ObjectMeta{Name: "testapp", Namespace: "agent"}}
+		a.addAppCreationToQueue(app)
+
+		// Should not have an event in queue
+		items := a.queues.SendQ("agent").Len()
+		assert.Equal(t, 0, items)
+
+		// App should be managed by now
+		assert.True(t, a.appManager.IsManaged("agent/testapp"))
+	})
+}
+
+func Test_addAppUpdateToQueue(t *testing.T) {
+	a := newAgent(t)
+	a.remote.SetClientID("agent")
+	a.emitter = event.NewEventSource("principal")
+	err := a.queues.Create("agent")
+	require.NoError(t, err)
+
+	t.Run("Update event for autonomous agent", func(t *testing.T) {
+		app := &v1alpha1.Application{ObjectMeta: v1.ObjectMeta{Name: "guestbook", Namespace: "agent"}}
+		// App must be already managed for event to be generated
+		_ = a.appManager.Manage("agent/guestbook")
+		a.mode = types.AgentModeAutonomous
+		a.addAppUpdateToQueue(app, app)
+		defer a.appManager.Unmanage("agent/guestbook")
+
+		ev, _ := a.queues.SendQ("agent").Get()
+		require.NotNil(t, ev)
+		assert.Equal(t, event.SpecUpdate.String(), ev.Type())
+	})
+
+	t.Run("Update event for managed agent", func(t *testing.T) {
+		app := &v1alpha1.Application{ObjectMeta: v1.ObjectMeta{Name: "guestbook", Namespace: "agent"}}
+		// App must be already managed for event to be generated
+		_ = a.appManager.Manage("agent/guestbook")
+		a.mode = types.AgentModeManaged
+		a.addAppUpdateToQueue(app, app)
+		defer a.appManager.Unmanage("agent/guestbook")
+
+		ev, _ := a.queues.SendQ("agent").Get()
+		require.NotNil(t, ev)
+		assert.Equal(t, event.StatusUpdate.String(), ev.Type())
+	})
+
+	t.Run("Update event for unmanaged application", func(t *testing.T) {
+		app := &v1alpha1.Application{ObjectMeta: v1.ObjectMeta{Name: "guestbook", Namespace: "agent"}}
+		a.addAppUpdateToQueue(app, app)
+		defer a.appManager.Unmanage("agent/guestbook")
+		require.Equal(t, 0, a.queues.SendQ("agent").Len())
+	})
+
+}
+
+func Test_addAppDeletionToQueue(t *testing.T) {
+	a := newAgent(t)
+	a.remote.SetClientID("agent")
+	a.emitter = event.NewEventSource("principal")
+	err := a.queues.Create("agent")
+	require.NoError(t, err)
+
+	t.Run("Deletion event for managed application", func(t *testing.T) {
+		app := &v1alpha1.Application{ObjectMeta: v1.ObjectMeta{Name: "guestbook", Namespace: "agent"}}
+		// App must be already managed for event to be generated
+		_ = a.appManager.Manage("agent/guestbook")
+		a.addAppDeletionToQueue(app)
+		ev, _ := a.queues.SendQ("agent").Get()
+		assert.Equal(t, event.Delete.String(), ev.Type())
+		require.False(t, a.appManager.IsManaged("agent/guestbook"))
+	})
+	t.Run("Deletion event for unmanaged application", func(t *testing.T) {
+		app := &v1alpha1.Application{ObjectMeta: v1.ObjectMeta{Name: "guestbook", Namespace: "agent"}}
+		// App must be already managed for event to be generated
+		a.addAppDeletionToQueue(app)
+		ev, _ := a.queues.SendQ("agent").Get()
+		assert.Equal(t, event.Delete.String(), ev.Type())
+		require.False(t, a.appManager.IsManaged("agent/guestbook"))
+	})
+}
+
+func Test_deleteNamespaceCallback(t *testing.T) {
+	a := newAgent(t)
+	a.remote.SetClientID("agent")
+	a.emitter = event.NewEventSource("principal")
+	err := a.queues.Create("agent")
+	require.NoError(t, err)
+
+	t.Run("Delete queue with same name as namespace", func(t *testing.T) {
+		ns := &corev1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "agent"}}
+		a.deleteNamespaceCallback(ns)
+		require.False(t, a.queues.HasQueuePair("agent"))
+		// Recreate queue so that following tests will work
+		a.queues.Create("agent")
+	})
+	t.Run("Unrelated namespace deletion", func(t *testing.T) {
+		ns := &corev1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "argocd"}}
+		a.deleteNamespaceCallback(ns)
+		require.True(t, a.queues.HasQueuePair("agent"))
+	})
+}

--- a/pkg/client/remote.go
+++ b/pkg/client/remote.go
@@ -398,6 +398,12 @@ func (r *Remote) SetClientMode(mode types.AgentMode) {
 	r.clientMode = mode
 }
 
+// SetClientID sets the client ID for this remote
+// The only use case for this is to be used in unit testing.
+func (r *Remote) SetClientID(id string) {
+	r.clientID = id
+}
+
 func log() *logrus.Entry {
 	return logrus.WithField("module", "Connector")
 }


### PR DESCRIPTION
**What does this PR do / why we need it**:

When an app is deleted on the agent, it was not unmanaged. That prevented the agent from creating a new app with the same name again.

In addition, this PR adds unit tests for the agent's informer callbacks.

**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:


**Checklist**

* [ ] Documentation update is required by this PR (and has been updated) OR no documentation update is required.

