### PR TITLE
chore: Fix the README link to dev/demo env

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ See the [quickstart guide](docs/hack/quickstart.md) for more information.
 
 ## Hacking, testing, demoing
 
-For a development and demo environment, we provide [some scripts and docs](https://github.com/argoproj-labs/argocd-agent/tree/main/hack/demo-env). 
+For a development and demo environment, we provide [some scripts and docs](https://github.com/argoproj-labs/argocd-agent/tree/main/hack/dev-env).
 
 Please refer to the [Contributing](#contributing) section below for information on how to contribute.
 


### PR DESCRIPTION
**What does this PR do / why we need it**:
In the current dev/demo portion of the [README](https://github.com/argoproj-labs/argocd-agent?tab=readme-ov-file#hacking-testing-demoing), the link to the [some scripts and docs](https://github.com/argoproj-labs/argocd-agent/tree/main/hack/demo-env) is broken.
This is a quick chore fix to update the link to the correct location.

**Which issue(s) this PR fixes**:
NA chore fix.

**How to test changes / Special notes to the reviewer**:

**Checklist**

* [ ] Documentation update is required by this PR (and has been updated) OR no documentation update is required.