### PR TITLE
fix: When ResourceProxy is disabled, the principal should not look for the ResourceProxyTLS

### DIFF
--- a/cmd/principal/main.go
+++ b/cmd/principal/main.go
@@ -141,19 +141,22 @@ func NewPrincipalRunCommand() *cobra.Command {
 				opts = append(opts, principal.WithTLSRootCaFromFile(rootCaPath))
 			}
 
-			var proxyTls *tls.Config
-			if resourceProxyCertPath != "" && resourceProxyKeyPath != "" && resourceProxyCAPath != "" {
-				proxyTls, err = getResourceProxyTLSConfigFromFiles(resourceProxyCertPath, resourceProxyKeyPath, resourceProxyCAPath)
-			} else {
-				proxyTls, err = getResourceProxyTLSConfigFromKube(kubeConfig, namespace)
-			}
-			if err != nil {
-				cmdutil.Fatal("Error reading TLS config for resource proxy: %v", err)
-			}
 			opts = append(opts, principal.WithRequireClientCerts(requireClientCerts))
 			opts = append(opts, principal.WithClientCertSubjectMatch(clientCertSubjectMatch))
 			opts = append(opts, principal.WithResourceProxyEnabled(enableResourceProxy))
-			opts = append(opts, principal.WithResourceProxyTLS(proxyTls))
+
+			if enableResourceProxy {
+				var proxyTls *tls.Config
+				if resourceProxyCertPath != "" && resourceProxyKeyPath != "" && resourceProxyCAPath != "" {
+					proxyTls, err = getResourceProxyTLSConfigFromFiles(resourceProxyCertPath, resourceProxyKeyPath, resourceProxyCAPath)
+				} else {
+					proxyTls, err = getResourceProxyTLSConfigFromKube(kubeConfig, namespace)
+				}
+				if err != nil {
+					cmdutil.Fatal("Error reading TLS config for resource proxy: %v", err)
+				}
+				opts = append(opts, principal.WithResourceProxyTLS(proxyTls))
+			}
 
 			if jwtKey != "" {
 				opts = append(opts, principal.WithTokenSigningKeyFromFile(jwtKey))


### PR DESCRIPTION
**What does this PR do / why we need it**:
The principal pod is crashing when ResourceProxy is disabled because it needs the ResourceProxyTLS.
This fix is to make sure the principal skip looking for the ResourceProxyTLS when ResourceProxy is disabled.

**Which issue(s) this PR fixes**:

Fixes https://github.com/argoproj-labs/argocd-agent/issues/316

**How to test changes / Special notes to the reviewer**:
Built and tested locally.
Set principal deployment env `ARGOCD_PRINCIPAL_ENABLE_RESOURCE_PROXY` to false.
Apply the deployment and it did not crash with the changes.

**Checklist**

* [ ] Documentation update is required by this PR (and has been updated) OR no documentation update is required.

