### PR TITLE
feat: Add TLS secret name configuration for agent and principal

### DIFF
--- a/cmd/principal/main.go
+++ b/cmd/principal/main.go
@@ -61,7 +61,7 @@ func NewPrincipalRunCommand() *cobra.Command {
 		allowTLSGenerate          bool
 		allowJwtGenerate          bool
 		authMethod                string
-		tlsCaSecretName           string
+		rootCaSecretName          string
 		rootCaPath                string
 		requireClientCerts        bool
 		clientCertSubjectMatch    bool
@@ -165,8 +165,8 @@ func NewPrincipalRunCommand() *cobra.Command {
 				logrus.Infof("Loading root CA certificate from file %s", rootCaPath)
 				opts = append(opts, principal.WithTLSRootCaFromFile(rootCaPath))
 			} else {
-				logrus.Infof("Loading root CA certificate from secret %s/%s", namespace, tlsCaSecretName)
-				opts = append(opts, principal.WithTLSRootCaFromSecret(kubeConfig.Clientset, namespace, tlsCaSecretName, "tls.crt"))
+				logrus.Infof("Loading root CA certificate from secret %s/%s", namespace, rootCaSecretName)
+				opts = append(opts, principal.WithTLSRootCaFromSecret(kubeConfig.Clientset, namespace, rootCaSecretName, "tls.crt"))
 			}
 
 			opts = append(opts, principal.WithRequireClientCerts(requireClientCerts))
@@ -305,8 +305,8 @@ func NewPrincipalRunCommand() *cobra.Command {
 	command.Flags().BoolVar(&allowTLSGenerate, "insecure-tls-generate",
 		env.BoolWithDefault("ARGOCD_PRINCIPAL_TLS_SERVER_ALLOW_GENERATE", false),
 		"INSECURE: Generate and use temporary TLS cert and key")
-	command.Flags().StringVar(&tlsCaSecretName, "tls-ca-secret-name",
-		env.StringWithDefault("ARGOCD_PRINCIPAL_TLS_CA_SECRET_NAME", nil, config.SecretNamePrincipalCA),
+	command.Flags().StringVar(&rootCaSecretName, "tls-ca-secret-name",
+		env.StringWithDefault("ARGOCD_PRINCIPAL_TLS_SERVER_ROOT_CA_SECRET_NAME", nil, config.SecretNamePrincipalCA),
 		"Secret name of TLS CA certificate")
 	command.Flags().StringVar(&rootCaPath, "root-ca-path",
 		env.StringWithDefault("ARGOCD_PRINCIPAL_TLS_SERVER_ROOT_CA_PATH", nil, ""),

--- a/cmd/principal/main.go
+++ b/cmd/principal/main.go
@@ -45,35 +45,39 @@ import (
 
 func NewPrincipalRunCommand() *cobra.Command {
 	var (
-		listenHost             string
-		listenPort             int
-		logLevel               string
-		logFormat              string
-		metricsPort            int
-		namespace              string
-		allowedNamespaces      []string
-		kubeConfig             string
-		kubeContext            string
-		tlsCert                string
-		tlsKey                 string
-		jwtKey                 string
-		allowTLSGenerate       bool
-		allowJwtGenerate       bool
-		authMethod             string
-		rootCaPath             string
-		requireClientCerts     bool
-		clientCertSubjectMatch bool
-		autoNamespaceAllow     bool
-		autoNamespacePattern   string
-		autoNamespaceLabels    []string
-		enableWebSocket        bool
-		enableResourceProxy    bool
-		pprofPort              int
-		resourceProxyCertPath  string
-		resourceProxyKeyPath   string
-		resourceProxyCAPath    string
-		showVersion            bool
-		versionFormat          string
+		listenHost                string
+		listenPort                int
+		logLevel                  string
+		logFormat                 string
+		metricsPort               int
+		namespace                 string
+		allowedNamespaces         []string
+		kubeConfig                string
+		kubeContext               string
+		tlsSecretName             string
+		tlsCert                   string
+		tlsKey                    string
+		jwtKey                    string
+		allowTLSGenerate          bool
+		allowJwtGenerate          bool
+		authMethod                string
+		tlsCaSecretName           string
+		rootCaPath                string
+		requireClientCerts        bool
+		clientCertSubjectMatch    bool
+		autoNamespaceAllow        bool
+		autoNamespacePattern      string
+		autoNamespaceLabels       []string
+		enableWebSocket           bool
+		enableResourceProxy       bool
+		pprofPort                 int
+		resourceProxySecretName   string
+		resourceProxyCertPath     string
+		resourceProxyKeyPath      string
+		resourceProxyCaSecretName string
+		resourceProxyCAPath       string
+		showVersion               bool
+		versionFormat             string
 
 		// Minimum time duration for agent to wait before sending next keepalive ping to principal
 		// if agent sends ping more often than specified interval then connection will be dropped
@@ -153,14 +157,16 @@ func NewPrincipalRunCommand() *cobra.Command {
 			} else if (tlsCert != "" && tlsKey == "") || (tlsCert == "" && tlsKey != "") {
 				cmdutil.Fatal("Both --tls-cert and --tls-key have to be given")
 			} else {
-				logrus.Infof("Loading gRPC TLS certificate from secret %s/%s", namespace, config.SecretNamePrincipalCA)
-				opts = append(opts, principal.WithTLSKeyPairFromSecret(kubeConfig.Clientset, config.SecretNamePrincipalTLS, namespace))
+				logrus.Infof("Loading gRPC TLS certificate from secret %s/%s", namespace, tlsSecretName)
+				opts = append(opts, principal.WithTLSKeyPairFromSecret(kubeConfig.Clientset, namespace, tlsSecretName))
 			}
 
 			if rootCaPath != "" {
+				logrus.Infof("Loading root CA certificate from file %s", rootCaPath)
 				opts = append(opts, principal.WithTLSRootCaFromFile(rootCaPath))
 			} else {
-				opts = append(opts, principal.WithTLSRootCaFromSecret(kubeConfig.Clientset, config.SecretNamePrincipalCA, namespace, "tls.crt"))
+				logrus.Infof("Loading root CA certificate from secret %s/%s", namespace, tlsCaSecretName)
+				opts = append(opts, principal.WithTLSRootCaFromSecret(kubeConfig.Clientset, namespace, tlsCaSecretName, "tls.crt"))
 			}
 
 			opts = append(opts, principal.WithRequireClientCerts(requireClientCerts))
@@ -170,9 +176,11 @@ func NewPrincipalRunCommand() *cobra.Command {
 			if enableResourceProxy {
 				var proxyTLS *tls.Config
 				if resourceProxyCertPath != "" && resourceProxyKeyPath != "" && resourceProxyCAPath != "" {
+					logrus.Infof("Loading resource proxy TLS configuration from files cert=%s, key=%s and ca=%s", resourceProxyCertPath, resourceProxyKeyPath, resourceProxyCAPath)
 					proxyTLS, err = getResourceProxyTLSConfigFromFiles(resourceProxyCertPath, resourceProxyKeyPath, resourceProxyCAPath)
 				} else {
-					proxyTLS, err = getResourceProxyTLSConfigFromKube(kubeConfig, namespace)
+					logrus.Infof("Loading resource proxy TLS certificate from secrets %s/%s and %s/%s", namespace, resourceProxySecretName, namespace, resourceProxyCaSecretName)
+					proxyTLS, err = getResourceProxyTLSConfigFromKube(kubeConfig, namespace, resourceProxySecretName, resourceProxyCaSecretName)
 				}
 				if err != nil {
 					cmdutil.Fatal("Error reading TLS config for resource proxy: %v", err)
@@ -285,6 +293,9 @@ func NewPrincipalRunCommand() *cobra.Command {
 		env.StringSliceWithDefault("ARGOCD_PRINCIPAL_NAMESPACE_CREATE_LABELS", nil, []string{}),
 		"Labels to apply to auto-created namespaces")
 
+	command.Flags().StringVar(&tlsSecretName, "tls-secret-name",
+		env.StringWithDefault("ARGOCD_PRINCIPAL_TLS_SECRET_NAME", nil, config.SecretNamePrincipalTLS),
+		"Secret name of TLS certificate and key")
 	command.Flags().StringVar(&tlsCert, "tls-cert",
 		env.StringWithDefault("ARGOCD_PRINCIPAL_TLS_SERVER_CERT_PATH", nil, ""),
 		"Use TLS certificate from path")
@@ -294,6 +305,9 @@ func NewPrincipalRunCommand() *cobra.Command {
 	command.Flags().BoolVar(&allowTLSGenerate, "insecure-tls-generate",
 		env.BoolWithDefault("ARGOCD_PRINCIPAL_TLS_SERVER_ALLOW_GENERATE", false),
 		"INSECURE: Generate and use temporary TLS cert and key")
+	command.Flags().StringVar(&tlsCaSecretName, "tls-ca-secret-name",
+		env.StringWithDefault("ARGOCD_PRINCIPAL_TLS_CA_SECRET_NAME", nil, config.SecretNamePrincipalCA),
+		"Secret name of TLS CA certificate")
 	command.Flags().StringVar(&rootCaPath, "root-ca-path",
 		env.StringWithDefault("ARGOCD_PRINCIPAL_TLS_SERVER_ROOT_CA_PATH", nil, ""),
 		"Path to a file containing the root CA certificate for verifying client certs of agents")
@@ -304,12 +318,18 @@ func NewPrincipalRunCommand() *cobra.Command {
 		env.BoolWithDefault("ARGOCD_PRINCIPAL_TLS_CLIENT_CERT_MATCH_SUBJECT", false),
 		"Whether a client cert's subject must match the agent name")
 
+	command.Flags().StringVar(&resourceProxySecretName, "resource-proxy-secret-name",
+		env.StringWithDefault("ARGOCD_PRINCIPAL_RESOURCE_PROXY_SECRET_NAME", nil, config.SecretNameProxyTLS),
+		"Secret name of the resource proxy")
 	command.Flags().StringVar(&resourceProxyCertPath, "resource-proxy-cert-path",
 		env.StringWithDefault("ARGOCD_PRINCIPAL_RESOURCE_PROXY_TLS_CERT_PATH", nil, ""),
 		"Path to a file containing the resource proxy's TLS certificate")
 	command.Flags().StringVar(&resourceProxyKeyPath, "resource-proxy-key-path",
 		env.StringWithDefault("ARGOCD_PRINCIPAL_RESOURCE_PROXY_TLS_KEY_PATH", nil, ""),
 		"Path to a file containing the resource proxy's TLS private key")
+	command.Flags().StringVar(&resourceProxyCaSecretName, "resource-proxy-ca-secret-name",
+		env.StringWithDefault("ARGOCD_PRINCIPAL_RESOURCE_PROXY_CA_SECRET_NAME", nil, config.SecretNamePrincipalCA),
+		"Secret name of the resource proxy's CA certificate")
 	command.Flags().StringVar(&resourceProxyCAPath, "resource-proxy-ca-path",
 		env.StringWithDefault("ARGOCD_PRINCIPAL_RESOURCE_PROXY_TLS_CA_PATH", nil, ""),
 		"Path to a file containing the resource proxy's TLS CA data")
@@ -375,15 +395,15 @@ func observer(interval time.Duration) {
 //
 // The secret names where the certificates are stored in are hard-coded at the
 // moment.
-func getResourceProxyTLSConfigFromKube(kubeClient *kube.KubernetesClient, namespace string) (*tls.Config, error) {
+func getResourceProxyTLSConfigFromKube(kubeClient *kube.KubernetesClient, namespace, certName, caName string) (*tls.Config, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
-	proxyCert, err := tlsutil.TLSCertFromSecret(ctx, kubeClient.Clientset, namespace, config.SecretNameProxyTLS)
+	proxyCert, err := tlsutil.TLSCertFromSecret(ctx, kubeClient.Clientset, namespace, certName)
 	if err != nil {
 		return nil, fmt.Errorf("error getting proxy certificate: %w", err)
 	}
 
-	clientCA, err := tlsutil.X509CertPoolFromSecret(ctx, kubeClient.Clientset, namespace, config.SecretNamePrincipalCA, "tls.crt")
+	clientCA, err := tlsutil.X509CertPoolFromSecret(ctx, kubeClient.Clientset, namespace, caName, "tls.crt")
 	if err != nil {
 		return nil, fmt.Errorf("error getting client CA certificate: %w", err)
 	}

--- a/install/kubernetes/agent/agent-deployment.yaml
+++ b/install/kubernetes/agent/agent-deployment.yaml
@@ -45,6 +45,12 @@ spec:
                 name: argocd-agent-params
                 key: agent.namespace
                 optional: true
+          - name: ARGOCD_AGENT_TLS_SECRET_NAME
+            valueFrom:
+              configMapKeyRef:
+                name: argocd-agent-params
+                key: agent.tls.secret-name
+                optional: true
           - name: ARGOCD_AGENT_TLS_CLIENT_CERT_PATH
             valueFrom:
               configMapKeyRef:
@@ -62,6 +68,12 @@ spec:
               configMapKeyRef:
                 name: argocd-agent-params
                 key: agent.tls.client.insecure
+                optional: true
+          - name: ARGOCD_AGENT_TLS_ROOT_CA_SECRET_NAME
+            valueFrom:
+              configMapKeyRef:
+                name: argocd-agent-params
+                key: agent.tls.root-ca-secret-name
                 optional: true
           - name: ARGOCD_AGENT_TLS_ROOT_CA_PATH
             valueFrom:

--- a/install/kubernetes/agent/agent-params-cm.yaml
+++ b/install/kubernetes/agent/agent-params-cm.yaml
@@ -22,16 +22,16 @@ data:
   # agent.tls.root-ca-secret-name: The name of the secret containing the
   # certificates for the TLS root certificate authority used to validate the
   # remote principal.
-  # Default: ""
-  agent.tls.root-ca-secret-name: ""
+  # Default: "argocd-agent-ca"
+  agent.tls.root-ca-secret-name: "argocd-agent-ca"
   # agent.tls.root-ca-path: The path to a file containing the certificates for
   # the TLS root certificate authority used to validate the remote principal. 
   # Default: ""
   agent.tls.root-ca-path: ""
   # agent.tls.secret-name: The name of the secret containing the agent
   # certificate.
-  # Default: ""
-  agent.tls.secret-name: ""
+  # Default: "argocd-agent-client-tls"
+  agent.tls.secret-name: "argocd-agent-client-tls"
   # agent.tls.client.cert-path: Path to a file containing the agent's TLS client
   # certificate.
   # Default: ""

--- a/install/kubernetes/agent/agent-params-cm.yaml
+++ b/install/kubernetes/agent/agent-params-cm.yaml
@@ -19,10 +19,19 @@ data:
   # credentials. Insecure. Do only use for development purposes.
   # Default: false
   agent.tls.client.insecure: "false"
+  # agent.tls.root-ca-secret-name: The name of the secret containing the
+  # certificates for the TLS root certificate authority used to validate the
+  # remote principal.
+  # Default: ""
+  agent.tls.root-ca-secret-name: ""
   # agent.tls.root-ca-path: The path to a file containing the certificates for
   # the TLS root certificate authority used to validate the remote principal. 
   # Default: ""
   agent.tls.root-ca-path: ""
+  # agent.tls.secret-name: The name of the secret containing the agent
+  # certificate.
+  # Default: ""
+  agent.tls.secret-name: ""
   # agent.tls.client.cert-path: Path to a file containing the agent's TLS client
   # certificate.
   # Default: ""

--- a/install/kubernetes/principal/principal-deployment.yaml
+++ b/install/kubernetes/principal/principal-deployment.yaml
@@ -75,6 +75,12 @@ spec:
                 name: argocd-agent-params
                 key: principal.namespace-create.labels
                 optional: true
+          - name: ARGOCD_PRINCIPAL_TLS_SECRET_NAME
+            valueFrom:
+              configMapKeyRef:
+                name: argocd-agent-params
+                key: principal.tls.secret-name
+                optional: true
           - name: ARGOCD_PRINCIPAL_TLS_SERVER_CERT_PATH
             valueFrom:
               configMapKeyRef:
@@ -99,6 +105,12 @@ spec:
                 name: argocd-agent-params
                 key: principal.tls.client-cert.require
                 optional: true
+          - name: ARGOCD_PRINCIPAL_TLS_CA_SECRET_NAME
+            valueFrom:
+              configMapKeyRef:
+                name: argocd-agent-params
+                key: principal.tls.ca.secret-name
+                optional: true
           - name: ARGOCD_PRINCIPAL_TLS_SERVER_ROOT_CA_PATH
             valueFrom:
               configMapKeyRef:
@@ -110,6 +122,36 @@ spec:
               configMapKeyRef:
                 name: argocd-agent-params
                 key: principal.tls.client-cert.match-subject
+                optional: true
+          - name: ARGOCD_PRINCIPAL_RESOURCE_PROXY_SECRET_NAME
+            valueFrom:
+              configMapKeyRef:
+                name: argocd-agent-params
+                key: principal.resource-proxy.secret-name
+                optional: true
+          - name: ARGOCD_PRINCIPAL_RESOURCE_PROXY_TLS_CERT_PATH
+            valueFrom:
+              configMapKeyRef:
+                name: argocd-agent-params
+                key: principal.resource-proxy.tls.cert-path
+                optional: true
+          - name: ARGOCD_PRINCIPAL_RESOURCE_PROXY_TLS_KEY_PATH
+            valueFrom:
+              configMapKeyRef:
+                name: argocd-agent-params
+                key: principal.resource-proxy.tls.key-path
+                optional: true
+          - name: ARGOCD_PRINCIPAL_RESOURCE_PROXY_CA_SECRET_NAME
+            valueFrom:
+              configMapKeyRef:
+                name: argocd-agent-params
+                key: principal.resource-proxy.ca.secret-name
+                optional: true
+          - name: ARGOCD_PRINCIPAL_RESOURCE_PROXY_CA_PATH
+            valueFrom:
+              configMapKeyRef:
+                name: argocd-agent-params
+                key: principal.resource-proxy.ca.path
                 optional: true
           - name: ARGOCD_PRINCIPAL_JWT_ALLOW_GENERATE
             valueFrom:

--- a/install/kubernetes/principal/principal-deployment.yaml
+++ b/install/kubernetes/principal/principal-deployment.yaml
@@ -159,6 +159,12 @@ spec:
                 name: argocd-agent-params
                 key: principal.jwt.allow-generate
                 optional: true
+          - name: ARGOCD_PRINCIPAL_JWT_SECRET_NAME
+            valueFrom:
+              configMapKeyRef:
+                name: argocd-agent-params
+                key: principal.jwt.secret-name
+                optional: true
           - name: ARGOCD_PRINCIPAL_JWT_KEY_PATH
             valueFrom:
               configMapKeyRef:

--- a/install/kubernetes/principal/principal-deployment.yaml
+++ b/install/kubernetes/principal/principal-deployment.yaml
@@ -105,11 +105,11 @@ spec:
                 name: argocd-agent-params
                 key: principal.tls.client-cert.require
                 optional: true
-          - name: ARGOCD_PRINCIPAL_TLS_CA_SECRET_NAME
+          - name: ARGOCD_PRINCIPAL_TLS_SERVER_ROOT_CA_SECRET_NAME
             valueFrom:
               configMapKeyRef:
                 name: argocd-agent-params
-                key: principal.tls.ca.secret-name
+                key: principal.tls.server.root-ca-secret-name
                 optional: true
           - name: ARGOCD_PRINCIPAL_TLS_SERVER_ROOT_CA_PATH
             valueFrom:

--- a/install/kubernetes/principal/principal-params-cm.yaml
+++ b/install/kubernetes/principal/principal-params-cm.yaml
@@ -40,6 +40,9 @@ data:
   # "key=value". Empty values are not allowed. Multiple labels can be given
   # as a comma separated list, e.g. "foo=bar,bar=baz"
   principal.namespace-create.labels: ""
+  # principal.tls.secret-name: The name of the secret containing the TLS certificate and key.
+  # Default: ""
+  principal.tls.secret-name: ""
   # principal.tls.server.cert-path: Path to the TLS certificate to be used by
   # the gRPC server.
   # Default: ""
@@ -65,6 +68,26 @@ data:
   # in a client certificate presented by an agent to the agent's name.
   # Default: false
   principal.tls.client-cert.match-subject: "false"
+  # principal.resource-proxy.secret-name: The name of the secret containing
+  # the TLS certificate and key for the resource proxy.
+  # Default: ""
+  principal.resource-proxy.secret-name: ""
+  # principal.resource-proxy.tls.cert-path: Path to the TLS certificate to be used by
+  # the resource proxy.
+  # Default: ""
+  principal.resource-proxy.tls.cert-path: ""
+  # principal.resource-proxy.tls.key-path: Path to the TLS private key to be used by
+  # the resource proxy.
+  # Default: ""
+  principal.resource-proxy.tls.key-path: ""
+  # principal.resource-proxy.ca.secret-name: The name of the secret containing
+  # the CA certificate for the resource proxy.
+  # Default: ""
+  principal.resource-proxy.ca.secret-name: ""
+  # principal.resource-proxy.ca.path: Path to the CA certificate to be used by
+  # the resource proxy.
+  # Default: ""
+  principal.resource-proxy.ca.path: ""
   # principal.jwt.allow-generate: Whether to allow the principal to generate
   # its own private key for signing JWT tokens. This is insecure. Do only use
   # for development.

--- a/install/kubernetes/principal/principal-params-cm.yaml
+++ b/install/kubernetes/principal/principal-params-cm.yaml
@@ -41,8 +41,8 @@ data:
   # as a comma separated list, e.g. "foo=bar,bar=baz"
   principal.namespace-create.labels: ""
   # principal.tls.secret-name: The name of the secret containing the TLS certificate and key.
-  # Default: ""
-  principal.tls.secret-name: ""
+  # Default: "argocd-agent-principal-tls"
+  principal.tls.secret-name: "argocd-agent-principal-tls"
   # principal.tls.server.cert-path: Path to the TLS certificate to be used by
   # the gRPC server.
   # Default: ""
@@ -61,8 +61,8 @@ data:
   # Default: false
   principal.tls.client-cert.require: "false"
   # principal.tls.server.secret-name: The name of the secret containing the root CA TLS certificate.
-  # Default: ""
-  principal.tls.server.root-ca-secret-name: ""
+  # Default: "argocd-agent-ca"
+  principal.tls.server.root-ca-secret-name: "argocd-agent-ca"
   # principal.tls.server.root-ca-path: Path to a TLS root certificate authority
   # to be used to validate agent's client certificates against.
   # Default: ""
@@ -73,8 +73,8 @@ data:
   principal.tls.client-cert.match-subject: "false"
   # principal.resource-proxy.secret-name: The name of the secret containing
   # the TLS certificate and key for the resource proxy.
-  # Default: ""
-  principal.resource-proxy.secret-name: ""
+  # Default: "argocd-agent-resource-proxy-tls"
+  principal.resource-proxy.secret-name: "argocd-agent-resource-proxy-tls"
   # principal.resource-proxy.tls.cert-path: Path to the TLS certificate to be used by
   # the resource proxy.
   # Default: ""
@@ -85,8 +85,8 @@ data:
   principal.resource-proxy.tls.key-path: ""
   # principal.resource-proxy.ca.secret-name: The name of the secret containing
   # the CA certificate for the resource proxy.
-  # Default: ""
-  principal.resource-proxy.ca.secret-name: ""
+  # Default: "argocd-agent-ca"
+  principal.resource-proxy.ca.secret-name: "argocd-agent-ca"
   # principal.resource-proxy.ca.path: Path to the CA certificate to be used by
   # the resource proxy.
   # Default: ""
@@ -97,8 +97,8 @@ data:
   # Default: false
   principal.jwt.allow-generate: "false"
   # principal.jwt.secret-name: The name of the secret containing the JWT signing key.
-  # Default: ""
-  principal.jwt.secret-name: ""
+  # Default: "argocd-agent-jwt"
+  principal.jwt.secret-name: "argocd-agent-jwt"
   # principal.jwt.key-path: Path to the private key to be used for signing JWT
   # tokens.
   # Default: ""

--- a/install/kubernetes/principal/principal-params-cm.yaml
+++ b/install/kubernetes/principal/principal-params-cm.yaml
@@ -96,9 +96,13 @@ data:
   # for development.
   # Default: false
   principal.jwt.allow-generate: "false"
+  # principal.jwt.secret-name: The name of the secret containing the JWT signing key.
+  # Default: ""
+  principal.jwt.secret-name: ""
   # principal.jwt.key-path: Path to the private key to be used for signing JWT
   # tokens.
-  principal.jwt.key-path: "/app/config/jwt/jwt.key"
+  # Default: ""
+  principal.jwt.key-path: ""
   # principal.auth: The authentication method. Must be in the
   # format <method>:<configuration>. Valid values are:
   # - "userpass:_path_to_encrypted_creds_" where _path_to_encrypted_creds_ is

--- a/install/kubernetes/principal/principal-params-cm.yaml
+++ b/install/kubernetes/principal/principal-params-cm.yaml
@@ -7,11 +7,11 @@ data:
   # for all interfaces.
   # Default: ""
   principal.listen.host: ""
-  # principal.listen.port: The port the gRPC server should listen on. 
+  # principal.listen.port: The port the gRPC server should listen on.
   # Default: 8443
   principal.listen.port: "8443"
   # principal.log.level: The logging level to use. One of trace, debug, info,
-  # warn or error. 
+  # warn or error.
   # Default: info
   principal.log.level: info
   # principal.metrics.port: The port the metrics server should listen on.
@@ -56,14 +56,17 @@ data:
   # configured. This is insecure. Do only use for development.
   # Default: false
   principal.tls.server.allow-generate: "false"
-  # principal.tls.server.root-ca-path: Path to a TLS root certificate authority
-  # to be used to validate agent's client certificates against.
-  # Default: ""
-  principal.tls.server.root-ca-path: ""
   # principal.tls.client-cert.require: Whether to require client certs from
   # agents upon connection.
   # Default: false
   principal.tls.client-cert.require: "false"
+  # principal.tls.server.secret-name: The name of the secret containing the root CA TLS certificate.
+  # Default: ""
+  principal.tls.server.root-ca-secret-name: ""
+  # principal.tls.server.root-ca-path: Path to a TLS root certificate authority
+  # to be used to validate agent's client certificates against.
+  # Default: ""
+  principal.tls.server.root-ca-path: ""
   # principal.tls.client-cert.match-subject: Whether to match the subject field
   # in a client certificate presented by an agent to the agent's name.
   # Default: false

--- a/pkg/client/remote.go
+++ b/pkg/client/remote.go
@@ -151,7 +151,7 @@ func WithTLSClientCertFromFile(certPath, keyPath string) RemoteOption {
 
 // WithTLSClientCertFromSecret configures the remote to present the client cert
 // loaded from the secret on every outbound connection.
-func WithTLSClientCertFromSecret(kube kubernetes.Interface, name, namespace string) RemoteOption {
+func WithTLSClientCertFromSecret(kube kubernetes.Interface, namespace, name string) RemoteOption {
 	return func(r *Remote) error {
 		c, err := tlsutil.TLSCertFromSecret(context.Background(), kube, namespace, name)
 		if err != nil {
@@ -202,7 +202,7 @@ func WithRootAuthoritiesFromFile(caPath string) RemoteOption {
 // field. Otherwise, the ConfigMap is expected to contain one or more
 // certificates in each field of the ConfigMap, and all certificates will be
 // loaded into the certificate pool.
-func WithRootAuthoritiesFromSecret(kube kubernetes.Interface, name, namespace, field string) RemoteOption {
+func WithRootAuthoritiesFromSecret(kube kubernetes.Interface, namespace, name, field string) RemoteOption {
 	return func(r *Remote) error {
 		pool, err := tlsutil.X509CertPoolFromSecret(context.Background(), kube, namespace, name, field)
 		if err != nil {

--- a/principal/options.go
+++ b/principal/options.go
@@ -151,7 +151,7 @@ func WithTokenSigningKeyFromFile(path string) ServerOption {
 // WithTokenSigningKeyFromSecret sets the RSA private key to use for signing the tokens
 // issued by the Server. The key will be loaded from the secret referred to by name and namespace.
 // The secret should contain a JWT signing key in the "jwt.key" field.
-func WithTokenSigningKeyFromSecret(kube kubernetes.Interface, name, namespace string) ServerOption {
+func WithTokenSigningKeyFromSecret(kube kubernetes.Interface, namespace, name string) ServerOption {
 	return func(o *Server) error {
 		key, err := tlsutil.JWTSigningKeyFromSecret(context.Background(), kube, namespace, name)
 		if err != nil {

--- a/principal/options.go
+++ b/principal/options.go
@@ -213,7 +213,7 @@ func WithTLSRootCaFromFile(caPath string) ServerOption {
 // If field is non-empty, only loads certificates stored in the named field.
 // Otherwise, if field is empty, loads certificates from all fields in the
 // Secret.
-func WithTLSRootCaFromSecret(kube kubernetes.Interface, name string, namespace, field string) ServerOption {
+func WithTLSRootCaFromSecret(kube kubernetes.Interface, namespace, name, field string) ServerOption {
 	return func(o *Server) error {
 		pool, err := tlsutil.X509CertPoolFromSecret(context.Background(), kube, namespace, name, field)
 		if err != nil {
@@ -258,7 +258,7 @@ func WithTLSKeyPairFromPath(certPath, keyPath string) ServerOption {
 // WithTLSKeyPairFromSecret configures the TLS certificate and private key to
 // be used by the server. The keypair will be loaded from the secret referred
 // to by name and namespace. The secret must be of type tls.
-func WithTLSKeyPairFromSecret(kube kubernetes.Interface, name, namespace string) ServerOption {
+func WithTLSKeyPairFromSecret(kube kubernetes.Interface, namespace, name string) ServerOption {
 	return func(o *Server) error {
 		c, err := tlsutil.TLSCertFromSecret(context.Background(), kube, namespace, name)
 		if err != nil {


### PR DESCRIPTION
**What does this PR do / why we need it**:
- Introduce flags for specifying TLS secret names in agent and principal commands.
- Update deployment and config maps to reference new TLS secret names.
- Modify functions to accept parameters in a consistent order for better readability (namespace before name)
- Enhance logging for TLS certificate loading from secrets.

This change allows users to configure TLS certificates more flexibly,
improving security and usability in Kubernetes deployments.

**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:


**Checklist**

* [] Documentation update is required by this PR (and has been updated) OR no documentation update is required.
