### PR TITLE
fix: agent should use the default queue name instead of client ID

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -254,6 +254,8 @@ func (a *Agent) Start(ctx context.Context) error {
 		metrics.StartMetricsServer(metrics.WithListener("", a.options.metricsPort))
 	}
 
+	a.emitter = event.NewEventSource(fmt.Sprintf("agent://%s", "agent-managed"))
+
 	// Start the Application backend in the background
 	go func() {
 		if err := a.appManager.StartBackend(a.context); err != nil {
@@ -298,8 +300,6 @@ func (a *Agent) Start(ctx context.Context) error {
 		// this.
 		_ = a.maintainConnection()
 	}
-
-	a.emitter = event.NewEventSource(fmt.Sprintf("agent://%s", "agent-managed"))
 
 	return err
 }

--- a/agent/connection_test.go
+++ b/agent/connection_test.go
@@ -29,15 +29,12 @@ func TestResyncOnStart(t *testing.T) {
 	a.kubeClient.RestConfig = &rest.Config{}
 	logCtx := log()
 
-	err := a.queues.Create(a.remote.ClientID())
-	assert.Nil(t, err)
-
 	t.Run("should return if the agent has already been synced", func(t *testing.T) {
 		a.resyncedOnStart = true
 		err := a.resyncOnStart(logCtx)
 		assert.Nil(t, err)
 
-		sendQ := a.queues.SendQ(a.remote.ClientID())
+		sendQ := a.queues.SendQ(defaultQueueName)
 		assert.Zero(t, sendQ.Len())
 	})
 
@@ -47,7 +44,7 @@ func TestResyncOnStart(t *testing.T) {
 		err := a.resyncOnStart(logCtx)
 		assert.Nil(t, err)
 
-		sendQ := a.queues.SendQ(a.remote.ClientID())
+		sendQ := a.queues.SendQ(defaultQueueName)
 		assert.Equal(t, 1, sendQ.Len())
 
 		ev, shutdown := sendQ.Get()
@@ -63,7 +60,7 @@ func TestResyncOnStart(t *testing.T) {
 		err := a.resyncOnStart(logCtx)
 		assert.Nil(t, err)
 
-		sendQ := a.queues.SendQ(a.remote.ClientID())
+		sendQ := a.queues.SendQ(defaultQueueName)
 		assert.Equal(t, 1, sendQ.Len())
 
 		ev, shutdown := sendQ.Get()

--- a/agent/inbound.go
+++ b/agent/inbound.go
@@ -162,7 +162,7 @@ func (a *Agent) processIncomingResourceRequest(ev *event.Event) error {
 		logCtx.Tracef("marshaled resource")
 	}
 
-	q := a.queues.SendQ(a.remote.ClientID())
+	q := a.queues.SendQ(defaultQueueName)
 	if q == nil {
 		logCtx.Error("Remote queue disappeared")
 		return nil
@@ -338,9 +338,9 @@ func (a *Agent) processIncomingResourceResyncEvent(ev *event.Event) error {
 		return err
 	}
 
-	sendQ := a.queues.SendQ(a.remote.ClientID())
+	sendQ := a.queues.SendQ(defaultQueueName)
 	if sendQ == nil {
-		return fmt.Errorf("remote queue disappeared for agent: %s", a.remote.ClientID())
+		return fmt.Errorf("send queue not found for the default queue pair")
 	}
 
 	resyncHandler := resync.NewRequestHandler(dynClient, sendQ, a.emitter, a.resources, logCtx)

--- a/agent/outbound.go
+++ b/agent/outbound.go
@@ -47,14 +47,14 @@ func (a *Agent) addAppCreationToQueue(app *v1alpha1.Application) {
 		return
 	}
 
-	q := a.queues.SendQ(a.remote.ClientID())
+	q := a.queues.SendQ(defaultQueueName)
 	if q == nil {
 		logCtx.Error("Default queue disappeared!")
 		return
 	}
 
 	q.Add(a.emitter.ApplicationEvent(event.Create, app))
-	logCtx.WithField("sendq_len", q.Len()).WithField("sendq_name", a.remote.ClientID()).Debugf("Added app create event to send queue")
+	logCtx.WithField("sendq_len", q.Len()).WithField("sendq_name", defaultQueueName).Debugf("Added app create event to send queue")
 }
 
 // addAppUpdateToQueue processes an application update event originating from
@@ -74,7 +74,7 @@ func (a *Agent) addAppUpdateToQueue(old *v1alpha1.Application, new *v1alpha1.App
 		return
 	}
 
-	q := a.queues.SendQ(a.remote.ClientID())
+	q := a.queues.SendQ(defaultQueueName)
 	if q == nil {
 		logCtx.Error("Default queue disappeared!")
 		return
@@ -94,7 +94,7 @@ func (a *Agent) addAppUpdateToQueue(old *v1alpha1.Application, new *v1alpha1.App
 	// q.Add(ev)
 	logCtx.
 		WithField("sendq_len", q.Len()).
-		WithField("sendq_name", a.remote.ClientID()).
+		WithField("sendq_name", defaultQueueName).
 		Debugf("Added event of type %s to send queue", eventType)
 }
 
@@ -112,7 +112,7 @@ func (a *Agent) addAppDeletionToQueue(app *v1alpha1.Application) {
 		_ = a.appManager.Unmanage(app.QualifiedName())
 	}
 
-	q := a.queues.SendQ(a.remote.ClientID())
+	q := a.queues.SendQ(defaultQueueName)
 	if q == nil {
 		logCtx.Error("Default queue disappeared!")
 		return


### PR DESCRIPTION
**What does this PR do / why we need it**:

Since each agent connects to a single principal, the queue name can be a constant. We can keep the queue open even if the agent is disconnected from the principal.

**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:


**Checklist**

* [ ] Documentation update is required by this PR (and has been updated) OR no documentation update is required.

