### PR TITLE
fix: don't remove the queue/eventwriter on disconnect

### DIFF
--- a/principal/apis/eventstream/eventstream_test.go
+++ b/principal/apis/eventstream/eventstream_test.go
@@ -41,7 +41,7 @@ func Test_Subscribe(t *testing.T) {
 	t.Run("Test send to subcription stream", func(t *testing.T) {
 		qs := queue.NewSendRecvQueues()
 		qs.Create("default")
-		s := NewServer(qs, metric, cluster)
+		s := NewServer(qs, event.NewEventWritersMap(), metric, cluster)
 		st := &mock.MockEventServer{
 			AgentName: "default",
 			AgentMode: string(types.AgentModeManaged),
@@ -74,7 +74,7 @@ func Test_Subscribe(t *testing.T) {
 	t.Run("Test recv from subscription stream", func(t *testing.T) {
 		qs := queue.NewSendRecvQueues()
 		qs.Create("default")
-		s := NewServer(qs, metric, cluster)
+		s := NewServer(qs, event.NewEventWritersMap(), metric, cluster)
 		st := &mock.MockEventServer{AgentName: "default", Application: v1alpha1.Application{
 			ObjectMeta: v1.ObjectMeta{
 				Name:      "foo",
@@ -91,7 +91,7 @@ func Test_Subscribe(t *testing.T) {
 		})
 		err := s.Subscribe(st)
 		require.NoError(t, err)
-		require.False(t, qs.HasQueuePair("default"))
+		require.True(t, qs.HasQueuePair("default"))
 		assert.Equal(t, 2, int(st.NumRecv.Load()))
 		assert.Equal(t, 0, int(st.NumSent.Load()))
 	})
@@ -99,7 +99,7 @@ func Test_Subscribe(t *testing.T) {
 	t.Run("Test connection closed by peer", func(t *testing.T) {
 		qs := queue.NewSendRecvQueues()
 		qs.Create("default")
-		s := NewServer(qs, metric, cluster)
+		s := NewServer(qs, event.NewEventWritersMap(), metric, cluster)
 		st := &mock.MockEventServer{AgentName: "default"}
 		st.AddRecvHook(func(s *mock.MockEventServer) error {
 			return fmt.Errorf("some error")
@@ -113,7 +113,7 @@ func Test_Subscribe(t *testing.T) {
 	t.Run("Test no agent information in context", func(t *testing.T) {
 		qs := queue.NewSendRecvQueues()
 		qs.Create("default")
-		s := NewServer(qs, metric, cluster)
+		s := NewServer(qs, event.NewEventWritersMap(), metric, cluster)
 		st := &mock.MockEventServer{AgentName: ""}
 		err := s.Subscribe(st)
 		assert.Error(t, err)
@@ -122,7 +122,7 @@ func Test_Subscribe(t *testing.T) {
 	t.Run("Test events being discarded for unmanaged agent", func(t *testing.T) {
 		qs := queue.NewSendRecvQueues()
 		qs.Create("default")
-		s := NewServer(qs, metric, cluster)
+		s := NewServer(qs, event.NewEventWritersMap(), metric, cluster)
 		st := &mock.MockEventServer{
 			AgentName: "default",
 			AgentMode: string(types.AgentModeAutonomous),

--- a/principal/callbacks.go
+++ b/principal/callbacks.go
@@ -259,5 +259,8 @@ func (s *Server) deleteNamespaceCallback(outbound *corev1.Namespace) {
 		return
 	}
 
+	// Remove eventwriter associated with this agent
+	s.eventWriters.Remove(outbound.Name)
+
 	logCtx.Tracef("Deleted the queue pair since the agent namespace is deleted")
 }

--- a/principal/listen.go
+++ b/principal/listen.go
@@ -217,6 +217,6 @@ func (s *Server) registerGrpcServices(metrics *metrics.PrincipalMetrics) error {
 	}
 	authapi.RegisterAuthenticationServer(s.grpcServer, authSrv)
 	versionapi.RegisterVersionServer(s.grpcServer, version.NewServer(s.authenticate))
-	eventstreamapi.RegisterEventStreamServer(s.grpcServer, eventstream.NewServer(s.queues, metrics, s.clusterMgr, eventstream.WithNotifyOnConnect(s.notifyOnConnect)))
+	eventstreamapi.RegisterEventStreamServer(s.grpcServer, eventstream.NewServer(s.queues, s.eventWriters, metrics, s.clusterMgr, eventstream.WithNotifyOnConnect(s.notifyOnConnect)))
 	return nil
 }

--- a/principal/server.go
+++ b/principal/server.go
@@ -129,6 +129,8 @@ type Server struct {
 	notifyOnConnect chan types.Agent
 	// handlers to run when an agent connects to the principal
 	handlersOnConnect []handlersOnConnect
+
+	eventWriters *event.EventWritersMap
 }
 
 type handlersOnConnect func(agent types.Agent) error
@@ -157,6 +159,7 @@ func NewServer(ctx context.Context, kubeClient *kube.KubernetesClient, namespace
 		resyncStatus:    newResyncStatus(),
 		resources:       resources.NewAgentResources(),
 		notifyOnConnect: make(chan types.Agent),
+		eventWriters:    event.NewEventWritersMap(),
 	}
 
 	s.ctx, s.ctxCancel = context.WithCancel(ctx)


### PR DESCRIPTION
**What does this PR do / why we need it**:

Currently, we remove the queue/eventwriter in the Subscribe() when an agent disconnects with the principal. We recreate the queue if there are new events from the informer. However, the queue/eventwriter could have some pending events yet to be transmitted. Removing them could lead to losing these pending events. We want the queue to keep the events, even if there is a transient disconnect between the agent and the principal.

1. Don't remove the queue and the eventwriter on disconnect
2. sendFunc() should exit when the client context is cancelled
3. Remove the queue/eventwriter when the namespace is deleted.

**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:


**Checklist**

* [ ] Documentation update is required by this PR (and has been updated) OR no documentation update is required.

