### PR TITLE
fix: Load CA certificate from a secret

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -249,7 +249,7 @@ func NewAgent(ctx context.Context, client *kube.KubernetesClient, namespace stri
 
 func (a *Agent) Start(ctx context.Context) error {
 	infCtx, cancelFn := context.WithCancel(ctx)
-	log().Infof("Starting %s (agent) v%s (ns=%s, allowed_namespaces=%v, mode=%s)", a.version.Name(), a.version.Version(), a.namespace, a.options.namespaces, a.mode)
+	log().Infof("Starting %s (agent) v%s (ns=%s, allowed_namespaces=%v, mode=%s, auth=%s)", a.version.Name(), a.version.Version(), a.namespace, a.options.namespaces, a.mode, a.remote.AuthMethod())
 	a.context = infCtx
 	a.cancelFn = cancelFn
 

--- a/cmd/principal/main.go
+++ b/cmd/principal/main.go
@@ -160,7 +160,7 @@ func NewPrincipalRunCommand() *cobra.Command {
 			if rootCaPath != "" {
 				opts = append(opts, principal.WithTLSRootCaFromFile(rootCaPath))
 			} else {
-				opts = append(opts, principal.WithTLSRootCaFromSecret(kubeConfig.Clientset, config.SecretNamePrincipalCA, namespace))
+				opts = append(opts, principal.WithTLSRootCaFromSecret(kubeConfig.Clientset, config.SecretNamePrincipalCA, namespace, "tls.crt"))
 			}
 
 			opts = append(opts, principal.WithRequireClientCerts(requireClientCerts))

--- a/hack/dev-env/start-agent-autonomous.sh
+++ b/hack/dev-env/start-agent-autonomous.sh
@@ -32,7 +32,7 @@ fi
 
 go run github.com/argoproj-labs/argocd-agent/cmd/agent \
     --agent-mode autonomous \
-    --creds userpass:${SCRIPTPATH}/creds/creds.agent-autonomous \
+    --creds mtls:any \
     --server-address 127.0.0.1 \
     --insecure-tls \
     --kubecontext vcluster-agent-autonomous \

--- a/hack/dev-env/start-agent-managed.sh
+++ b/hack/dev-env/start-agent-managed.sh
@@ -31,7 +31,7 @@ fi
 
 go run github.com/argoproj-labs/argocd-agent/cmd/agent \
     --agent-mode managed \
-    --creds userpass:${SCRIPTPATH}/creds/creds.agent-managed \
+    --creds "mtls:any" \
     --server-address 127.0.0.1 \
     --insecure-tls \
     --kubecontext vcluster-agent-managed \

--- a/hack/dev-env/start-principal.sh
+++ b/hack/dev-env/start-principal.sh
@@ -42,4 +42,6 @@ go run github.com/argoproj-labs/argocd-agent/cmd/principal \
 	--kubecontext vcluster-control-plane \
 	--log-level trace \
 	--namespace argocd \
-	--auth "userpass:${SCRIPTPATH}/creds/users.control-plane" $ARGS
+	--auth "mtls:CN=([^,]+)" \
+	$ARGS
+	#--auth "userpass:${SCRIPTPATH}/creds/users.control-plane" $ARGS

--- a/pkg/client/remote.go
+++ b/pkg/client/remote.go
@@ -458,6 +458,10 @@ func (r *Remote) ClientID() string {
 	return r.clientID
 }
 
+func (r *Remote) AuthMethod() string {
+	return r.authMethod
+}
+
 func (r *Remote) SetClientMode(mode types.AgentMode) {
 	r.clientMode = mode
 }

--- a/pkg/client/remote.go
+++ b/pkg/client/remote.go
@@ -450,18 +450,23 @@ func (r *Remote) Connect(ctx context.Context, forceReauth bool) error {
 	return nil
 }
 
+// Conn returns this remote's underlying gRPC connection object. It should
+// be treated as read-only.
 func (r *Remote) Conn() *grpc.ClientConn {
 	return r.conn
 }
 
+// ClientID returns the client ID used by this remote
 func (r *Remote) ClientID() string {
 	return r.clientID
 }
 
+// AuthMethod returns the name of the auth method configured for this remote
 func (r *Remote) AuthMethod() string {
 	return r.authMethod
 }
 
+// SetClientMode sets the client mode to be used by this remote
 func (r *Remote) SetClientMode(mode types.AgentMode) {
 	r.clientMode = mode
 }

--- a/principal/options.go
+++ b/principal/options.go
@@ -190,8 +190,6 @@ func WithTLSRootCaFromFile(caPath string) ServerOption {
 		if !ok {
 			return fmt.Errorf("invalid certificate data in %s", caPath)
 		}
-		//nolint:staticcheck
-		log().Infof("Loaded %d cert(s) into the root CA pool", len(o.options.rootCa.Subjects()))
 		return nil
 	}
 }
@@ -203,7 +201,6 @@ func WithTLSRootCaFromSecret(kube kubernetes.Interface, name string, namespace s
 			return err
 		}
 		o.options.rootCa = pool
-		log().Infof("Loaded %d cert(s) into the root CA pool", len(o.options.rootCa.Subjects()))
 		return nil
 	}
 }

--- a/principal/options.go
+++ b/principal/options.go
@@ -194,9 +194,14 @@ func WithTLSRootCaFromFile(caPath string) ServerOption {
 	}
 }
 
-func WithTLSRootCaFromSecret(kube kubernetes.Interface, name string, namespace string) ServerOption {
+// WithTLSRootCaFromSecret loads the root CAs to be used to validate client
+// certificates from the Kubernetes Secret referred to by namespace and name.
+// If field is non-empty, only loads certificates stored in the named field.
+// Otherwise, if field is empty, loads certificates from all fields in the
+// Secret.
+func WithTLSRootCaFromSecret(kube kubernetes.Interface, name string, namespace, field string) ServerOption {
 	return func(o *Server) error {
-		pool, err := tlsutil.X509CertPoolFromSecret(context.Background(), kube, namespace, name, "tls.crt")
+		pool, err := tlsutil.X509CertPoolFromSecret(context.Background(), kube, namespace, name, field)
 		if err != nil {
 			return err
 		}

--- a/principal/options.go
+++ b/principal/options.go
@@ -196,6 +196,18 @@ func WithTLSRootCaFromFile(caPath string) ServerOption {
 	}
 }
 
+func WithTLSRootCaFromSecret(kube kubernetes.Interface, name string, namespace string) ServerOption {
+	return func(o *Server) error {
+		pool, err := tlsutil.X509CertPoolFromSecret(context.Background(), kube, namespace, name, "tls.crt")
+		if err != nil {
+			return err
+		}
+		o.options.rootCa = pool
+		log().Infof("Loaded %d cert(s) into the root CA pool", len(o.options.rootCa.Subjects()))
+		return nil
+	}
+}
+
 // WithRequireClientCerts sets whether all incoming agent connections must
 // present a valid client certificate before being accepted.
 func WithRequireClientCerts(require bool) ServerOption {


### PR DESCRIPTION
**What does this PR do / why we need it**:

This fix enables the principal to load the CA certificate from a secret, like the agent does.

Also, it enables mTLS authentication in the dev env, replacing the deprecated userpass authentication.

**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:


**Checklist**

* [ ] Documentation update is required by this PR (and has been updated) OR no documentation update is required.

