### PR TITLE
chore(e2e): Fix race condition for agent configuration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,11 +50,11 @@ build: agent principal cli
 .PHONY: setup-e2e2
 setup-e2e2:
 	./hack/dev-env/setup-vcluster-env.sh create
+	./hack/dev-env/gen-creds.sh
+	./hack/dev-env/create-agent-config.sh
 
 .PHONY: start-e2e2
 start-e2e2: cli install-goreman
-	./hack/dev-env/gen-creds.sh
-	./hack/dev-env/create-agent-config.sh
 	goreman -exit-on-stop=false -f hack/dev-env/Procfile.e2e start
 
 .PHONY: test-e2e2

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ fmt:
 build: agent principal cli
 
 .PHONY: setup-e2e2
-setup-e2e2:
+setup-e2e2: cli
 	./hack/dev-env/setup-vcluster-env.sh create
 	./hack/dev-env/gen-creds.sh
 	./hack/dev-env/create-agent-config.sh


### PR DESCRIPTION
**What does this PR do / why we need it**:

Agent configuration is created in the `start-e2e` target. However, we run the `start-e2e` target in the background, and GH actions will progress quickly to the next step in the workflow.

Sometimes, when the runner is a little slow, the agent configuration does not yet exist when required.

This PR moves the agent configuration creation to `setup-e2e` target.

**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:


**Checklist**

* [ ] Documentation update is required by this PR (and has been updated) OR no documentation update is required.

