### PR TITLE
feat: Add version flag to principal command

### DIFF
--- a/cmd/principal/main.go
+++ b/cmd/principal/main.go
@@ -35,6 +35,7 @@ import (
 	"github.com/argoproj-labs/argocd-agent/internal/kube"
 	"github.com/argoproj-labs/argocd-agent/internal/labels"
 	"github.com/argoproj-labs/argocd-agent/internal/tlsutil"
+	"github.com/argoproj-labs/argocd-agent/internal/version"
 	"github.com/argoproj-labs/argocd-agent/principal"
 	cacheutil "github.com/argoproj/argo-cd/v2/util/cache"
 
@@ -71,6 +72,8 @@ func NewPrincipalRunCommand() *cobra.Command {
 		resourceProxyCertPath  string
 		resourceProxyKeyPath   string
 		resourceProxyCAPath    string
+		showVersion            bool
+		versionFormat          string
 
 		// Minimum time duration for agent to wait before sending next keepalive ping to principal
 		// if agent sends ping more often than specified interval then connection will be dropped
@@ -83,6 +86,11 @@ func NewPrincipalRunCommand() *cobra.Command {
 	var command = &cobra.Command{
 		Short: "Run the argocd-agent principal component",
 		Run: func(c *cobra.Command, args []string) {
+			if showVersion {
+				cmdutil.PrintVersion(version.New("argocd-agent", "principal"), versionFormat)
+				os.Exit(0)
+			}
+
 			ctx, cancelFn := context.WithCancel(context.Background())
 			defer cancelFn()
 
@@ -322,6 +330,8 @@ func NewPrincipalRunCommand() *cobra.Command {
 	command.Flags().StringVar(&kubeConfig, "kubeconfig", "", "Path to a kubeconfig file to use")
 	command.Flags().StringVar(&kubeContext, "kubecontext", "", "Override the default kube context")
 	command.Flags().BoolVar(&enablePprof, "enable-pprof", false, "Enable pprof server")
+	command.Flags().BoolVar(&showVersion, "version", false, "Display version information and exit")
+	command.Flags().StringVar(&versionFormat, "version-format", "text", "Output version information in format: text, json, json-indent")
 
 	return command
 


### PR DESCRIPTION
**What does this PR do / why we need it**:
Introduce a `--version` flag to the principal command, allowing users to display version information for the argocd-agent. An optional `--version-format` flag specifies the output format (text, json, or json-indent).

**Which issue(s) this PR fixes**:
Fixed #354

**How to test changes / Special notes to the reviewer**:
i implemented the `--version` flag in the same way as it is currently implemented in the agent. is there a reason this is not a separate sub command in both cases? i can make that change as well, if it is preferred.

**Checklist**

* [] Documentation update is required by this PR (and has been updated) OR no documentation update is required.
