### PR TITLE
chore: Add script to convert Argo CD cluster secrets to kubeconf

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ test/profile
 vendor/
 .vscode
 build/
+__pycache__

--- a/hack/secret-to-kubeconf/README.md
+++ b/hack/secret-to-kubeconf/README.md
@@ -1,0 +1,212 @@
+# Argo CD Cluster Secret to Kubeconfig Converter
+
+This utility converts Argo CD cluster secrets stored in a Kubernetes cluster into kubectl-compatible kubeconfig contexts.
+
+## Overview
+
+Argo CD stores cluster connection information as Kubernetes secrets with the label `argocd.argoproj.io/secret-type=cluster`. This script reads these secrets and converts them into standard kubectl kubeconfig format, allowing you to access all your Argo CD-managed clusters directly with kubectl.
+
+## Prerequisites
+
+- Python 3.6 or higher
+- Access to a Kubernetes cluster that contains Argo CD cluster secrets
+- kubectl configured to access the source cluster
+
+## Installation
+
+1. Install the required Python dependencies:
+
+```bash
+pip install -r requirements.txt
+```
+
+Or install manually:
+
+```bash
+pip install kubernetes PyYAML
+```
+
+## Usage
+
+### Basic Usage
+
+```bash
+# Convert using current context
+python3 clustersecret-to-kubeconf.py
+
+# Convert using specific context
+python3 clustersecret-to-kubeconf.py --context <source-context>
+```
+
+Where `<source-context>` is the kubectl context for the cluster that contains your Argo CD cluster secrets. If not specified, the current context will be used.
+
+**Note**: By default, the script writes to `~/.kube/argocd-clusters` to avoid overwriting your existing kubeconfig file.
+
+### Advanced Usage
+
+```bash
+# Use a custom kubeconfig file
+python3 clustersecret-to-kubeconf.py --context my-cluster --kubeconfig /path/to/custom/config
+
+# Write to your main kubeconfig (use with caution)
+python3 clustersecret-to-kubeconf.py --context my-cluster --kubeconfig ~/.kube/config
+
+# Handle development clusters with self-signed certificates
+python3 clustersecret-to-kubeconf.py --insecure
+
+# Dry run to see what would be converted
+python3 clustersecret-to-kubeconf.py --context my-cluster --dry-run
+```
+
+### Examples
+
+1. **List available contexts first:**
+   ```bash
+   kubectl config get-contexts
+   ```
+
+2. **Convert cluster secrets from the current context (writes to ~/.kube/argocd-clusters):**
+   ```bash
+   python3 clustersecret-to-kubeconf.py
+   ```
+
+3. **Convert cluster secrets from a specific context:**
+   ```bash
+   python3 clustersecret-to-kubeconf.py --context my-argo-cd-cluster
+   ```
+
+4. **Convert and write to a custom kubeconfig:**
+   ```bash
+   python3 clustersecret-to-kubeconf.py --context my-argo-cd-cluster --kubeconfig ~/.kube/argo-clusters
+   ```
+
+5. **Use the converted clusters with kubectl:**
+   ```bash
+   # Use the separate kubeconfig file
+   kubectl --kubeconfig ~/.kube/argocd-clusters config get-contexts
+   
+   # Or set KUBECONFIG environment variable
+   export KUBECONFIG=~/.kube/argocd-clusters
+   kubectl config get-contexts
+   ```
+
+6. **Dry run to preview what will be converted:**
+   ```bash
+   python3 clustersecret-to-kubeconf.py --dry-run
+   ```
+
+## How It Works
+
+1. **Connects to Source Cluster**: Uses the specified kubectl context to connect to the cluster containing Argo CD cluster secrets.
+
+2. **Discovers Cluster Secrets**: Searches for Kubernetes secrets with the label `argocd.argoproj.io/secret-type=cluster` across all namespaces.
+
+3. **Parses Secret Data**: Extracts cluster configuration from the secret's `config` field, which contains:
+   - Cluster server URL
+   - TLS certificate authority data
+   - Client certificate and key data (for mTLS)
+   - Username and password (for basic auth)
+   - Insecure skip TLS verify flag
+
+4. **Creates Kubeconfig Entries**: For each cluster secret, creates:
+   - A cluster entry with server URL and CA certificate
+   - A user entry with authentication credentials
+   - A context entry linking the cluster and user
+
+5. **Updates Kubeconfig**: Appends the new contexts to a separate kubeconfig file (default: `~/.kube/argocd-clusters`) to avoid overwriting your existing configuration.
+
+## Supported Authentication Methods
+
+The script supports the following authentication methods that Argo CD uses:
+
+- **TLS Client Certificates**: Uses `certData` and `keyData` from the cluster secret
+- **Basic Authentication**: Uses `username` and `password` from the cluster secret
+- **Certificate Authority**: Uses `caData` for server certificate validation
+- **Insecure Connections**: Respects the `insecure` flag for skipping TLS verification
+
+## Output
+
+After successful conversion, you can use kubectl to switch between the converted contexts:
+
+```bash
+# List all contexts in the Argo CD kubeconfig
+kubectl --kubeconfig ~/.kube/argocd-clusters config get-contexts
+
+# Switch to a converted context
+kubectl --kubeconfig ~/.kube/argocd-clusters config use-context <cluster-name>
+
+# Test the connection
+kubectl --kubeconfig ~/.kube/argocd-clusters cluster-info
+
+# Or set the KUBECONFIG environment variable for convenience
+export KUBECONFIG=~/.kube/argocd-clusters
+kubectl config get-contexts
+kubectl config use-context <cluster-name>
+kubectl cluster-info
+```
+
+## Merging with Main Kubeconfig (Optional)
+
+If you want to merge the Argo CD clusters with your main kubeconfig, you can use kubectl's built-in merge functionality:
+
+```bash
+# Merge Argo CD clusters into your main kubeconfig
+kubectl config view --kubeconfig ~/.kube/argocd-clusters --flatten > /tmp/argocd-clusters.yaml
+kubectl config view --flatten > /tmp/main-config.yaml
+
+# Combine them (Argo CD clusters will be appended)
+cat /tmp/main-config.yaml /tmp/argocd-clusters.yaml > ~/.kube/config
+
+# Clean up
+rm /tmp/argocd-clusters.yaml /tmp/main-config.yaml
+```
+
+**Note**: Always backup your existing kubeconfig before merging:
+```bash
+cp ~/.kube/config ~/.kube/config.backup
+```
+
+## Troubleshooting
+
+### No Cluster Secrets Found
+
+If you see "No Argo CD cluster secrets found", check:
+
+1. You're connected to the correct cluster that contains Argo CD
+2. Argo CD is properly installed and has cluster secrets
+3. You have permissions to read secrets in the Argo CD namespace
+
+### Permission Errors
+
+Ensure you have the necessary RBAC permissions to read secrets:
+
+```bash
+kubectl auth can-i get secrets --all-namespaces
+```
+
+### TLS Connection Issues
+
+If you encounter SSL/TLS certificate errors when connecting to development clusters:
+
+```bash
+# Use the --insecure flag for development clusters with self-signed certificates
+python3 clustersecret-to-kubeconf.py --insecure
+
+# Or configure your kubeconfig to handle the certificates properly
+kubectl config set-cluster my-cluster --insecure-skip-tls-verify=true
+```
+
+### Invalid Cluster Configuration
+
+If some clusters fail to convert, check the Argo CD cluster secret format. The script expects the standard Argo CD cluster secret structure.
+
+## Security Considerations
+
+- The script reads sensitive cluster credentials from Kubernetes secrets
+- Generated kubeconfig files contain authentication credentials
+- Ensure proper file permissions on your kubeconfig file
+- Consider using separate kubeconfig files for different environments
+
+## Contributing
+
+This script is part of the argocd-agent project. Please follow the project's contribution guidelines when making changes. 

