### PR TITLE
feat: agent and principal should resync on start up

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ setup-e2e2:
 start-e2e2: cli install-goreman
 	./hack/dev-env/gen-creds.sh
 	./hack/dev-env/create-agent-config.sh
-	goreman -f hack/dev-env/Procfile.e2e start
+	goreman -exit-on-stop=false -f hack/dev-env/Procfile.e2e start
 
 .PHONY: test-e2e2
 test-e2e2:

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -32,6 +32,7 @@ import (
 	"github.com/argoproj-labs/argocd-agent/internal/manager/appproject"
 	"github.com/argoproj-labs/argocd-agent/internal/metrics"
 	"github.com/argoproj-labs/argocd-agent/internal/queue"
+	"github.com/argoproj-labs/argocd-agent/internal/resources"
 	"github.com/argoproj-labs/argocd-agent/internal/version"
 	"github.com/argoproj-labs/argocd-agent/pkg/client"
 	"github.com/argoproj-labs/argocd-agent/pkg/types"
@@ -77,6 +78,11 @@ type Agent struct {
 
 	// metrics holds agent side metrics
 	metrics *metrics.AgentMetrics
+
+	// determines if a resync check is done with the principal when the agent restarts.
+	resyncedOnStart bool
+	// resources is a list of all the resources that are currently being managed by the agent
+	resources *resources.Resources
 }
 
 const defaultQueueName = "default"
@@ -231,6 +237,8 @@ func NewAgent(ctx context.Context, client *kube.KubernetesClient, namespace stri
 		return nil, err
 	}
 	a.namespaceManager = kubenamespace.NewKubernetesBackend(nsInformer)
+
+	a.resources = resources.NewResources()
 
 	a.syncCh = make(chan bool, 1)
 	return a, nil

--- a/agent/connection.go
+++ b/agent/connection.go
@@ -253,16 +253,16 @@ func (a *Agent) resyncOnStart(logCtx *logrus.Entry) error {
 		return fmt.Errorf("no send queue found for the remote: %s", a.remote.ClientID())
 	}
 
-	// Agent is the source of truth in autonomous mode. So, the agent must request entity
+	// Agent is the source of truth in autonomous mode. So, the agent must request resource
 	// resync with the principal
 	if a.mode == types.AgentModeAutonomous {
-		ev, err := a.emitter.RequestEntityResyncEvent()
+		ev, err := a.emitter.RequestResourceResyncEvent()
 		if err != nil {
-			return fmt.Errorf("failed to create request entity resync event: %w", err)
+			return fmt.Errorf("failed to create RequestResourceResync event: %w", err)
 		}
 
 		sendQ.Add(ev)
-		logCtx.Trace("Sent a request for entity resync")
+		logCtx.Trace("Sent a request for resource resync")
 	} else {
 		logCtx.Trace("Checking if the agent is out of sync with the principal")
 
@@ -276,18 +276,18 @@ func (a *Agent) resyncOnStart(logCtx *logrus.Entry) error {
 		resyncHandler := resync.NewRequestHandler(dynClient, sendQ, a.emitter, a.resources, logCtx)
 		go resyncHandler.SendRequestUpdates(a.context)
 
-		// Agent should request basic entity list from the principal to detect deleted
+		// Agent should request SyncedResourceList from the principal to detect deleted
 		// resources on the agent side.
 		checksum := a.resources.Checksum()
 
 		// send the checksum to the principal
-		ev, err := a.emitter.RequestBasicEntityListEvent(checksum)
+		ev, err := a.emitter.RequestSyncedResourceListEvent(checksum)
 		if err != nil {
-			return fmt.Errorf("failed to create basic entity list event: %v", err)
+			return fmt.Errorf("failed to create synced resource list event: %v", err)
 		}
 
 		sendQ.Add(ev)
-		logCtx.Trace("Sent a request for basic entity list")
+		logCtx.Trace("Sent a request for SyncedResourceList")
 	}
 	a.resyncedOnStart = true
 	return nil

--- a/agent/connection_test.go
+++ b/agent/connection_test.go
@@ -1,0 +1,73 @@
+// Copyright 2024 The argocd-agent Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package agent
+
+import (
+	"testing"
+
+	"github.com/argoproj-labs/argocd-agent/internal/event"
+	"github.com/argoproj-labs/argocd-agent/pkg/types"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestResyncOnStart(t *testing.T) {
+	a := newAgent(t)
+	a.emitter = event.NewEventSource("test")
+	logCtx := log()
+
+	err := a.queues.Create(a.remote.ClientID())
+	assert.Nil(t, err)
+
+	t.Run("should return if the agent has already been synced", func(t *testing.T) {
+		a.resyncedOnStart = true
+		err := a.resyncOnStart(logCtx)
+		assert.Nil(t, err)
+
+		sendQ := a.queues.SendQ(a.remote.ClientID())
+		assert.Zero(t, sendQ.Len())
+	})
+
+	t.Run("send request entity resync in autonomous mode", func(t *testing.T) {
+		a.resyncedOnStart = false
+		a.mode = types.AgentModeAutonomous
+		err := a.resyncOnStart(logCtx)
+		assert.Nil(t, err)
+
+		sendQ := a.queues.SendQ(a.remote.ClientID())
+		assert.Equal(t, 1, sendQ.Len())
+
+		ev, shutdown := sendQ.Get()
+		assert.False(t, shutdown)
+
+		assert.Equal(t, event.EventRequestEntityResync.String(), ev.Type())
+		assert.True(t, a.resyncedOnStart)
+	})
+
+	t.Run("send basic entity list in managed mode", func(t *testing.T) {
+		a.resyncedOnStart = false
+		a.mode = types.AgentModeManaged
+		err := a.resyncOnStart(logCtx)
+		assert.Nil(t, err)
+
+		sendQ := a.queues.SendQ(a.remote.ClientID())
+		assert.Equal(t, 1, sendQ.Len())
+
+		ev, shutdown := sendQ.Get()
+		assert.False(t, shutdown)
+
+		assert.Equal(t, event.RequestBasicEntity.String(), ev.Type())
+		assert.True(t, a.resyncedOnStart)
+	})
+}

--- a/agent/connection_test.go
+++ b/agent/connection_test.go
@@ -20,11 +20,13 @@ import (
 	"github.com/argoproj-labs/argocd-agent/internal/event"
 	"github.com/argoproj-labs/argocd-agent/pkg/types"
 	"github.com/stretchr/testify/assert"
+	"k8s.io/client-go/rest"
 )
 
 func TestResyncOnStart(t *testing.T) {
 	a := newAgent(t)
 	a.emitter = event.NewEventSource("test")
+	a.kubeClient.RestConfig = &rest.Config{}
 	logCtx := log()
 
 	err := a.queues.Create(a.remote.ClientID())

--- a/agent/connection_test.go
+++ b/agent/connection_test.go
@@ -1,4 +1,4 @@
-// Copyright 2024 The argocd-agent Authors
+// Copyright 2025 The argocd-agent Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/agent/connection_test.go
+++ b/agent/connection_test.go
@@ -41,7 +41,7 @@ func TestResyncOnStart(t *testing.T) {
 		assert.Zero(t, sendQ.Len())
 	})
 
-	t.Run("send request entity resync in autonomous mode", func(t *testing.T) {
+	t.Run("send resource resync request in autonomous mode", func(t *testing.T) {
 		a.resyncedOnStart = false
 		a.mode = types.AgentModeAutonomous
 		err := a.resyncOnStart(logCtx)
@@ -53,11 +53,11 @@ func TestResyncOnStart(t *testing.T) {
 		ev, shutdown := sendQ.Get()
 		assert.False(t, shutdown)
 
-		assert.Equal(t, event.EventRequestEntityResync.String(), ev.Type())
+		assert.Equal(t, event.EventRequestResourceResync.String(), ev.Type())
 		assert.True(t, a.resyncedOnStart)
 	})
 
-	t.Run("send basic entity list in managed mode", func(t *testing.T) {
+	t.Run("send synced resource list request in managed mode", func(t *testing.T) {
 		a.resyncedOnStart = false
 		a.mode = types.AgentModeManaged
 		err := a.resyncOnStart(logCtx)
@@ -69,7 +69,7 @@ func TestResyncOnStart(t *testing.T) {
 		ev, shutdown := sendQ.Get()
 		assert.False(t, shutdown)
 
-		assert.Equal(t, event.RequestBasicEntity.String(), ev.Type())
+		assert.Equal(t, event.SyncedResourceList.String(), ev.Type())
 		assert.True(t, a.resyncedOnStart)
 	})
 }

--- a/agent/inbound.go
+++ b/agent/inbound.go
@@ -346,31 +346,31 @@ func (a *Agent) processIncomingResourceResyncEvent(ev *event.Event) error {
 	resyncHandler := resync.NewRequestHandler(dynClient, sendQ, a.emitter, a.resources, logCtx)
 
 	switch ev.Type() {
-	case event.RequestBasicEntity:
+	case event.SyncedResourceList:
 		if a.mode != types.AgentModeAutonomous {
-			return fmt.Errorf("agent can only handle basic entity list request in the autonomous mode")
+			return fmt.Errorf("agent can only handle SyncedResourceList request in the autonomous mode")
 		}
 
-		req, err := ev.RequestBasicEntityListRequest()
+		req, err := ev.RequestSyncedResourceList()
 		if err != nil {
 			return err
 		}
 
-		return resyncHandler.ProcessBasicEntityListRequest(a.remote.ClientID(), req)
-	case event.ResponseBasicEntity:
+		return resyncHandler.ProcessSyncedResourceListRequest(a.remote.ClientID(), req)
+	case event.ResponseSyncedResource:
 		if a.mode != types.AgentModeManaged {
-			return fmt.Errorf("agent can only handle basic entity request in the managed mode")
+			return fmt.Errorf("agent can only handle SyncedResource request in the managed mode")
 		}
 
-		req, err := ev.BasicEntity()
+		req, err := ev.SyncedResource()
 		if err != nil {
 			return err
 		}
 
-		return resyncHandler.ProcessIncomingBasicEntity(a.context, req, a.remote.ClientID())
+		return resyncHandler.ProcessIncomingSyncedResource(a.context, req, a.remote.ClientID())
 	case event.EventRequestUpdate:
 		if a.mode != types.AgentModeAutonomous {
-			return fmt.Errorf("agent can only handle request update in the autonomous mode")
+			return fmt.Errorf("agent can only handle RequestUpdate in the autonomous mode")
 		}
 
 		incoming, err := ev.RequestUpdate()
@@ -381,12 +381,12 @@ func (a *Agent) processIncomingResourceResyncEvent(ev *event.Event) error {
 		incoming.Namespace = a.namespace
 
 		return resyncHandler.ProcessRequestUpdateEvent(a.context, a.remote.ClientID(), incoming)
-	case event.EventRequestEntityResync:
+	case event.EventRequestResourceResync:
 		if a.mode != types.AgentModeManaged {
-			return fmt.Errorf("agent can only handle request entity resync in the managed mode")
+			return fmt.Errorf("agent can only handle ResourceResync request in the managed mode")
 		}
 
-		return resyncHandler.ProcessIncomingRequestEntityResync(a.context, a.remote.ClientID())
+		return resyncHandler.ProcessIncomingResourceResyncRequest(a.context, a.remote.ClientID())
 	default:
 		return fmt.Errorf("invalid type of resource resync: %s", ev.Type())
 	}

--- a/agent/inbound_test.go
+++ b/agent/inbound_test.go
@@ -654,28 +654,28 @@ func Test_processIncomingResourceResyncEvent(t *testing.T) {
 	assert.Nil(t, err)
 	a.emitter = event.NewEventSource("test")
 
-	t.Run("discard basic entity list in managed mode", func(t *testing.T) {
+	t.Run("discard SyncedResourceList request in managed mode", func(t *testing.T) {
 		a.mode = types.AgentModeManaged
 
-		ev, err := a.emitter.RequestBasicEntityListEvent([]byte{})
+		ev, err := a.emitter.RequestSyncedResourceListEvent([]byte{})
 		assert.Nil(t, err)
 
-		expected := "agent can only handle basic entity list request in the autonomous mode"
+		expected := "agent can only handle SyncedResourceList request in the autonomous mode"
 		err = a.processIncomingResourceResyncEvent(event.New(ev, event.TargetResourceResync))
 		assert.Equal(t, expected, err.Error())
 	})
 
-	t.Run("process basic entity list in autonomous mode", func(t *testing.T) {
+	t.Run("process SyncedResourceList request in autonomous mode", func(t *testing.T) {
 		a.mode = types.AgentModeAutonomous
 
-		ev, err := a.emitter.RequestBasicEntityListEvent([]byte{})
+		ev, err := a.emitter.RequestSyncedResourceListEvent([]byte{})
 		assert.Nil(t, err)
 
 		err = a.processIncomingResourceResyncEvent(event.New(ev, event.TargetResourceResync))
 		assert.Nil(t, err)
 	})
 
-	t.Run("process basic entity in managed mode", func(t *testing.T) {
+	t.Run("process SyncedResources in managed mode", func(t *testing.T) {
 		a.mode = types.AgentModeManaged
 
 		res := resources.ResourceKey{
@@ -683,20 +683,20 @@ func Test_processIncomingResourceResyncEvent(t *testing.T) {
 			Namespace: "test",
 			Kind:      "Application",
 		}
-		ev, err := a.emitter.BasicEntityEvent(res)
+		ev, err := a.emitter.SyncedResourceEvent(res)
 		assert.Nil(t, err)
 
 		err = a.processIncomingResourceResyncEvent(event.New(ev, event.TargetResourceResync))
 		assert.NotNil(t, err)
 	})
 
-	t.Run("discard basic entity in autonomous mode", func(t *testing.T) {
+	t.Run("discard SyncedResources in autonomous mode", func(t *testing.T) {
 		a.mode = types.AgentModeAutonomous
 
-		ev, err := a.emitter.BasicEntityEvent(resources.ResourceKey{})
+		ev, err := a.emitter.SyncedResourceEvent(resources.ResourceKey{})
 		assert.Nil(t, err)
 
-		expected := "agent can only handle basic entity request in the managed mode"
+		expected := "agent can only handle SyncedResource request in the managed mode"
 		err = a.processIncomingResourceResyncEvent(event.New(ev, event.TargetResourceResync))
 		assert.Equal(t, expected, err.Error())
 	})
@@ -722,28 +722,28 @@ func Test_processIncomingResourceResyncEvent(t *testing.T) {
 		ev, err := a.emitter.RequestUpdateEvent(update)
 		assert.Nil(t, err)
 
-		expected := "agent can only handle request update in the autonomous mode"
+		expected := "agent can only handle RequestUpdate in the autonomous mode"
 		err = a.processIncomingResourceResyncEvent(event.New(ev, event.TargetResourceResync))
 		assert.Equal(t, expected, err.Error())
 	})
 
-	t.Run("process request entity resync in managed mode", func(t *testing.T) {
+	t.Run("process RequestResourceResync in managed mode", func(t *testing.T) {
 		a.mode = types.AgentModeManaged
 
-		ev, err := a.emitter.RequestEntityResyncEvent()
+		ev, err := a.emitter.RequestResourceResyncEvent()
 		assert.Nil(t, err)
 
 		err = a.processIncomingResourceResyncEvent(event.New(ev, event.TargetResourceResync))
 		assert.Nil(t, err)
 	})
 
-	t.Run("discard request entity resync in autonomous mode", func(t *testing.T) {
+	t.Run("discard RequestResourceResync in autonomous mode", func(t *testing.T) {
 		a.mode = types.AgentModeAutonomous
 
-		ev, err := a.emitter.RequestEntityResyncEvent()
+		ev, err := a.emitter.RequestResourceResyncEvent()
 		assert.Nil(t, err)
 
-		expected := "agent can only handle request entity resync in the managed mode"
+		expected := "agent can only handle ResourceResync request in the managed mode"
 		err = a.processIncomingResourceResyncEvent(event.New(ev, event.TargetResourceResync))
 		assert.Equal(t, expected, err.Error())
 	})

--- a/agent/outbound.go
+++ b/agent/outbound.go
@@ -16,6 +16,7 @@ package agent
 
 import (
 	"github.com/argoproj-labs/argocd-agent/internal/event"
+	"github.com/argoproj-labs/argocd-agent/internal/resources"
 	"github.com/argoproj-labs/argocd-agent/pkg/types"
 	"github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
@@ -26,6 +27,8 @@ import (
 func (a *Agent) addAppCreationToQueue(app *v1alpha1.Application) {
 	logCtx := log().WithField("event", "NewApp").WithField("application", app.QualifiedName())
 	logCtx.Debugf("New app event")
+
+	a.resources.Add(resources.NewResourceKeyFromApp(app))
 
 	// Update events trigger a new event sometimes, too. If we've already seen
 	// the app, we just ignore the request then.
@@ -100,6 +103,8 @@ func (a *Agent) addAppUpdateToQueue(old *v1alpha1.Application, new *v1alpha1.App
 func (a *Agent) addAppDeletionToQueue(app *v1alpha1.Application) {
 	logCtx := log().WithField("event", "DeleteApp").WithField("application", app.QualifiedName())
 	logCtx.Debugf("Delete app event")
+
+	a.resources.Remove(resources.NewResourceKeyFromApp(app))
 
 	if !a.appManager.IsManaged(app.QualifiedName()) {
 		logCtx.Warn("App is not managed, proceeding anyways")

--- a/internal/event/event.go
+++ b/internal/event/event.go
@@ -357,8 +357,7 @@ func (evs EventSource) RequestUpdateEvent(reqUpdate *RequestUpdate) (*cloudevent
 }
 
 // RequestEntityResync is sent by the source to a peer when the source process restarts.
-// It informs the peer that the source process restarted and it might be out of sync with the
-// source.
+// It informs the peer that the source process restarted and it might be out of sync with the source.
 type RequestEntityResync struct {
 }
 

--- a/internal/event/event.go
+++ b/internal/event/event.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/argoproj-labs/argocd-agent/internal/grpcutil"
+	"github.com/argoproj-labs/argocd-agent/internal/resources"
 	"github.com/argoproj-labs/argocd-agent/pkg/api/grpc/eventstreamapi"
 	"github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
 	"github.com/google/uuid"
@@ -46,25 +47,30 @@ const TypePrefix = "io.argoproj.argocd-agent.event"
 // Supported EventTypes that are sent agent <-> principal. Note that not every
 // EventType is supported by every EventTarget.
 const (
-	Ping            EventType = TypePrefix + ".ping"
-	Pong            EventType = TypePrefix + ".pong"
-	Create          EventType = TypePrefix + ".create"
-	Delete          EventType = TypePrefix + ".delete"
-	Update          EventType = TypePrefix + ".update"
-	SpecUpdate      EventType = TypePrefix + ".spec-update"
-	StatusUpdate    EventType = TypePrefix + ".status-update"
-	OperationUpdate EventType = TypePrefix + ".operation-update"
-	EventProcessed  EventType = TypePrefix + ".processed"
-	GetRequest      EventType = TypePrefix + ".get"
-	GetResponse     EventType = TypePrefix + ".response"
+	Ping                     EventType = TypePrefix + ".ping"
+	Pong                     EventType = TypePrefix + ".pong"
+	Create                   EventType = TypePrefix + ".create"
+	Delete                   EventType = TypePrefix + ".delete"
+	Update                   EventType = TypePrefix + ".update"
+	SpecUpdate               EventType = TypePrefix + ".spec-update"
+	StatusUpdate             EventType = TypePrefix + ".status-update"
+	OperationUpdate          EventType = TypePrefix + ".operation-update"
+	EventProcessed           EventType = TypePrefix + ".processed"
+	GetRequest               EventType = TypePrefix + ".get"
+	GetResponse              EventType = TypePrefix + ".response"
+	RequestBasicEntity       EventType = TypePrefix + ".request-basic-entity-list"
+	ResponseBasicEntity      EventType = TypePrefix + ".response-basic-entity"
+	EventRequestUpdate       EventType = TypePrefix + ".request-update"
+	EventRequestEntityResync EventType = TypePrefix + ".request-entity-resync"
 )
 
 const (
-	TargetUnknown     EventTarget = "unknown"
-	TargetApplication EventTarget = "application"
-	TargetAppProject  EventTarget = "appproject"
-	TargetEventAck    EventTarget = "eventProcessed"
-	TargetResource    EventTarget = "resource"
+	TargetUnknown        EventTarget = "unknown"
+	TargetApplication    EventTarget = "application"
+	TargetAppProject     EventTarget = "appproject"
+	TargetEventAck       EventTarget = "eventProcessed"
+	TargetResource       EventTarget = "resource"
+	TargetResourceResync EventTarget = "resourceResync"
 )
 
 const (
@@ -256,6 +262,122 @@ func (evs EventSource) ProcessedEvent(evType EventType, ev *Event) *cloudevents.
 	return &cev
 }
 
+// RequestBasicEntityList is sent by a peer to the source when the peer process restarts.
+// Peer sends a checksum of all the resource keys to the source to detect orphaned resources.
+// Managed mode: Sent from Agent to Principal
+// Autonomous mode: Sent from Principal to Agent
+type RequestBasicEntityList struct {
+	// checksum of all the resource keys managed by that component
+	Checksum []byte `json:"checksum"`
+}
+
+func (evs EventSource) RequestBasicEntityListEvent(checksum []byte) (*cloudevents.Event, error) {
+	reqUUID := uuid.NewString()
+	req := &RequestBasicEntityList{
+		Checksum: checksum,
+	}
+
+	cev := cloudevents.NewEvent()
+	cev.SetSource(evs.source)
+	cev.SetSpecVersion(cloudEventSpecVersion)
+	cev.SetType(RequestBasicEntity.String())
+	cev.SetDataSchema(TargetResourceResync.String())
+	cev.SetExtension(resourceID, reqUUID)
+	cev.SetExtension(eventID, reqUUID)
+
+	err := cev.SetData(cloudevents.ApplicationJSON, req)
+	return &cev, err
+}
+
+// BasicEntity is a response to the BasicEntityList request and is sent for each resource managed by the source.
+// On receiving the BasicEntityList request, the source will calculate the checksum of all its resource keys.
+// If the checksum doesn't match, the source will send the BasicEntity event for each resource.
+type BasicEntity struct {
+	Name      string `json:"name"`
+	Namespace string `json:"namespace,omitempty"`
+	UID       string `json:"uid"`
+	Kind      string `json:"kind"`
+}
+
+func (evs EventSource) BasicEntityEvent(resourceKey resources.ResourceKey) (*cloudevents.Event, error) {
+	reqUUID := uuid.NewString()
+	basicEntity := BasicEntity{
+		Name:      resourceKey.Name,
+		Namespace: resourceKey.Namespace,
+		UID:       resourceKey.UID,
+		Kind:      resourceKey.Kind,
+	}
+
+	cev := cloudevents.NewEvent()
+	cev.SetSource(evs.source)
+	cev.SetSpecVersion(cloudEventSpecVersion)
+	cev.SetType(ResponseBasicEntity.String())
+	cev.SetDataSchema(TargetResourceResync.String())
+	cev.SetExtension(resourceID, reqUUID)
+	cev.SetExtension(eventID, reqUUID)
+
+	err := cev.SetData(cloudevents.ApplicationJSON, basicEntity)
+	return &cev, err
+}
+
+// RequestUpdate is used to request the latest content of a resource and is
+// sent from a peer to the source of truth. The peer calculates the spec checksum
+// of a resource and sends it in the RequestUpdate event. The source will calculate
+// the spec checksum on its side and sends a SpecUpdate event if the checksums don't match.
+type RequestUpdate struct {
+	Name      string `json:"name"`
+	Namespace string `json:"namespace,omitempty"`
+	UID       string `json:"uid"`
+	Kind      string `json:"kind"`
+	Checksum  []byte `json:"checksum"`
+}
+
+func NewRequestUpdate(name, namespace, kind, uid string, checksum []byte) *RequestUpdate {
+	return &RequestUpdate{
+		Name:      name,
+		Namespace: namespace,
+		UID:       uid,
+		Kind:      kind,
+		Checksum:  checksum,
+	}
+}
+
+func (evs EventSource) RequestUpdateEvent(reqUpdate *RequestUpdate) (*cloudevents.Event, error) {
+	reqUUID := uuid.NewString()
+	cev := cloudevents.NewEvent()
+	cev.SetSource(evs.source)
+	cev.SetSpecVersion(cloudEventSpecVersion)
+	cev.SetType(EventRequestUpdate.String())
+	cev.SetDataSchema(TargetResourceResync.String())
+	cev.SetExtension(resourceID, reqUUID)
+	cev.SetExtension(eventID, reqUUID)
+
+	err := cev.SetData(cloudevents.ApplicationJSON, reqUpdate)
+	return &cev, err
+}
+
+// RequestEntityResync is sent by the source to a peer when the source process restarts.
+// It informs the peer that the source process restarted and it might be out of sync with the
+// source.
+type RequestEntityResync struct {
+}
+
+func (evs EventSource) RequestEntityResyncEvent() (*cloudevents.Event, error) {
+	reqUUID := uuid.NewString()
+	req := &RequestEntityResync{}
+
+	cev := cloudevents.NewEvent()
+	cev.SetSource(evs.source)
+	cev.SetSpecVersion(cloudEventSpecVersion)
+	cev.SetType(EventRequestEntityResync.String())
+	cev.SetDataSchema(TargetResourceResync.String())
+	cev.SetExtension(resourceID, reqUUID)
+	cev.SetExtension(eventID, reqUUID)
+
+	err := cev.SetData(cloudevents.ApplicationJSON, req)
+	return &cev, err
+}
+
 // FromWire validates an event from the wire in protobuf format, converts it
 // into an Event object and returns it. If the event on the wire is invalid,
 // or could not be converted for another reason, FromWire returns an error.
@@ -283,6 +405,8 @@ func Target(raw *cloudevents.Event) EventTarget {
 		return TargetResource
 	case TargetEventAck.String():
 		return TargetEventAck
+	case TargetResourceResync.String():
+		return TargetResourceResync
 	}
 	return ""
 }
@@ -347,6 +471,30 @@ func (ev Event) ResourceResponse() (*ResourceResponse, error) {
 	return resp, err
 }
 
+func (ev Event) RequestBasicEntityListRequest() (*RequestBasicEntityList, error) {
+	basicEntityList := &RequestBasicEntityList{}
+	err := ev.event.DataAs(basicEntityList)
+	return basicEntityList, err
+}
+
+func (ev Event) BasicEntity() (*BasicEntity, error) {
+	basicEntity := &BasicEntity{}
+	err := ev.event.DataAs(basicEntity)
+	return basicEntity, err
+}
+
+func (ev Event) RequestEntityResync() (*RequestEntityResync, error) {
+	reqEntity := &RequestEntityResync{}
+	err := ev.event.DataAs(reqEntity)
+	return reqEntity, err
+}
+
+func (ev Event) RequestUpdate() (*RequestUpdate, error) {
+	reqUpdate := &RequestUpdate{}
+	err := ev.event.DataAs(reqUpdate)
+	return reqUpdate, err
+}
+
 type streamWriter interface {
 	Send(*eventstreamapi.Event) error
 	Context() context.Context
@@ -398,6 +546,7 @@ func (ew *EventWriter) Add(ev *cloudevents.Event) {
 	logCtx := ew.log.WithFields(logrus.Fields{
 		"resource_id": ResourceID(ev),
 		"event_id":    EventID(ev),
+		"type":        ev.Type(),
 	})
 
 	ew.mu.Lock()

--- a/internal/manager/appproject/appproject.go
+++ b/internal/manager/appproject/appproject.go
@@ -174,6 +174,10 @@ func createAppProject(ctx context.Context, m *AppProjectManager, project *v1alph
 	return nil, nil
 }
 
+func (m *AppProjectManager) Get(ctx context.Context, name, namespace string) (*v1alpha1.AppProject, error) {
+	return m.appprojectBackend.Get(ctx, name, namespace)
+}
+
 // UpdateAppProject updates the AppProject resource on the agent's backend.
 //
 // The AppProject on the agent will inherit labels and annotations as well as the spec

--- a/internal/resources/resources.go
+++ b/internal/resources/resources.go
@@ -15,7 +15,7 @@
 package resources
 
 import (
-	"crypto/md5"
+	"crypto/sha256"
 	"fmt"
 	"sort"
 	"strings"
@@ -217,18 +217,18 @@ func (r *Resources) Checksum() []byte {
 	}
 
 	if len(resources) != 0 {
-		return calculateChecksum(resources)
+		return calculateSHA256(resources)
 	}
 
 	return nil
 }
 
-func calculateChecksum(item []string) []byte {
+func calculateSHA256(item []string) []byte {
 	// sort the items to ensure a consistent hash
 	sort.Strings(item)
 
 	joinedItems := strings.Join(item, "")
-	hash := md5.Sum([]byte(joinedItems))
+	hash := sha256.Sum256([]byte(joinedItems))
 
 	return hash[:]
 }

--- a/internal/resources/resources.go
+++ b/internal/resources/resources.go
@@ -1,4 +1,4 @@
-// Copyright 2024 The argocd-agent Authors
+// Copyright 2025 The argocd-agent Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -151,9 +151,9 @@ func (r *AgentResources) Checksum(agent string) []byte {
 	return agentResources.Checksum()
 }
 
-// Resources is a map of all the resources that are currently in the cluster.
-// It is dynamically populated when handling informer events and is used to quickly generate the
-// checksum and send resync messages without having to query the API server.
+// Resources is a map of all the resources(apps,appProjects,etc) that are managed by the agent/principal.
+// It is dynamically populated by the agent/principal while handling informer events and is used
+// to quickly generate the checksum and send resync messages without having to query the API server.
 type Resources struct {
 	// key: ResourceKey of the resource
 	resources map[ResourceKey]bool

--- a/internal/resources/resources.go
+++ b/internal/resources/resources.go
@@ -15,7 +15,7 @@
 package resources
 
 import (
-	"crypto/sha256"
+	"crypto/md5"
 	"fmt"
 	"sort"
 	"strings"
@@ -217,18 +217,18 @@ func (r *Resources) Checksum() []byte {
 	}
 
 	if len(resources) != 0 {
-		return calculateSHA256(resources)
+		return calculateChecksum(resources)
 	}
 
 	return nil
 }
 
-func calculateSHA256(item []string) []byte {
+func calculateChecksum(item []string) []byte {
 	// sort the items to ensure a consistent hash
 	sort.Strings(item)
 
 	joinedItems := strings.Join(item, "")
-	hash := sha256.Sum256([]byte(joinedItems))
+	hash := md5.Sum([]byte(joinedItems))
 
 	return hash[:]
 }

--- a/internal/resources/resources.go
+++ b/internal/resources/resources.go
@@ -1,0 +1,234 @@
+// Copyright 2024 The argocd-agent Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resources
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"sort"
+	"strings"
+	"sync"
+
+	"github.com/argoproj-labs/argocd-agent/internal/manager"
+	"github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
+)
+
+const (
+	applicationKind = "Application"
+	appProjectKind  = "AppProject"
+)
+
+// ResourceKey uniquely identifies a resource in the cluster
+type ResourceKey struct {
+	Name      string
+	Namespace string
+	Kind      string
+
+	// Source UID of the resource. It should be same for both agent and principal.
+	// Source: .ObjectMeta.UID of the resource in the cluster
+	// Peer: UID from the source-uid annotation
+	UID string
+}
+
+func (r *ResourceKey) String() string {
+	return fmt.Sprintf("%s/%s/%s/%s", r.Kind, r.Namespace, r.Name, r.UID)
+}
+
+func NewResourceKeyFromApp(app *v1alpha1.Application) ResourceKey {
+	// sourceUID annotation indicates that the app was created from a source.
+	// So, consider the source UID instead of the resource UID.
+	sourceUID, ok := app.Annotations[manager.SourceUIDAnnotation]
+	if ok {
+		return newResourceKey(applicationKind, app.Name, app.Namespace, sourceUID)
+	}
+
+	return newResourceKey(applicationKind, app.Name, app.Namespace, string(app.UID))
+}
+
+func NewResourceKeyFromAppProject(appProject *v1alpha1.AppProject) ResourceKey {
+	// sourceUID annotation indicates that the app was created from a source.
+	// So, consider the source UID instead of the resource UID.
+	sourceUID, ok := appProject.Annotations[manager.SourceUIDAnnotation]
+	if ok {
+		return newResourceKey(appProjectKind, appProject.Name, appProject.Namespace, sourceUID)
+	}
+
+	return newResourceKey(appProjectKind, appProject.Name, appProject.Namespace, string(appProject.UID))
+}
+
+func newResourceKey(kind, name, namespace, uid string) ResourceKey {
+	return ResourceKey{
+		Kind:      kind,
+		Namespace: namespace,
+		Name:      name,
+		UID:       uid,
+	}
+}
+
+// AgentResources keeps track of all the resources that are associated with a specific agent
+type AgentResources struct {
+	// key: agent name
+	resources map[string]*Resources
+
+	mu sync.RWMutex
+}
+
+func NewAgentResources() *AgentResources {
+	return &AgentResources{
+		resources: make(map[string]*Resources),
+	}
+}
+
+func (r *AgentResources) Add(agent string, key ResourceKey) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if r.resources[agent] == nil {
+		r.resources[agent] = NewResources()
+	}
+
+	r.resources[agent].Add(key)
+}
+
+func (r *AgentResources) Remove(agent string, key ResourceKey) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	r.resources[agent].Remove(key)
+
+	if len(r.resources[agent].resources) == 0 {
+		delete(r.resources, agent)
+	}
+}
+
+func (r *AgentResources) GetAllResources(agent string) []ResourceKey {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	res, ok := r.resources[agent]
+	if ok {
+		return res.GetAll()
+	}
+
+	return []ResourceKey{}
+}
+
+func (r *AgentResources) Get(agent string) *Resources {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	return r.resources[agent]
+}
+
+func (r *AgentResources) Len() int {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	return len(r.resources)
+}
+
+func (r *AgentResources) Checksum(agent string) []byte {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	agentResources, ok := r.resources[agent]
+	if !ok {
+		return []byte{}
+	}
+
+	return agentResources.Checksum()
+}
+
+// Resources is a map of all the resources that are currently in the cluster.
+// It is dynamically populated when handling informer events and is used to quickly generate the
+// checksum and send resync messages without having to query the API server.
+type Resources struct {
+	// key: ResourceKey of the resource
+	resources map[ResourceKey]bool
+
+	mu sync.RWMutex
+}
+
+func NewResources() *Resources {
+	return &Resources{
+		resources: make(map[ResourceKey]bool),
+	}
+}
+
+func (r *Resources) Add(key ResourceKey) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	r.resources[key] = true
+}
+
+func (r *Resources) Len() int {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	return len(r.resources)
+}
+
+func (r *Resources) Remove(key ResourceKey) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	delete(r.resources, key)
+}
+
+func (r *Resources) GetAll() []ResourceKey {
+	if r == nil {
+		return []ResourceKey{}
+	}
+
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	res := make([]ResourceKey, 0, len(r.resources))
+	for item := range r.resources {
+		res = append(res, item)
+	}
+
+	return res
+}
+
+// Checksum calculates the checksum of all the resources keys
+func (r *Resources) Checksum() []byte {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	resources := make([]string, 0, len(r.resources))
+	for res := range r.resources {
+		// we are omitting the namespace while calculating checksum because the
+		// resource namespace might differ on the agent and principal
+		resources = append(resources, fmt.Sprintf("%s/%s/%s", res.Kind, res.Name, res.UID))
+	}
+
+	if len(resources) != 0 {
+		return calculateSHA256(resources)
+	}
+
+	return nil
+}
+
+func calculateSHA256(item []string) []byte {
+	// sort the items to ensure a consistent hash
+	sort.Strings(item)
+
+	joinedItems := strings.Join(item, "")
+	hash := sha256.Sum256([]byte(joinedItems))
+
+	return hash[:]
+}

--- a/internal/resources/resources_test.go
+++ b/internal/resources/resources_test.go
@@ -1,4 +1,4 @@
-// Copyright 2024 The argocd-agent Authors
+// Copyright 2025 The argocd-agent Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/resources/resources_test.go
+++ b/internal/resources/resources_test.go
@@ -1,0 +1,168 @@
+// Copyright 2024 The argocd-agent Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resources
+
+import (
+	"fmt"
+	"strconv"
+	"testing"
+
+	"github.com/argoproj-labs/argocd-agent/internal/manager"
+	"github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+func Test_NewResourceKey(t *testing.T) {
+	app := &v1alpha1.Application{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-app",
+			Namespace: "default",
+			UID:       "12345",
+		},
+	}
+
+	appProject := &v1alpha1.AppProject{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-appproject",
+			Namespace: "default",
+			UID:       "67890",
+		},
+	}
+
+	expected := ResourceKey{
+		Kind:      applicationKind,
+		Name:      "test-app",
+		Namespace: "default",
+		UID:       "12345",
+	}
+
+	t.Run("resource key for an app without sourceUID annotation", func(t *testing.T) {
+		got := NewResourceKeyFromApp(app)
+		assert.Equal(t, expected, got)
+	})
+
+	t.Run("resource key for an app resource with sourceUID annotation", func(t *testing.T) {
+		app.Annotations = map[string]string{
+			manager.SourceUIDAnnotation: "source-uid-123",
+		}
+
+		expected.UID = app.Annotations[manager.SourceUIDAnnotation]
+
+		got := NewResourceKeyFromApp(app)
+		assert.Equal(t, expected, got)
+	})
+
+	t.Run("resource key for an appProject without sourceUID annotation", func(t *testing.T) {
+		expected := ResourceKey{
+			Kind:      appProjectKind,
+			Name:      "test-appproject",
+			Namespace: "default",
+			UID:       "67890",
+		}
+
+		got := NewResourceKeyFromAppProject(appProject)
+		assert.Equal(t, expected, got)
+	})
+
+	t.Run("resource key for an appProject resource with sourceUID annotation", func(t *testing.T) {
+		appProject.Annotations = map[string]string{
+			manager.SourceUIDAnnotation: "source-uid-456",
+		}
+
+		expected := ResourceKey{
+			Kind:      appProjectKind,
+			Name:      "test-appproject",
+			Namespace: "default",
+			UID:       "source-uid-456",
+		}
+
+		got := NewResourceKeyFromAppProject(appProject)
+		assert.Equal(t, expected, got)
+	})
+}
+
+func Test_AgentResources(t *testing.T) {
+	res := NewAgentResources()
+
+	resKeys := make([]ResourceKey, 10)
+	for i := 0; i < 10; i++ {
+		app := &v1alpha1.Application{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      fmt.Sprintf("test-%d", i),
+				Namespace: "default",
+				UID:       types.UID(strconv.Itoa(i)),
+			},
+		}
+
+		resKeys[i] = NewResourceKeyFromApp(app)
+	}
+
+	// Add the resources
+	for i := 0; i < len(resKeys)/2; i++ {
+		res.Add("first", resKeys[i])
+	}
+
+	for i := len(resKeys) / 2; i < len(resKeys); i++ {
+		res.Add("second", resKeys[i])
+	}
+
+	isEqualSlice := func(a, b []ResourceKey) bool {
+		if len(a) != len(b) {
+			return false
+		}
+
+		freq := map[ResourceKey]int{}
+		for i := 0; i < len(a); i++ {
+			freq[a[i]]++
+		}
+
+		for i := 0; i < len(b); i++ {
+			if freq[b[i]] == 0 {
+				return false
+			}
+			freq[b[i]]--
+		}
+		return true
+	}
+
+	assert.Equal(t, 2, res.Len())
+	assert.Equal(t, 2, res.Len())
+
+	// Verify if they are added to the correct resource map
+	first := res.GetAllResources("first")
+	assert.Len(t, first, 5)
+	assert.True(t, isEqualSlice(first, resKeys[:5]))
+
+	second := res.GetAllResources("second")
+	assert.Len(t, second, 5)
+	assert.True(t, isEqualSlice(second, resKeys[5:]))
+
+	assert.NotNil(t, res.Checksum("first"))
+	assert.NotNil(t, res.Checksum("second"))
+
+	// Remove all the resources
+	for i := 0; i < len(resKeys)/2; i++ {
+		res.Remove("first", resKeys[i])
+	}
+
+	for i := len(resKeys) / 2; i < len(resKeys); i++ {
+		res.Remove("second", resKeys[i])
+	}
+
+	assert.Empty(t, res.Checksum("first"))
+	assert.Empty(t, res.Checksum("second"))
+}

--- a/internal/resync/resync.go
+++ b/internal/resync/resync.go
@@ -17,7 +17,7 @@ package resync
 import (
 	"bytes"
 	"context"
-	"crypto/md5"
+	"crypto/sha256"
 	"encoding/json"
 	"fmt"
 
@@ -355,7 +355,7 @@ func generateSpecChecksum(resObj *unstructured.Unstructured) ([]byte, error) {
 		return nil, fmt.Errorf("failed to marshal application spec: %v", err)
 	}
 
-	checksum := md5.Sum(specBytes)
+	checksum := sha256.Sum256(specBytes)
 
 	return checksum[:], nil
 }

--- a/internal/resync/resync.go
+++ b/internal/resync/resync.go
@@ -1,4 +1,4 @@
-// Copyright 2024 The argocd-agent Authors
+// Copyright 2025 The argocd-agent Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/resync/resync.go
+++ b/internal/resync/resync.go
@@ -17,7 +17,7 @@ package resync
 import (
 	"bytes"
 	"context"
-	"crypto/sha256"
+	"crypto/md5"
 	"encoding/json"
 	"fmt"
 
@@ -355,7 +355,7 @@ func generateSpecChecksum(resObj *unstructured.Unstructured) ([]byte, error) {
 		return nil, fmt.Errorf("failed to marshal application spec: %v", err)
 	}
 
-	checksum := sha256.Sum256(specBytes)
+	checksum := md5.Sum(specBytes)
 
 	return checksum[:], nil
 }

--- a/internal/resync/resync.go
+++ b/internal/resync/resync.go
@@ -1,0 +1,346 @@
+// Copyright 2024 The argocd-agent Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resync
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+
+	"github.com/argoproj-labs/argocd-agent/internal/event"
+	"github.com/argoproj-labs/argocd-agent/internal/manager"
+	"github.com/argoproj-labs/argocd-agent/internal/resources"
+	"github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
+	cloudevent "github.com/cloudevents/sdk-go/v2/event"
+	"github.com/sirupsen/logrus"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/util/workqueue"
+)
+
+// RequestHandler handles all the resync requests that are exchanged when the agent/principal process restarts.
+// Depending on the agent mode, the sync messages are common to both the agent and the principal.
+type RequestHandler struct {
+	dynClient dynamic.Interface
+
+	sendQ workqueue.TypedRateLimitingInterface[*cloudevent.Event]
+
+	events *event.EventSource
+
+	resources *resources.Resources
+
+	log *logrus.Entry
+}
+
+func NewRequestHandler(dynClient dynamic.Interface, queue workqueue.TypedRateLimitingInterface[*cloudevent.Event], events *event.EventSource, resources *resources.Resources, log *logrus.Entry) *RequestHandler {
+	return &RequestHandler{
+		dynClient: dynClient,
+		sendQ:     queue,
+		events:    events,
+		log:       log,
+		resources: resources,
+	}
+}
+
+func (r *RequestHandler) ProcessBasicEntityListRequest(agentName string, req *event.RequestBasicEntityList) error {
+	r.log.Trace("Received a request for basic entity list")
+
+	if r.resources == nil || r.resources.Len() == 0 {
+		r.log.Trace("No resources found for this agent. Skipping basic entity.")
+		return nil
+	}
+
+	checksum := r.resources.Checksum()
+	if bytes.Equal(req.Checksum, checksum) {
+		r.log.Info("Agent and Principal checksums match. Skipping basic entity")
+		return nil
+	}
+
+	// At this stage we know that the agent and the principal are out of sync.
+	// We need to send the basic entity for each resource to the agent.
+
+	r.log.Info("Agent and Principal checksums do not match, sending the basic entity of all resources")
+
+	resources := r.resources.GetAll()
+	for _, res := range resources {
+		ev, err := r.events.BasicEntityEvent(res)
+		if err != nil {
+			return fmt.Errorf("failed to create basic entity event: %w", err)
+		}
+
+		r.log.WithField("name", res.Name).WithField("kind", res.Kind).Trace("Sent basic entity")
+		r.sendQ.Add(ev)
+	}
+
+	return nil
+}
+
+func (r *RequestHandler) ProcessIncomingBasicEntity(ctx context.Context, incoming *event.BasicEntity, agentID string) error {
+	logCtx := r.log.WithFields(logrus.Fields{
+		"kind":      incoming.Kind,
+		"namespace": incoming.Namespace,
+		"name":      incoming.Name,
+		"uid":       incoming.UID,
+	})
+
+	logCtx.Trace("Received a basic entity event")
+
+	var reqUpdate *event.RequestUpdate
+
+	gvr, err := getGroupVersionResource(incoming.Kind)
+	if err != nil {
+		return err
+	}
+
+	// Check if the given resource exists locally
+	resClient := r.dynClient.Resource(gvr)
+	res, err := resClient.Namespace(incoming.Namespace).Get(ctx, incoming.Name, v1.GetOptions{})
+	if err != nil {
+		if !apierrors.IsNotFound(err) {
+			return err
+		}
+
+		// The incoming app is not found locally
+		reqUpdate = event.NewRequestUpdate(incoming.Name, incoming.Namespace, incoming.Kind, "", nil)
+	} else {
+		reqUpdate, err = newRequestUpdateFromObject(res)
+		if err != nil {
+			return fmt.Errorf("failed to construct a request update for resource: %s", res.GetName())
+		}
+	}
+
+	reqUpdateEvent, err := r.events.RequestUpdateEvent(reqUpdate)
+	if err != nil {
+		return err
+	}
+
+	r.sendQ.Add(reqUpdateEvent)
+	logCtx.Trace("Sent a request update event after processing the basic entity request")
+
+	return nil
+}
+
+func (r *RequestHandler) ProcessIncomingRequestEntityResync(ctx context.Context, queueID string) error {
+	r.log.Trace("Received a request for entity resync")
+
+	resources := r.resources.GetAll()
+	for _, resource := range resources {
+		gvr, err := getGroupVersionResource(resource.Kind)
+		if err != nil {
+			return err
+		}
+
+		resClient := r.dynClient.Resource(gvr)
+		res, err := resClient.Namespace(resource.Namespace).Get(ctx, resource.Name, v1.GetOptions{})
+		if err != nil {
+			r.log.Errorf("failed to get resource: %v", err)
+			continue
+		}
+
+		reqUpdate, err := newRequestUpdateFromObject(res)
+		if err != nil {
+			r.log.Errorf("failed to construct a request update from resource: %s", resource.Name)
+			continue
+		}
+
+		ev, err := r.events.RequestUpdateEvent(reqUpdate)
+		if err != nil {
+			r.log.Errorf("failed to create request update event: %v", err)
+			continue
+		}
+
+		r.sendQ.Add(ev)
+		r.log.WithField("kind", resource.Kind).WithField("name", resource.Name).Trace("Sent a request update event after processing the entity resync")
+	}
+
+	return nil
+}
+
+func (r *RequestHandler) ProcessRequestUpdateEvent(ctx context.Context, agentName string, reqUpdate *event.RequestUpdate) error {
+	logCtx := r.log.WithFields(logrus.Fields{
+		"name":      reqUpdate.Name,
+		"kind":      reqUpdate.Kind,
+		"namespace": reqUpdate.Namespace,
+	})
+
+	logCtx.Trace("Received a request for the resource update event")
+
+	gvr, err := getGroupVersionResource(reqUpdate.Kind)
+	if err != nil {
+		return err
+	}
+
+	// Check if the given resource exists locally
+	resClient := r.dynClient.Resource(gvr)
+	res, err := resClient.Namespace(reqUpdate.Namespace).Get(ctx, reqUpdate.Name, v1.GetOptions{})
+	if err != nil {
+		if !apierrors.IsNotFound(err) {
+			return err
+		}
+
+		// The resource doesn't exist on the source. So, send a delete event to remove the orphaned resource from the peer.
+		return r.handleDeletedResource(logCtx, reqUpdate)
+	}
+
+	// The resource exists on the source. Compare the checksum and check if we need to send a SpecUpdate event.
+	checksum, err := generateSpecChecksum(res)
+	if err != nil {
+		return fmt.Errorf("failed to generate checksum for resource %s/%s: %w", res.GetKind(), res.GetName(), err)
+	}
+
+	// Do nothing if the incoming spec and the existing spec matches
+	if bytes.Equal(checksum[:], reqUpdate.Checksum) {
+		logCtx.Trace("Checksum of the incoming request update matches with the local resource")
+		return nil
+	}
+
+	logCtx.Trace("Checksums do not match. Sending a specUpdate event")
+
+	return r.handleUpdatedResource(logCtx, reqUpdate, res)
+}
+
+func (r *RequestHandler) handleUpdatedResource(logCtx *logrus.Entry, reqUpdate *event.RequestUpdate, res *unstructured.Unstructured) error {
+	resBytes, err := res.MarshalJSON()
+	if err != nil {
+		return err
+	}
+
+	switch reqUpdate.Kind {
+	case "Application":
+		app := &v1alpha1.Application{}
+		err := json.Unmarshal(resBytes, app)
+		if err != nil {
+			return err
+		}
+
+		ev := r.events.ApplicationEvent(event.SpecUpdate, app)
+		logCtx.Trace("Sending a request to update the application")
+		r.sendQ.Add(ev)
+
+	case "AppProject":
+		appProject := &v1alpha1.AppProject{}
+		err := json.Unmarshal(resBytes, appProject)
+		if err != nil {
+			return err
+		}
+
+		ev := r.events.AppProjectEvent(event.SpecUpdate, appProject)
+		logCtx.Trace("Sending a request to update the appProject")
+		r.sendQ.Add(ev)
+	default:
+		return fmt.Errorf("unknown resource Kind: %s", reqUpdate.Kind)
+	}
+
+	return nil
+}
+
+func (r *RequestHandler) handleDeletedResource(logCtx *logrus.Entry, reqUpdate *event.RequestUpdate) error {
+	switch reqUpdate.Kind {
+	case "Application":
+		app := &v1alpha1.Application{
+			ObjectMeta: v1.ObjectMeta{
+				Name:      reqUpdate.Name,
+				Namespace: reqUpdate.Namespace,
+			},
+		}
+
+		ev := r.events.ApplicationEvent(event.Delete, app)
+		logCtx.Trace("Sending a request to delete the orphaned application")
+		r.sendQ.Add(ev)
+		return nil
+
+	case "AppProject":
+		appProject := &v1alpha1.AppProject{
+			ObjectMeta: v1.ObjectMeta{
+				Name:      reqUpdate.Name,
+				Namespace: reqUpdate.Namespace,
+			},
+		}
+		ev := r.events.AppProjectEvent(event.Delete, appProject)
+		logCtx.Trace("Sending a request to delete the orphaned appProject")
+		r.sendQ.Add(ev)
+		return nil
+	default:
+		return fmt.Errorf("unknown resource Kind: %s", reqUpdate.Kind)
+	}
+}
+
+func newRequestUpdateFromObject(res *unstructured.Unstructured) (*event.RequestUpdate, error) {
+	// RequestUpdate is always sent by the peer. So, the object must have the source UID annotation
+	annotations := res.GetAnnotations()
+	sourceUID, ok := annotations[manager.SourceUIDAnnotation]
+	if !ok {
+		return nil, fmt.Errorf("source UID annotation not found for resource: %s", res.GetName())
+	}
+
+	checksum, err := generateSpecChecksum(res)
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate checksum for resource %s/%s: %w", res.GetKind(), res.GetName(), err)
+	}
+
+	reqUpdate := event.NewRequestUpdate(res.GetName(), res.GetNamespace(), res.GetKind(), sourceUID, checksum[:])
+	return reqUpdate, nil
+}
+
+func getGroupVersionResource(kind string) (schema.GroupVersionResource, error) {
+	switch kind {
+	case "Application":
+		return schema.GroupVersionResource{
+			Group:    "argoproj.io",
+			Resource: "applications",
+			Version:  "v1alpha1",
+		}, nil
+	case "AppProject":
+		return schema.GroupVersionResource{
+			Group:    "argoproj.io",
+			Resource: "appprojects",
+			Version:  "v1alpha1",
+		}, nil
+	default:
+		return schema.GroupVersionResource{}, fmt.Errorf("unexpected Kind: %s", kind)
+	}
+}
+
+func generateSpecChecksum(resObj *unstructured.Unstructured) ([]byte, error) {
+	res := resObj.DeepCopy()
+
+	resSpec, ok := res.Object["spec"]
+	if !ok {
+		return nil, fmt.Errorf("spec field not found for resource: %s", res.GetName())
+	}
+
+	specMap, ok := resSpec.(map[string]interface{})
+	if !ok {
+		return nil, fmt.Errorf("unable to convert the spec object of %s:%s to a map", res.GetKind(), res.GetName())
+	}
+
+	// The destination field will be modified to "in-cluster" by the agent.
+	// Principal and the agent checksums will differ if we don't remove the destination field.
+	delete(specMap, "destination")
+
+	specBytes, err := json.Marshal(resSpec)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal application spec: %v", err)
+	}
+
+	checksum := sha256.Sum256(specBytes)
+
+	return checksum[:], nil
+}

--- a/internal/resync/resync_test.go
+++ b/internal/resync/resync_test.go
@@ -1,4 +1,4 @@
-// Copyright 2024 The argocd-agent Authors
+// Copyright 2025 The argocd-agent Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/resync/resync_test.go
+++ b/internal/resync/resync_test.go
@@ -1,0 +1,348 @@
+// Copyright 2024 The argocd-agent Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resync
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/argoproj-labs/argocd-agent/internal/event"
+	"github.com/argoproj-labs/argocd-agent/internal/manager"
+	"github.com/argoproj-labs/argocd-agent/internal/queue"
+	"github.com/argoproj-labs/argocd-agent/internal/resources"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic/fake"
+)
+
+const (
+	testAgentName = "test"
+)
+
+func Test_ProcessIncomingBasicEntityList(t *testing.T) {
+	resNum := 10
+	handler := createFakeHandler(t)
+
+	t.Run("return nil if there are no resources", func(t *testing.T) {
+		incoming := &event.RequestBasicEntityList{
+			Checksum: []byte("test"),
+		}
+
+		err := handler.ProcessBasicEntityListRequest(testAgentName, incoming)
+		assert.Nil(t, err)
+	})
+
+	t.Run("return nil if checksum matches", func(t *testing.T) {
+		for i := 0; i < resNum; i++ {
+			name := fmt.Sprintf("test-%d", i)
+			testResource := resources.ResourceKey{
+				Name:      name,
+				Namespace: name,
+				Kind:      "Application",
+				UID:       name,
+			}
+			handler.resources.Add(testResource)
+		}
+
+		expChecksum := handler.resources.Checksum()
+
+		incoming := &event.RequestBasicEntityList{
+			Checksum: expChecksum,
+		}
+
+		err := handler.ProcessBasicEntityListRequest(testAgentName, incoming)
+		assert.Nil(t, err)
+
+		assert.Zero(t, handler.sendQ.Len())
+	})
+
+	t.Run("send basic entity event for all resources if the checksum doesn't match", func(t *testing.T) {
+		testResources := make([]resources.ResourceKey, resNum)
+		for i := 0; i < resNum; i++ {
+			name := fmt.Sprintf("test-%d", i)
+			testResource := resources.ResourceKey{
+				Name:      name,
+				Namespace: name,
+				Kind:      "Application",
+				UID:       name,
+			}
+			handler.resources.Add(testResource)
+			testResources[i] = testResource
+		}
+
+		incoming := &event.RequestBasicEntityList{
+			Checksum: []byte("random"),
+		}
+
+		err := handler.ProcessBasicEntityListRequest(testAgentName, incoming)
+		assert.Nil(t, err)
+
+		assert.Equal(t, handler.sendQ.Len(), resNum)
+
+		for i := 0; i < resNum; i++ {
+			ev, shutdown := handler.sendQ.Get()
+			assert.False(t, shutdown)
+			assert.Equal(t, event.ResponseBasicEntity.String(), ev.Type())
+		}
+	})
+}
+
+func Test_ProcessIncomingBasicEntity(t *testing.T) {
+	handler := createFakeHandler(t)
+
+	t.Run("create request update without checksum if resource not found", func(t *testing.T) {
+		incoming := &event.BasicEntity{
+			Name:      "test-app",
+			Namespace: "default",
+			Kind:      "Application",
+			UID:       "test-uid",
+		}
+
+		err := handler.ProcessIncomingBasicEntity(context.Background(), incoming, testAgentName)
+		assert.Nil(t, err)
+
+		ev, shutdown := handler.sendQ.Get()
+		assert.False(t, shutdown)
+		assert.Equal(t, event.EventRequestUpdate.String(), ev.Type())
+
+		got := &event.RequestUpdate{}
+		err = ev.DataAs(got)
+		assert.Nil(t, err)
+		assert.Empty(t, got.Checksum)
+	})
+
+	t.Run("create request update with checksum if resource exists", func(t *testing.T) {
+		resource := fakeUnresApp()
+		resource.SetAnnotations(map[string]string{
+			manager.SourceUIDAnnotation: "source-uid",
+		})
+
+		gvr, err := getGroupVersionResource("Application")
+		assert.Nil(t, err)
+
+		_, err = handler.dynClient.Resource(gvr).Namespace("default").
+			Create(context.Background(), resource, v1.CreateOptions{})
+		assert.Nil(t, err)
+
+		incoming := &event.BasicEntity{
+			Name:      "test-app",
+			Namespace: "default",
+			Kind:      "Application",
+			UID:       "test-uid",
+		}
+
+		err = handler.ProcessIncomingBasicEntity(context.Background(), incoming, testAgentName)
+		assert.Nil(t, err)
+
+		ev, shutdown := handler.sendQ.Get()
+		assert.False(t, shutdown)
+		assert.Equal(t, event.EventRequestUpdate.String(), ev.Type())
+
+		got := &event.RequestUpdate{}
+		err = ev.DataAs(got)
+		assert.Nil(t, err)
+		checksum, err := generateSpecChecksum(resource)
+		assert.Nil(t, err)
+		assert.Equal(t, checksum, got.Checksum)
+	})
+}
+
+func Test_ProcessIncomingRequestEntityResync(t *testing.T) {
+	handler := createFakeHandler(t)
+
+	t.Run("send request updates for all resources", func(t *testing.T) {
+		resource := fakeUnresApp()
+		resource.SetAnnotations(map[string]string{
+			manager.SourceUIDAnnotation: "source-uid",
+		})
+
+		gvr, err := getGroupVersionResource("Application")
+		assert.Nil(t, err)
+
+		_, err = handler.dynClient.Resource(gvr).Namespace("default").
+			Create(context.Background(), resource, v1.CreateOptions{})
+		assert.Nil(t, err)
+
+		handler.resources.Add(resources.ResourceKey{
+			Name:      "test-app",
+			Namespace: "default",
+			Kind:      "Application",
+			UID:       "test-uid",
+		})
+
+		err = handler.ProcessIncomingRequestEntityResync(context.Background(), testAgentName)
+		assert.Nil(t, err)
+
+		assert.Equal(t, 1, handler.sendQ.Len())
+		ev, shutdown := handler.sendQ.Get()
+		assert.False(t, shutdown)
+		assert.Equal(t, event.EventRequestUpdate.String(), ev.Type())
+		got := &event.RequestUpdate{}
+		err = ev.DataAs(got)
+		assert.Nil(t, err)
+		checksum, err := generateSpecChecksum(resource)
+		assert.Nil(t, err)
+		assert.Equal(t, checksum, got.Checksum)
+	})
+}
+
+func Test_generateSpecChecksum(t *testing.T) {
+	t.Run("generate checksum for valid resource", func(t *testing.T) {
+		resource := fakeUnresApp()
+
+		checksum, err := generateSpecChecksum(resource)
+		assert.Nil(t, err)
+		assert.NotNil(t, checksum)
+	})
+
+	t.Run("return error if spec field is missing", func(t *testing.T) {
+		resource := fakeUnresApp()
+		delete(resource.Object, "spec")
+
+		_, err := generateSpecChecksum(resource)
+		assert.NotNil(t, err)
+		assert.Equal(t, "spec field not found for resource: test-app", err.Error())
+	})
+
+	t.Run("return error if spec field is not a map", func(t *testing.T) {
+		resource := fakeUnresApp()
+		resource.Object["spec"] = "invalid-spec"
+
+		_, err := generateSpecChecksum(resource)
+		assert.NotNil(t, err)
+		assert.Equal(t, "unable to convert the spec object of Application:test-app to a map", err.Error())
+	})
+
+	t.Run("generate checksum for resource with destination field", func(t *testing.T) {
+		resource := fakeUnresApp()
+		resource.Object["spec"] = map[string]interface{}{
+			"project":     "default",
+			"destination": "in-cluster",
+		}
+
+		checksum, err := generateSpecChecksum(resource)
+		assert.Nil(t, err)
+		assert.NotNil(t, checksum)
+	})
+}
+
+func Test_ProcessRequestUpdateEvent(t *testing.T) {
+	ctx := context.Background()
+	handler := createFakeHandler(t)
+
+	t.Run("return nil if resource exists and checksum matches", func(t *testing.T) {
+		resource := fakeUnresApp()
+
+		gvr, err := getGroupVersionResource("Application")
+		assert.Nil(t, err)
+
+		_, err = handler.dynClient.Resource(gvr).Namespace("default").Create(ctx, resource, v1.CreateOptions{})
+		assert.Nil(t, err)
+
+		checksum, err := generateSpecChecksum(resource)
+		assert.Nil(t, err)
+
+		reqUpdate := &event.RequestUpdate{
+			Name:      "test-app",
+			Namespace: "default",
+			Kind:      "Application",
+			Checksum:  checksum,
+		}
+
+		err = handler.ProcessRequestUpdateEvent(ctx, testAgentName, reqUpdate)
+		assert.Nil(t, err)
+		assert.Zero(t, handler.sendQ.Len())
+
+		err = handler.dynClient.Resource(gvr).Namespace("default").Delete(ctx, resource.GetName(), v1.DeleteOptions{})
+		assert.Nil(t, err)
+	})
+
+	t.Run("send delete event if resource does not exist", func(t *testing.T) {
+		reqUpdate := &event.RequestUpdate{
+			Name:      "non-existent-app",
+			Namespace: "default",
+			Kind:      "Application",
+		}
+
+		err := handler.ProcessRequestUpdateEvent(ctx, testAgentName, reqUpdate)
+		assert.Nil(t, err)
+
+		ev, shutdown := handler.sendQ.Get()
+		assert.False(t, shutdown)
+		assert.Equal(t, event.Delete.String(), ev.Type())
+	})
+
+	t.Run("send spec update event if checksum does not match", func(t *testing.T) {
+		resource := fakeUnresApp()
+
+		gvr, err := getGroupVersionResource("Application")
+		assert.Nil(t, err)
+
+		_, err = handler.dynClient.Resource(gvr).Namespace("default").Create(ctx, resource, v1.CreateOptions{})
+		assert.Nil(t, err)
+
+		reqUpdate := &event.RequestUpdate{
+			Name:      "test-app",
+			Namespace: "default",
+			Kind:      "Application",
+			Checksum:  []byte("invalid-checksum"),
+		}
+
+		err = handler.ProcessRequestUpdateEvent(ctx, testAgentName, reqUpdate)
+		assert.Nil(t, err)
+
+		ev, shutdown := handler.sendQ.Get()
+		assert.False(t, shutdown)
+		assert.Equal(t, event.SpecUpdate.String(), ev.Type())
+
+		err = handler.dynClient.Resource(gvr).Namespace("default").Delete(ctx, resource.GetName(), v1.DeleteOptions{})
+		assert.Nil(t, err)
+	})
+}
+
+func createFakeHandler(t *testing.T) *RequestHandler {
+	evs := event.NewEventSource("test")
+
+	agentName := "test"
+	queues := queue.NewSendRecvQueues()
+
+	err := queues.Create(agentName)
+	assert.Nil(t, err)
+
+	dynClient := fake.NewSimpleDynamicClient(&runtime.Scheme{})
+	res := resources.NewResources()
+	return NewRequestHandler(dynClient, queues.SendQ(agentName), evs, res, logrus.NewEntry(logrus.New()))
+}
+
+func fakeUnresApp() *unstructured.Unstructured {
+	resource := &unstructured.Unstructured{}
+	resource.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "argoproj.io",
+		Version: "v1alpha1",
+		Kind:    "Application",
+	})
+	resource.SetName("test-app")
+	resource.SetNamespace("default")
+	resource.SetUID("test-uid")
+	resource.Object["spec"] = map[string]interface{}{
+		"project": "default",
+	}
+	return resource
+}

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -70,3 +70,23 @@ const (
 	ContextAgentIdentifier EventContextKey = "agent_name"
 	ContextAgentMode       EventContextKey = "agent_mode"
 )
+
+type Agent struct {
+	name string
+	mode string
+}
+
+func (a Agent) Name() string {
+	return a.name
+}
+
+func (a Agent) Mode() string {
+	return a.mode
+}
+
+func NewAgent(name, mode string) Agent {
+	return Agent{
+		name: name,
+		mode: mode,
+	}
+}

--- a/principal/event.go
+++ b/principal/event.go
@@ -302,23 +302,23 @@ func (s *Server) processIncomingResourceResyncEvent(ctx context.Context, agentNa
 	resyncHandler := resync.NewRequestHandler(dynClient, sendQ, s.events, s.resources.Get(agentName), logCtx)
 
 	switch ev.Type() {
-	case event.RequestBasicEntity.String():
+	case event.SyncedResourceList.String():
 		if agentMode != types.AgentModeManaged {
-			return fmt.Errorf("principal can only handle basic entity list in the managed mode")
+			return fmt.Errorf("principal can only handle SyncedResourceList request in the managed mode")
 		}
 
-		incoming := &event.RequestBasicEntityList{}
+		incoming := &event.RequestSyncedResourceList{}
 		if err := ev.DataAs(incoming); err != nil {
 			return err
 		}
 
-		return resyncHandler.ProcessBasicEntityListRequest(agentName, incoming)
-	case event.ResponseBasicEntity.String():
+		return resyncHandler.ProcessSyncedResourceListRequest(agentName, incoming)
+	case event.ResponseSyncedResource.String():
 		if agentMode != types.AgentModeAutonomous {
-			return fmt.Errorf("principal can only handle basic entity in autonomous mode")
+			return fmt.Errorf("principal can only handle SyncedResource request in autonomous mode")
 		}
 
-		incoming := &event.BasicEntity{}
+		incoming := &event.SyncedResource{}
 		if err := ev.DataAs(incoming); err != nil {
 			return err
 		}
@@ -326,7 +326,7 @@ func (s *Server) processIncomingResourceResyncEvent(ctx context.Context, agentNa
 		// Using agentName as the namespace
 		incoming.Namespace = agentName
 
-		return resyncHandler.ProcessIncomingBasicEntity(ctx, incoming, agentName)
+		return resyncHandler.ProcessIncomingSyncedResource(ctx, incoming, agentName)
 	case event.EventRequestUpdate.String():
 		if agentMode != types.AgentModeManaged {
 			return fmt.Errorf("principal can only handle request update in the managed mode")
@@ -338,17 +338,17 @@ func (s *Server) processIncomingResourceResyncEvent(ctx context.Context, agentNa
 		}
 
 		return resyncHandler.ProcessRequestUpdateEvent(ctx, agentName, incoming)
-	case event.EventRequestEntityResync.String():
+	case event.EventRequestResourceResync.String():
 		if agentMode != types.AgentModeAutonomous {
-			return fmt.Errorf("principal can only handle request entity resync in autonomous mode")
+			return fmt.Errorf("principal can only handle ResourceResync request in autonomous mode")
 		}
 
-		incoming := &event.RequestEntityResync{}
+		incoming := &event.RequestResourceResync{}
 		if err := ev.DataAs(incoming); err != nil {
 			return err
 		}
 
-		return resyncHandler.ProcessIncomingRequestEntityResync(ctx, agentName)
+		return resyncHandler.ProcessIncomingResourceResyncRequest(ctx, agentName)
 	default:
 		return fmt.Errorf("invalid type of resource resync: %s", ev.Type())
 	}

--- a/principal/event_test.go
+++ b/principal/event_test.go
@@ -440,48 +440,48 @@ func Test_processIncomingResourceResyncEvent(t *testing.T) {
 	assert.Nil(t, err)
 	s.events = event.NewEventSource("test")
 
-	t.Run("discard basic entity list in autonomous mode", func(t *testing.T) {
+	t.Run("discard SyncedResourceList in autonomous mode", func(t *testing.T) {
 		s.setAgentMode(agentName, types.AgentModeAutonomous)
 
-		ev, err := s.events.RequestBasicEntityListEvent([]byte{})
+		ev, err := s.events.RequestSyncedResourceListEvent([]byte{})
 		assert.Nil(t, err)
 
-		expected := "principal can only handle basic entity list in the managed mode"
+		expected := "principal can only handle SyncedResourceList request in the managed mode"
 		err = s.processIncomingResourceResyncEvent(ctx, agentName, ev)
 		assert.Equal(t, expected, err.Error())
 	})
 
-	t.Run("process basic entity list in managed mode", func(t *testing.T) {
+	t.Run("process SyncedResourceList in managed mode", func(t *testing.T) {
 		s.setAgentMode(agentName, types.AgentModeManaged)
 
-		ev, err := s.events.RequestBasicEntityListEvent([]byte{})
+		ev, err := s.events.RequestSyncedResourceListEvent([]byte{})
 		assert.Nil(t, err)
 
 		err = s.processIncomingResourceResyncEvent(ctx, agentName, ev)
 		assert.Nil(t, err)
 	})
 
-	t.Run("process basic entity in autonomous mode", func(t *testing.T) {
+	t.Run("process SyncedResource in autonomous mode", func(t *testing.T) {
 		s.setAgentMode(agentName, types.AgentModeAutonomous)
 
 		res := resources.ResourceKey{
 			Name: "sample",
 			Kind: "Application",
 		}
-		ev, err := s.events.BasicEntityEvent(res)
+		ev, err := s.events.SyncedResourceEvent(res)
 		assert.Nil(t, err)
 
 		err = s.processIncomingResourceResyncEvent(ctx, agentName, ev)
 		assert.NotNil(t, err)
 	})
 
-	t.Run("discard basic entity in managed mode", func(t *testing.T) {
+	t.Run("discard SyncedResource in managed mode", func(t *testing.T) {
 		s.setAgentMode(agentName, types.AgentModeManaged)
 
-		ev, err := s.events.BasicEntityEvent(resources.ResourceKey{})
+		ev, err := s.events.SyncedResourceEvent(resources.ResourceKey{})
 		assert.Nil(t, err)
 
-		expected := "principal can only handle basic entity in autonomous mode"
+		expected := "principal can only handle SyncedResource request in autonomous mode"
 		err = s.processIncomingResourceResyncEvent(ctx, agentName, ev)
 		assert.Equal(t, expected, err.Error())
 	})
@@ -512,23 +512,23 @@ func Test_processIncomingResourceResyncEvent(t *testing.T) {
 		assert.Equal(t, expected, err.Error())
 	})
 
-	t.Run("process request entity resync in autonomous mode", func(t *testing.T) {
+	t.Run("process ResourceResync in autonomous mode", func(t *testing.T) {
 		s.setAgentMode(agentName, types.AgentModeAutonomous)
 
-		ev, err := s.events.RequestEntityResyncEvent()
+		ev, err := s.events.RequestResourceResyncEvent()
 		assert.Nil(t, err)
 
 		err = s.processIncomingResourceResyncEvent(ctx, agentName, ev)
 		assert.Nil(t, err)
 	})
 
-	t.Run("discard request entity resync in managed mode", func(t *testing.T) {
+	t.Run("discard ResourceResync in managed mode", func(t *testing.T) {
 		s.setAgentMode(agentName, types.AgentModeManaged)
 
-		ev, err := s.events.RequestEntityResyncEvent()
+		ev, err := s.events.RequestResourceResyncEvent()
 		assert.Nil(t, err)
 
-		expected := "principal can only handle request entity resync in autonomous mode"
+		expected := "principal can only handle ResourceResync request in autonomous mode"
 		err = s.processIncomingResourceResyncEvent(ctx, agentName, ev)
 		assert.Equal(t, expected, err.Error())
 	})

--- a/principal/listen.go
+++ b/principal/listen.go
@@ -216,6 +216,6 @@ func (s *Server) registerGrpcServices(metrics *metrics.PrincipalMetrics) error {
 	}
 	authapi.RegisterAuthenticationServer(s.grpcServer, authSrv)
 	versionapi.RegisterVersionServer(s.grpcServer, version.NewServer(s.authenticate))
-	eventstreamapi.RegisterEventStreamServer(s.grpcServer, eventstream.NewServer(s.queues, metrics))
+	eventstreamapi.RegisterEventStreamServer(s.grpcServer, eventstream.NewServer(s.queues, metrics, eventstream.WithNotifyOnConnect(s.notifyOnConnect)))
 	return nil
 }

--- a/principal/server.go
+++ b/principal/server.go
@@ -540,26 +540,26 @@ func (s *Server) handleResyncOnConnect(agent types.Agent) error {
 		resyncHandler := resync.NewRequestHandler(dynClient, sendQ, s.events, s.resources.Get(agent.Name()), logCtx)
 		go resyncHandler.SendRequestUpdates(s.ctx)
 
-		// Principal should send basic entity list to revert any deletions on the Principal side.
+		// Principal should request SyncedResourceList to revert any deletions on the Principal side.
 		checksum := s.resources.Checksum(agent.Name())
 
 		// send the checksum to the principal
-		ev, err := s.events.RequestBasicEntityListEvent(checksum)
+		ev, err := s.events.RequestSyncedResourceListEvent(checksum)
 		if err != nil {
-			return fmt.Errorf("failed to create basic entity list event: %v", err)
+			return fmt.Errorf("failed to create SyncedResourceList event: %v", err)
 		}
 
 		sendQ.Add(ev)
-		logCtx.Trace("Sent a request for basic entity list")
+		logCtx.Trace("Sent a request for SyncedResourceList")
 	} else {
-		// In managed mode, principal is the source of truth and the it should request entity resync
-		ev, err := s.events.RequestEntityResyncEvent()
+		// In managed mode, principal is the source of truth and the it should request resource resync
+		ev, err := s.events.RequestResourceResyncEvent()
 		if err != nil {
-			return fmt.Errorf("failed to create request entity resync event: %v", err)
+			return fmt.Errorf("failed to create ResourceResync event: %v", err)
 		}
 
 		sendQ.Add(ev)
-		logCtx.Trace("Sent a request for entity resync")
+		logCtx.Trace("Sent a request for ResourceResync")
 	}
 
 	s.resyncStatus.resynced(agent.Name())

--- a/principal/server.go
+++ b/principal/server.go
@@ -40,6 +40,7 @@ import (
 	"github.com/argoproj-labs/argocd-agent/internal/manager/appproject"
 	"github.com/argoproj-labs/argocd-agent/internal/metrics"
 	"github.com/argoproj-labs/argocd-agent/internal/queue"
+	"github.com/argoproj-labs/argocd-agent/internal/resources"
 	"github.com/argoproj-labs/argocd-agent/internal/tlsutil"
 	"github.com/argoproj-labs/argocd-agent/internal/version"
 	"github.com/argoproj-labs/argocd-agent/pkg/types"
@@ -53,7 +54,6 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/watch"
-	"k8s.io/client-go/kubernetes"
 )
 
 type Server struct {
@@ -91,7 +91,7 @@ type Server struct {
 	// events is used to construct events to pass on the wire to connected agents.
 	events     *event.EventSource
 	version    *version.Version
-	kubeClient kubernetes.Interface
+	kubeClient *kube.KubernetesClient
 
 	autoNamespaceAllow   bool
 	autoNamespacePattern *regexp.Regexp
@@ -119,7 +119,17 @@ type Server struct {
 	// Minimum time duration for agent to wait before sending next keepalive ping to principal
 	// if agent sends ping more often than specified interval then connection will be dropped
 	keepAliveMinimumInterval time.Duration
+	// resources is a map of all resource keys for each agent
+	resources *resources.AgentResources
+	// resyncStatus indicates whether an agent has been resyned after the principal restarts
+	resyncStatus *resyncStatus
+	// notifyOnConnect will notify to run the handlers when an agent connects to the principal
+	notifyOnConnect chan types.Agent
+	// handlers to run when an agent connects to the principal
+	handlersOnConnect []handlersOnConnect
 }
+
+type handlersOnConnect func(agent types.Agent) error
 
 // noAuthEndpoints is a list of endpoints that are available without the need
 // for the request to be authenticated.
@@ -136,12 +146,15 @@ const defaultResourceProxyListenerAddr = "0.0.0.0:9090"
 
 func NewServer(ctx context.Context, kubeClient *kube.KubernetesClient, namespace string, opts ...ServerOption) (*Server, error) {
 	s := &Server{
-		options:    defaultOptions(),
-		queues:     queue.NewSendRecvQueues(),
-		namespace:  namespace,
-		noauth:     noAuthEndpoints,
-		version:    version.New("argocd-agent", "principal"),
-		kubeClient: kubeClient.Clientset,
+		options:         defaultOptions(),
+		queues:          queue.NewSendRecvQueues(),
+		namespace:       namespace,
+		noauth:          noAuthEndpoints,
+		version:         version.New("argocd-agent", "principal"),
+		kubeClient:      kubeClient,
+		resyncStatus:    newResyncStatus(),
+		resources:       resources.NewAgentResources(),
+		notifyOnConnect: make(chan types.Agent),
 	}
 
 	s.ctx, s.ctxCancel = context.WithCancel(ctx)
@@ -151,6 +164,10 @@ func NewServer(ctx context.Context, kubeClient *kube.KubernetesClient, namespace
 		if err != nil {
 			return nil, err
 		}
+	}
+
+	s.handlersOnConnect = []handlersOnConnect{
+		s.handleResyncOnConnect,
 	}
 
 	if s.authMethods == nil {
@@ -289,10 +306,12 @@ func NewServer(ctx context.Context, kubeClient *kube.KubernetesClient, namespace
 
 	// Instantiate the cluster manager to handle Argo CD cluster secrets for
 	// agents.
-	s.clusterMgr, err = cluster.NewManager(s.ctx, s.namespace, s.kubeClient)
+	s.clusterMgr, err = cluster.NewManager(s.ctx, s.namespace, s.kubeClient.Clientset)
 	if err != nil {
 		return nil, err
 	}
+
+	s.resources = resources.NewAgentResources()
 
 	return s, nil
 }
@@ -364,6 +383,8 @@ func (s *Server) Start(ctx context.Context, errch chan error) error {
 		}()
 	}
 
+	go s.RunHandlersOnConnect(s.ctx)
+
 	err := s.StartEventProcessor(s.ctx)
 	if err != nil {
 		return nil
@@ -428,6 +449,110 @@ func (s *Server) Start(ctx context.Context, errch chan error) error {
 	}
 	log().Infof("Namespace informer synced and ready")
 
+	return nil
+}
+
+// When the principal process restarts, the agent could be out of sync with the principal.
+// resyncStatus indicates whether we need to inform the agent that the principal has been restarted.
+type resyncStatus struct {
+	mu sync.RWMutex
+	// key: agent name
+	resync map[string]bool
+}
+
+func newResyncStatus() *resyncStatus {
+	return &resyncStatus{
+		resync: map[string]bool{},
+	}
+}
+
+func (rs *resyncStatus) isResynced(agentName string) bool {
+	rs.mu.RLock()
+	defer rs.mu.RUnlock()
+
+	_, ok := rs.resync[agentName]
+	return ok
+}
+
+func (rs *resyncStatus) resynced(agentName string) {
+	rs.mu.Lock()
+	defer rs.mu.Unlock()
+
+	rs.resync[agentName] = true
+}
+
+// RunHandlersOnConnect runs the registered handlers when an agent connects to the principal
+func (s *Server) RunHandlersOnConnect(ctx context.Context) {
+	for {
+		select {
+		case <-ctx.Done():
+			log().Errorf("stop running handlers: %v", ctx.Err())
+			return
+		case agent := <-s.notifyOnConnect:
+			logCtx := log().WithFields(logrus.Fields{
+				"agent": agent.Name(),
+				"mode":  agent.Mode(),
+			})
+
+			logCtx.Trace("Running handlers on a newly connected agent")
+			for _, handler := range s.handlersOnConnect {
+				if err := handler(agent); err != nil {
+					logCtx.Errorf("failed to run handler: %v", err)
+				}
+			}
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+}
+
+// handleResyncOnConnect is called whenever an agent connects and it determines if an agent needs to be
+// resynced with the principal. We use resyncStatus to differentiate if the principal has restarted (resync required)
+// or the agent has just reconnected after a network issue (no resync). When the process restarts, we lose the
+// resync status and thereby trigger the resync mechanism whenever the agent connects back.
+func (s *Server) handleResyncOnConnect(agent types.Agent) error {
+	logCtx := log().WithFields(logrus.Fields{
+		"agent": agent.Name(),
+		"mode":  agent.Mode(),
+	})
+
+	if s.resyncStatus.isResynced(agent.Name()) {
+		logCtx.Trace("Skipping resync messages since the principal has synced with this agent before")
+		return nil
+	}
+
+	logCtx.Trace("Checking if the principal is out of sync with the agent")
+
+	sendQ := s.queues.SendQ(agent.Name())
+	if sendQ == nil {
+		return fmt.Errorf("no send queue found for agent: %s", agent.Name())
+	}
+
+	// In autonomous mode, principal acts as peer and it should request the basic entity list from the agent.
+	if agent.Mode() == types.AgentModeAutonomous.String() {
+		checksum := s.resources.Checksum(agent.Name())
+
+		fmt.Println("Checksum for agent", agent.Name(), checksum)
+
+		// send the checksum to the principal
+		ev, err := s.events.RequestBasicEntityListEvent(checksum)
+		if err != nil {
+			return fmt.Errorf("failed to create basic entity list event: %v", err)
+		}
+
+		sendQ.Add(ev)
+		logCtx.Trace("Sent a request for basic entity list")
+	} else {
+		// In managed mode, principal is the source of truth and the it should request entity resync
+		ev, err := s.events.RequestEntityResyncEvent()
+		if err != nil {
+			return fmt.Errorf("failed to create request entity resync event: %v", err)
+		}
+
+		sendQ.Add(ev)
+		logCtx.Trace("Sent a request for entity resync")
+	}
+
+	s.resyncStatus.resynced(agent.Name())
 	return nil
 }
 

--- a/principal/server.go
+++ b/principal/server.go
@@ -531,8 +531,6 @@ func (s *Server) handleResyncOnConnect(agent types.Agent) error {
 	if agent.Mode() == types.AgentModeAutonomous.String() {
 		checksum := s.resources.Checksum(agent.Name())
 
-		fmt.Println("Checksum for agent", agent.Name(), checksum)
-
 		// send the checksum to the principal
 		ev, err := s.events.RequestBasicEntityListEvent(checksum)
 		if err != nil {

--- a/principal/server_test.go
+++ b/principal/server_test.go
@@ -120,7 +120,7 @@ func Test_handleResyncOnConnect(t *testing.T) {
 		assert.Zero(t, sendQ.Len())
 	})
 
-	t.Run("request basic entity list in autonomous mode", func(t *testing.T) {
+	t.Run("request SyncedResourceList in autonomous mode", func(t *testing.T) {
 		s.resyncStatus = newResyncStatus()
 
 		err = s.handleResyncOnConnect(agent)
@@ -131,10 +131,10 @@ func Test_handleResyncOnConnect(t *testing.T) {
 
 		ev, shutdown := sendQ.Get()
 		assert.False(t, shutdown)
-		assert.Equal(t, event.RequestBasicEntity.String(), ev.Type())
+		assert.Equal(t, event.SyncedResourceList.String(), ev.Type())
 	})
 
-	t.Run("request entity resync in managed mode", func(t *testing.T) {
+	t.Run("request resource resync in managed mode", func(t *testing.T) {
 		agent = types.NewAgent("test", types.AgentModeManaged.String())
 		s.resyncStatus = newResyncStatus()
 
@@ -146,7 +146,7 @@ func Test_handleResyncOnConnect(t *testing.T) {
 
 		ev, shutdown := sendQ.Get()
 		assert.False(t, shutdown)
-		assert.Equal(t, event.EventRequestEntityResync.String(), ev.Type())
+		assert.Equal(t, event.EventRequestResourceResync.String(), ev.Type())
 	})
 }
 

--- a/principal/server_test.go
+++ b/principal/server_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"k8s.io/client-go/rest"
 )
 
 var certTempl = x509.Certificate{
@@ -101,6 +102,7 @@ func Test_handleResyncOnConnect(t *testing.T) {
 	s, err := NewServer(context.TODO(), kube.NewKubernetesFakeClient(), testNamespace,
 		WithGeneratedTokenSigningKey(),
 	)
+	s.kubeClient.RestConfig = &rest.Config{}
 	require.NoError(t, err)
 	s.events = event.NewEventSource("test")
 

--- a/test/e2e2/resync_test.go
+++ b/test/e2e2/resync_test.go
@@ -1,0 +1,402 @@
+// Copyright 2025 The argocd-agent Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package e2e2
+
+import (
+	"testing"
+	"time"
+
+	"github.com/argoproj-labs/argocd-agent/test/e2e2/fixture"
+	argoapp "github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
+	"github.com/stretchr/testify/suite"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+type ResyncTestSuite struct {
+	fixture.BaseSuite
+}
+
+func (suite *ResyncTestSuite) TearDownTest() {
+	suite.BaseSuite.TearDownTest()
+	requires := suite.Require()
+
+	// Ensure that all the components are running after runnings the tests
+	if !fixture.IsProcessRunning("process") {
+		err := fixture.StartProcess("principal")
+		requires.NoError(err)
+	}
+
+	if !fixture.IsProcessRunning("agent-managed") {
+		err := fixture.StartProcess("agent-managed")
+		requires.NoError(err)
+	}
+
+	if !fixture.IsProcessRunning("agent-autonomous") {
+		err := fixture.StartProcess("agent-autonomous")
+		requires.NoError(err)
+	}
+}
+
+// Managed Mode: delete the app from the control-plane when the principal process is
+// down and ensure that the app is deleted from the workload cluster when the principal process restarts
+func (suite *ResyncTestSuite) Test_ResyncDeletionOnPrincipalStartupManaged() {
+	requires := suite.Require()
+
+	app := suite.createManagedApp()
+	key := fixture.ToNamespacedName(app)
+
+	// Stop the principal and delete the app from the control-plane
+	err := fixture.StopProcess("principal")
+	requires.NoError(err)
+
+	requires.Eventually(func() bool {
+		return !fixture.IsProcessRunning("principal")
+	}, 30*time.Second, 1*time.Second)
+
+	err = suite.PrincipalClient.Delete(suite.Ctx, app, metav1.DeleteOptions{})
+	requires.NoError(err)
+
+	// App should still exist on the workload cluster
+	err = suite.ManagedAgentClient.Get(suite.Ctx, key, app, metav1.GetOptions{})
+	requires.NoError(err)
+
+	// Start the principal and ensure that the app is deleted from the workload cluster
+	err = fixture.StartProcess("principal")
+	requires.NoError(err)
+
+	requires.Eventually(func() bool {
+		return fixture.IsProcessRunning("principal")
+	}, 30*time.Second, 1*time.Second)
+
+	requires.Eventually(func() bool {
+		app := argoapp.Application{}
+		err := suite.ManagedAgentClient.Get(suite.Ctx, key, &app, metav1.GetOptions{})
+		return errors.IsNotFound(err)
+	}, 60*time.Second, 1*time.Second)
+}
+
+// Managed Mode: update the app on the control-plane when the principal process is down and ensure
+// that the app gets updated on the workload when the principal process restarts
+func (suite *ResyncTestSuite) Test_ResyncUpdatesOnPrincipalStartupManaged() {
+	requires := suite.Require()
+
+	app := suite.createManagedApp()
+	key := fixture.ToNamespacedName(app)
+
+	// Stop the principal and update the app on the control-plane
+	err := fixture.StopProcess("principal")
+	requires.NoError(err)
+
+	requires.Eventually(func() bool {
+		return !fixture.IsProcessRunning("principal")
+	}, 30*time.Second, 1*time.Second)
+
+	err = suite.PrincipalClient.EnsureApplicationUpdate(suite.Ctx, key, func(a *argoapp.Application) error {
+		a.Spec.Source.Path = "guestbook"
+		return nil
+	}, metav1.UpdateOptions{})
+	requires.NoError(err)
+
+	// App should not be updated on the workload cluster
+	err = suite.ManagedAgentClient.Get(suite.Ctx, key, app, metav1.GetOptions{})
+	requires.NoError(err)
+	requires.Equal("kustomize-guestbook", app.Spec.Source.Path)
+
+	// Start the principal and ensure that the app is updated on the workload cluster
+	err = fixture.StartProcess("principal")
+	requires.NoError(err)
+
+	requires.Eventually(func() bool {
+		return fixture.IsProcessRunning("principal")
+	}, 30*time.Second, 1*time.Second)
+
+	requires.Eventually(func() bool {
+		app := argoapp.Application{}
+		err := suite.ManagedAgentClient.Get(suite.Ctx, key, &app, metav1.GetOptions{})
+		return err == nil &&
+			app.Spec.Source.Path == "guestbook"
+	}, 60*time.Second, 1*time.Second)
+}
+
+// Managed Mode: delete the app from the workload cluster when the agent process is down and
+// ensure that the app gets recreated on the workload cluster when the agent process is restarted
+func (suite *ResyncTestSuite) Test_ResyncDeletionOnAgentStartupManaged() {
+	requires := suite.Require()
+
+	app := suite.createManagedApp()
+	key := fixture.ToNamespacedName(app)
+
+	// Stop the agent and delete the app
+	err := fixture.StopProcess("agent-managed")
+	requires.NoError(err)
+
+	requires.Eventually(func() bool {
+		return !fixture.IsProcessRunning("agent-managed")
+	}, 30*time.Second, 1*time.Second)
+
+	err = suite.ManagedAgentClient.Delete(suite.Ctx, app, metav1.DeleteOptions{})
+	requires.NoError(err)
+
+	// Start the agent and ensure that the app is recreated on the agent side
+	err = fixture.StartProcess("agent-managed")
+	requires.NoError(err)
+
+	requires.Eventually(func() bool {
+		return fixture.IsProcessRunning("agent-managed")
+	}, 30*time.Second, 1*time.Second)
+
+	requires.Eventually(func() bool {
+		app := argoapp.Application{}
+		err := suite.ManagedAgentClient.Get(suite.Ctx, key, &app, metav1.GetOptions{})
+		return err == nil
+	}, 60*time.Second, 1*time.Second)
+}
+
+// Autonomous Mode: delete the app when the agent process is down and ensure that the app is
+// deleted on the principal side when the agent process is restarted
+func (suite *ResyncTestSuite) Test_ResyncDeletionOnAgentStartupAutonomous() {
+	requires := suite.Require()
+
+	app := suite.createAutonomousApp()
+	principalKey := types.NamespacedName{Name: app.Name, Namespace: "agent-autonomous"}
+
+	// Stop the agent process and delete the app on the agent side
+	err := fixture.StopProcess("agent-autonomous")
+	requires.NoError(err)
+
+	requires.Eventually(func() bool {
+		return !fixture.IsProcessRunning("agent-autonomous")
+	}, 30*time.Second, 1*time.Second)
+
+	err = suite.AutonomousAgentClient.Delete(suite.Ctx, app, metav1.DeleteOptions{})
+	requires.NoError(err)
+
+	// App should still exist on the principal
+	err = suite.PrincipalClient.Get(suite.Ctx, principalKey, app, metav1.GetOptions{})
+	requires.NoError(err)
+
+	// Start the agent process and ensure that the app is deleted on the principal
+	err = fixture.StartProcess("agent-autonomous")
+	requires.NoError(err)
+
+	requires.Eventually(func() bool {
+		return fixture.IsProcessRunning("agent-autonomous")
+	}, 30*time.Second, 1*time.Second)
+
+	requires.Eventually(func() bool {
+		app := argoapp.Application{}
+		err := suite.PrincipalClient.Get(suite.Ctx, principalKey, &app, metav1.GetOptions{})
+		return errors.IsNotFound(err)
+	}, 60*time.Second, 1*time.Second)
+}
+
+// Autonomous Mode: update the app on the workload when the agent process is down and ensure
+// that the app is updated on the principal side when the agent process is restarted
+func (suite *ResyncTestSuite) Test_ResyncUpdatesOnAgentStartupAutonomous() {
+	requires := suite.Require()
+
+	app := suite.createAutonomousApp()
+	principalKey := types.NamespacedName{Name: app.Name, Namespace: "agent-autonomous"}
+	agentKey := fixture.ToNamespacedName(app)
+
+	// Stop the agent process and update the app on the agent side
+	err := fixture.StopProcess("agent-autonomous")
+	requires.NoError(err)
+
+	requires.Eventually(func() bool {
+		return !fixture.IsProcessRunning("agent-autonomous")
+	}, 30*time.Second, 1*time.Second)
+
+	app.Spec.Source.Path = "guestbook"
+	err = suite.AutonomousAgentClient.EnsureApplicationUpdate(suite.Ctx, agentKey, func(a *argoapp.Application) error {
+		a.Spec.Source.Path = "guestbook"
+		return nil
+	}, metav1.UpdateOptions{})
+	requires.NoError(err)
+
+	// App should not be updated on the principal
+	err = suite.PrincipalClient.Get(suite.Ctx, principalKey, app, metav1.GetOptions{})
+	requires.NoError(err)
+	requires.Equal("kustomize-guestbook", app.Spec.Source.Path)
+
+	// Start the agent process and ensure that the app is updated on the principal
+	err = fixture.StartProcess("agent-autonomous")
+	requires.NoError(err)
+
+	requires.Eventually(func() bool {
+		return fixture.IsProcessRunning("agent-autonomous")
+	}, 30*time.Second, 1*time.Second)
+
+	requires.Eventually(func() bool {
+		app := argoapp.Application{}
+		err := suite.PrincipalClient.Get(suite.Ctx, principalKey, &app, metav1.GetOptions{})
+		return err == nil &&
+			app.Spec.Source.Path == "guestbook"
+	}, 60*time.Second, 1*time.Second)
+}
+
+// Autonomous Mode: delete the app from the control-plane when the principal process is down and
+// ensure that the app is recreated on the control-plane when the principal process is restarted
+func (suite *ResyncTestSuite) Test_ResyncDeletionOnPrincipalStartupAutonomous() {
+	requires := suite.Require()
+
+	app := suite.createAutonomousApp()
+	principalKey := types.NamespacedName{Name: app.Name, Namespace: "agent-autonomous"}
+	agentKey := fixture.ToNamespacedName(app)
+
+	// Stop the principal process and delete the app on the principal side
+	err := fixture.StopProcess("principal")
+	requires.NoError(err)
+
+	requires.Eventually(func() bool {
+		return !fixture.IsProcessRunning("principal")
+	}, 30*time.Second, 1*time.Second)
+
+	principalApp := app.DeepCopy()
+	principalApp.Namespace = "agent-autonomous"
+	err = suite.PrincipalClient.Delete(suite.Ctx, principalApp, metav1.DeleteOptions{})
+	requires.NoError(err)
+
+	// App should still exist on the agent
+	err = suite.AutonomousAgentClient.Get(suite.Ctx, agentKey, app, metav1.GetOptions{})
+	requires.NoError(err)
+
+	// Start the principal process and ensure that the app is created on the principal
+	err = fixture.StartProcess("principal")
+	requires.NoError(err)
+
+	requires.Eventually(func() bool {
+		return fixture.IsProcessRunning("principal")
+	}, 30*time.Second, 1*time.Second)
+
+	requires.Eventually(func() bool {
+		err := suite.PrincipalClient.Get(suite.Ctx, principalKey, principalApp, metav1.GetOptions{})
+		return err == nil
+	}, 60*time.Second, 1*time.Second)
+}
+
+func (suite *ResyncTestSuite) createAutonomousApp() *argoapp.Application {
+	requires := suite.Require()
+	// Create an autonomous application on the autonomous-agent's cluster
+	app := argoapp.Application{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "guestbook",
+			Namespace: "argocd",
+			Finalizers: []string{
+				"resources-finalizer.argocd.argoproj.io",
+			},
+		},
+		Spec: argoapp.ApplicationSpec{
+			Project: "default",
+			Source: &argoapp.ApplicationSource{
+				RepoURL:        "https://github.com/argoproj/argocd-example-apps",
+				TargetRevision: "HEAD",
+				Path:           "kustomize-guestbook",
+			},
+			Destination: argoapp.ApplicationDestination{
+				Server:    "https://kubernetes.default.svc",
+				Namespace: "guestbook",
+			},
+			SyncPolicy: &argoapp.SyncPolicy{
+				SyncOptions: argoapp.SyncOptions{
+					"CreateNamespace=true",
+				},
+			},
+		},
+	}
+	err := suite.AutonomousAgentClient.Create(suite.Ctx, &app, metav1.CreateOptions{})
+	requires.NoError(err)
+
+	principalKey := types.NamespacedName{Name: app.Name, Namespace: "agent-autonomous"}
+	agentKey := fixture.ToNamespacedName(&app)
+
+	// Ensure the app has been pushed to the principal
+	requires.Eventually(func() bool {
+		app := argoapp.Application{}
+		err := suite.PrincipalClient.Get(suite.Ctx, principalKey, &app, metav1.GetOptions{})
+		return err == nil
+	}, 30*time.Second, 1*time.Second)
+
+	// Check that the .spec field of the principal matches that of the
+	// autonomous-agent
+	app = argoapp.Application{}
+	err = suite.AutonomousAgentClient.Get(suite.Ctx, agentKey, &app, metav1.GetOptions{})
+	requires.NoError(err)
+	papp := argoapp.Application{}
+	err = suite.PrincipalClient.Get(suite.Ctx, principalKey, &papp, metav1.GetOptions{})
+	requires.NoError(err)
+	requires.Equal(&app.Spec, &papp.Spec)
+
+	return &app
+}
+
+func (suite *ResyncTestSuite) createManagedApp() *argoapp.Application {
+	requires := suite.Require()
+	// Create a managed application on the control-plane cluster
+	app := argoapp.Application{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "guestbook",
+			Namespace: "agent-managed",
+		},
+		Spec: argoapp.ApplicationSpec{
+			Project: "default",
+			Source: &argoapp.ApplicationSource{
+				RepoURL:        "https://github.com/argoproj/argocd-example-apps",
+				TargetRevision: "HEAD",
+				Path:           "kustomize-guestbook",
+			},
+			Destination: argoapp.ApplicationDestination{
+				Server:    "https://kubernetes.default.svc",
+				Namespace: "guestbook",
+			},
+			SyncPolicy: &argoapp.SyncPolicy{
+				SyncOptions: argoapp.SyncOptions{
+					"CreateNamespace=true",
+				},
+			},
+		},
+	}
+	err := suite.PrincipalClient.Create(suite.Ctx, &app, metav1.CreateOptions{})
+	requires.NoError(err)
+
+	key := fixture.ToNamespacedName(&app)
+
+	// Ensure the app has been pushed to the workload cluster
+	requires.Eventually(func() bool {
+		app := argoapp.Application{}
+		err := suite.ManagedAgentClient.Get(suite.Ctx, key, &app, metav1.GetOptions{})
+		return err == nil
+	}, 30*time.Second, 1*time.Second)
+
+	// Check that the .spec field of the workload cluster matches that of the control-plane
+	app = argoapp.Application{}
+	err = suite.PrincipalClient.Get(suite.Ctx, key, &app, metav1.GetOptions{})
+	// The destination on the agent will be set to in-cluster
+	app.Spec.Destination.Name = "in-cluster"
+	app.Spec.Destination.Server = ""
+	requires.NoError(err)
+	mapp := argoapp.Application{}
+	err = suite.ManagedAgentClient.Get(suite.Ctx, key, &mapp, metav1.GetOptions{})
+	requires.NoError(err)
+	requires.Equal(&app.Spec, &mapp.Spec)
+
+	return &app
+}
+
+func TestResyncTestSuite(t *testing.T) {
+	suite.Run(t, new(ResyncTestSuite))
+}


### PR DESCRIPTION
**What does this PR do / why we need it**:

Currently, the agent and the principal might get out of sync when they miss events that occur when they are down. Jonathan proposed an [algorithm](https://docs.google.com/document/d/1NwQaYxmRva8irx_clPTqRu_YQ8MNeFNXSTJoOgv7ZRs/edit?tab=t.0#heading=h.u46lpf9a77zp) with message types that would handle these scenarios. This PR implements the proposed logic to resync the agent/principal when they restart.

Changes introduced:

- New event types that are exchanged when the agent/principal restarts. These events are exchanged only ONCE when the process restarts
- Use checksums to avoid redundant events. If the checksums match, we can assume that the components are in sync
- Support for both managed and autonomous mode
- Unit tests

Simple sequence diagram for the logic proposed in the [doc](https://docs.google.com/document/d/1NwQaYxmRva8irx_clPTqRu_YQ8MNeFNXSTJoOgv7ZRs/edit?tab=t.0#heading=h.u46lpf9a77zp):
[Managed Mode](https://github.com/user-attachments/assets/5b234896-ced8-4e01-ac9e-bec74199b37c)
[Autonomous Mode](https://github.com/user-attachments/assets/035347d4-d4a8-48b4-8e9f-fb308c68d409)

**Which issue(s) this PR fixes**:

Fixes https://github.com/argoproj-labs/argocd-agent/issues/94

**How to test changes / Special notes to the reviewer**:

- Create an app and ensure that it is synced to the agent
- Stop the principal process
- Delete/Update the app on the control plane
- The agent and the principal are now out of sync
- Restart the principal process
- The agent should be in sync with the principal


**Checklist**

* [ ] Documentation update is required by this PR (and has been updated) OR no documentation update is required.

