### PR TITLE
test(e2e): Add fixtures for process control to e2e test suite

### DIFF
--- a/test/e2e2/fixture/goreman.go
+++ b/test/e2e2/fixture/goreman.go
@@ -1,0 +1,54 @@
+package fixture
+
+import (
+	"bufio"
+	"bytes"
+	"os/exec"
+)
+
+// StopProcess stops the named process managed by goreman
+func StopProcess(processName string) error {
+	cmd := exec.Command("goreman", "run", "stop", processName)
+	return cmd.Run()
+}
+
+// StartProcess starts the named process managed by goreman
+func StartProcess(processName string) error {
+	cmd := exec.Command("goreman", "run", "start", processName)
+	return cmd.Run()
+}
+
+// IsProcessRunning returns whether the named process managed by goreman is
+// running
+func IsProcessRunning(processName string) bool {
+	out := &bytes.Buffer{}
+	cmd := exec.Command("goreman", "run", "status")
+	cmd.Stdout = out
+	err := cmd.Run()
+	if err != nil {
+		panic(err)
+	}
+	sc := bufio.NewScanner(out)
+	for sc.Scan() {
+		l := sc.Text()
+		if len(l) < 2 {
+			panic("unknown output")
+		}
+		switch l[0] {
+		case '*':
+			// process running
+			if l[1:] == processName {
+				return true
+			}
+		case ' ':
+			// process not running
+			if l[1:] == processName {
+				return false
+			}
+		default:
+			panic("unknown output")
+		}
+	}
+	// process not found
+	return false
+}

--- a/test/e2e2/fixture_test.go
+++ b/test/e2e2/fixture_test.go
@@ -542,6 +542,15 @@ func (suite *FixtureTestSuite) Test_SyncApplication() {
 	requires.NoError(err)
 }
 
+func (suite *FixtureTestSuite) Test_Goreman_StartStopStatus_Sanity() {
+	const process = "principal"
+	requires := suite.Require()
+	requires.True(fixture.IsProcessRunning(process))
+	requires.NoError(fixture.StopProcess(process))
+	requires.False(fixture.IsProcessRunning(process))
+	requires.NoError(fixture.StartProcess(process))
+}
+
 func XTestFixtureTestSuite(t *testing.T) {
 	suite.Run(t, new(FixtureTestSuite))
 }

--- a/test/e2e2/rp_test.go
+++ b/test/e2e2/rp_test.go
@@ -181,7 +181,6 @@ func (suite *ResourceProxyTestSuite) Test_ResourceProxy_Argo() {
 		if app.Status.Sync.Status == v1alpha1.SyncStatusCodeSynced && app.Status.Health.Status == health.HealthStatusHealthy {
 			return true
 		} else {
-			suite.T().Logf("Waiting. Status is %s/%s", app.Status.Sync.Status, app.Status.Health.Status)
 			// Sometimes, the sync hangs on the workload cluster. We trigger
 			// a sync every 5th or so retry.
 			if retries > 0 && retries%5 == 0 {


### PR DESCRIPTION
**What does this PR do / why we need it**:

Add process control fixtures to e2e test suite

**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:

1. Start e2e enviroment: `make start-e2e2`
2. In another terminal, run the sanity tests: `go test -testify.m ^(Test_Goreman_StartStopStatus_Sanity)$ github.com/argoproj-labs/argocd-agent/test/e2e2 -v -count=1 -race -failfast`

**Checklist**

* [ ] Documentation update is required by this PR (and has been updated) OR no documentation update is required.

