### PR TITLE
chore(dev-env): Allow log level to be set from env

### DIFF
--- a/hack/dev-env/start-agent-autonomous.sh
+++ b/hack/dev-env/start-agent-autonomous.sh
@@ -37,7 +37,7 @@ go run github.com/argoproj-labs/argocd-agent/cmd/agent \
     --insecure-tls \
     --kubecontext vcluster-agent-autonomous \
     --namespace argocd \
-    --log-level trace $ARGS \
+    --log-level ${ARGOCD_AGENT_LOG_LEVEL:-trace} $ARGS \
     --metrics-port 8182 \
     --healthz-port 8002 \
     #--enable-compression true

--- a/hack/dev-env/start-agent-managed.sh
+++ b/hack/dev-env/start-agent-managed.sh
@@ -36,7 +36,7 @@ go run github.com/argoproj-labs/argocd-agent/cmd/agent \
     --insecure-tls \
     --kubecontext vcluster-agent-managed \
     --namespace agent-managed \
-    --log-level trace $ARGS \
+    --log-level ${ARGOCD_AGENT_LOG_LEVEL:-trace} $ARGS \
     --healthz-port 8001 \
     #--enable-compression true
     #--keep-alive-ping-interval 15m

--- a/hack/dev-env/start-principal.sh
+++ b/hack/dev-env/start-principal.sh
@@ -40,7 +40,7 @@ go run github.com/argoproj-labs/argocd-agent/cmd/principal \
 	--allowed-namespaces '*' \
 	--insecure-jwt-generate \
 	--kubecontext vcluster-control-plane \
-	--log-level trace \
+	--log-level ${ARGOCD_AGENT_LOG_LEVEL:-trace} \
 	--namespace argocd \
 	--auth "mtls:CN=([^,]+)" \
 	$ARGS


### PR DESCRIPTION
**What does this PR do / why we need it**:

Sometimes, the default trace level used in the dev-env can be overwhelming. This allows the log level to be set by using `ARGOCD_AGENT_LOG_LEVEL` environment variable.

**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:


**Checklist**

* [ ] Documentation update is required by this PR (and has been updated) OR no documentation update is required.

