### PR TITLE
feat: Agent's connection info should be exposed in cluster resource

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ start-e2e2: cli install-goreman
 
 .PHONY: test-e2e2
 test-e2e2:
-	go test -count=1 -v -race -timeout 30m github.com/argoproj-labs/argocd-agent/test/e2e2
+	./test/run-e2e.sh
 
 .PHONY: test
 test:

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/argoproj-labs/argocd-agent
 go 1.23.0
 
 require (
+	github.com/alicebob/miniredis/v2 v2.33.0
 	github.com/argoproj/argo-cd/v2 v2.14.5
 	github.com/argoproj/gitops-engine v0.7.1-0.20250304190342-43fce7ce19f1
 	github.com/cloudevents/sdk-go/binding/format/protobuf/v2 v2.15.2
@@ -11,6 +12,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.3.1
 	github.com/prometheus/client_golang v1.21.1
+	github.com/redis/go-redis/v9 v9.7.1
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/cobra v1.9.1
 	github.com/stretchr/testify v1.10.0
@@ -38,6 +40,7 @@ require (
 	github.com/Masterminds/semver/v3 v3.3.1 // indirect
 	github.com/Microsoft/go-winio v0.6.1 // indirect
 	github.com/ProtonMail/go-crypto v1.1.5 // indirect
+	github.com/alicebob/gopher-json v0.0.0-20200520072559-a9ecdc9d1d3a // indirect
 	github.com/argoproj/pkg v0.13.7-0.20230626144333-d56162821bd1 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/blang/semver/v4 v4.0.0 // indirect
@@ -113,7 +116,6 @@ require (
 	github.com/prometheus/client_model v0.6.1 // indirect
 	github.com/prometheus/common v0.62.0 // indirect
 	github.com/prometheus/procfs v0.15.1 // indirect
-	github.com/redis/go-redis/v9 v9.7.1 // indirect
 	github.com/robfig/cron/v3 v3.0.1 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3 // indirect
@@ -130,6 +132,7 @@ require (
 	github.com/x448/float16 v0.8.4 // indirect
 	github.com/xanzy/ssh-agent v0.3.3 // indirect
 	github.com/xlab/treeprint v1.2.0 // indirect
+	github.com/yuin/gopher-lua v1.1.1 // indirect
 	go.starlark.net v0.0.0-20230525235612-a134d8f9ddca // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.26.0 // indirect

--- a/hack/dev-env/Procfile.e2e
+++ b/hack/dev-env/Procfile.e2e
@@ -1,3 +1,3 @@
 principal: hack/dev-env/start-principal.sh
-agent-managed: hack/dev-env/start-agent-managed.sh
-agent-autonomous: hack/dev-env/start-agent-autonomous.sh
+agent-managed: sleep 5s && hack/dev-env/start-agent-managed.sh
+agent-autonomous: sleep 5s && hack/dev-env/start-agent-autonomous.sh

--- a/hack/dev-env/start-agent-managed.sh
+++ b/hack/dev-env/start-agent-managed.sh
@@ -16,7 +16,7 @@
 set -ex -o pipefail
 ARGS=$*
 if ! kubectl config get-contexts | tail -n +2 | awk '{ print $2 }' | grep -qE '^vcluster-agent-managed$'; then
-    echo "kube context vcluster-agent-autonomous is not configured; missing setup?" >&2
+    echo "kube context vcluster-agent-managed is not configured; missing setup?" >&2
     exit 1
 fi
 SCRIPTPATH="$( cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"

--- a/internal/argocd/cluster/cluster.go
+++ b/internal/argocd/cluster/cluster.go
@@ -1,0 +1,105 @@
+// Copyright 2025 The argocd-agent Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cluster
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+
+	"github.com/argoproj/argo-cd/v2/common"
+	appv1 "github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
+	cacheutil "github.com/argoproj/argo-cd/v2/util/cache"
+	appstatecache "github.com/argoproj/argo-cd/v2/util/cache/appstate"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// UpdateClusterConnectionInfo updates cluster info with connection state and time in mapped cluster
+func (m *Manager) UpdateClusterConnectionInfo(agentName, status string, t time.Time) {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+
+	// Check if we have a mapping for the requested agent
+	cluster := m.mapping(agentName)
+	if cluster == nil {
+		log().Errorf("Agent %s is not mapped to any cluster", agentName)
+		return
+	}
+
+	// Create Redis client and cache
+	redisOptions := &redis.Options{Addr: m.redisAddress}
+
+	if err := common.SetOptionalRedisPasswordFromKubeConfig(m.ctx, m.kubeclient, m.namespace, redisOptions); err != nil {
+		log().Errorf("Failed to fetch & set redis password for namespace %s: %v", m.namespace, err)
+	}
+	redisClient := redis.NewClient(redisOptions)
+
+	cache := appstatecache.NewCache(cacheutil.NewCache(
+		cacheutil.NewRedisCache(redisClient, time.Minute, m.redisCompressionType)), time.Minute)
+
+	state := "disconnected"
+	if status == appv1.ConnectionStatusSuccessful {
+		state = "connected"
+	}
+
+	// update the info
+	if err := cache.SetClusterInfo(cluster.Server,
+		&appv1.ClusterInfo{
+			ConnectionState: appv1.ConnectionState{
+				Status:     status,
+				Message:    fmt.Sprintf("Agent: '%s' is %s with principal", agentName, state),
+				ModifiedAt: &metav1.Time{Time: t}}},
+	); err != nil {
+		log().Errorf("Failed to update connection info in Cluster: '%s' mapped with Agent: '%s'. Error: %v", cluster.Name, agentName, err)
+		return
+	}
+
+	log().Infof("Updated connection status to '%s' in Cluster: '%s' mapped with Agent: '%s'", status, cluster.Name, agentName)
+}
+
+// refreshClusterConnectionInfo gets latest cluster info from cache and re-saves it to avoid deletion of info
+// by ArgoCD after cache expiration time duration (i.e. 10 Minute)
+func (m *Manager) refreshClusterConnectionInfo() {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+
+	// iterate through all clusters
+	for agentName, cluster := range m.clusters {
+		// Create Redis client and cache
+		redisOptions := &redis.Options{Addr: m.redisAddress}
+
+		if err := common.SetOptionalRedisPasswordFromKubeConfig(m.ctx, m.kubeclient, m.namespace, redisOptions); err != nil {
+			log().Errorf("Failed to fetch & set redis password for namespace %s: %v", m.namespace, err)
+		}
+		redisClient := redis.NewClient(redisOptions)
+
+		cache := appstatecache.NewCache(cacheutil.NewCache(
+			cacheutil.NewRedisCache(redisClient, time.Minute, m.redisCompressionType)), time.Minute)
+
+		// fetch latest info
+		clusterInfo := &appv1.ClusterInfo{}
+		if err := cache.GetClusterInfo(cluster.Server, clusterInfo); err != nil {
+			log().Errorf("Failed to get connection info from Cluster: '%s' mapped with Agent: '%s'. Error: %v", cluster.Name, agentName, err)
+			return
+		}
+
+		// re-save same info
+		if err := cache.SetClusterInfo(cluster.Server, clusterInfo); err != nil {
+			log().Errorf("Failed to refresh connection info in Cluster: '%s' mapped with Agent: '%s'. Error: %v", cluster.Name, agentName, err)
+			return
+		}
+	}
+}

--- a/internal/argocd/cluster/cluster_test.go
+++ b/internal/argocd/cluster/cluster_test.go
@@ -1,0 +1,129 @@
+// Copyright 2025 The argocd-agent Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cluster
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/argoproj-labs/argocd-agent/test/fake/kube"
+	"github.com/argoproj/argo-cd/v2/common"
+	appv1 "github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
+	cacheutil "github.com/argoproj/argo-cd/v2/util/cache"
+	appstatecache "github.com/argoproj/argo-cd/v2/util/cache/appstate"
+	"github.com/redis/go-redis/v9"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func setup(t *testing.T, redisAddress string) (string, *Manager) {
+	t.Helper()
+	agentName, clusterName := "agent-test", "cluster"
+	m := &Manager{
+		namespace:            "default",
+		ctx:                  context.Background(),
+		kubeclient:           kube.NewFakeKubeClient(),
+		clusters:             make(map[string]*appv1.Cluster),
+		redisAddress:         redisAddress,
+		redisCompressionType: cacheutil.RedisCompressionNone,
+	}
+
+	// map cluster with agent
+	err := m.MapCluster(agentName, &appv1.Cluster{Name: clusterName})
+	require.NoError(t, err)
+
+	// create redis secret
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: common.RedisInitialCredentials},
+		Data:       map[string][]byte{common.RedisInitialCredentialsKey: []byte("password123")},
+	}
+	_, err = m.kubeclient.CoreV1().Secrets(m.namespace).Create(m.ctx, secret, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	return agentName, m
+}
+
+func getClusterInfo(t *testing.T, agentName string, m *Manager) appv1.ClusterInfo {
+
+	// Create Redis client and cache
+	redisOptions := &redis.Options{Addr: m.redisAddress}
+	err := common.SetOptionalRedisPasswordFromKubeConfig(m.ctx, m.kubeclient, m.namespace, redisOptions)
+	require.NoError(t, err)
+
+	redisClient := redis.NewClient(redisOptions)
+	cache := appstatecache.NewCache(cacheutil.NewCache(
+		cacheutil.NewRedisCache(redisClient, time.Hour, m.redisCompressionType)), time.Hour)
+
+	// fetch cluster info
+	var clusterInfo appv1.ClusterInfo
+	cluster := m.mapping(agentName)
+	err = cache.GetClusterInfo(cluster.Server, &clusterInfo)
+	require.NoError(t, err)
+	require.NotNil(t, clusterInfo)
+	return clusterInfo
+}
+
+func Test_UpdateClusterInfo(t *testing.T) {
+	miniRedis, err := miniredis.Run()
+	defer miniRedis.Close()
+	require.NoError(t, err)
+	require.NotNil(t, miniRedis)
+
+	agentName, m := setup(t, miniRedis.Addr())
+
+	t.Run("Update cluster info when agent is connected", func(t *testing.T) {
+		// update cluster info
+		m.UpdateClusterConnectionInfo(agentName, appv1.ConnectionStatusSuccessful, time.Now())
+
+		// verify cluster info is updated
+		clusterInfo := getClusterInfo(t, agentName, m)
+		require.Equal(t, clusterInfo.ConnectionState.Status, appv1.ConnectionStatusSuccessful)
+		require.Equal(t, clusterInfo.ConnectionState.Message, fmt.Sprintf("Agent: '%s' is connected with principal", agentName))
+		require.True(t, clusterInfo.ConnectionState.ModifiedAt.After(time.Now().Add(-1*time.Second)))
+
+		time.Sleep(3 * time.Second)
+
+		// re-save info
+		m.refreshClusterConnectionInfo()
+
+		// verify cluster info is same
+		clusterInfoNew := getClusterInfo(t, agentName, m)
+		require.Equal(t, clusterInfo, clusterInfoNew)
+	})
+
+	t.Run("Update cluster info when agent is disconnected", func(t *testing.T) {
+		// update cluster info
+		m.UpdateClusterConnectionInfo(agentName, appv1.ConnectionStatusFailed, time.Now())
+
+		// verify cluster info is updated
+		clusterInfo := getClusterInfo(t, agentName, m)
+		require.Equal(t, clusterInfo.ConnectionState.Status, appv1.ConnectionStatusFailed)
+		require.Equal(t, clusterInfo.ConnectionState.Message, fmt.Sprintf("Agent: '%s' is disconnected with principal", agentName))
+		require.True(t, clusterInfo.ConnectionState.ModifiedAt.After(time.Now().Add(-1*time.Second)))
+
+		time.Sleep(3 * time.Second)
+
+		// re-save info
+		m.refreshClusterConnectionInfo()
+
+		// verify cluster info is same
+		clusterInfoNew := getClusterInfo(t, agentName, m)
+		require.Equal(t, clusterInfo, clusterInfoNew)
+	})
+}

--- a/internal/argocd/cluster/informer_test.go
+++ b/internal/argocd/cluster/informer_test.go
@@ -15,7 +15,7 @@ import (
 
 func Test_onClusterAdded(t *testing.T) {
 	t.Run("Successfully add a cluster", func(t *testing.T) {
-		m, err := NewManager(context.TODO(), "argocd", kube.NewFakeKubeClient())
+		m, err := NewManager(context.TODO(), "argocd", "", "", kube.NewFakeKubeClient())
 		require.NoError(t, err)
 		s := &v1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
@@ -29,7 +29,7 @@ func Test_onClusterAdded(t *testing.T) {
 		assert.Len(t, m.clusters, 1)
 	})
 	t.Run("Secret is missing one or more labels", func(t *testing.T) {
-		m, err := NewManager(context.TODO(), "argocd", kube.NewFakeKubeClient())
+		m, err := NewManager(context.TODO(), "argocd", "", "", kube.NewFakeKubeClient())
 		require.NoError(t, err)
 		s := &v1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
@@ -46,7 +46,7 @@ func Test_onClusterAdded(t *testing.T) {
 		assert.Len(t, m.clusters, 0)
 	})
 	t.Run("Target agent already has a mapping", func(t *testing.T) {
-		m, err := NewManager(context.TODO(), "argocd", kube.NewFakeKubeClient())
+		m, err := NewManager(context.TODO(), "argocd", "", "", kube.NewFakeKubeClient())
 		require.NoError(t, err)
 		s := &v1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
@@ -83,7 +83,7 @@ func Test_onClusterUpdated(t *testing.T) {
 				Name: "cluster",
 			},
 		}
-		m, err := NewManager(context.TODO(), "argocd", kube.NewFakeKubeClient())
+		m, err := NewManager(context.TODO(), "argocd", "", "", kube.NewFakeKubeClient())
 		require.NoError(t, err)
 		m.mapCluster("agent1", &v1alpha1.Cluster{})
 		assert.NotNil(t, m.mapping("agent1"))
@@ -111,7 +111,7 @@ func Test_onClusterUpdated(t *testing.T) {
 				Name: "cluster2",
 			},
 		}
-		m, err := NewManager(context.TODO(), "argocd", kube.NewFakeKubeClient())
+		m, err := NewManager(context.TODO(), "argocd", "", "", kube.NewFakeKubeClient())
 		require.NoError(t, err)
 		m.mapCluster("agent1", &v1alpha1.Cluster{Name: "cluster1"})
 		assert.NotNil(t, m.mapping("agent1"))

--- a/internal/argocd/cluster/manager_test.go
+++ b/internal/argocd/cluster/manager_test.go
@@ -41,7 +41,7 @@ func newClusterSecret(t *testing.T, agentName string) (*v1alpha1.Cluster, *v1.Se
 
 func Test_StartStop(t *testing.T) {
 	clt := kube.NewFakeClientsetWithResources()
-	m, err := NewManager(context.TODO(), "argocd", clt)
+	m, err := NewManager(context.TODO(), "argocd", "", "", clt)
 	require.NoError(t, err)
 	require.NotNil(t, m)
 	err = m.Start()
@@ -52,7 +52,7 @@ func Test_StartStop(t *testing.T) {
 
 func Test_onClusterAdd(t *testing.T) {
 	clt := kube.NewFakeClientsetWithResources()
-	m, err := NewManager(context.TODO(), "argocd", clt)
+	m, err := NewManager(context.TODO(), "argocd", "", "", clt)
 	require.NoError(t, err)
 	require.NotNil(t, m)
 	err = m.Start()

--- a/principal/listen.go
+++ b/principal/listen.go
@@ -216,6 +216,6 @@ func (s *Server) registerGrpcServices(metrics *metrics.PrincipalMetrics) error {
 	}
 	authapi.RegisterAuthenticationServer(s.grpcServer, authSrv)
 	versionapi.RegisterVersionServer(s.grpcServer, version.NewServer(s.authenticate))
-	eventstreamapi.RegisterEventStreamServer(s.grpcServer, eventstream.NewServer(s.queues, metrics, eventstream.WithNotifyOnConnect(s.notifyOnConnect)))
+	eventstreamapi.RegisterEventStreamServer(s.grpcServer, eventstream.NewServer(s.queues, metrics, s.clusterMgr, eventstream.WithNotifyOnConnect(s.notifyOnConnect)))
 	return nil
 }

--- a/principal/options.go
+++ b/principal/options.go
@@ -31,6 +31,7 @@ import (
 	"time"
 
 	"github.com/argoproj-labs/argocd-agent/internal/auth"
+	cacheutil "github.com/argoproj/argo-cd/v2/util/cache"
 )
 
 // supportedTLSVersion is a list of TLS versions we support
@@ -67,6 +68,8 @@ type ServerOptions struct {
 	requireClientCerts     bool
 	rootCa                 *x509.CertPool
 	clientCertSubjectMatch bool
+	redisAddress           string
+	redisCompressionType   cacheutil.RedisCompressionType
 }
 
 type ServerOption func(o *Server) error
@@ -381,6 +384,19 @@ func WithResourceProxyTLS(tlsConfig *tls.Config) ServerOption {
 func WithKeepAliveMinimumInterval(interval time.Duration) ServerOption {
 	return func(o *Server) error {
 		o.keepAliveMinimumInterval = interval
+		return nil
+	}
+}
+
+func WithRedis(redisAddress, redisCompressionTypeStr string) ServerOption {
+	return func(o *Server) error {
+		redisCompressionType, err := cacheutil.CompressionTypeFromString(redisCompressionTypeStr)
+		if err != nil {
+			return err
+		}
+		o.options.redisCompressionType = redisCompressionType
+		o.options.redisAddress = redisAddress
+
 		return nil
 	}
 }

--- a/principal/server.go
+++ b/principal/server.go
@@ -308,7 +308,7 @@ func NewServer(ctx context.Context, kubeClient *kube.KubernetesClient, namespace
 
 	// Instantiate the cluster manager to handle Argo CD cluster secrets for
 	// agents.
-	s.clusterMgr, err = cluster.NewManager(s.ctx, s.namespace, s.kubeClient.Clientset)
+	s.clusterMgr, err = cluster.NewManager(s.ctx, s.namespace, s.options.redisAddress, s.options.redisCompressionType, s.kubeClient.Clientset)
 	if err != nil {
 		return nil, err
 	}

--- a/test/e2e2/clusterinfo_test.go
+++ b/test/e2e2/clusterinfo_test.go
@@ -1,0 +1,119 @@
+// Copyright 2025 The argocd-agent Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package e2e2
+
+import (
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/argoproj-labs/argocd-agent/test/e2e2/fixture"
+	appv1 "github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
+	"github.com/stretchr/testify/suite"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type ClusterTestSuite struct {
+	fixture.BaseSuite
+}
+
+func (suite *ClusterTestSuite) TearDownTest() {
+	suite.BaseSuite.TearDownTest()
+}
+
+var message = "Agent: '%s' is %s with principal"
+
+func (suite *ClusterTestSuite) Test_ClusterInfo_Managed() {
+	agentName := "agent-managed"
+	requires := suite.Require()
+
+	// Verify that connection status has been updated when agent is already connected
+	requires.Eventually(func() bool {
+		return fixture.HasConnectionInfo(os.Getenv(fixture.ManagedAgentServerKey), appv1.ConnectionState{
+			Status:  appv1.ConnectionStatusSuccessful,
+			Message: fmt.Sprintf(message, agentName, "connected"),
+		})
+	}, 30*time.Second, 1*time.Second)
+
+	// Stop the agent
+	err := fixture.StopProcess(agentName)
+	requires.NoError(err)
+
+	// Verify that connection status is updated when agent is disconnected
+	requires.Eventually(func() bool {
+		return fixture.HasConnectionInfo(os.Getenv(fixture.ManagedAgentServerKey), appv1.ConnectionState{
+			Status:     appv1.ConnectionStatusFailed,
+			Message:    fmt.Sprintf(message, agentName, "disconnected"),
+			ModifiedAt: &metav1.Time{Time: time.Now()},
+		})
+	}, 30*time.Second, 1*time.Second)
+
+	// Restart the agent
+	err = fixture.StartProcess(agentName)
+	requires.NoError(err)
+
+	// Verify that connection status is updated again when agent is re-connected
+	requires.Eventually(func() bool {
+		return fixture.HasConnectionInfo(os.Getenv(fixture.ManagedAgentServerKey), appv1.ConnectionState{
+			Status:     appv1.ConnectionStatusSuccessful,
+			Message:    fmt.Sprintf(message, agentName, "connected"),
+			ModifiedAt: &metav1.Time{Time: time.Now()},
+		})
+	}, 30*time.Second, 1*time.Second)
+}
+
+func (suite *ClusterTestSuite) Test_ClusterInfo_Autonomous() {
+	agentName := "agent-autonomous"
+	requires := suite.Require()
+
+	// Verify the connection status is updated when agent is already connected
+	requires.Eventually(func() bool {
+		return fixture.HasConnectionInfo(os.Getenv(fixture.AutonomousAgentServerKey), appv1.ConnectionState{
+			Status:  appv1.ConnectionStatusSuccessful,
+			Message: fmt.Sprintf(message, agentName, "connected"),
+		})
+	}, 30*time.Second, 1*time.Second)
+
+	// Stop the agent
+	err := fixture.StopProcess(agentName)
+	requires.NoError(err)
+
+	// Verify that connection status is updated when agent is disconnected
+	requires.Eventually(func() bool {
+		return fixture.HasConnectionInfo(os.Getenv(fixture.AutonomousAgentServerKey), appv1.ConnectionState{
+			Status:     appv1.ConnectionStatusFailed,
+			Message:    fmt.Sprintf(message, agentName, "disconnected"),
+			ModifiedAt: &metav1.Time{Time: time.Now()},
+		})
+	}, 30*time.Second, 1*time.Second)
+
+	// Restart the agent
+	err = fixture.StartProcess(agentName)
+	requires.NoError(err)
+
+	// Verify that connection status is updated again when agent is re-connected
+	requires.Eventually(func() bool {
+		return fixture.HasConnectionInfo(os.Getenv(fixture.AutonomousAgentServerKey), appv1.ConnectionState{
+			Status:     appv1.ConnectionStatusSuccessful,
+			Message:    fmt.Sprintf(message, agentName, "connected"),
+			ModifiedAt: &metav1.Time{Time: time.Now()},
+		})
+	}, 30*time.Second, 1*time.Second)
+}
+
+func TestClusterTestSuite(t *testing.T) {
+	suite.Run(t, new(ClusterTestSuite))
+}

--- a/test/e2e2/fixture/cluster.go
+++ b/test/e2e2/fixture/cluster.go
@@ -1,0 +1,74 @@
+// Copyright 2025 The argocd-agent Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fixture
+
+import (
+	"os"
+	"time"
+
+	appv1 "github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
+	cacheutil "github.com/argoproj/argo-cd/v2/util/cache"
+	appstatecache "github.com/argoproj/argo-cd/v2/util/cache/appstate"
+	"github.com/redis/go-redis/v9"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	ManagedAgentServerKey    = "AGENT_E2E_MANAGED_CLUSTER_SERVER"
+	AutonomousAgentServerKey = "AGENT_E2E_AUTONOMOUS_CLUSTER_SERVER"
+	RedisServerAddressKey    = "AGENT_E2E_REDIS_SERVER_ADDRESS"
+	RedisServerPasswordKey   = "AGENT_E2E_REDIS_PASSWORD"
+)
+
+func HasConnectionInfo(serverName string, expected appv1.ConnectionState) bool {
+	actual, err := getClusterInfo(serverName)
+
+	if err != nil {
+		return false
+	}
+
+	return actual.ConnectionState.Status == expected.Status &&
+		actual.ConnectionState.Message == expected.Message &&
+		verifyConnectionModificationTime(actual.ConnectionState.ModifiedAt, expected.ModifiedAt)
+}
+
+// getClusterInfo retrieves connection info from control plane's Redis server
+func getClusterInfo(server string) (appv1.ClusterInfo, error) {
+
+	// Create Redis client and cache
+	redisOptions := &redis.Options{Addr: os.Getenv(RedisServerAddressKey),
+		Password: os.Getenv(RedisServerPasswordKey)}
+
+	redisClient := redis.NewClient(redisOptions)
+	cache := appstatecache.NewCache(cacheutil.NewCache(
+		cacheutil.NewRedisCache(redisClient, time.Hour, cacheutil.RedisCompressionGZip)), time.Hour)
+
+	// fetch cluster info
+	var clusterInfo appv1.ClusterInfo
+	err := cache.GetClusterInfo(server, &clusterInfo)
+
+	return clusterInfo, err
+}
+
+func verifyConnectionModificationTime(actualTime *metav1.Time, expectedTime *metav1.Time) bool {
+	// initially we don't know when agent was started, hence just checking actual time is not Nil
+	if expectedTime == nil && actualTime != nil {
+		return true
+	}
+
+	// if expected time is provided then verify that actual time is within 5 sec range from expected time,
+	// because starting agent may take some time
+	return actualTime.After(expectedTime.Add(-5 * time.Second))
+}

--- a/test/run-e2e.sh
+++ b/test/run-e2e.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+# Copyright 2025 The argocd-agent Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -ex -o pipefail
+ARGS=$*
+if ! kubectl config get-contexts | tail -n +2 | awk '{ print $2 }' | grep -qE '^vcluster-control-plane$'; then
+    echo "kube context vcluster-control-plane is not configured; missing setup?" >&2
+    exit 1
+fi
+
+# Export Redis server address as env variable
+if test "${AGENT_E2E_REDIS_SERVER_ADDRESS}" = ""; then
+       ipaddr=$(kubectl --context vcluster-control-plane -n argocd get svc argocd-redis -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+       hostname=$(kubectl --context vcluster-control-plane -n argocd get svc argocd-redis -o jsonpath='{.status.loadBalancer.ingress[0].hostname}')
+       if test "$ipaddr" != ""; then
+               AGENT_E2E_REDIS_SERVER_ADDRESS=$ipaddr:6379
+       elif test "$hostname" != ""; then
+               AGENT_E2E_REDIS_SERVER_ADDRESS=$hostname:6379
+       else
+               echo "Could not determine Redis server address." >&2
+               exit 1
+       fi
+       export AGENT_E2E_REDIS_SERVER_ADDRESS
+fi
+
+# Export Redis server password as env variable
+if test "${AGENT_E2E_REDIS_PASSWORD}" = ""; then
+       password=$(kubectl --context vcluster-control-plane -n argocd get secret argocd-redis -o jsonpath='{.data.auth}')
+       if test "$password" != ""; then
+               AGENT_E2E_REDIS_PASSWORD="$(base64 -d <<< $password)"
+       else
+               echo "Could not determine Redis password." >&2
+               exit 1
+       fi
+       export AGENT_E2E_REDIS_PASSWORD
+fi
+
+# Export managed cluster server address as env variable
+if test "${AGENT_E2E_MANAGED_CLUSTER_SERVER}" = ""; then
+       managedClusterServer=$(kubectl --context vcluster-control-plane -n argocd get secret cluster-agent-managed -o jsonpath='{.data.server}')
+       if test "$managedClusterServer" != ""; then
+               AGENT_E2E_MANAGED_CLUSTER_SERVER="$(base64 -d <<< $managedClusterServer)"
+       else
+               echo "Could not determine managed cluster." >&2
+               exit 1
+       fi
+       export AGENT_E2E_MANAGED_CLUSTER_SERVER
+fi
+
+# Export autonomous cluster server address as env variable
+if test "${AGENT_E2E_AUTONOMOUS_CLUSTER_SERVER}" = ""; then
+       autonomousClusterServer=$(kubectl --context vcluster-control-plane -n argocd get secret cluster-agent-autonomous -o jsonpath='{.data.server}')
+       if test "$autonomousClusterServer" != ""; then
+               AGENT_E2E_AUTONOMOUS_CLUSTER_SERVER="$(base64 -d <<< $autonomousClusterServer)"
+       else
+               echo "Could not determine autonomous cluster." >&2
+               exit 1
+       fi
+       export AGENT_E2E_AUTONOMOUS_CLUSTER_SERVER
+fi
+
+go test -count=1 -v -race -timeout 30m github.com/argoproj-labs/argocd-agent/test/e2e2


### PR DESCRIPTION
### Description
This PR is to expose agent's connection status and other details via Cluster resource.


Fixes https://github.com/argoproj-labs/argocd-agent/issues/130


#### Note
To update cluster info Principal needs to connect with Redis. For this I a using LoadBalancer hostname, (which could be changed to internal address when we run within container) ss of now for development in local we are using LoadBalancer. 