### PR TITLE
feat: PKI manipulation using CLI

### DIFF
--- a/cmd/ctl/agent.go
+++ b/cmd/ctl/agent.go
@@ -135,7 +135,7 @@ func NewAgentCreateCommand() *cobra.Command {
 				cmdutil.Fatal("%v", err)
 			}
 
-			clt, err := kube.NewKubernetesClientFromConfig(ctx, globalOpts.namespace, "", globalOpts.context)
+			clt, err := kube.NewKubernetesClientFromConfig(ctx, globalOpts.namespace, "", globalOpts.principalContext)
 			if err != nil {
 				cmdutil.Fatal("Could not create Kubernetes client: %v", err)
 			}
@@ -233,7 +233,7 @@ func NewAgentListCommand() *cobra.Command {
 		Run: func(cmd *cobra.Command, args []string) {
 			ctx := context.TODO()
 			labelSelector = append(labelSelector, cluster.LabelKeyClusterAgentMapping)
-			clt, err := kube.NewKubernetesClientFromConfig(ctx, globalOpts.namespace, "", globalOpts.context)
+			clt, err := kube.NewKubernetesClientFromConfig(ctx, globalOpts.namespace, "", globalOpts.principalContext)
 			if err != nil {
 				cmdutil.Fatal("Could not create Kubernetes client: %v", err)
 			}
@@ -396,7 +396,7 @@ func NewAgentReconfigureCommand() *cobra.Command {
 				changed = true
 			}
 			if reissueClientCert {
-				clt, err := kube.NewKubernetesClientFromConfig(context.Background(), globalOpts.namespace, "", globalOpts.context)
+				clt, err := kube.NewKubernetesClientFromConfig(context.Background(), globalOpts.namespace, "", globalOpts.principalContext)
 				if err != nil {
 					cmdutil.Fatal("Could not create Kubernetes client: %v", err)
 				}
@@ -459,7 +459,7 @@ func labelSliceToMap(labels []string) (map[string]string, error) {
 
 func loadClusterSecret(agentName string) (*v1alpha1.Cluster, error) {
 	ctx := context.TODO()
-	clt, err := kube.NewKubernetesClientFromConfig(ctx, globalOpts.namespace, "", globalOpts.context)
+	clt, err := kube.NewKubernetesClientFromConfig(ctx, globalOpts.namespace, "", globalOpts.principalContext)
 	if err != nil {
 		return nil, err
 	}
@@ -480,7 +480,7 @@ func loadClusterSecret(agentName string) (*v1alpha1.Cluster, error) {
 
 func saveClusterSecret(agentName string, clstr *v1alpha1.Cluster) error {
 	ctx := context.TODO()
-	clt, err := kube.NewKubernetesClientFromConfig(ctx, globalOpts.namespace, "", globalOpts.context)
+	clt, err := kube.NewKubernetesClientFromConfig(ctx, globalOpts.namespace, "", globalOpts.principalContext)
 	if err != nil {
 		return err
 	}

--- a/cmd/ctl/ca.go
+++ b/cmd/ctl/ca.go
@@ -407,7 +407,7 @@ func NewPKIIssueAgentClientCert() *cobra.Command {
 // sign it using the principal's CA. The issue function will take the CA's
 // certificate and private key as argument, and will return the generated
 // secret's certificate and private key as PEM encoded string. The resulting
-// certificate will be saved to a secret refered to by outContext, outName and
+// certificate will be saved to a secret referred to by outContext, outName and
 // outNamespace.
 func issueAndSaveSecret(outContext, outName, outNamespace string, upsert bool, issue func(*x509.Certificate, crypto.PrivateKey) (string, string, error)) {
 	ctx := context.TODO()

--- a/cmd/ctl/ca.go
+++ b/cmd/ctl/ca.go
@@ -379,7 +379,7 @@ func NewPKIIssueAgentClientCert() *cobra.Command {
 		Short: "Issue a client certificate for an agent",
 		Run: func(cmd *cobra.Command, args []string) {
 			if len(args) == 0 {
-				cmd.Help()
+				_ = cmd.Help()
 				fmt.Println("Agent name must be given.")
 				os.Exit(1)
 			}

--- a/cmd/ctl/ca.go
+++ b/cmd/ctl/ca.go
@@ -403,7 +403,12 @@ func NewPKIIssueAgentClientCert() *cobra.Command {
 	return command
 }
 
-// issueAndSaveSecret issues
+// issueAndSaveSecret uses the issue callback to create a TLS certificate and
+// sign it using the principal's CA. The issue function will take the CA's
+// certificate and private key as argument, and will return the generated
+// secret's certificate and private key as PEM encoded string. The resulting
+// certificate will be saved to a secret refered to by outContext, outName and
+// outNamespace.
 func issueAndSaveSecret(outContext, outName, outNamespace string, upsert bool, issue func(*x509.Certificate, crypto.PrivateKey) (string, string, error)) {
 	ctx := context.TODO()
 
@@ -469,7 +474,7 @@ func issueAndSaveSecret(outContext, outName, outNamespace string, upsert bool, i
 			if err != nil {
 				cmdutil.Fatal("Could not update secret: %v", err)
 			} else {
-				fmt.Printf("Secret updated.\n")
+				fmt.Printf("Secret %s/%s updated.\n", outNamespace, outName)
 			}
 		}
 	} else {

--- a/cmd/ctl/main.go
+++ b/cmd/ctl/main.go
@@ -48,7 +48,7 @@ func NewRootCommand() *cobra.Command {
 	configGroup := &cobra.Group{ID: "config", Title: "Configuration"}
 	command.AddGroup(configGroup)
 	command.AddCommand(NewAgentCommand())
-	command.AddCommand(NewCACommand())
+	command.AddCommand(NewPKICommand())
 	command.AddCommand(NewVersionCommand())
 	addGlobalFlags(command, globalOpts)
 	return command
@@ -71,12 +71,14 @@ func NewVersionCommand() *cobra.Command {
 }
 
 type GlobalFlags struct {
-	context   string
-	namespace string
+	principalContext string
+	agentContext     string
+	namespace        string
 }
 
 func addGlobalFlags(command *cobra.Command, opts *GlobalFlags) {
-	command.PersistentFlags().StringVarP(&opts.context, "context", "x", env.StringWithDefault("ARGOCD_AGENT_CONTEXT", nil, ""), "The Kubernetes context to operate in")
+	command.PersistentFlags().StringVarP(&opts.principalContext, "principal-context", "P", env.StringWithDefault("ARGOCD_AGENT_PRINCIPAL_CONTEXT", nil, ""), "The Kubernetes context of the principal")
+	command.PersistentFlags().StringVarP(&opts.agentContext, "agent-context", "A", env.StringWithDefault("ARGOCD_AGENT_AGENT_CONTEXT", nil, ""), "The Kubernetes context of the agent")
 	command.PersistentFlags().StringVarP(&opts.namespace, "namespace", "n", "argocd", "The Kubernetes namespace to operate in")
 }
 

--- a/cmd/ctl/main.go
+++ b/cmd/ctl/main.go
@@ -71,15 +71,17 @@ func NewVersionCommand() *cobra.Command {
 }
 
 type GlobalFlags struct {
-	principalContext string
-	agentContext     string
-	namespace        string
+	principalContext   string
+	principalNamespace string
+	agentContext       string
+	agentNamespace     string
 }
 
 func addGlobalFlags(command *cobra.Command, opts *GlobalFlags) {
-	command.PersistentFlags().StringVarP(&opts.principalContext, "principal-context", "P", env.StringWithDefault("ARGOCD_AGENT_PRINCIPAL_CONTEXT", nil, ""), "The Kubernetes context of the principal")
-	command.PersistentFlags().StringVarP(&opts.agentContext, "agent-context", "A", env.StringWithDefault("ARGOCD_AGENT_AGENT_CONTEXT", nil, ""), "The Kubernetes context of the agent")
-	command.PersistentFlags().StringVarP(&opts.namespace, "namespace", "n", "argocd", "The Kubernetes namespace to operate in")
+	command.PersistentFlags().StringVar(&opts.principalContext, "principal-context", env.StringWithDefault("ARGOCD_AGENT_PRINCIPAL_CONTEXT", nil, ""), "The Kubernetes context of the principal")
+	command.PersistentFlags().StringVar(&opts.principalNamespace, "principal-namespace", env.StringWithDefault("ARGOCD_AGENT_PRINCIPAL_NAMESPACE", nil, "argocd"), "The Kubernetes namespace the principal is installed in")
+	command.PersistentFlags().StringVar(&opts.agentContext, "agent-context", env.StringWithDefault("ARGOCD_AGENT_AGENT_CONTEXT", nil, ""), "The Kubernetes context of the agent")
+	command.PersistentFlags().StringVar(&opts.agentNamespace, "agent-namespace", env.StringWithDefault("ARGOCD_AGENT_AGENT_NAMESPACE", nil, "argocd"), "The Kubernetes namespace the agent is installed in")
 }
 
 func main() {

--- a/cmd/principal/main.go
+++ b/cmd/principal/main.go
@@ -142,14 +142,17 @@ func NewPrincipalRunCommand() *cobra.Command {
 
 			opts = append(opts, principal.WithNamespaces(allowedNamespaces...))
 
-			if tlsCert != "" && tlsKey != "" {
+			if allowTlsGenerate {
+				logrus.Info("Using one-time generated TLS certificate for gRPC")
+				opts = append(opts, principal.WithGeneratedTLS("argocd-agent-principal--generated"))
+			} else if tlsCert != "" && tlsKey != "" {
+				logrus.Infof("Loading gRPC TLS configuration from files cert=%s and key=%s", tlsCert, tlsKey)
 				opts = append(opts, principal.WithTLSKeyPairFromPath(tlsCert, tlsKey))
 			} else if (tlsCert != "" && tlsKey == "") || (tlsCert == "" && tlsKey != "") {
 				cmdutil.Fatal("Both --tls-cert and --tls-key have to be given")
-			} else if allowTlsGenerate {
-				opts = append(opts, principal.WithGeneratedTLS("argocd-agent"))
 			} else {
-				cmdutil.Fatal("No TLS configuration given and auto generation not allowed.")
+				logrus.Infof("Loading gRPC TLS certificate from secret %s/%s", namespace, config.SecretNamePrincipalCA)
+				opts = append(opts, principal.WithTLSKeyPairFromSecret(kubeConfig.Clientset, config.SecretNamePrincipalTls, namespace))
 			}
 
 			if rootCaPath != "" {

--- a/hack/dev-env/create-agent-config.sh
+++ b/hack/dev-env/create-agent-config.sh
@@ -30,13 +30,13 @@ if ! test -x ${AGENTCTL}; then
 	exit 1
 fi
 
-if ! ${AGENTCTL} ca inspect >/dev/null 2>&1; then
-	${AGENTCTL} ca generate
+if ! ${AGENTCTL} pki inspect >/dev/null 2>&1; then
+	${AGENTCTL} pki init
 else
 	echo "Reusing existing agent CA"
 fi
 
-${AGENTCTL} ca issue --upsert -N "IP:127.0.0.1,IP:${IPADDR}" resource-proxy
+${AGENTCTL} pki issue --upsert -N "IP:127.0.0.1,IP:${IPADDR}" resource-proxy
 
 AGENTS="agent-managed agent-autonomous"
 for agent in ${AGENTS}; do

--- a/hack/dev-env/start-principal.sh
+++ b/hack/dev-env/start-principal.sh
@@ -38,7 +38,6 @@ fi
 SCRIPTPATH="$( cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
 go run github.com/argoproj-labs/argocd-agent/cmd/principal \
 	--allowed-namespaces '*' \
-	--insecure-tls-generate \
 	--insecure-jwt-generate \
 	--kubecontext vcluster-control-plane \
 	--log-level trace \

--- a/internal/config/constants.go
+++ b/internal/config/constants.go
@@ -10,8 +10,12 @@ const SecretNamePrincipalCA = "argocd-agent-ca"
 
 // SecretNamePrincipalGrpcTls is the name of the secret containing the TLS
 // configuration for the principal's gRPC service.
-const SecretNameGrpcTls = "argocd-agent-grpc-tls"
+const SecretNamePrincipalTls = "argocd-agent-principal-tls"
 
 // SecretNamePrincipalProxyTls is the name of the secret containing the TLS
 // configuration for the principal's resource proxy.
-const SecretNameProxyTls = "resource-proxy-tls"
+const SecretNameProxyTls = "argocd-agent-resource-proxy-tls"
+
+// SecretNameAgentClientCert is the name of the secret containing the TLS
+// client certificate + key for an agent.
+const SecretNameAgentClientCert = "argocd-agent-client-tls"

--- a/internal/tlsutil/generate_test.go
+++ b/internal/tlsutil/generate_test.go
@@ -49,7 +49,7 @@ func Test_GenerateCaCertificate(t *testing.T) {
 	})
 	t.Run("Generate server certificate", func(t *testing.T) {
 		certSubj := "abcdefg"
-		certData, keyData, err := GenerateServerCertificate(certSubj, cert.Leaf, cert.PrivateKey, []string{"IP:127.0.0.1"})
+		certData, keyData, err := GenerateServerCertificate(certSubj, cert.Leaf, cert.PrivateKey, []string{"127.0.0.1"}, []string{"localhost"})
 		require.NoError(t, err)
 		ccert, err := tls.X509KeyPair([]byte(certData), []byte(keyData))
 		require.NoError(t, err)

--- a/internal/tlsutil/generate_test.go
+++ b/internal/tlsutil/generate_test.go
@@ -60,6 +60,7 @@ func Test_GenerateCaCertificate(t *testing.T) {
 		assert.Equal(t, "test", ccert.Leaf.Issuer.CommonName)
 		ip := net.ParseIP("127.0.0.1")
 		assert.Contains(t, ccert.Leaf.IPAddresses, ip[len(ip)-4:])
+		assert.Contains(t, ccert.Leaf.DNSNames, "localhost")
 	})
 
 }


### PR DESCRIPTION
**What does this PR do / why we need it**:

Consolidates and simplifies previous `argocd-agentctl ca` command into `argocd-agentctl pki`, including the ability to issue client certificates for the agents.

**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:

* Functionality is mostly tested by setting up the end-to-end tests. The scripts make use of the pki command.
* Output of the pki command is intended for test/dev purposes only. It's not considered production grade PKI.

**Checklist**

* [ ] Documentation update is required by this PR (and has been updated) OR no documentation update is required.

