### PR TITLE
chore: Remove-mounted-tls-secrets

### DIFF
--- a/install/kubernetes/agent/agent-deployment.yaml
+++ b/install/kubernetes/agent/agent-deployment.yaml
@@ -103,8 +103,6 @@ spec:
             seccompProfile:
               type: RuntimeDefault
           volumeMounts:
-            - name: tls-secret
-              mountPath: /app/config/tls
             - name: userpass-passwd
               mountPath: /app/config/creds
       serviceAccountName: argocd-agent-agent
@@ -115,13 +113,3 @@ spec:
           items:
           - key: credentials
             path: userpass.creds
-      - name: tls-secret
-        secret:
-          secretName: argocd-agent-client-tls
-          items:
-          - key: tls.crt
-            path: tls.crt
-          - key: tls.key
-            path: tls.key
-          - key: ca.crt
-            path: ca.crt

--- a/install/kubernetes/agent/agent-params-cm.yaml
+++ b/install/kubernetes/agent/agent-params-cm.yaml
@@ -22,15 +22,15 @@ data:
   # agent.tls.root-ca-path: The path to a file containing the certificates for
   # the TLS root certificate authority used to validate the remote principal. 
   # Default: ""
-  agent.tls.root-ca-path: "/app/config/tls/ca.crt"
+  agent.tls.root-ca-path: ""
   # agent.tls.client.cert-path: Path to a file containing the agent's TLS client
   # certificate.
   # Default: ""
-  agent.tls.client.cert-path: "/app/config/tls/tls.crt"
+  agent.tls.client.cert-path: ""
   # agent.tls.client.cert-path: Path to a file containing the agent's TLS client
   # private key.
   # Default: ""
-  agent.tls.client.key-path: "/app/config/tls/tls.key"
+  agent.tls.client.key-path: ""
   # agent.log.level: The log level the agent should use. Valid values are
   # trace, debug, info, warn and error.
   # Default: "info"
@@ -49,3 +49,4 @@ data:
   # agent.metrics.port: The port the metrics server should listen on.
   # Default: 8181
   agent.metrics.port: "8181"
+  

--- a/install/kubernetes/principal/principal-deployment.yaml
+++ b/install/kubernetes/principal/principal-deployment.yaml
@@ -150,8 +150,6 @@ spec:
           volumeMounts:
             - name: jwt-secret
               mountPath: /app/config/jwt
-            - name: tls-secret
-              mountPath: /app/config/tls
             - name: userpass-passwd
               mountPath: /app/config/userpass
       serviceAccountName: argocd-agent-principal
@@ -168,13 +166,3 @@ spec:
           items:
           - key: jwt.key
             path: jwt.key
-      - name: tls-secret
-        secret:
-          secretName: argocd-agent-tls
-          items:
-          - key: tls.key
-            path: tls.key
-          - key: tls.crt
-            path: tls.crt
-          - key: ca.crt
-            path: ca.crt

--- a/install/kubernetes/principal/principal-params-cm.yaml
+++ b/install/kubernetes/principal/principal-params-cm.yaml
@@ -19,8 +19,8 @@ data:
   principal.metrics.port: "8000"
   # principal.namespace: The namespace the principal will operate in. If left
   # blank, the namespace where the pod is running in will be used.
-  # Default: ""
-  principal.namespace: ""
+  # Default: "argocd"
+  principal.namespace: "argocd"
   # principal.allowed-namespaces: A list of namespaces the principal shall
   # watch and process Argo CD resources in. Seperate entries using commas.
   # Entries may contain shell-style wildcards.
@@ -43,11 +43,11 @@ data:
   # principal.tls.server.cert-path: Path to the TLS certificate to be used by
   # the gRPC server.
   # Default: ""
-  principal.tls.server.cert-path: "/app/config/tls/tls.crt"
+  principal.tls.server.cert-path: ""
   # principal.tls.server.key-path: Path to the TLS private key to be used by
   # the gRPC server.
   # Default: ""
-  principal.tls.server.key-path: "/app/config/tls/tls.key"
+  principal.tls.server.key-path: ""
   # principal.tls.server.allow-generate: Whether to allow the principal to
   # generate its own set of TLS cert and key on startup when none are
   # configured. This is insecure. Do only use for development.
@@ -56,7 +56,7 @@ data:
   # principal.tls.server.root-ca-path: Path to a TLS root certificate authority
   # to be used to validate agent's client certificates against.
   # Default: ""
-  principal.tls.server.root-ca-path: "/app/config/tls/ca.crt"
+  principal.tls.server.root-ca-path: ""
   # principal.tls.client-cert.require: Whether to require client certs from
   # agents upon connection.
   # Default: false


### PR DESCRIPTION
**What does this PR do / why we need it**:
Remove hardcoded TLS certificate paths in agent and principal
ConfigMaps to enhance security and avoid potential misconfigurations.
Set default values to empty strings for TLS-related fields.

**Which issue(s) this PR fixes**:

Fixes #431

**How to test changes / Special notes to the reviewer**:
a clean installation of either the principal or an agent should only require `argocd-agent-principal-tls` or `argocd-agent-client-tls` with crt/key fields, and `argocd-agent-ca` with crt field.

**Checklist**

* [ ] Documentation update is required by this PR (and has been updated) OR no documentation update is required.

