### PR TITLE
build: Add service manifest to expose metrics server

### DIFF
--- a/install/kubernetes/agent/agent-metrics-service.yaml
+++ b/install/kubernetes/agent/agent-metrics-service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+      app.kubernetes.io/name: argocd-agent-agent
+      app.kubernetes.io/part-of: argocd-agent
+      app.kubernetes.io/component: agent
+  name: argocd-agent-agent-metrics
+spec:
+  ports:
+    - name: metrics
+      protocol: TCP
+      port: 8181
+      targetPort: 8181
+  selector:
+    app.kubernetes.io/name: argocd-agent-agent

--- a/install/kubernetes/agent/kustomization.yaml
+++ b/install/kubernetes/agent/kustomization.yaml
@@ -4,3 +4,4 @@ resources:
 - agent-rolebinding.yaml
 - agent-deployment.yaml
 - agent-params-cm.yaml
+- agent-metrics-service.yaml

--- a/install/kubernetes/principal/kustomization.yaml
+++ b/install/kubernetes/principal/kustomization.yaml
@@ -7,3 +7,4 @@ resources:
 - principal-deployment.yaml
 - principal-service.yaml
 - principal-params-cm.yaml
+- principal-metrics-service.yaml

--- a/install/kubernetes/principal/principal-metrics-service.yaml
+++ b/install/kubernetes/principal/principal-metrics-service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/name: argocd-agent-principal
+    app.kubernetes.io/part-of: argocd-agent
+    app.kubernetes.io/component: principal
+  name: argocd-agent-principal-metrics
+spec:
+  ports:
+    - name: metrics
+      protocol: TCP
+      port: 8000
+      targetPort: 8000
+  selector:
+    app.kubernetes.io/name: argocd-agent-principal


### PR DESCRIPTION
This PR is to add kube manifests to expose metrics servers running on principal and agent via a Service.