### PR TITLE
fix: change the app namespace to match the agent namespace

### DIFF
--- a/hack/dev-env/apps/managed-guestbook.yaml
+++ b/hack/dev-env/apps/managed-guestbook.yaml
@@ -2,7 +2,7 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   name: guestbook
-  namespace: argocd
+  namespace: agent-managed
 spec:
   project: default
   source:


### PR DESCRIPTION
**What does this PR do / why we need it**:

Currently, the sample app in the dev-env for managed mode is created in the argocd namespace. Whereas, we expect the resource to be created in the agent namespace which is `agent-managed` on the control plane.


**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:


**Checklist**

* [ ] Documentation update is required by this PR (and has been updated) OR no documentation update is required.

