### PR TITLE
feat: Load JWT signing key from Kubernetes secret

### DIFF
--- a/cmd/principal/main.go
+++ b/cmd/principal/main.go
@@ -185,7 +185,8 @@ func NewPrincipalRunCommand() *cobra.Command {
 			} else if allowJwtGenerate {
 				opts = append(opts, principal.WithGeneratedTokenSigningKey())
 			} else {
-				cmdutil.Fatal("No JWT signing key given and auto generation not allowed.")
+				logrus.Infof("Loading JWT signing key from secret %s/%s", namespace, config.SecretNameJWT)
+				opts = append(opts, principal.WithTokenSigningKeyFromSecret(kubeConfig.Clientset, config.SecretNameJWT, namespace))
 			}
 
 			authMethods := auth.NewMethods()

--- a/hack/dev-env/create-agent-config.sh
+++ b/hack/dev-env/create-agent-config.sh
@@ -21,6 +21,8 @@ RECREATE="$1"
 SCRIPTPATH="$( cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
 BASEPATH="$( cd -- "$(dirname "$0")/../.." >/dev/null 2>&1 ; pwd -P )"
 AGENTCTL=${BASEPATH}/dist/argocd-agentctl
+KUBECTL=$(which kubectl)
+OPENSSL=$(which openssl)
 
 export ARGOCD_AGENT_PRINCIPAL_CONTEXT=vcluster-control-plane
 export ARGOCD_AGENT_PRINCIPAL_NAMESPACE=argocd
@@ -51,6 +53,10 @@ ${AGENTCTL} pki issue resource-proxy --upsert \
 	--principal-namespace argocd \
 	--ip "127.0.0.1,${IPADDR}"
 echo "  -> Resource proxy TLS config created."
+
+echo "[*] Creating JWT signing key and secret"
+${OPENSSL} genpkey -algorithm RSA -out /tmp/jwt.key -pkeyopt rsa_keygen_bits:2048
+${kubectl} create secret generic --context ${ARGOCD_AGENT_PRINCIPAL_CONTEXT} -n argocd argocd-agent-jwt --from-file=jwt.key=/tmp/jwt.key
 
 AGENTS="agent-managed agent-autonomous"
 for agent in ${AGENTS}; do

--- a/hack/dev-env/start-principal.sh
+++ b/hack/dev-env/start-principal.sh
@@ -38,10 +38,8 @@ fi
 SCRIPTPATH="$( cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
 go run github.com/argoproj-labs/argocd-agent/cmd/principal \
 	--allowed-namespaces '*' \
-	--insecure-jwt-generate \
 	--kubecontext vcluster-control-plane \
 	--log-level ${ARGOCD_AGENT_LOG_LEVEL:-trace} \
 	--namespace argocd \
 	--auth "mtls:CN=([^,]+)" \
 	$ARGS
-	#--auth "userpass:${SCRIPTPATH}/creds/users.control-plane" $ARGS

--- a/internal/config/constants.go
+++ b/internal/config/constants.go
@@ -19,3 +19,7 @@ const SecretNameProxyTLS = "argocd-agent-resource-proxy-tls"
 // SecretNameAgentClientCert is the name of the secret containing the TLS
 // client certificate + key for an agent.
 const SecretNameAgentClientCert = "argocd-agent-client-tls"
+
+// SecretNameJWT is the name of the secret containing the JWT signing key
+// for the principal.
+const SecretNameJWT = "argocd-agent-jwt"

--- a/principal/options.go
+++ b/principal/options.go
@@ -148,6 +148,20 @@ func WithTokenSigningKeyFromFile(path string) ServerOption {
 	}
 }
 
+// WithTokenSigningKeyFromSecret sets the RSA private key to use for signing the tokens
+// issued by the Server. The key will be loaded from the secret referred to by name and namespace.
+// The secret should contain a JWT signing key in the "jwt.key" field.
+func WithTokenSigningKeyFromSecret(kube kubernetes.Interface, name, namespace string) ServerOption {
+	return func(o *Server) error {
+		key, err := tlsutil.JWTSigningKeyFromSecret(context.Background(), kube, namespace, name)
+		if err != nil {
+			return err
+		}
+		o.options.signingKey = key
+		return nil
+	}
+}
+
 // WithListenerPort sets the listening port for the server. If the port is not
 // valid, an error is returned.
 func WithListenerPort(port int) ServerOption {


### PR DESCRIPTION
**What does this PR do / why we need it**:

Add the ability to load the JWT signing key from a Kubernetes secret in addition to from a file. This makes setup a little bit easier for people who do not care about secrets being stored in etcd.

Another follow-up PR will add functionality to the argocd-agentctl CLI to manage the secret and add documentation.

**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:

* Create the JWT secret with a private key in it
* Start principal without --insecure-jwt-generate flag

**Checklist**

* [ ] Documentation update is required by this PR (and has been updated) OR no documentation update is required.

