### PR TITLE
feat: enable compression for communication over gRPC

### DIFF
--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -37,23 +37,24 @@ import (
 
 func NewAgentRunCommand() *cobra.Command {
 	var (
-		serverAddress   string
-		serverPort      int
-		logLevel        string
-		logFormat       string
-		insecure        bool
-		rootCAPath      string
-		kubeConfig      string
-		kubeContext     string
-		namespace       string
-		agentMode       string
-		creds           string
-		showVersion     bool
-		versionFormat   string
-		tlsClientCrt    string
-		tlsClientKey    string
-		enableWebSocket bool
-		metricsPort     int
+		serverAddress     string
+		serverPort        int
+		logLevel          string
+		logFormat         string
+		insecure          bool
+		rootCAPath        string
+		kubeConfig        string
+		kubeContext       string
+		namespace         string
+		agentMode         string
+		creds             string
+		showVersion       bool
+		versionFormat     string
+		tlsClientCrt      string
+		tlsClientKey      string
+		enableWebSocket   bool
+		metricsPort       int
+		enableCompression bool
 
 		// Time interval for agent to principal ping
 		// Ex: "30m", "1h" or "1h20m10s". Valid time units are "s", "m", "h".
@@ -107,6 +108,7 @@ func NewAgentRunCommand() *cobra.Command {
 			remoteOpts = append(remoteOpts, client.WithWebSocket(enableWebSocket))
 			remoteOpts = append(remoteOpts, client.WithClientMode(types.AgentModeFromString(agentMode)))
 			remoteOpts = append(remoteOpts, client.WithKeepAlivePingInterval(keepAlivePingInterval))
+			remoteOpts = append(remoteOpts, client.WithCompression(enableCompression))
 
 			if serverAddress != "" && serverPort > 0 && serverPort < 65536 {
 				remote, err = client.NewRemote(serverAddress, serverPort, remoteOpts...)
@@ -186,6 +188,9 @@ func NewAgentRunCommand() *cobra.Command {
 	command.Flags().DurationVar(&keepAlivePingInterval, "keep-alive-ping-interval",
 		env.DurationWithDefault("ARGOCD_AGENT_KEEP_ALIVE_PING_INTERVAL", nil, 0),
 		"Ping interval to keep connection alive with Principal")
+	command.Flags().BoolVar(&enableCompression, "enable-compression",
+		env.BoolWithDefault("ARGOCD_AGENT_ENABLE_COMPRESSION", false),
+		"Use compression while sending data between Principal and Agent using gRPC")
 
 	command.Flags().StringVar(&kubeConfig, "kubeconfig", "", "Path to a kubeconfig file to use")
 	command.Flags().StringVar(&kubeContext, "kubecontext", "", "Override the default kube context")

--- a/hack/dev-env/start-agent-autonomous.sh
+++ b/hack/dev-env/start-agent-autonomous.sh
@@ -30,4 +30,5 @@ go run github.com/argoproj-labs/argocd-agent/cmd/agent \
     --namespace argocd \
     --log-level trace $ARGS \
     --metrics-port 8182 \
+    #--enable-compression true
     #--keep-alive-ping-interval 15m

--- a/hack/dev-env/start-agent-managed.sh
+++ b/hack/dev-env/start-agent-managed.sh
@@ -29,4 +29,5 @@ go run github.com/argoproj-labs/argocd-agent/cmd/agent \
     --kubecontext vcluster-agent-managed \
     --namespace agent-managed \
     --log-level trace $ARGS \
+    #--enable-compression true
     #--keep-alive-ping-interval 15m

--- a/principal/listen.go
+++ b/principal/listen.go
@@ -38,6 +38,7 @@ import (
 	"github.com/argoproj-labs/argocd-agent/principal/apis/eventstream"
 	"github.com/argoproj-labs/argocd-agent/principal/apis/version"
 	grpchttp1server "golang.stackrox.io/grpc-http1/server"
+	_ "google.golang.org/grpc/encoding/gzip"
 )
 
 const listenerRetries = 5


### PR DESCRIPTION
This PR enables users to send/receive compressed data stream between Principal and Agent. User can enable/disable compression by setting `enable-compression` flag to `True` or setting `ARGOCD_AGENT_ENABLE_COMPRESSION` env variable at agent side. There is no action needed at Principal because at server side registered compressors will be used automatically. As of now `gzip` compression is used.

Fixes https://github.com/argoproj-labs/argocd-agent/issues/113