--- a/hack/secret-to-kubeconf/clustersecret-to-kubeconf.py
+++ b/hack/secret-to-kubeconf/clustersecret-to-kubeconf.py
@@ -1,0 +1,383 @@
+#!/usr/bin/env python3
+"""
+Argo CD Cluster Secret to Kubeconfig Converter
+
+This script reads Argo CD cluster secrets from a Kubernetes cluster and converts
+them into kubectl-compatible configuration. All configurations are written to
+the same kubeconfig file as separate contexts.
+
+Usage:
+    python3 clustersecret-to-kubeconf.py --context <source-context> [options]
+"""
+
+import argparse
+import base64
+import json
+import os
+import sys
+import yaml
+from pathlib import Path
+from typing import Dict, List, Optional, Any
+
+try:
+    from kubernetes import client, config
+    from kubernetes.client.rest import ApiException
+except ImportError:
+    print("Error: kubernetes package not found. Please install it with:")
+    print("pip install kubernetes")
+    sys.exit(1)
+
+
+class ArgoCDClusterSecretConverter:
+    """Converts Argo CD cluster secrets to kubectl kubeconfig format."""
+    
+    def __init__(self, source_context: str, kubeconfig_path: str = None, insecure: bool = False):
+        """
+        Initialize the converter.
+        
+        Args:
+            source_context: The Kubernetes context to use for reading secrets
+            kubeconfig_path: Path to the kubeconfig file to write to
+            insecure: Whether to skip TLS verification for the source cluster
+        """
+        self.source_context = source_context
+        self.kubeconfig_path = kubeconfig_path or os.path.expanduser("~/.kube/argocd-clusters")
+        self.insecure = insecure
+        self.k8s_client = None
+        self.existing_config = {}
+        
+    def load_k8s_client(self) -> None:
+        """Load the Kubernetes client with the specified context."""
+        try:
+            if self.insecure:
+                # For insecure connections, we need to disable SSL verification at the urllib3 level
+                import urllib3
+                urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+                
+                # Load the kubeconfig first to get the host information
+                if self.source_context:
+                    config.load_kube_config(context=self.source_context)
+                else:
+                    config.load_kube_config()
+                
+                # Get the current configuration that was loaded
+                current_config = client.Configuration.get_default_copy()
+                
+                # Create a new configuration with the same host but disabled SSL verification
+                configuration = current_config
+                configuration.verify_ssl = False
+                # Do NOT set ssl_ca_cert, cert_file, or key_file to None, to preserve authentication
+                self.k8s_client = client.CoreV1Api(client.ApiClient(configuration))
+            else:
+                # Use standard kubeconfig loading
+                if self.source_context:
+                    config.load_kube_config(context=self.source_context)
+                else:
+                    config.load_kube_config()
+                self.k8s_client = client.CoreV1Api()
+            
+        except Exception as e:
+            print(f"Error loading Kubernetes client: {e}")
+            print("If you're connecting to a development cluster with self-signed certificates,")
+            print("try using the --insecure flag:")
+            print("  python3 clustersecret-to-kubeconf.py --insecure")
+            print("Or set KUBECONFIG environment variable or use --context to specify a different context.")
+            sys.exit(1)
+    
+    def load_existing_kubeconfig(self) -> None:
+        """Load existing kubeconfig if it exists."""
+        if os.path.exists(self.kubeconfig_path):
+            try:
+                with open(self.kubeconfig_path, 'r') as f:
+                    self.existing_config = yaml.safe_load(f) or {}
+            except Exception as e:
+                print(f"Warning: Could not load existing kubeconfig: {e}")
+                self.existing_config = {}
+        else:
+            self.existing_config = {
+                'apiVersion': 'v1',
+                'kind': 'Config',
+                'clusters': [],
+                'users': [],
+                'contexts': [],
+                'current-context': ''
+            }
+    
+    def get_argo_cd_cluster_secrets(self) -> List[Dict[str, Any]]:
+        """
+        Retrieve Argo CD cluster secrets from the Kubernetes cluster.
+        
+        Returns:
+            List of cluster secret objects
+        """
+        try:
+            # Look for secrets with Argo CD cluster labels
+            # Argo CD typically uses these labels for cluster secrets
+            label_selector = "argocd.argoproj.io/secret-type=cluster"
+            
+            secrets = self.k8s_client.list_secret_for_all_namespaces(
+                label_selector=label_selector
+            )
+            
+            if not secrets.items:
+                print("No Argo CD cluster secrets found.")
+                print("Make sure you're connected to the cluster that contains Argo CD cluster secrets.")
+                print("Argo CD cluster secrets should have the label: argocd.argoproj.io/secret-type=cluster")
+                return []
+            
+            return secrets.items
+            
+        except ApiException as e:
+            print(f"Error retrieving secrets: {e}")
+            return []
+        except Exception as e:
+            print(f"Unexpected error: {e}")
+            return []
+    
+    def parse_cluster_secret(self, secret) -> Optional[Dict[str, Any]]:
+        """
+        Parse an Argo CD cluster secret and extract cluster configuration.
+        
+        Args:
+            secret: Kubernetes secret object
+            
+        Returns:
+            Dictionary containing cluster configuration or None if invalid
+        """
+        try:
+            # Get the cluster configuration from the secret
+            config_data = secret.data.get('config')
+            if not config_data:
+                print(f"Warning: No config data found in secret {secret.metadata.name}")
+                return None
+            
+            # Decode the base64 encoded config
+            config_str = base64.b64decode(config_data).decode('utf-8')
+            cluster_config = json.loads(config_str)
+            
+            # Extract cluster information
+            cluster_name = secret.metadata.name.replace('cluster-', '').replace('-cluster', '')
+            
+            # Check for server URL in multiple locations
+            server_url = None
+            
+            # 1. Check in tlsClientConfig.server
+            server_url = cluster_config.get('tlsClientConfig', {}).get('server', '')
+            
+            # 2. Check at top level of config
+            if not server_url:
+                server_url = cluster_config.get('server', '')
+            
+            # 3. Check directly in secret data (Argo CD format)
+            if not server_url and 'server' in secret.data:
+                server_url = base64.b64decode(secret.data['server']).decode('utf-8')
+            
+            if not server_url:
+                print(f"Warning: No server URL found in secret {secret.metadata.name}")
+                return None
+            
+            # Extract TLS configuration
+            tls_config = cluster_config.get('tlsClientConfig', {})
+            ca_data = tls_config.get('caData', '')
+            cert_data = tls_config.get('certData', '')
+            key_data = tls_config.get('keyData', '')
+            
+            # Extract basic auth if present
+            basic_auth = cluster_config.get('username', ''), cluster_config.get('password', '')
+            
+            return {
+                'name': cluster_name,
+                'server': server_url,
+                'ca_data': ca_data,
+                'cert_data': cert_data,
+                'key_data': key_data,
+                'username': basic_auth[0],
+                'password': basic_auth[1],
+                'insecure_skip_tls_verify': tls_config.get('insecure', False)
+            }
+            
+        except Exception as e:
+            print(f"Error parsing secret {secret.metadata.name}: {e}")
+            return None
+    
+    def add_cluster_to_kubeconfig(self, cluster_info: Dict[str, Any]) -> None:
+        """
+        Add a cluster configuration to the kubeconfig.
+        
+        Args:
+            cluster_info: Dictionary containing cluster configuration
+        """
+        cluster_name = cluster_info['name']
+        
+        # Create cluster entry
+        cluster_entry = {
+            'name': cluster_name,
+            'cluster': {
+                'server': cluster_info['server'],
+                'insecure-skip-tls-verify': cluster_info['insecure_skip_tls_verify']
+            }
+        }
+        
+        # Add CA certificate if present
+        if cluster_info['ca_data']:
+            cluster_entry['cluster']['certificate-authority-data'] = cluster_info['ca_data']
+        
+        # Create user entry
+        user_entry = {
+            'name': f"{cluster_name}-user",
+            'user': {}
+        }
+        
+        # Add client certificate if present
+        if cluster_info['cert_data'] and cluster_info['key_data']:
+            user_entry['user']['client-certificate-data'] = cluster_info['cert_data']
+            user_entry['user']['client-key-data'] = cluster_info['key_data']
+        
+        # Add basic auth if present
+        elif cluster_info['username'] and cluster_info['password']:
+            user_entry['user']['username'] = cluster_info['username']
+            user_entry['user']['password'] = cluster_info['password']
+        
+        # Create context entry
+        context_entry = {
+            'name': cluster_name,
+            'context': {
+                'cluster': cluster_name,
+                'user': f"{cluster_name}-user"
+            }
+        }
+        
+        # Add to existing config
+        self.existing_config['clusters'].append(cluster_entry)
+        self.existing_config['users'].append(user_entry)
+        self.existing_config['contexts'].append(context_entry)
+        
+        print(f"Added cluster: {cluster_name} -> {cluster_info['server']}")
+    
+    def write_kubeconfig(self) -> None:
+        """Write the updated kubeconfig to file."""
+        try:
+            # Ensure the directory exists
+            os.makedirs(os.path.dirname(self.kubeconfig_path), exist_ok=True)
+            
+            with open(self.kubeconfig_path, 'w') as f:
+                yaml.dump(self.existing_config, f, default_flow_style=False)
+            
+            print(f"\nKubeconfig updated successfully: {self.kubeconfig_path}")
+            print(f"Added {len(self.existing_config['contexts'])} new contexts")
+            
+        except Exception as e:
+            print(f"Error writing kubeconfig: {e}")
+            sys.exit(1)
+    
+    def convert(self) -> None:
+        """Main conversion method."""
+        context_display = self.source_context or "current context"
+        print(f"Reading Argo CD cluster secrets from context: {context_display}")
+        
+        # Load Kubernetes client
+        self.load_k8s_client()
+        
+        # Load existing kubeconfig
+        self.load_existing_kubeconfig()
+        
+        # Get Argo CD cluster secrets
+        secrets = self.get_argo_cd_cluster_secrets()
+        
+        if not secrets:
+            print("No Argo CD cluster secrets found. Exiting.")
+            return
+        
+        print(f"Found {len(secrets)} Argo CD cluster secrets")
+        
+        # Process each secret
+        converted_count = 0
+        for secret in secrets:
+            cluster_info = self.parse_cluster_secret(secret)
+            if cluster_info:
+                self.add_cluster_to_kubeconfig(cluster_info)
+                converted_count += 1
+        
+        if converted_count > 0:
+            # Write updated kubeconfig
+            self.write_kubeconfig()
+            print(f"\nSuccessfully converted {converted_count} cluster secrets to kubeconfig contexts")
+        else:
+            print("No valid cluster secrets were converted.")
+
+
+def main():
+    """Main function to handle command line arguments and run the converter."""
+    parser = argparse.ArgumentParser(
+        description="Convert Argo CD cluster secrets to kubectl kubeconfig format",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  # Convert using current context
+  python3 clustersecret-to-kubeconf.py
+  
+  # Convert using specific context
+  python3 clustersecret-to-kubeconf.py --context my-cluster
+  
+  # Convert and write to custom kubeconfig file
+  python3 clustersecret-to-kubeconf.py --context my-cluster --kubeconfig /path/to/config
+  
+  # Convert from development cluster with self-signed certificates
+  python3 clustersecret-to-kubeconf.py --insecure
+  
+  # Write to default location (~/.kube/argocd-clusters) using current context
+  python3 clustersecret-to-kubeconf.py
+  
+  # List available contexts first
+  kubectl config get-contexts
+        """
+    )
+    
+    parser.add_argument(
+        '--context',
+        required=False,
+        help='Kubernetes context to use for reading Argo CD cluster secrets (default: current context)'
+    )
+    
+    parser.add_argument(
+        '--kubeconfig',
+        help='Path to kubeconfig file to write to (default: ~/.kube/argocd-clusters)'
+    )
+    
+    parser.add_argument(
+        '--dry-run',
+        action='store_true',
+        help='Show what would be converted without writing to kubeconfig'
+    )
+    
+    parser.add_argument(
+        '--insecure',
+        action='store_true',
+        help='Skip TLS verification for the source cluster (useful for development clusters with self-signed certificates)'
+    )
+    
+    args = parser.parse_args()
+    
+    # Create converter and run
+    converter = ArgoCDClusterSecretConverter(
+        source_context=args.context,
+        kubeconfig_path=args.kubeconfig,
+        insecure=args.insecure
+    )
+    
+    if args.dry_run:
+        print("DRY RUN MODE - No changes will be made")
+        context_display = args.context or "current context"
+        print(f"Would read Argo CD cluster secrets from context: {context_display}")
+        # For dry run, we'll just show what secrets would be processed
+        converter.load_k8s_client()
+        secrets = converter.get_argo_cd_cluster_secrets()
+        print(f"Would process {len(secrets)} Argo CD cluster secrets:")
+        for secret in secrets:
+            print(f"  - {secret.metadata.name}")
+    else:
+        converter.convert()
+
+
+if __name__ == "__main__":
+    main() 

--- a/hack/secret-to-kubeconf/requirements.txt
+++ b/hack/secret-to-kubeconf/requirements.txt
@@ -1,0 +1,2 @@
+kubernetes>=28.1.0
+PyYAML>=6.0 

--- a/hack/secret-to-kubeconf/test_cluster_secret.py
+++ b/hack/secret-to-kubeconf/test_cluster_secret.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""
+Test script for the Argo CD cluster secret converter.
+
+This script creates mock Argo CD cluster secrets to test the converter functionality.
+"""
+
+import base64
+import json
+import yaml
+from unittest.mock import Mock, patch
+import sys
+import os
+
+# Add the current directory to the path so we can import our module
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+# Import the main script as a module
+import importlib.util
+spec = importlib.util.spec_from_file_location("clustersecret_to_kubeconf", "clustersecret-to-kubeconf.py")
+clustersecret_to_kubeconf = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(clustersecret_to_kubeconf)
+
+ArgoCDClusterSecretConverter = clustersecret_to_kubeconf.ArgoCDClusterSecretConverter
+
+
+def create_mock_secret(name, server_url, ca_data=None, cert_data=None, key_data=None, 
+                      username=None, password=None, insecure=False):
+    """Create a mock Argo CD cluster secret."""
+    # Create the cluster configuration
+    cluster_config = {
+        'tlsClientConfig': {
+            'server': server_url,
+            'insecure': insecure
+        }
+    }
+    
+    if ca_data:
+        cluster_config['tlsClientConfig']['caData'] = ca_data
+    if cert_data:
+        cluster_config['tlsClientConfig']['certData'] = cert_data
+    if key_data:
+        cluster_config['tlsClientConfig']['keyData'] = key_data
+    if username:
+        cluster_config['username'] = username
+    if password:
+        cluster_config['password'] = password
+    
+    # Create the secret object
+    secret = Mock()
+    secret.metadata.name = name
+    secret.data = {
+        'config': base64.b64encode(json.dumps(cluster_config).encode('utf-8'))
+    }
+    
+    return secret
+
+
+def test_converter():
+    """Test the converter with mock data."""
+    print("Testing Argo CD Cluster Secret Converter...")
+    
+    # Create mock secrets
+    mock_secrets = [
+        create_mock_secret(
+            name='cluster-prod-cluster',
+            server_url='https://prod-cluster.example.com:6443',
+            ca_data='LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCg==',  # Mock CA data
+            cert_data='LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCg==',  # Mock cert data
+            key_data='LS0tLS1CRUdJTiBQUklWQVRFIEtFWS0tLS0tCg=='   # Mock key data
+        ),
+        create_mock_secret(
+            name='cluster-staging-cluster',
+            server_url='https://staging-cluster.example.com:6443',
+            username='admin',
+            password='secret-password',
+            insecure=True
+        ),
+        create_mock_secret(
+            name='cluster-dev-cluster',
+            server_url='https://dev-cluster.example.com:6443',
+            ca_data='LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCg==',
+            cert_data='LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCg==',
+            key_data='LS0tLS1CRUdJTiBQUklWQVRFIEtFWS0tLS0tCg=='
+        )
+    ]
+    
+    # Create converter instance
+    converter = ArgoCDClusterSecretConverter('test-context')
+    
+    # Test parsing each secret
+    print("\nTesting secret parsing:")
+    for secret in mock_secrets:
+        cluster_info = converter.parse_cluster_secret(secret)
+        if cluster_info:
+            print(f"✓ Successfully parsed {secret.metadata.name}")
+            print(f"  Server: {cluster_info['server']}")
+            print(f"  Name: {cluster_info['name']}")
+            print(f"  Insecure: {cluster_info['insecure_skip_tls_verify']}")
+        else:
+            print(f"✗ Failed to parse {secret.metadata.name}")
+    
+    # Test kubeconfig generation
+    print("\nTesting kubeconfig generation:")
+    converter.load_existing_kubeconfig()
+    
+    for secret in mock_secrets:
+        cluster_info = converter.parse_cluster_secret(secret)
+        if cluster_info:
+            converter.add_cluster_to_kubeconfig(cluster_info)
+    
+    # Print the generated kubeconfig
+    print("\nGenerated kubeconfig structure:")
+    print(f"Clusters: {len(converter.existing_config['clusters'])}")
+    print(f"Users: {len(converter.existing_config['users'])}")
+    print(f"Contexts: {len(converter.existing_config['contexts'])}")
+    
+    # Show the contexts
+    for context in converter.existing_config['contexts']:
+        print(f"  - {context['name']}")
+    
+    print("\nTest completed successfully!")
+
+
+if __name__ == "__main__":
+    test_converter() 


### PR DESCRIPTION
**What does this PR do / why we need it**:

This script allows you to create a kubeconfig file from Argo CD's cluster secrets. It's intended for development purposes, e.g. to debug the resource proxy.

It's been vibe coded using Cursor.

**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:


**Checklist**

* [ ] Documentation update is required by this PR (and has been updated) OR no documentation update is required.

