### PR TITLE
chore(build): Upgrade golangci-lint to v2.1.6

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -89,9 +89,9 @@ jobs:
         with:
           go-version: ${{ env.GOLANG_VERSION }}
       - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@3cfe3a4abbb849e10058ce4af15d205b6da42804 # v4.0.0
+        uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8.0.0
         with:
-          version: v1.62.0
+          version: v2.1.6
           args: --verbose
 
 

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,11 +1,42 @@
+version: "2"
 run:
-  timeout: 10m
   tests: false
 linters:
   enable:
-    - gofmt
-    - goimports
     - misspell
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+  settings:
+    staticcheck:
+      checks:
+        - all
+        - '-QF1001'
+        - '-QF1003'
+        - '-QF1008'
+        - '-QF1007'
+        - '-QF1011'
+        - '-ST1003'
+        - '-ST1016'
+        - '-ST1023'
 issues:
   max-issues-per-linter: 0
   max-same-issues: 0
+formatters:
+  enable:
+    - gofmt
+    - goimports
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ BIN_DIR := $(current_dir)/build/bin
 
 PROTOC_GEN_GO_VERSION?=v1.28
 PROTOC_GEN_GO_GRPC_VERSION=v1.2
-GOLANG_CI_LINT_VERSION=v1.62.0
+GOLANG_CI_LINT_VERSION=v2.1.6
 MOCKERY_V2_VERSION?=v2.43.0
 
 GO_BIN_DIR=$(shell go env GOPATH)/bin
@@ -87,7 +87,7 @@ clean-all: clean
 	mkdir -p build/bin
 
 ./build/bin/golangci-lint: ./build/bin
-	GOBIN=$(BIN_DIR) go install github.com/golangci/golangci-lint/cmd/golangci-lint@$(GOLANG_CI_LINT_VERSION)
+	GOBIN=$(BIN_DIR) go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANG_CI_LINT_VERSION)
 
 ./build/bin/protoc-gen-go: ./build/bin
 	GOBIN=$(BIN_DIR) go install google.golang.org/protobuf/cmd/protoc-gen-go@$(PROTOC_GEN_GO_VERSION)


### PR DESCRIPTION
**What does this PR do / why we need it**:

This updates the version of golangci-lint to 2.1.6 and the corresponding action to 8.0.0.

**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:

There are a few exclusion I had to add to the configuration, which are mainly style related. We will fix them one after the other in subsequent PRs.

**Checklist**

* [ ] Documentation update is required by this PR (and has been updated) OR no documentation update is required.

