### PR TITLE
chore: fix flaky unit test

### DIFF
--- a/internal/argocd/cluster/cluster_test.go
+++ b/internal/argocd/cluster/cluster_test.go
@@ -95,7 +95,7 @@ func Test_UpdateClusterInfo(t *testing.T) {
 		clusterInfo := getClusterInfo(t, agentName, m)
 		require.Equal(t, clusterInfo.ConnectionState.Status, appv1.ConnectionStatusSuccessful)
 		require.Equal(t, clusterInfo.ConnectionState.Message, fmt.Sprintf("Agent: '%s' is connected with principal", agentName))
-		require.True(t, clusterInfo.ConnectionState.ModifiedAt.After(time.Now().Add(-1*time.Second)))
+		require.True(t, clusterInfo.ConnectionState.ModifiedAt.After(time.Now().Add(-2*time.Second)))
 
 		time.Sleep(3 * time.Second)
 
@@ -115,7 +115,7 @@ func Test_UpdateClusterInfo(t *testing.T) {
 		clusterInfo := getClusterInfo(t, agentName, m)
 		require.Equal(t, clusterInfo.ConnectionState.Status, appv1.ConnectionStatusFailed)
 		require.Equal(t, clusterInfo.ConnectionState.Message, fmt.Sprintf("Agent: '%s' is disconnected with principal", agentName))
-		require.True(t, clusterInfo.ConnectionState.ModifiedAt.After(time.Now().Add(-1*time.Second)))
+		require.True(t, clusterInfo.ConnectionState.ModifiedAt.After(time.Now().Add(-2*time.Second)))
 
 		time.Sleep(3 * time.Second)
 


### PR DESCRIPTION
This PR is to fix a flaky unit test, where `Test_UpdateClusterInfo` test fails sometimes because getClusterInfo() takes more than 1 second to fetch data from Redis cache. It is fixed by increasing time range. It can be tested by running below command to confirm.

`go test -run Test_UpdateClusterInfo -count 100 -failfast`