### PR TITLE
chore(dev-env): Check for required binaries before running

### DIFF
--- a/hack/dev-env/setup-vcluster-env.sh
+++ b/hack/dev-env/setup-vcluster-env.sh
@@ -25,6 +25,11 @@ VCLUSTERS_AGENTS="agent-managed:argocd agent-autonomous:argocd"
 gen_admin_pwd="${ARGOCD_AGENT_GEN_ADMIN_PWD:-true}"
 action="$1"
 
+required_binaries="kubectl jq htpasswd kustomize vcluster git"
+for bin in $required_binaries; do
+	which $bin >/dev/null 2>&1 || (echo "Required binary $bin not found in \$PATH" >&2; exit 1)
+done
+
 # Kubectl context to restore
 initial_context=$(kubectl config current-context)
 


### PR DESCRIPTION
**What does this PR do / why we need it**:

If a required binary is missing on the user's machine, the setup script errors out pretty late depending on which binary it is. 

This PR checks if a binary is missing, let the user know and exit early.

**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:


**Checklist**

* [ ] Documentation update is required by this PR (and has been updated) OR no documentation update is required.

