### PR TITLE
feat: proxy redis traffic from principal to agents

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -216,6 +216,7 @@ jobs:
         run: |
           kubectl --context vcluster-agent-autonomous logs -n argocd argocd-application-controller-0 > /tmp/vcluster-agent-autonomous-controller.log
           kubectl --context vcluster-agent-managed logs -n argocd argocd-application-controller-0 > /tmp/vcluster-agent-managed-controller.log
+          kubectl --context vcluster-control-plane logs -n argocd deployment/argocd-server > /tmp/vcluster-control-plane-server.log
         if: ${{ failure() }}
       - name: Upload e2e-argocd-agent logs
         uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
@@ -241,3 +242,10 @@ jobs:
           name: vcluster-agent-managed-controller.log
           path: /tmp/vcluster-agent-managed-controller.log
         if: ${{ failure() }}
+      - name: Upload vcluster-control-plane-server logs
+        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+        with:
+          name: vcluster-control-plane-server.log
+          path: /tmp/vcluster-control-plane-server.log
+        if: ${{ failure() }}
+

--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ setup-e2e2: cli
 
 .PHONY: start-e2e2
 start-e2e2: cli install-goreman
-	goreman -exit-on-stop=false -f hack/dev-env/Procfile.e2e start
+	./hack/dev-env/start-e2e2.sh
 
 .PHONY: test-e2e2
 test-e2e2:

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -87,6 +87,9 @@ type Agent struct {
 	resyncedOnStart bool
 	// resources is a list of all the resources that are currently being managed by the agent
 	resources *resources.Resources
+
+	// redisProxyMsgHandler manages redis connection state for agent
+	redisProxyMsgHandler *redisProxyMsgHandler
 }
 
 const defaultQueueName = "default"
@@ -117,6 +120,7 @@ func NewAgent(ctx context.Context, client *kube.KubernetesClient, namespace stri
 	a.infStopCh = make(chan struct{})
 	a.namespace = namespace
 	a.mode = types.AgentModeAutonomous
+	a.redisProxyMsgHandler = &redisProxyMsgHandler{}
 
 	for _, o := range opts {
 		err := o(a)
@@ -251,6 +255,18 @@ func NewAgent(ctx context.Context, client *kube.KubernetesClient, namespace stri
 	a.resources = resources.NewResources()
 
 	a.syncCh = make(chan bool, 1)
+
+	argoClient, argoCache, err := a.getRedisClientAndCache()
+	if err != nil {
+		return nil, err
+	}
+
+	a.redisProxyMsgHandler.argoCDRedisCache = argoCache
+	a.redisProxyMsgHandler.argoCDRedisClient = argoClient
+	a.redisProxyMsgHandler.connections = &connectionEntries{
+		connMap: map[string]connectionEntry{},
+	}
+
 	return a, nil
 }
 

--- a/agent/inbound_redis.go
+++ b/agent/inbound_redis.go
@@ -1,0 +1,341 @@
+package agent
+
+import (
+	"context"
+	"crypto/tls"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/argoproj-labs/argocd-agent/internal/event"
+	"github.com/argoproj-labs/argocd-agent/pkg/types"
+	rediscache "github.com/go-redis/cache/v9"
+	"github.com/redis/go-redis/v9"
+	"github.com/sirupsen/logrus"
+)
+
+// redisProxyMsgHandler manages redis connection state for agent
+type redisProxyMsgHandler struct {
+	redisAddress  string
+	redisUsername string
+	redisPassword string
+
+	// argoCDRedisClient is the client API to agent redis
+	argoCDRedisClient *redis.Client
+
+	// argoCDRedisCache is the cache API to agent redis
+	argoCDRedisCache *rediscache.Cache
+
+	// connections maintains statistics about redis connections from principal
+	connections *connectionEntries
+}
+
+// connectionEntries maintains statistics about redis connections from principal
+type connectionEntries struct {
+	// lock should be acquired before reading/writing to connMap
+	lock sync.RWMutex
+
+	// connMap maintains a list of when a ping was last seen from each connection (uuid). This allows us to close stale connections.
+	// - key is connection uuid
+	connMap map[string]connectionEntry // acquire lock before accessing
+}
+
+// connectionEntry describes statistics about a specific connection (uuid)
+type connectionEntry struct {
+	// lastPing the time at which the last ping message was received from principal
+	lastPing time.Time
+}
+
+// processIncomingRedisRequest handles incoming redis-specific events from principal, including get/subscribe (from argo cd) and ping (internal).
+func (a *Agent) processIncomingRedisRequest(ev *event.Event) error {
+
+	rreq, err := ev.RedisRequest()
+	if err != nil {
+		return err
+	}
+	logCtx := log().WithFields(logrus.Fields{
+		"method":         "processIncomingRedisRequest",
+		"uuid":           rreq.UUID,
+		"connectionUUID": rreq.ConnectionUUID,
+	})
+
+	logCtx.Tracef("Start processing incoming redis request %v", rreq)
+
+	var responseBody *event.RedisResponseBody
+
+	if rreq.Body.Get != nil {
+		var err error
+
+		responseBody, err = a.handleRedisGetMessage(logCtx, rreq)
+		if err != nil {
+			return err
+		}
+
+	} else if rreq.Body.Subscribe != nil {
+
+		var err error
+		responseBody, err = a.handleRedisSubscribeMessage(logCtx, rreq)
+		if err != nil {
+			return err
+		}
+
+	} else if rreq.Body.Ping != nil {
+
+		// We have seeng a ping for this connection, so update the lifecycle struct
+		connections := a.redisProxyMsgHandler.connections
+
+		connections.lock.Lock()
+		defer connections.lock.Unlock()
+		connections.connMap[rreq.ConnectionUUID] = connectionEntry{
+			lastPing: time.Now(),
+		}
+
+		// Send pong back to principal
+		responseBody = &event.RedisResponseBody{
+			Pong: &event.RedisResponseBodyPong{},
+		}
+		logCtx.Tracef("Queuing Redis pong response")
+
+	} else {
+		logCtx.Error("Unrecognized redis request body")
+		return nil
+	}
+
+	if responseBody == nil {
+		logCtx.Error("Response command not defined")
+		return nil
+	}
+
+	q := a.queues.SendQ(defaultQueueName)
+	if q == nil {
+		logCtx.Error("Remote queue disappeared")
+		return nil
+	}
+	q.Add(a.emitter.NewRedisResponseEvent(rreq.UUID, rreq.ConnectionUUID, *responseBody))
+	logCtx.Trace("Emitted redis resource response")
+
+	return nil
+}
+
+func (a *Agent) handleRedisSubscribeMessage(logCtx *logrus.Entry, rreq *event.RedisRequest) (*event.RedisResponseBody, error) {
+	channelName := rreq.Body.Subscribe.ChannelName
+
+	logCtx.Tracef("Start processing redis SUBSCRIBE request with key '%s'", channelName)
+
+	// The autonomous Redis does not use namespace in key, so we need to strip it. See strip function for details.
+	if a.mode == types.AgentModeAutonomous {
+		var err error
+		channelName, err = stripNamespaceFromKeyForAutonomousAgentForRedis(channelName, logCtx)
+		if err != nil {
+			logCtx.WithError(err).Errorf("unable to transform SUBSCRIBE key for autonomous agent '%s'", channelName)
+			return nil, fmt.Errorf("unable to transform SUBSCRIBE key for autonomous agent: %v", err)
+		}
+	}
+
+	// Subscribe to the argo cd redis channel via redis client
+	pubsub := a.redisProxyMsgHandler.argoCDRedisClient.Subscribe(context.Background(), channelName)
+
+	// Send back a response to principal, to indicate the subscription command was received
+	res := &event.RedisResponseBody{
+		SubscribeResponse: &event.RedisResponseBodySubscribeResponse{
+			Error: "", // no error
+		},
+	}
+
+	// Set the lastPing to the current time, as we know the connection is valid as of now
+	connLifecycle := a.redisProxyMsgHandler.connections
+
+	connLifecycle.lock.Lock()
+	defer connLifecycle.lock.Unlock()
+	connLifecycle.connMap[rreq.ConnectionUUID] = connectionEntry{
+		lastPing: time.Now(),
+	}
+
+	// Start a new go-routine to read the redis subscribe channel for events, and send them back asynchronously
+	go func() {
+		a.forwardRedisSubscribeNotificationsToPrincipal(pubsub, rreq, channelName, logCtx)
+	}()
+
+	return res, nil
+
+}
+
+// forwardRedisSubscribeNotificationsToPrincipal reads subscription events from agent Argo CD redis, then sends them to principal.
+// - This function will also close local redis connections for principal connections that are no longer active (based on pings received)
+func (a *Agent) forwardRedisSubscribeNotificationsToPrincipal(pubsub *redis.PubSub, rreq *event.RedisRequest, channelName string, logCtx *logrus.Entry) {
+	ticker := time.NewTicker(1 * time.Minute)
+
+	ch := pubsub.Channel()
+
+	logCtx = logCtx.WithField("channel-name", channelName)
+	for {
+		select {
+
+		case <-ticker.C:
+			// Every X minutes, check if the connection is still active based on when we received the last ping
+
+			connLifecycle := a.redisProxyMsgHandler.connections
+
+			var lastPing *time.Time
+			connLifecycle.lock.RLock()
+			entry, ok := connLifecycle.connMap[rreq.ConnectionUUID]
+			if ok {
+				lastPing = &entry.lastPing
+			}
+			connLifecycle.lock.RUnlock()
+
+			if lastPing == nil {
+				logCtx.Error("lastPing for a connection should never be nil")
+				continue
+			}
+
+			// If the connection has not been active for X minutes, close the connection
+			if time.Since(*lastPing) >= time.Minute*10 {
+				pubsub.Close()
+				logCtx.WithField("lastPing", lastPing).Trace("closing redis connection due to inactivity")
+				return
+			}
+
+		case readFromChannel := <-ch:
+
+			logCtx.Tracef("Redis subscription '%s' returned value of %d bytes", channelName, len(readFromChannel.Payload))
+			// We don't output the content of the returned value, as it may contain sensitive information (and also because it's often binary)
+
+			// The only subscription messages we expect/support have an empty payload
+			if len(readFromChannel.Payload) != 0 || len(readFromChannel.PayloadSlice) != 0 {
+				logCtx.Errorf("unexpected payload length from Redis subscription: %d %d", len(readFromChannel.Payload), len(readFromChannel.PayloadSlice))
+				continue
+			}
+
+			pushEventToPrincipal := event.RedisResponseBody{}
+
+			pushEventToPrincipal.PushFromSubscribe = &event.RedisResponseBodyPushFromSubscribe{
+				ChannelName: rreq.Body.Subscribe.ChannelName,
+			}
+
+			q := a.queues.SendQ(defaultQueueName)
+			if q == nil {
+				logCtx.Error("Remote queue disappeared")
+				return
+			}
+			q.Add(a.emitter.NewRedisResponseEvent(rreq.UUID, rreq.ConnectionUUID, pushEventToPrincipal))
+			logCtx.Tracef("Emitted Subscribe push event")
+		}
+	}
+
+}
+
+func (a *Agent) handleRedisGetMessage(logCtx *logrus.Entry, rreq *event.RedisRequest) (*event.RedisResponseBody, error) {
+	key := rreq.Body.Get.Key
+
+	logCtx.Tracef("Start processing redis GET request with key '%s'", key)
+
+	if a.mode == types.AgentModeAutonomous {
+		var err error
+		key, err = stripNamespaceFromKeyForAutonomousAgentForRedis(key, logCtx)
+		if err != nil {
+			logCtx.WithError(err).Errorf("unable to transform GET key for autonomous agent '%s'", key)
+			return nil, fmt.Errorf("unable to transform GET key for autonomous agent: %v", err)
+		}
+	}
+
+	// Connect to local redis to GET key/value, and store response
+	getBody := event.RedisResponseBodyGet{}
+
+	var data []byte
+	err := a.redisProxyMsgHandler.argoCDRedisCache.GetSkippingLocalCache(context.Background(), key, &data)
+	if errors.Is(err, rediscache.ErrCacheMiss) {
+		getBody.Bytes = nil
+		getBody.CacheHit = false
+		getBody.Error = ""
+	} else if err != nil {
+		getBody.Bytes = nil
+		getBody.CacheHit = false
+		getBody.Error = err.Error()
+	} else {
+		getBody.Bytes = data
+		getBody.CacheHit = true
+		getBody.Error = ""
+	}
+
+	res := &event.RedisResponseBody{
+		Get: &getBody,
+	}
+
+	logCtx.Tracef("Queuing Redis GET '%s' response: %d bytes / %v / %v", key, len(getBody.Bytes), getBody.CacheHit, getBody.Error)
+
+	return res, nil
+}
+
+// stripNamespaceFromKeyForAutonomousAgentForRedis will remove the namespace from the namespace_name field of the redis key when running on an autonomous agent. See example below.
+// - Autonomous agent does not use application namespaces besides 'argocd', and thus this redis key must be transformed.
+//
+// Example:
+// "app|managed-resources|agent-autonomous_my-app|1.8.3"
+// "app|resources-tree|agent-autonomous_my-app|1.8.3.gz
+// needs to be converted to, e.g.
+// "app|resources-tree|my-app|1.8.3.gz
+func stripNamespaceFromKeyForAutonomousAgentForRedis(key string, logCtx *logrus.Entry) (string, error) {
+
+	var matchedPrefix string
+	expectedPrefixes := []string{
+		"app|resources-tree|",
+		"app|managed-resources|",
+	}
+	for _, expectedPrefix := range expectedPrefixes {
+		if strings.HasPrefix(key, expectedPrefix) {
+			matchedPrefix = expectedPrefix
+			break
+		}
+	}
+	if matchedPrefix == "" {
+		err := fmt.Errorf("unexpected redis key request: '%s'", key)
+		logCtx.WithError(err).Error("Unable to reply to redis get request")
+		return "", err
+	}
+
+	components := strings.Split(key, "|")
+
+	if len(components) != 4 {
+		err := fmt.Errorf("unexpected key format: '%s'", key)
+		logCtx.WithError(err).Error("Unable to reply to redis get request")
+		return "", err
+	}
+
+	appName := components[2]
+
+	underscoreIndex := strings.Index(appName, "_")
+	if underscoreIndex == -1 {
+		err := fmt.Errorf("unexpected key format, missing '_': '%s'", key)
+		logCtx.WithError(err).Error("Unable to reply to redis get request")
+		return "", err
+
+	}
+	components[2] = appName[underscoreIndex+1:]
+
+	key = strings.Join(components, "|")
+
+	return key, nil
+
+}
+
+func (a *Agent) getRedisClientAndCache() (*redis.Client, *rediscache.Cache, error) {
+	var tlsConfig *tls.Config = nil
+
+	opts := &redis.Options{
+		Addr:       a.redisProxyMsgHandler.redisAddress,
+		Password:   a.redisProxyMsgHandler.redisPassword,
+		DB:         0,
+		MaxRetries: 3,
+		TLSConfig:  tlsConfig,
+		Username:   a.redisProxyMsgHandler.redisUsername,
+	}
+
+	client := redis.NewClient(opts)
+	cache := rediscache.New(&rediscache.Options{Redis: client})
+
+	return client, cache, nil
+
+}

--- a/agent/inbound_redis.go
+++ b/agent/inbound_redis.go
@@ -83,14 +83,14 @@ func (a *Agent) processIncomingRedisRequest(ev *event.Event) error {
 
 	} else if rreq.Body.Ping != nil {
 
-		// We have seeng a ping for this connection, so update the lifecycle struct
+		// We have seen a ping for this connection, so update the lifecycle struct
 		connections := a.redisProxyMsgHandler.connections
 
 		connections.lock.Lock()
-		defer connections.lock.Unlock()
 		connections.connMap[rreq.ConnectionUUID] = connectionEntry{
 			lastPing: time.Now(),
 		}
+		connections.lock.Unlock()
 
 		// Send pong back to principal
 		responseBody = &event.RedisResponseBody{

--- a/agent/inbound_redis_test.go
+++ b/agent/inbound_redis_test.go
@@ -1,0 +1,283 @@
+package agent
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/argoproj-labs/argocd-agent/internal/event"
+	"github.com/argoproj-labs/argocd-agent/pkg/types"
+	rediscache "github.com/go-redis/cache/v9"
+	"github.com/go-redis/redismock/v9"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_stripNamespaceFromKeyForAutonomousAgent(t *testing.T) {
+
+	logCtx := log()
+
+	type testEntry struct {
+		name          string
+		key           string
+		expectedValue string
+		errorExpected bool
+	}
+
+	testEntries := []testEntry{
+		{
+			name:          "'app|managed-resources' is correctly stripped",
+			key:           "app|managed-resources|agent-autonomous_my-app|1.8.3",
+			expectedValue: "app|managed-resources|my-app|1.8.3",
+			errorExpected: false,
+		},
+		{
+			name:          "'app|resources-tree' is correctly stripped",
+			key:           "app|resources-tree|agent-autonomous_my-app|1.8.3.gz",
+			expectedValue: "app|resources-tree|my-app|1.8.3.gz",
+			errorExpected: false,
+		},
+		{
+			name:          "unexpected key format with an unexpected prefix",
+			key:           "unexpected-key-format",
+			expectedValue: "",
+			errorExpected: true,
+		},
+		{
+			name:          "expected prefix, but unexpected format",
+			key:           "app|managed-resources|agent-autonomous_my-app|UNEXPECTED-FORMAT|1.8.3",
+			expectedValue: "",
+			errorExpected: true,
+		},
+		{
+			name:          "expected prefix, expecteded format, but no underscore",
+			key:           "app|managed-resources|agent-autonomous!my-app|1.8.3",
+			expectedValue: "",
+			errorExpected: true,
+		},
+	}
+
+	for _, testEntry := range testEntries {
+
+		t.Run(testEntry.name, func(t *testing.T) {
+
+			res, err := stripNamespaceFromKeyForAutonomousAgentForRedis(testEntry.key, logCtx)
+
+			require.Equal(t, testEntry.expectedValue, res)
+			require.Equal(t, testEntry.errorExpected, err != nil, "error: %v", err)
+
+		})
+	}
+}
+
+func TestAgent_handleRedisGetMessage(t *testing.T) {
+	logCtx := logrus.NewEntry(logrus.New())
+
+	tests := []struct {
+		name             string
+		redisKey         string
+		mockSetup        func(mock redismock.ClientMock, agentMode types.AgentMode)
+		expectedResult   *event.RedisResponseBody
+		expectedError    bool
+		expectedErrorMsg string
+	}{
+		{
+			name:     "successful cache hit",
+			redisKey: "app|managed-resources|agent_my-app|1.8.3",
+			mockSetup: func(mock redismock.ClientMock, agentMode types.AgentMode) {
+				testData := []byte("test-data")
+				if agentMode == types.AgentModeAutonomous {
+					// Autonomous agent will strip the agent prefix from the key
+					mock.ExpectGet("app|managed-resources|my-app|1.8.3").SetVal(string(testData))
+				} else {
+					mock.ExpectGet("app|managed-resources|agent_my-app|1.8.3").SetVal(string(testData))
+				}
+			},
+			expectedResult: &event.RedisResponseBody{
+				Get: &event.RedisResponseBodyGet{
+					Bytes:    []byte("test-data"),
+					CacheHit: true,
+					Error:    "",
+				},
+			},
+			expectedError: false,
+		},
+		{
+			name:     "cache miss",
+			redisKey: "app|managed-resources|agent_missing-app|1.8.3",
+			mockSetup: func(mock redismock.ClientMock, agentMode types.AgentMode) {
+				if agentMode == types.AgentModeAutonomous {
+					// Autonomous agent will strip the agent prefix from the key
+					mock.ExpectGet("app|managed-resources|missing-app|1.8.3").RedisNil()
+				} else {
+					mock.ExpectGet("app|managed-resources|agent_missing-app|1.8.3").RedisNil()
+				}
+			},
+			expectedResult: &event.RedisResponseBody{
+				Get: &event.RedisResponseBodyGet{
+					Bytes:    nil,
+					CacheHit: false,
+					Error:    "",
+				},
+			},
+			expectedError: false,
+		},
+		{
+			name:     "redis error in managed mode",
+			redisKey: "app|managed-resources|agent_error-app|1.8.3",
+			mockSetup: func(mock redismock.ClientMock, agentMode types.AgentMode) {
+				if agentMode == types.AgentModeAutonomous {
+					// Autonomous agent will strip the agent prefix from the key
+					mock.ExpectGet("app|managed-resources|error-app|1.8.3").SetErr(errors.New("redis connection failed"))
+				} else {
+					mock.ExpectGet("app|managed-resources|agent_error-app|1.8.3").SetErr(errors.New("redis connection failed"))
+				}
+			},
+			expectedResult: &event.RedisResponseBody{
+				Get: &event.RedisResponseBodyGet{
+					Bytes:    nil,
+					CacheHit: false,
+					Error:    "redis connection failed",
+				},
+			},
+			expectedError: false,
+		},
+	}
+
+	agentModes := []types.AgentMode{types.AgentModeManaged, types.AgentModeAutonomous}
+
+	for _, agentMode := range agentModes {
+
+		for _, tt := range tests {
+			t.Run(tt.name+"_"+string(agentMode), func(t *testing.T) {
+				// Create mock Redis client
+				mockClient, mock := redismock.NewClientMock()
+
+				// Setup mock expectations
+				tt.mockSetup(mock, agentMode)
+
+				// Create test agent
+				agent := &Agent{
+					mode: agentMode,
+					redisProxyMsgHandler: &redisProxyMsgHandler{
+						argoCDRedisCache: rediscache.New(&rediscache.Options{Redis: mockClient}),
+					},
+				}
+
+				// Create test request
+				request := &event.RedisRequest{
+					UUID:           "test-uuid",
+					ConnectionUUID: "test-connection-uuid",
+					Body: event.RedisCommandBody{
+						Get: &event.RedisCommandBodyGet{
+							Key: tt.redisKey,
+						},
+					},
+				}
+
+				// Call the function under test
+				result, err := agent.handleRedisGetMessage(logCtx, request)
+
+				// Check error expectations
+				if tt.expectedError {
+					require.Error(t, err)
+					if tt.expectedErrorMsg != "" {
+						require.Contains(t, err.Error(), tt.expectedErrorMsg)
+					}
+					require.Nil(t, result)
+				} else {
+					require.NoError(t, err)
+					require.NotNil(t, result)
+					require.Equal(t, tt.expectedResult, result)
+				}
+
+				// Verify all mock expectations were met
+				require.NoError(t, mock.ExpectationsWereMet())
+			})
+		}
+
+	}
+}
+
+func TestAgent_handleRedisSubscribeMessage_ManagedMode(t *testing.T) {
+	logCtx := logrus.NewEntry(logrus.New())
+
+	tests := []struct {
+		name             string
+		channelName      string
+		expectedResult   *event.RedisResponseBody
+		expectedError    bool
+		expectedErrorMsg string
+	}{
+		{
+			name:        "successful subscription",
+			channelName: "app|managed-resources|agent_my-app|1.8.3",
+			expectedResult: &event.RedisResponseBody{
+				SubscribeResponse: &event.RedisResponseBodySubscribeResponse{
+					Error: "",
+				},
+			},
+			expectedError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create mock Redis client - Note: We cannot mock Subscribe as it's not supported by redismock
+			// So we will test the parts of the function we can test without actually calling Subscribe
+			mockClient, _ := redismock.NewClientMock()
+
+			// Create connection entries map
+			connections := &connectionEntries{
+				connMap: make(map[string]connectionEntry),
+			}
+
+			// Create test agent in managed mode
+			agent := &Agent{
+				mode: types.AgentModeManaged,
+				redisProxyMsgHandler: &redisProxyMsgHandler{
+					argoCDRedisClient: mockClient,
+					connections:       connections,
+				},
+			}
+
+			// Create test request
+			connectionUUID := "test-connection-uuid"
+			request := &event.RedisRequest{
+				UUID:           "test-uuid",
+				ConnectionUUID: connectionUUID,
+				Body: event.RedisCommandBody{
+					Subscribe: &event.RedisCommandBodySubscribe{
+						ChannelName: tt.channelName,
+					},
+				},
+			}
+
+			// Call the function under test
+			result, err := agent.handleRedisSubscribeMessage(logCtx, request)
+
+			// Check error expectations
+			if tt.expectedError {
+				require.Error(t, err)
+				if tt.expectedErrorMsg != "" {
+					require.Contains(t, err.Error(), tt.expectedErrorMsg)
+				}
+				require.Nil(t, result)
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, result)
+				require.Equal(t, tt.expectedResult, result)
+
+				// Verify connection lifecycle was updated
+				connections.lock.RLock()
+				connEntry, exists := connections.connMap[connectionUUID]
+				connections.lock.RUnlock()
+
+				require.True(t, exists, "Connection entry should exist")
+				require.WithinDuration(t, time.Now(), connEntry.lastPing, 5*time.Second, "lastPing should be recent")
+			}
+
+			// Note: We skip mock expectations verification since Subscribe is not supported in redismock
+		})
+	}
+}

--- a/agent/inbound_redis_test.go
+++ b/agent/inbound_redis_test.go
@@ -1,3 +1,17 @@
+// Copyright 2025 The argocd-agent Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package agent
 
 import (

--- a/agent/options.go
+++ b/agent/options.go
@@ -71,3 +71,24 @@ func WithHealthzPort(port int) AgentOption {
 		}
 	}
 }
+
+func WithRedisHost(host string) AgentOption {
+	return func(o *Agent) error {
+		o.redisProxyMsgHandler.redisAddress = host
+		return nil
+	}
+}
+
+func WithRedisUsername(username string) AgentOption {
+	return func(o *Agent) error {
+		o.redisProxyMsgHandler.redisUsername = username
+		return nil
+	}
+}
+
+func WithRedisPassword(password string) AgentOption {
+	return func(o *Agent) error {
+		o.redisProxyMsgHandler.redisPassword = password
+		return nil
+	}
+}

--- a/cmd/argocd-agent/agent.go
+++ b/cmd/argocd-agent/agent.go
@@ -40,33 +40,31 @@ import (
 // NewAgentRunCommand returns a new agent run command.
 func NewAgentRunCommand() *cobra.Command {
 	var (
-		serverAddress            string
-		serverPort               int
-		logLevel                 string
-		logFormat                string
-		insecure                 bool
-		rootCASecretName         string
-		rootCAPath               string
-		kubeConfig               string
-		kubeContext              string
-		namespace                string
-		agentMode                string
-		creds                    string
-		showVersion              bool
-		versionFormat            string
-		tlsSecretName            string
-		tlsClientCrt             string
-		tlsClientKey             string
-		enableWebSocket          bool
-		metricsPort              int
-		healthzPort              int
-		enableCompression        bool
-		pprofPort                int
-		redisAddr                string
-		redisUsername            string
-		redisPassword            string
-		autonomousAgentRedisHost string
-		managedAgentRedisHost    string
+		serverAddress     string
+		serverPort        int
+		logLevel          string
+		logFormat         string
+		insecure          bool
+		rootCASecretName  string
+		rootCAPath        string
+		kubeConfig        string
+		kubeContext       string
+		namespace         string
+		agentMode         string
+		creds             string
+		showVersion       bool
+		versionFormat     string
+		tlsSecretName     string
+		tlsClientCrt      string
+		tlsClientKey      string
+		enableWebSocket   bool
+		metricsPort       int
+		healthzPort       int
+		enableCompression bool
+		pprofPort         int
+		redisAddr         string
+		redisUsername     string
+		redisPassword     string
 
 		// Time interval for agent to principal ping
 		// Ex: "30m", "1h" or "1h20m10s". Valid time units are "s", "m", "h".
@@ -177,12 +175,6 @@ func NewAgentRunCommand() *cobra.Command {
 			agentOpts = append(agentOpts, agent.WithMode(agentMode))
 			agentOpts = append(agentOpts, agent.WithHealthzPort(healthzPort))
 
-			if agentMode == "autonomous" && autonomousAgentRedisHost != "" {
-				redisAddr = autonomousAgentRedisHost
-			} else if agentMode == "managed" && managedAgentRedisHost != "" {
-				redisAddr = managedAgentRedisHost
-			}
-
 			agentOpts = append(agentOpts, agent.WithRedisHost(redisAddr))
 			agentOpts = append(agentOpts, agent.WithRedisUsername(redisUsername))
 			agentOpts = append(agentOpts, agent.WithRedisPassword(redisPassword))
@@ -223,14 +215,6 @@ func NewAgentRunCommand() *cobra.Command {
 	command.Flags().StringVar(&redisPassword, "redis-password",
 		env.StringWithDefault("REDIS_PASSWORD", nil, ""),
 		"The password to connect to redis with")
-
-	command.Flags().StringVar(&autonomousAgentRedisHost, "autonomous-agent-redis-host",
-		env.StringWithDefault("AUTONOMOUS_AGENT_REDIS_ADDR", nil, ""),
-		"The redis address to use when running in autonomous mode")
-
-	command.Flags().StringVar(&managedAgentRedisHost, "managed-agent-redis-host",
-		env.StringWithDefault("MANAGED_AGENT_REDIS_ADDR", nil, ""),
-		"The redis address to use when running in managed mode")
 
 	command.Flags().StringVar(&logFormat, "log-format",
 		env.StringWithDefault("ARGOCD_PRINCIPAL_LOG_FORMAT", nil, "text"),

--- a/cmd/argocd-agent/principal.go
+++ b/cmd/argocd-agent/principal.go
@@ -363,9 +363,11 @@ func NewPrincipalRunCommand() *cobra.Command {
 	command.Flags().DurationVar(&keepAliveMinimumInterval, "keepalive-min-interval",
 		env.DurationWithDefault("ARGOCD_PRINCIPAL_KEEP_ALIVE_MIN_INTERVAL", nil, 0),
 		"Drop agent connections that send keepalive pings more often than the specified interval") // It should be less than "keep-alive-ping-interval" of agent
+
 	command.Flags().StringVar(&redisAddress, "redis-server-address",
-		env.StringWithDefault("ARGOCD_PRINCIPAL_REDIS_SERVER_ADDRESS", nil, ""),
+		env.StringWithDefault("ARGOCD_PRINCIPAL_REDIS_SERVER_ADDRESS", nil, "argocd-redis:6379"),
 		"Redis server hostname and port (e.g. argocd-redis:6379).")
+
 	command.Flags().StringVar(&redisCompressionType, "redis-compression-type",
 		env.StringWithDefault("ARGOCD_PRINCIPAL_REDIS_COMPRESSION_TYPE", nil, string(cacheutil.RedisCompressionGZip)),
 		"Compression algorithm required by Redis. (possible values: gzip, none. Default value: gzip)")

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,8 @@ require (
 	github.com/argoproj/gitops-engine v0.7.1-0.20250521000818-c08b0a72c1f1
 	github.com/cloudevents/sdk-go/binding/format/protobuf/v2 v2.16.1
 	github.com/cloudevents/sdk-go/v2 v2.16.1
+	github.com/go-redis/cache/v9 v9.0.0
+	github.com/go-redis/redismock/v9 v9.2.0
 	github.com/golang-jwt/jwt/v5 v5.2.2
 	github.com/google/uuid v1.6.0
 	github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.3.2
@@ -62,6 +64,7 @@ require (
 	github.com/chai2010/gettext-go v1.0.2 // indirect
 	github.com/cloudflare/circl v1.3.7 // indirect
 	github.com/coder/websocket v1.8.12 // indirect
+	github.com/coreos/go-oidc/v3 v3.11.0 // indirect
 	github.com/cyphar/filepath-securejoin v0.3.6 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
@@ -72,16 +75,18 @@ require (
 	github.com/evanphx/json-patch v5.9.0+incompatible // indirect
 	github.com/exponent-io/jsonpath v0.0.0-20151013193312-d6023ce2651d // indirect
 	github.com/fatih/camelcase v1.0.0 // indirect
+	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/fxamacker/cbor/v2 v2.7.0 // indirect
 	github.com/go-errors/errors v1.4.2 // indirect
 	github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376 // indirect
 	github.com/go-git/go-billy/v5 v5.6.2 // indirect
 	github.com/go-git/go-git/v5 v5.13.2 // indirect
+	github.com/go-jose/go-jose/v4 v4.0.5 // indirect
 	github.com/go-logr/logr v1.4.2 // indirect
+	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-openapi/jsonpointer v0.21.0 // indirect
 	github.com/go-openapi/jsonreference v0.21.0 // indirect
 	github.com/go-openapi/swag v0.23.0 // indirect
-	github.com/go-redis/cache/v9 v9.0.0 // indirect
 	github.com/gobwas/glob v0.2.3 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang-jwt/jwt/v4 v4.5.2 // indirect
@@ -98,6 +103,10 @@ require (
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // indirect
 	github.com/gorilla/websocket v1.5.3 // indirect
 	github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79 // indirect
+	github.com/grpc-ecosystem/go-grpc-middleware v1.4.0 // indirect
+	github.com/grpc-ecosystem/grpc-gateway v1.16.0 // indirect
+	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
+	github.com/hashicorp/go-retryablehttp v0.7.7 // indirect
 	github.com/imdario/mergo v0.3.16 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 // indirect
@@ -127,6 +136,7 @@ require (
 	github.com/prometheus/client_model v0.6.1 // indirect
 	github.com/prometheus/common v0.62.0 // indirect
 	github.com/prometheus/procfs v0.15.1 // indirect
+	github.com/r3labs/diff v1.1.0 // indirect
 	github.com/robfig/cron/v3 v3.0.1 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3 // indirect
@@ -144,6 +154,11 @@ require (
 	github.com/xanzy/ssh-agent v0.3.3 // indirect
 	github.com/xlab/treeprint v1.2.0 // indirect
 	github.com/yuin/gopher-lua v1.1.1 // indirect
+	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
+	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.56.0 // indirect
+	go.opentelemetry.io/otel v1.35.0 // indirect
+	go.opentelemetry.io/otel/metric v1.35.0 // indirect
+	go.opentelemetry.io/otel/trace v1.35.0 // indirect
 	go.starlark.net v0.0.0-20230525235612-a134d8f9ddca // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.27.0 // indirect
@@ -153,6 +168,7 @@ require (
 	golang.org/x/text v0.27.0 // indirect
 	golang.org/x/time v0.12.0 // indirect
 	golang.org/x/tools v0.34.0 // indirect
+	google.golang.org/genproto v0.0.0-20240213162025-012b6fc9bca9 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20250324211829-b45e905df463 // indirect
 	gopkg.in/evanphx/json-patch.v4 v4.12.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -35,6 +35,7 @@ github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPd
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
 github.com/aws/aws-sdk-go v1.44.289/go.mod h1:aVsgQcEevwlmQ7qHE9I3h+dtQgpqhFB+i8Phjh7fkwI=
+github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM=
@@ -80,6 +81,8 @@ github.com/cloudflare/circl v1.3.7/go.mod h1:sRTcRWXGLrKw6yIGJ+l7amYJFfAXbZG0kBS
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/coder/websocket v1.8.12 h1:5bUXkEPPIbewrnkU8LTCLVaxi4N4J8ahufH2vlo4NAo=
 github.com/coder/websocket v1.8.12/go.mod h1:LNVeNrXQZfe5qhS9ALED3uA+l5pPqvwXg3CKoDBB2gs=
+github.com/coreos/go-oidc/v3 v3.11.0 h1:Ia3MxdwpSw702YW0xgfmP1GVCMA9aEFWu12XUZ3/OtI=
+github.com/coreos/go-oidc/v3 v3.11.0/go.mod h1:gE3LgjOgFoHi9a4ce4/tJczr0Ai2/BoDhf0r5lltWI0=
 github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
@@ -116,7 +119,11 @@ github.com/exponent-io/jsonpath v0.0.0-20151013193312-d6023ce2651d h1:105gxyaGwC
 github.com/exponent-io/jsonpath v0.0.0-20151013193312-d6023ce2651d/go.mod h1:ZZMPRZwes7CROmyNKgQzC3XPs6L/G2EJLHddWejkmf4=
 github.com/fatih/camelcase v1.0.0 h1:hxNvNX/xYBp0ovncs8WyWZrOrpBNub/JfaMvbURyft8=
 github.com/fatih/camelcase v1.0.0/go.mod h1:yN2Sb0lFhZJUdVvtELVWefmrXpuZESvPmqwoZc+/fpc=
+github.com/fatih/color v1.16.0 h1:zmkK9Ngbjj+K0yRhTVONQh1p/HknKYSlNT+vZCzyokM=
+github.com/fatih/color v1.16.0/go.mod h1:fL2Sau1YI5c0pdGEVCbKQbLXB6edEj1ZgiY4NijnWvE=
 github.com/felixge/httpsnoop v1.0.3/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
+github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=
+github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/fsnotify/fsnotify v1.8.0 h1:dAwr6QBTBZIkG8roQaJjGof0pp0EeF+tNV7YBP3F/8M=
@@ -138,10 +145,15 @@ github.com/go-git/go-git/v5 v5.13.2 h1:7O7xvsK7K+rZPKW6AQR1YyNhfywkv7B8/FsP3ki6Z
 github.com/go-git/go-git/v5 v5.13.2/go.mod h1:hWdW5P4YZRjmpGHwRH2v3zkWcNl6HeXaXQEMGb3NJ9A=
 github.com/go-jose/go-jose/v3 v3.0.3 h1:fFKWeig/irsp7XD2zBxvnmA/XaRWp5V3CBsZXJF7G7k=
 github.com/go-jose/go-jose/v3 v3.0.3/go.mod h1:5b+7YgP7ZICgJDBdfjZaIt+H/9L9T/YQrVfLAMboGkQ=
+github.com/go-jose/go-jose/v4 v4.0.5 h1:M6T8+mKZl/+fNNuFHvGIzDz7BTLQPIounk/b9dw3AaE=
+github.com/go-jose/go-jose/v4 v4.0.5/go.mod h1:s3P1lRrkT8igV8D9OjyL4WRyHvjB6a4JSllnOrmmBOA=
+github.com/go-kit/log v0.1.0/go.mod h1:zbhenjAZHb184qTLMA9ZjW7ThYL0H2mk7Q6pNt4vbaY=
+github.com/go-logfmt/logfmt v0.5.0/go.mod h1:wCYkCAKZfumFQihp8CzCvQ3paCTfi41vtzG1KdI/P7A=
 github.com/go-logr/logr v0.2.0/go.mod h1:z6/tIYblkpsD+a4lm/fGIIU9mZ+XfAiaFtq7xTgseGU=
 github.com/go-logr/logr v0.4.0/go.mod h1:z6/tIYblkpsD+a4lm/fGIIU9mZ+XfAiaFtq7xTgseGU=
 github.com/go-logr/logr v1.0.0/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.2.0/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
+github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.2.3/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.2.4/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.4.1/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
@@ -164,6 +176,9 @@ github.com/go-playground/webhooks/v6 v6.4.0 h1:KLa6y7bD19N48rxJDHM0DpE3T4grV7GxM
 github.com/go-playground/webhooks/v6 v6.4.0/go.mod h1:5lBxopx+cAJiBI4+kyRbuHrEi+hYRDdRHuRR4Ya5Ums=
 github.com/go-redis/cache/v9 v9.0.0 h1:0thdtFo0xJi0/WXbRVu8B066z8OvVymXTJGaXrVWnN0=
 github.com/go-redis/cache/v9 v9.0.0/go.mod h1:cMwi1N8ASBOufbIvk7cdXe2PbPjK/WMRL95FFHWsSgI=
+github.com/go-redis/redismock/v9 v9.2.0 h1:ZrMYQeKPECZPjOj5u9eyOjg8Nnb0BS9lkVIZ6IpsKLw=
+github.com/go-redis/redismock/v9 v9.2.0/go.mod h1:18KHfGDK4Y6c2R0H38EUGWAdc7ZQS9gfYxc94k7rWT0=
+github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0/go.mod h1:fyg7847qk6SyHyPtNmDHnmrv/HOrqktSC+C9fM+CJOE=
 github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572 h1:tfuBGBXKqDEevZMzYi5KSi8KkcZtzBcTgAUUtapy0OI=
 github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572/go.mod h1:9Pwr4B2jHnOSGXyyzV8ROjYa2ojvAY6HCGYYfMoC3Ls=
@@ -259,6 +274,12 @@ github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.3.2 h1:sGm2vDRFUrQJO/Veii4h4z
 github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.3.2/go.mod h1:wd1YpapPLivG6nQgbf7ZkG1hhSOXDhhn4MLTknx2aAc=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0 h1:gmcG1KaJ57LophUzW0Hy8NmPhnMZb4M0+kPpLofRdBo=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
+github.com/hashicorp/go-cleanhttp v0.5.2 h1:035FKYIWjmULyFRBKPs8TBQoi0x6d9G4xc9neXJWAZQ=
+github.com/hashicorp/go-cleanhttp v0.5.2/go.mod h1:kO/YDlP8L1346E6Sodw+PrpBSV4/SoxCXGY6BqNFT48=
+github.com/hashicorp/go-hclog v1.6.3 h1:Qr2kF+eVWjTiYmU7Y31tYlP1h0q/X3Nl3tPGdaB11/k=
+github.com/hashicorp/go-hclog v1.6.3/go.mod h1:W4Qnvbt70Wk/zYJryRzDRU/4r0kIg0PVHBcfoyhpF5M=
+github.com/hashicorp/go-retryablehttp v0.7.7 h1:C8hUCYzor8PIfXHa4UrZkU4VvK8o9ISHxT2Q8+VepXU=
+github.com/hashicorp/go-retryablehttp v0.7.7/go.mod h1:pkQpWZeYWskR+D1tR2O5OcBFOxfA7DoAO6xtkuQnHTk=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/ianlancetaylor/demangle v0.0.0-20240312041847-bd984b5ce465/go.mod h1:gx7rwoVhcfuVKG5uya9Hs3Sxj7EIvldVofAWIUtGouw=
@@ -290,6 +311,7 @@ github.com/klauspost/compress v1.18.0/go.mod h1:2Pp+KzxcywXVXMr50+X0Q/Lsb43OQHYW
 github.com/klauspost/cpuid/v2 v2.0.1/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa0213Md/qVLRg=
 github.com/klauspost/cpuid/v2 v2.2.3/go.mod h1:RVVoqg1df56z8g3pUjL/3lE5UfnlrJX8tyFgg4nqhuY=
 github.com/klauspost/cpuid/v2 v2.2.4/go.mod h1:RVVoqg1df56z8g3pUjL/3lE5UfnlrJX8tyFgg4nqhuY=
+github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.3/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
@@ -391,6 +413,7 @@ github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.1.0 h1:8SG7/vwALn54lVB/0yZ/MMwhFrPYtpEHQb2IpWsCzug=
 github.com/opencontainers/image-spec v1.1.0/go.mod h1:W4s4sFTMaBeK1BQLXbG4AdM2szdn85PY75RI83NrTrM=
+github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
 github.com/orisano/pixelmatch v0.0.0-20220722002657-fb0b55479cde/go.mod h1:nZgzbfBr3hhjoZnS66nKrHmduYNpc34ny7RK4z5/HM0=
 github.com/patrickmn/go-cache v2.1.0+incompatible h1:HRMgzkcYKYpi3C8ajMPV8OFXaaRUnok+kx1WdO15EQc=
 github.com/patrickmn/go-cache v2.1.0+incompatible/go.mod h1:3Qf8kWWT7OJRJbdiICTKqZju1ZixQ/KpMGzzAfe6+WQ=
@@ -399,6 +422,7 @@ github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR
 github.com/pjbgf/sha1cd v0.3.2 h1:a9wb0bp1oC2TGwStyn0Umc/IGKQnEgF0vVaZ8QF8eo4=
 github.com/pjbgf/sha1cd v0.3.2/go.mod h1:zQWigSxVmsHEZow5qaLtPYxpcKMMQpa09ixqBxuCS6A=
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=
+github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
@@ -423,8 +447,9 @@ github.com/robfig/cron/v3 v3.0.1/go.mod h1:eQICP3HwyT7UooqI/z+Ov+PtYAWygg1TEWWzG
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.6.1/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTEfhy4qGm1nDQc=
 github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
-github.com/rogpeppe/go-internal v1.12.0 h1:exVL4IDcn6na9z1rAb56Vxr+CgyK3nn3O+epU5NdKM8=
 github.com/rogpeppe/go-internal v1.12.0/go.mod h1:E+RYuTGaKKdloAfM02xzb0FW3Paa99yedzYV+kq4uf4=
+github.com/rogpeppe/go-internal v1.13.1 h1:KvO1DLK/DRN07sQ1LQKScxyZJuNnedQ5/wKSR38lUII=
+github.com/rogpeppe/go-internal v1.13.1/go.mod h1:uMEvuHeurkdAXX61udpOXGD/AzZDWNMNyH2VO9fmH0o=
 github.com/rs/xid v1.5.0/go.mod h1:trrq9SKmegXys3aeAKXMUTdJsYXVwGY3RLcfgqegfbg=
 github.com/rs/xid v1.6.0 h1:fV591PaemRlL6JfRxGDEPl69wICngIQ3shQtzfy2gxU=
 github.com/rs/xid v1.6.0/go.mod h1:7XoLgs4eV+QndskICGsho+ADou8ySMSjJKDIan90Nz0=
@@ -434,6 +459,7 @@ github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3 h1:n661drycOFuPLCN3Uc8sB6B/s6Z4t2xvBgU1htSHuq8=
 github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3/go.mod h1:A0bzQcvG0E7Rwjx0REVgAGH58e96+X0MeOfepqsbeW4=
+github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/sirupsen/logrus v1.8.1/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/sirupsen/logrus v1.9.2/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
@@ -514,10 +540,14 @@ go.opentelemetry.io/otel/trace v1.35.0 h1:dPpEfJu1sDIqruz7BHFG3c7528f6ddfSWfFDVt
 go.opentelemetry.io/otel/trace v1.35.0/go.mod h1:WUk7DtFp1Aw2MkvqGdwiXYDZZNvA/1J8o6xRXLrIkyc=
 go.starlark.net v0.0.0-20230525235612-a134d8f9ddca h1:VdD38733bfYv5tUZwEIskMM93VanwNIi5bIKnDrJdEY=
 go.starlark.net v0.0.0-20230525235612-a134d8f9ddca/go.mod h1:jxU+3+j+71eXOW14274+SmmuW82qJzl6iZSeqEtTGds=
+go.uber.org/atomic v1.7.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=
+go.uber.org/goleak v1.1.10/go.mod h1:8a7PlsEVH3e/a/GLqe5IIrQx6GzcnRmZEufDUTk4A7A=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
 go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
+go.uber.org/multierr v1.6.0/go.mod h1:cdWPpRnG4AhwMwsgIHip0KRBQjJy5kYEpYjJxpXp9iU=
 go.uber.org/multierr v1.11.0 h1:blXXJkSxSSfBVBlC76pxqeO+LN3aDfLQo+309xJstO0=
 go.uber.org/multierr v1.11.0/go.mod h1:20+QtiLqy0Nd6FdQB9TLXag12DsQkrbs3htMFfDN80Y=
+go.uber.org/zap v1.18.1/go.mod h1:xg/QME4nWcxGxrpdeYfq7UvYrLh66cuVKdrbD1XF/NI=
 go.uber.org/zap v1.27.0 h1:aJMhYGrd5QSmlpLMr2MftRKl7t8J8PTZPA732ud/XR8=
 go.uber.org/zap v1.27.0/go.mod h1:GB2qFLM7cTU87MWRP2mPIjqfIDnGu+VIO4V/SdhGo2E=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
@@ -547,6 +577,7 @@ golang.org/x/exp v0.0.0-20241108190413-2d47ceb2692f/go.mod h1:D5SMRVC3C2/4+F/DB1
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/lint v0.0.0-20190227174305-5b3e6a55c961/go.mod h1:wehouNa3lNwaWXcvxsM5YxQ5yQlVC4a0KAMCusXpPoU=
 golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
+golang.org/x/lint v0.0.0-20190930215403-16217165b5de/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.6.0-dev.0.20220106191415-9b9b3d81d5e3/go.mod h1:3p9vT2HGsQu2K1YbXdKPJLVgG5VJdoTa1poYQBtP1AY=
@@ -628,6 +659,7 @@ golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20190422165155-953cdadca894/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190904154756-749cb33beabd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191005200804-aed5e4c7ecf9/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -643,6 +675,7 @@ golang.org/x/sys v0.0.0-20210608053332-aa57babbf139/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210616094352-59db8d763f22/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211019181941-9d821ace8654/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20211025201205-69cdffdb9359/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220310020820-b874c991c1a5/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220319134239-a9b59b0215f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
@@ -727,6 +760,7 @@ golang.org/x/tools v0.0.0-20190226205152-f727befe758c/go.mod h1:9Yl7xja0Znq3iFh3
 golang.org/x/tools v0.0.0-20190311212946-11955173bddd/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
 golang.org/x/tools v0.0.0-20190425150028-36563e24a262/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
 golang.org/x/tools v0.0.0-20190524140312-2c0ae7006135/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
+golang.org/x/tools v0.0.0-20191108193012-7d206e10da11/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20200619180055-7c47624df98f/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20201224043029-2b0845dc783e/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
@@ -760,6 +794,7 @@ google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9Ywl
 google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
 google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
 google.golang.org/genproto v0.0.0-20190819201941-24fa4b261c55/go.mod h1:DMBHOl98Agz4BDEuKkezgsaosCRResVns1a3J2ZsMNc=
+google.golang.org/genproto v0.0.0-20200423170343-7949de9c1215/go.mod h1:55QSHmfGQM9UVYDPBsyGGes0y52j32PQ3BqQfXhyH3c=
 google.golang.org/genproto v0.0.0-20200513103714-09dca8ec2884/go.mod h1:55QSHmfGQM9UVYDPBsyGGes0y52j32PQ3BqQfXhyH3c=
 google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013/go.mod h1:NbSheEEYHJ7i3ixzK3sjbqSGDJWnxyFXZblF3eUsNvo=
 google.golang.org/genproto v0.0.0-20240213162025-012b6fc9bca9 h1:9+tzLLstTlPTRyJTh+ah5wIMsBW5c4tQwGTN3thOW9Y=
@@ -772,6 +807,7 @@ google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZi
 google.golang.org/grpc v1.23.0/go.mod h1:Y5yQAOtifL1yxbo5wqy6BxZv8vAUGQwXBOALyacEbxg=
 google.golang.org/grpc v1.25.1/go.mod h1:c3i+UQWmh7LiEpx4sFZnkU36qjEYZ0imhYfXVyQciAY=
 google.golang.org/grpc v1.27.0/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8abTk=
+google.golang.org/grpc v1.29.1/go.mod h1:itym6AZVZYACWQqET3MqgPpjcuV5QH3BxFS3IjizoKk=
 google.golang.org/grpc v1.33.1/go.mod h1:fr5YgcSWrqhRRxogOsw7RzIpsmvOZ6IcH4kBYTpR3n0=
 google.golang.org/grpc v1.73.0 h1:VIWSmpI2MegBtTuFt5/JWy2oXxtjJ/e89Z70ImfD2ok=
 google.golang.org/grpc v1.73.0/go.mod h1:50sbHOUqWoCQGI8V2HQLJM0B+LMlIUjNSZmow7EVBQc=

--- a/hack/dev-env/Procfile.e2e
+++ b/hack/dev-env/Procfile.e2e
@@ -1,3 +1,3 @@
 principal: hack/dev-env/start-principal.sh
-agent-managed: sleep 5s && hack/dev-env/start-agent-managed.sh
-agent-autonomous: sleep 5s && hack/dev-env/start-agent-autonomous.sh
+agent-managed: sleep 5s && REDIS_ADDR=$MANAGED_AGENT_REDIS_ADDR  hack/dev-env/start-agent-managed.sh
+agent-autonomous: sleep 5s && REDIS_ADDR=$AUTONOMOUS_AGENT_REDIS_ADDR  hack/dev-env/start-agent-autonomous.sh

--- a/hack/dev-env/agent-autonomous/kustomization.yaml
+++ b/hack/dev-env/agent-autonomous/kustomization.yaml
@@ -13,3 +13,4 @@ images:
 
 patches:
 - path: argocd-secret.yaml
+- path: redis-service.yaml

--- a/hack/dev-env/agent-autonomous/redis-service.yaml
+++ b/hack/dev-env/agent-autonomous/redis-service.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: argocd-redis
+spec:
+  type: LoadBalancer
+  loadBalancerIP: 192.168.56.226

--- a/hack/dev-env/agent-managed/kustomization.yaml
+++ b/hack/dev-env/agent-managed/kustomization.yaml
@@ -14,3 +14,4 @@ images:
 patches:
 - path: argocd-cmd-params-cm.yaml
 - path: argocd-secret.yaml
+- path: redis-service.yaml

--- a/hack/dev-env/agent-managed/redis-service.yaml
+++ b/hack/dev-env/agent-managed/redis-service.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: argocd-redis
+spec:
+  type: LoadBalancer
+  loadBalancerIP: 192.168.56.225

--- a/hack/dev-env/control-plane/argocd-cmd-params-cm.yaml
+++ b/hack/dev-env/control-plane/argocd-cmd-params-cm.yaml
@@ -4,3 +4,4 @@ metadata:
   name: argocd-cmd-params-cm
 data:
   application.namespaces: "*"
+  redis.server: redis-server-address:6379

--- a/hack/dev-env/create-agent-config.sh
+++ b/hack/dev-env/create-agent-config.sh
@@ -48,7 +48,7 @@ ${AGENTCTL} pki issue principal --upsert \
 	--ip "127.0.0.1,${IPADDR}"
 echo "  -> Principal TLS config created."
 
-echo "[*] Creating resouce proxy TLS configuration"
+echo "[*] Creating resource proxy TLS configuration"
 ${AGENTCTL} pki issue resource-proxy --upsert \
 	--principal-namespace argocd \
 	--ip "127.0.0.1,${IPADDR}"

--- a/hack/dev-env/reverse-tunnel/client/client.toml
+++ b/hack/dev-env/reverse-tunnel/client/client.toml
@@ -6,6 +6,10 @@ remote_addr = "EXTERNAL-HOSTNAME:2333" # The address of the server. The port mus
 token = "AUTHENTICATION_TOKEN" # Must be the same with the server to pass the validation
 local_addr = "127.0.0.1:9090" # The address of the service that needs to be forwarded
 
+[client.services.two]
+token = "AUTHENTICATION_TOKEN" # Must be the same with the server to pass the validation
+local_addr = "127.0.0.1:6379" # The address of the service that needs to be forwarded
+
 # Client Side Configuration
 [client.transport]
 type = "noise"

--- a/hack/dev-env/reverse-tunnel/client/run.sh
+++ b/hack/dev-env/reverse-tunnel/client/run.sh
@@ -5,7 +5,9 @@ SCRIPTPATH="$(
   pwd -P
 )"
 
-docker run --network host  --name rathole-proxy -it --rm -v "$SCRIPTPATH/client.toml:/app/config.toml" "quay.io/jgwest-redhat/rathole:latest@sha256:53999f80b69f9a5020e19e9c9be90fc34b973d9bd822d4fd44b968f2ebe0845f" --client /app/config.toml
+DOCKER_BIN=${DOCKER_BIN:-"docker"}
+
+"$DOCKER_BIN" run --network host  --name rathole-proxy -it --rm -v "$SCRIPTPATH/client.toml:/app/config.toml" "quay.io/jgwest-redhat/rathole:v0.5.0@sha256:53999f80b69f9a5020e19e9c9be90fc34b973d9bd822d4fd44b968f2ebe0845f" --client /app/config.toml
 # Container image is built from 'rathole-image' directory
 
 # or, without docker:

--- a/hack/dev-env/reverse-tunnel/server/deployment.yaml
+++ b/hack/dev-env/reverse-tunnel/server/deployment.yaml
@@ -14,10 +14,12 @@ spec:
         app: rathole-container
     spec:
       containers:
-        - image: 'quay.io/jgwest-redhat/rathole:latest@sha256:53999f80b69f9a5020e19e9c9be90fc34b973d9bd822d4fd44b968f2ebe0845f' # built by rathole-image directory
+        - image: 'quay.io/jgwest-redhat/rathole:v0.5.0@sha256:53999f80b69f9a5020e19e9c9be90fc34b973d9bd822d4fd44b968f2ebe0845f' # built by rathole-image directory
           name: rathole-container
           ports:
             - containerPort: 2333
+              protocol: TCP
+            - containerPort: 6379
               protocol: TCP
             - containerPort: 9090
               protocol: TCP

--- a/hack/dev-env/reverse-tunnel/server/server.toml
+++ b/hack/dev-env/reverse-tunnel/server/server.toml
@@ -6,6 +6,10 @@ bind_addr = "0.0.0.0:2333" # `2333` specifies the port that rathole listens for 
 token = "AUTHENTICATION_TOKEN" # Token that is used to authenticate the client for the service. Change to a arbitrary value.
 bind_addr = "0.0.0.0:9090" # `9090` specifies the port that exposes `one` to the Internet
 
+[server.services.two]
+token = "AUTHENTICATION_TOKEN" # Token that is used to authenticate the client for the service. Change to a arbitrary value.
+bind_addr = "0.0.0.0:6379" # `6379` specifies the port that exposes `two` to the Internet
+
 # Server Side Configuration
 [server.transport]
 type = "noise"

--- a/hack/dev-env/reverse-tunnel/server/service-internal.yaml
+++ b/hack/dev-env/reverse-tunnel/server/service-internal.yaml
@@ -8,5 +8,11 @@ spec:
     port: 9090
     targetPort: 9090
     protocol: TCP
+
+  - name: "6379"
+    port: 6379
+    targetPort: 6379
+    protocol: TCP
+
   selector:
     app: rathole-container

--- a/hack/dev-env/reverse-tunnel/setup.sh
+++ b/hack/dev-env/reverse-tunnel/setup.sh
@@ -5,6 +5,9 @@ SCRIPTPATH="$(
     pwd -P
 )"
 
+DOCKER_BIN=${DOCKER_BIN:-"docker"}
+
+
 TEMP_DIR=$(mktemp -d)
 
 echo "Using temporary directory: $TEMP_DIR"
@@ -16,7 +19,7 @@ generatePublicAndPrivateKey() {
 
   TEMP_FILE=$(mktemp)
 
-  docker run --rm quay.io/jgwest-redhat/rathole:latest  --genkey x25519 > $TEMP_FILE
+  "$DOCKER_BIN" run --rm "quay.io/jgwest-redhat/rathole:v0.5.0@sha256:53999f80b69f9a5020e19e9c9be90fc34b973d9bd822d4fd44b968f2ebe0845f"  --genkey x25519 > $TEMP_FILE
   if [ $? -ne 0 ]; then
     echo "Error: docker run command failed."
     exit 1
@@ -62,13 +65,13 @@ getExternalLoadBalancerIP() {
   for ((i=1; i<=MAX_ATTEMPTS; i++)); do
     
     echo ""
-    EXTERNAL_IP=$(kubectl get svc $SERVICE_NAME $K8S_CONTEXT $K8S_NAMESPACE -o jsonpath='{.status.loadBalancer.ingress[0].hostname}')
+    EXTERNAL_IP=$(kubectl get svc $SERVICE_NAME $K8S_CONTEXT_CONTROL_PLANE $K8S_NAMESPACE -o jsonpath='{.status.loadBalancer.ingress[0].hostname}')
 
     if [ -n "$EXTERNAL_IP" ]; then
       echo "External IP is $EXTERNAL_IP"
       break
     else
-      echo "External IP not yet available, attempting again in 5 seconds..."
+      echo "External IP for $SERVICE_NAME not yet available, attempting again in 5 seconds..."
       sleep 5
     fi
   done
@@ -89,10 +92,10 @@ configureClientAndServerToml
 echo ""
 echo "Installing Rathole on K8s"
 
-K8S_CONTEXT="--context=vcluster-control-plane"
+K8S_CONTEXT_CONTROL_PLANE="--context=vcluster-control-plane"
 K8S_NAMESPACE="-n argocd"
 
-kubectl apply $K8S_CONTEXT $K8S_NAMESPACE -k $TEMP_DIR/server 
+kubectl apply $K8S_CONTEXT_CONTROL_PLANE $K8S_NAMESPACE -k $TEMP_DIR/server 
 
 
 # Wait for rathole-container-external load balancer hostname
@@ -106,11 +109,11 @@ echo ""
 echo "Patching cluster-agent-managed secret on vcluster-control-plane"
 
 # Replace the .data.server field of the Secret
-kubectl $K8S_CONTEXT $K8S_NAMESPACE patch secret cluster-agent-managed  --type='json' -p='[{"op": "replace", "path": "/data/server", "value":"'"$NEW_VALUE_BASE64"'"}]'
+kubectl $K8S_CONTEXT_CONTROL_PLANE $K8S_NAMESPACE patch secret cluster-agent-managed  --type='json' -p='[{"op": "replace", "path": "/data/server", "value":"'"$NEW_VALUE_BASE64"'"}]'
 
 
 # Extract .data.config
-CONFIG_FIELD_VALUE=`kubectl $K8S_CONTEXT $K8S_NAMESPACE get secret cluster-agent-managed -o jsonpath='{.data.config}' | base64 --decode`
+CONFIG_FIELD_VALUE=`kubectl $K8S_CONTEXT_CONTROL_PLANE $K8S_NAMESPACE get secret cluster-agent-managed -o jsonpath='{.data.config}' | base64 --decode`
 
 # remove .data.config.tlsClientConfig.caData and set '.data.config.tlsClientConfig.insecure = true'
 TLS_CLIENT_CONFIG=`echo "$CONFIG_FIELD_VALUE" | jq -r '.tlsClientConfig' | jq 'del(.caData)' | jq '.insecure = true' `
@@ -119,12 +122,30 @@ CONFIG_FIELD_VALUE=`echo $CONFIG_FIELD_VALUE | jq ".tlsClientConfig = $TLS_CLIEN
 CONFIG_FIELD_VALUE_BASE64=$(echo -n "$CONFIG_FIELD_VALUE" | base64 -w 0)
 
 # Patch the secret with the new .data.config value
-kubectl $K8S_CONTEXT $K8S_NAMESPACE patch secret cluster-agent-managed  --type='json' -p='[{"op": "replace", "path": "/data/config", "value":"'"$CONFIG_FIELD_VALUE_BASE64"'"}]'
+kubectl $K8S_CONTEXT_CONTROL_PLANE $K8S_NAMESPACE patch secret cluster-agent-managed  --type='json' -p='[{"op": "replace", "path": "/data/config", "value":"'"$CONFIG_FIELD_VALUE_BASE64"'"}]'
+
+echo ""
+echo "Patching ConfigMap 'argocd-cmd-params-cm' to redirect redis to tunnel"
+kubectl $K8S_CONTEXT_CONTROL_PLANE $K8S_NAMESPACE patch configmap argocd-cmd-params-cm --type json --patch '[{"op": "add", "path": "/data/redis.server", "value": "rathole-container-internal:6379"}]'
+
+echo ""
+echo "Patching Service 'argocds-redis' to enable type: LoadBalancer, on vcluster-agent-managed"
+kubectl --context=vcluster-agent-managed $K8S_NAMESPACE patch service argocd-redis -p '{"spec":{"type":"LoadBalancer"}}'
+
+echo ""
+echo "Patching Service 'argocds-redis' to enable type: LoadBalancer, on vcluster-agent-autonomous"
+kubectl --context=vcluster-agent-autonomous $K8S_NAMESPACE patch service argocd-redis -p '{"spec":{"type":"LoadBalancer"}}'
+
+
+echo ""
+echo "Restarting all pods in argocd NS"
+kubectl $K8S_CONTEXT_CONTROL_PLANE $K8S_NAMESPACE delete pods --all
 
 echo ""
 echo "* Starting the rathole local client."
-echo "* - This may initially report an error while waiting for LoadBalancer service, but it will keep trying until connection is established."
+echo "* - This may initially report an error while waiting for LoadBalancer service ('Failed to run the control channel: (...): Name or service not known. '), but it will keep trying until connection is established."
 echo "* - You can also safely ignore this warning: 'Failed to run the data channel: Failed to read cmd: early eof'"
+echo "* - This message indicates you need to run 'make start-e2e2', or that it is not currently running: 'Failed to run the data channel: Failed to connect to 127.0.0.1:6379: Connection refused (os error 111)'"
 echo ""
 echo "CTRL-C / Command-C to terminate rathole tunnel."
 $TEMP_DIR/client/run.sh

--- a/hack/dev-env/setup-vcluster-env.sh
+++ b/hack/dev-env/setup-vcluster-env.sh
@@ -176,18 +176,18 @@ apply() {
 
     if [[ "$OPENSHIFT" != "" ]]; then
 
-        echo "-> Waiting for Redis load balancer on control plane Argo CD"
+        # echo "-> Waiting for Redis load balancer on control plane Argo CD"
 
-        while [ true ]
-        do
-            REDIS_ADDR=`kubectl --context vcluster-control-plane -n argocd   get service/argocd-redis -o json | jq -r '.status.loadBalancer.ingress[0].hostname'`
+        # while [ true ]
+        # do
+        #     REDIS_ADDR=`kubectl --context vcluster-control-plane -n argocd   get service/argocd-redis -o json | jq -r '.status.loadBalancer.ingress[0].hostname'`
 
-            if [[ "$REDIS_ADDR" != "" ]] && [[ "$REDIS_ADDR" != "null" ]]; then
-                break
-            fi
+        #     if [[ "$REDIS_ADDR" != "" ]] && [[ "$REDIS_ADDR" != "null" ]]; then
+        #         break
+        #     fi
 
-            sleep 2
-        done
+        #     sleep 2
+        # done
 
         echo "-> Waiting for repo-server load balancer on control plane Argo CD"
 
@@ -205,8 +205,10 @@ apply() {
     else
         # For all other cases, use hardcoded values
         REPO_SERVER_ADDR="${LB_NETWORK}.222"
-        REDIS_ADDR="${LB_NETWORK}.221"
+        # REDIS_ADDR="${LB_NETWORK}.221"
     fi
+
+    REDIS_ADDR=argocd-redis # Now that redis proxy is implemented, agent can connect to its own redis (I've left the existing logic above, for debugging purposes, to be removed at a later time)
 
     echo "Redis on control plane: $REDIS_ADDR"
     echo "Repo server URL on control plane: $REPO_SERVER_ADDR"

--- a/hack/dev-env/setup-vcluster-env.sh
+++ b/hack/dev-env/setup-vcluster-env.sh
@@ -131,6 +131,8 @@ apply() {
         sed -i.bak -e "/loadBalancerIP/s/192\.168\.56/${LB_NETWORK}/" $TMP_DIR/control-plane/redis-service.yaml
         sed -i.bak -e "/loadBalancerIP/s/192\.168\.56/${LB_NETWORK}/" $TMP_DIR/control-plane/repo-server-service.yaml
         sed -i.bak -e "/loadBalancerIP/s/192\.168\.56/${LB_NETWORK}/" $TMP_DIR/control-plane/server-service.yaml
+        sed -i.bak -e "/loadBalancerIP/s/192\.168\.56/${LB_NETWORK}/" $TMP_DIR/agent-managed/redis-service.yaml
+        sed -i.bak -e "/loadBalancerIP/s/192\.168\.56/${LB_NETWORK}/" $TMP_DIR/agent-autonomous/redis-service.yaml
     fi
 
     LATEST_RELEASE_TAG=`curl -s "https://api.github.com/repos/argoproj/argo-cd/releases/latest" | jq -r .tag_name`

--- a/hack/dev-env/start-e2e2.sh
+++ b/hack/dev-env/start-e2e2.sh
@@ -1,5 +1,20 @@
 #!/bin/bash
 
+# Copyright 2025 The argocd-agent Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
 # getExternalLoadBalancerIP will set EXTERNAL_IP with the load balancer hostname from the specified Service
 getExternalLoadBalancerIP() {
   SERVICE_NAME=$1

--- a/hack/dev-env/start-e2e2.sh
+++ b/hack/dev-env/start-e2e2.sh
@@ -1,4 +1,4 @@
-#/bin/bash
+#!/bin/bash
 
 # getExternalLoadBalancerIP will set EXTERNAL_IP with the load balancer hostname from the specified Service
 getExternalLoadBalancerIP() {

--- a/hack/dev-env/start-e2e2.sh
+++ b/hack/dev-env/start-e2e2.sh
@@ -1,0 +1,53 @@
+#/bin/bash
+
+# getExternalLoadBalancerIP will set EXTERNAL_IP with the load balancer hostname from the specified Service
+getExternalLoadBalancerIP() {
+  SERVICE_NAME=$1
+
+  MAX_ATTEMPTS=120
+
+  for ((i=1; i<=MAX_ATTEMPTS; i++)); do
+    
+    echo ""
+    EXTERNAL_IP=$(kubectl get svc $SERVICE_NAME $K8S_CONTEXT $K8S_NAMESPACE -o jsonpath='{.status.loadBalancer.ingress[0].hostname}')
+
+    if [ -n "$EXTERNAL_IP" ]; then
+      echo "External IP is $EXTERNAL_IP"
+      break
+    else
+      echo "External IP not yet available, attempting again in 5 seconds..."
+      sleep 5
+    fi
+  done
+
+  if [ $i -gt $MAX_ATTEMPTS ]; then
+    echo "Failed to obtain external IP after $MAX_ATTEMPTS attempts."
+    exit 1
+  fi
+
+}
+
+# Get hostname of control-plane redis
+K8S_CONTEXT="--context=vcluster-control-plane"
+K8S_NAMESPACE="-n argocd"
+getExternalLoadBalancerIP "argocd-redis"
+export ARGOCD_PRINCIPAL_REDIS_SERVER_ADDRESS="$EXTERNAL_IP:6379"
+
+
+# Get hostname of agent-managed redis
+K8S_CONTEXT="--context=vcluster-agent-managed"
+K8S_NAMESPACE="-n argocd"
+getExternalLoadBalancerIP "argocd-redis"
+export MANAGED_AGENT_REDIS_ADDR="$EXTERNAL_IP:6379"
+
+# Get hostname of agent-autonomous redis
+K8S_CONTEXT="--context=vcluster-agent-autonomous"
+K8S_NAMESPACE="-n argocd"
+getExternalLoadBalancerIP "argocd-redis"
+export AUTONOMOUS_AGENT_REDIS_ADDR="$EXTERNAL_IP:6379"
+
+
+export REDIS_PASSWORD=$(kubectl get secret argocd-redis --context=vcluster-agent-managed $K8S_NAMESPACE -o jsonpath='{.data.auth}' | base64 --decode)
+
+goreman -exit-on-stop=false -f hack/dev-env/Procfile.e2e start
+

--- a/hack/dev-env/start-e2e2.sh
+++ b/hack/dev-env/start-e2e2.sh
@@ -9,13 +9,18 @@ getExternalLoadBalancerIP() {
   for ((i=1; i<=MAX_ATTEMPTS; i++)); do
     
     echo ""
-    EXTERNAL_IP=$(kubectl get svc $SERVICE_NAME $K8S_CONTEXT $K8S_NAMESPACE -o jsonpath='{.status.loadBalancer.ingress[0].hostname}')
+    EXTERNAL_IP=$(kubectl get svc $SERVICE_NAME $K8S_CONTEXT $K8S_NAMESPACE -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+    EXTERNAL_HOST=$(kubectl get svc $SERVICE_NAME $K8S_CONTEXT $K8S_NAMESPACE -o jsonpath='{.status.loadBalancer.ingress[0].hostname}')
 
     if [ -n "$EXTERNAL_IP" ]; then
-      echo "External IP is $EXTERNAL_IP"
+      echo "External IP for $SERVICE_NAME on $K8S_CONTEXT is $EXTERNAL_IP"
+      break
+    elif [ -n "$EXTERNAL_HOST" ]; then
+      echo "External host for $SERVICE_NAME on $K8S_CONTEXT is $EXTERNAL_HOST"
+      EXTERNAL_IP=$EXTERNAL_HOST
       break
     else
-      echo "External IP not yet available, attempting again in 5 seconds..."
+      echo "External IP for $SERVICE_NAME on $K8S_CONTEXT not yet available, attempting again in 5 seconds..."
       sleep 5
     fi
   done

--- a/hack/test.sh
+++ b/hack/test.sh
@@ -16,4 +16,4 @@
 # Wrapper script to run unit tests for argocd-agent
 set -eo pipefail
 UNIT_LIST=$(go list ./... | grep -E -v '(mock|mocks|e2e|fake|pkg/api/grpc)')
-go test -race -timeout 10m -coverprofile test/out/coverage.out $UNIT_LIST
+go test -race -p 1 -timeout 10m -coverprofile test/out/coverage.out $UNIT_LIST

--- a/pkg/client/remote_test.go
+++ b/pkg/client/remote_test.go
@@ -52,6 +52,12 @@ func Test_Connect(t *testing.T) {
 	err = s.Start(context.Background(), errch)
 	require.NoError(t, err)
 
+	t.Cleanup(func() {
+		if s != nil {
+			require.NoError(t, s.Shutdown())
+		}
+	})
+
 	t.Run("Connect to a server", func(t *testing.T) {
 		r, err := NewRemote("127.0.0.1", s.ListenerForE2EOnly().Port(),
 			WithInsecureSkipTLSVerify(),

--- a/principal/event.go
+++ b/principal/event.go
@@ -328,7 +328,6 @@ func (s *Server) processRedisEventResponse(ctx context.Context, logCtx *logrus.E
 		trAgent, evChan := s.redisProxy.ConnectionIDTracker.Tracked(resReq.ConnectionUUID)
 		if trAgent != agentName {
 			err := fmt.Errorf("agent mismap between event and tracking for PushFromSubscribe: '%s' '%s' '%s'", trAgent, agentName, resReq.ConnectionUUID)
-			logCtx.WithError(err).Error("agent mismap between event and tracking")
 			return err
 		}
 

--- a/principal/listen_test.go
+++ b/principal/listen_test.go
@@ -157,7 +157,7 @@ func Test_Serve(t *testing.T) {
 	errch := make(chan error)
 
 	err = s.Start(context.Background(), errch)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Create and register authentication method
 	up := userPass(t, "hello", "world")

--- a/principal/redisproxy/redisproxy.go
+++ b/principal/redisproxy/redisproxy.go
@@ -86,7 +86,7 @@ func (rp *RedisProxy) Start() error {
 		}
 	}()
 
-	log().Infof("Redis proxy started")
+	log().Infof("Redis proxy started on %s", rp.listenAddress)
 
 	return nil
 }

--- a/principal/redisproxy/redisproxy.go
+++ b/principal/redisproxy/redisproxy.go
@@ -1,3 +1,17 @@
+// Copyright 2025 The argocd-agent Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package redisproxy
 
 import (
@@ -763,11 +777,17 @@ func extractAgentNameFromRedisCommandKey(redisKey string, logCtx *logrus.Entry) 
 			// mfst| is forwarded to principal, but I think this may not be a permanent behaviour.
 			// Example key:
 			// - mfst|annotation:app.kubernetes.io/instance|agent-managed_my-app|(revision id)|guestbook|3093507789|1.8.3.gz
-			logCtx.Info("redirecting mfst| redis key to principal redis")
+			logCtx.Debug("redirecting mfst| redis key to principal redis")
 			return "", nil
 		}
 
-		logCtx.Errorf("Unexpected redis key seen: '%s'. Redirecting to principal by default.", redisKey)
+		if strings.HasPrefix(redisKey, "cluster|") {
+			// cluster| is likewise forwarded to principal
+			logCtx.Debug("redirecting cluster| redis key to principal redis")
+			return "", nil
+		}
+
+		logCtx.Warningf("Unexpected redis key seen: '%s'. Redirecting to principal by default.", redisKey)
 
 		return "", nil
 	}

--- a/principal/redisproxy/redisproxy.go
+++ b/principal/redisproxy/redisproxy.go
@@ -1,0 +1,786 @@
+package redisproxy
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"strings"
+	"sync"
+	"time"
+	"unicode/utf8"
+
+	"github.com/argoproj-labs/argocd-agent/internal/event"
+	"github.com/argoproj-labs/argocd-agent/principal/tracker"
+	cloudevents "github.com/cloudevents/sdk-go/v2"
+	"github.com/google/uuid"
+	"github.com/sirupsen/logrus"
+)
+
+// RedisProxy proxies traffic from principal Argo CD, to either, a) agent Argo CD redis or b) principal Argo CD redis, depending on the type and content of message.
+type RedisProxy struct {
+
+	// EventIDTracker maintains a channel that can be used to send/receive synchronous events; that is, cases where we are sending a specific sync message and expecting a specific sync response. The request/response both share a single event id.
+	EventIDTracker *tracker.Tracker
+
+	// ConnectionIDTracker maintains a channel that can be used to send/receive events to be handled by a specific Argo CD connection
+	// - This is useful for asynchronous communication events, such as subscribe notifications
+	ConnectionIDTracker *tracker.Tracker
+
+	// sendSynchronousMessageToAgentFn is called to send a message (and wait for a response) to remote agent via principal's machinery
+	// - should not be used for asynchronous messages.
+	// - currently the main implementation is: 'sendSynchronousRedisMessageToAgent'
+	sendSynchronousMessageToAgentFn sendSynchronousMessageToAgentFuncType
+
+	// listenAddress is the address principal redis proxy will listen on
+	listenAddress string
+
+	// principalRedisAddress is the address of the principal redis server
+	principalRedisAddress string
+
+	// listener is the listener for the redis proxy
+	listener net.Listener
+}
+
+const (
+	constInternalNotify = "internal-notify"
+)
+
+// sendSynchronousMessageToAgentFuncType is the function signature used to send a message (and wait for a response) to remote agent via principal's machinery
+type sendSynchronousMessageToAgentFuncType func(agentName string, connectionUUID string, body event.RedisCommandBody) *event.RedisResponseBody
+
+func New(listenAddress string, principalRedisAddress string, sendSyncMessageToAgentFuncParam sendSynchronousMessageToAgentFuncType) *RedisProxy {
+
+	res := &RedisProxy{
+		sendSynchronousMessageToAgentFn: sendSyncMessageToAgentFuncParam,
+		EventIDTracker:                  tracker.New(),
+		ConnectionIDTracker:             tracker.New(),
+		principalRedisAddress:           principalRedisAddress,
+		listenAddress:                   listenAddress,
+	}
+
+	return res
+}
+
+// Start listening on redis proxy port, and handling connections
+func (rp *RedisProxy) Start() error {
+
+	l, err := net.Listen("tcp", rp.listenAddress)
+	if err != nil {
+		log().WithError(err).Error("error occurred on listening to addr: " + rp.listenAddress)
+		return err
+	}
+	rp.listener = l
+
+	// Start server and connection handler
+	go func() {
+		for {
+			conn, err := l.Accept()
+			if err != nil {
+				log().WithError(err).Error("error occurred on accepting connection")
+				return
+			}
+			go rp.handleConnection(conn)
+		}
+	}()
+
+	log().Infof("Redis proxy started")
+
+	return nil
+}
+
+// Stop listening on redis proxy port, and close server port listener
+func (rp *RedisProxy) Stop() error {
+	if rp.listener != nil {
+		return rp.listener.Close()
+	}
+	return nil
+}
+
+// handleConnection is passed a TCP-IP socket connection from a redis client (e.g. Argo CD server). handleConnection initializes the connection and passes it to the message loop function.
+// - This functions runs for the lifecycle of the connection.
+func (rp *RedisProxy) handleConnection(fromArgoCDConn net.Conn) {
+
+	defer fromArgoCDConn.Close()
+
+	connUUID := uuid.New().String()
+
+	logCtx := log().WithField("function", "redisFxn")
+	logCtx = logCtx.WithField("connUUID", connUUID)
+
+	redisConn, err := establishConnectionToPrincipalRedis(rp.principalRedisAddress, logCtx)
+	if err != nil {
+		logCtx.WithError(err).Error("unable to connect to principal redis")
+		return
+	}
+	defer redisConn.Close()
+
+	argoCDReader := bufio.NewReader(fromArgoCDConn) // input from argo cd
+
+	// All writing to Argo CD socket should be through this object. This is required as multiple go-routines may write to this socket.
+	argocdWriter := &argoCDRedisWriterInternal{
+		fromArgoCDWrite: bufio.NewWriter(fromArgoCDConn),
+		argoCDWriteLock: &sync.Mutex{},
+	}
+
+	redisReader := bufio.NewReader(redisConn) // input from principal redis
+	redisWriter := bufio.NewWriter(redisConn) // output to principal redis
+
+	endpointMessageChannel := startArgoCDRedisEndpointReader(logCtx, argoCDReader)
+
+	connectionCtx, connectionCancelFn := context.WithCancel(context.Background())
+	defer func() {
+		logCtx.Trace("cancelling connection context")
+		connectionCancelFn()
+	}()
+
+	go func() {
+		// Any traffic sent from principal redis will be automatically forwarded back to principal argocd, without any modification.
+		// - As of this writing, there is no need to proxy/MITM any traffic in the direction of (principal redis) -> (principal argo cd)
+		if err := forwardTrafficSimple("r->a", redisReader, argocdWriter, logCtx); err != nil {
+			logCtx.WithError(err).Error("traffic forwarder returned error")
+			return
+		}
+	}()
+
+	connState := &connectionState{
+		connectionCtx:               connectionCtx,
+		connectionCancelFn:          connectionCancelFn,
+		connUUID:                    connUUID,
+		connectionUUIDEventsChannel: nil,
+		pingRoutineStarted:          map[string]bool{},
+	}
+
+	rp.handleConnectionMessageLoop(connState, endpointMessageChannel, argocdWriter, redisWriter, logCtx)
+
+}
+
+// connectionState is the state we track for a specific TCP-IP socket connection from Argo CD. The lifecycle of this struct (and related goroutines/functions) is equivalent to the lifecycle of that TCP-IP socket.
+type connectionState struct {
+
+	// connectionCtx should be cancelled in order to cause all connection-related go-routines to complete
+	connectionCtx context.Context
+
+	// connectionCancelFn is the cancel function for above
+	connectionCancelFn context.CancelFunc
+
+	// connUUID is the immutable identifier for this specific TCP/IP socket connection from Argo CD <-> agent redis proxy
+	connUUID string
+
+	// connectionUUIDEventsChannel is the channel that is responsible for reading asynchronous redis subscription responses from agents, for this specific connection (the connection identified by connUUID)
+	connectionUUIDEventsChannel chan *cloudevents.Event
+
+	// pingRoutineStarted indicates whether the go routine that sends 'ping' messages to agents has been started for a specific agent (name)
+	// - This is used to ensure disconnected TCP-IP connections are closed on both sides (principal/agent)
+	// - map key is 'agent name', value is not used.
+	pingRoutineStarted map[string]bool
+}
+
+// handleConnectionMessageLoop is passed an initialized connection from handleConenction
+// - This functions runs for the lifecycle of the connection.
+func (rp *RedisProxy) handleConnectionMessageLoop(connState *connectionState, endpointMessageChannel chan parsedRedisCommand, argocdWriter argoCDRedisWriter, redisWriter *bufio.Writer, logCtx *logrus.Entry) {
+
+	defer logCtx.Trace("handleConnectionMessageLoop has exited")
+
+	for {
+
+		// readNextMessageFromArgoCDOrInternal will read from two channels:
+		// - one channel reading parsed redis messages from Argo CD
+		// - one channel reading from subscribe notifications, which receives notify (push) messages from agents
+
+		parsedRedisCommandVal := readNextMessageFromArgoCDOrInternal(connState, endpointMessageChannel, logCtx)
+
+		if parsedRedisCommandVal.connContextCancelled {
+			logCtx.Trace("exit due to cancelled context reported by readNextMessageFromArgoCDOrInternal")
+			return
+		}
+
+		if parsedRedisCommandVal.err != nil {
+			logCtx.WithError(parsedRedisCommandVal.err).Error("exit due to readNextMessage returned error")
+			return
+		}
+
+		logCtx.Tracef("processing redis command: %s", parsedRedisCommandVal.generateParsedCommandDebugString())
+
+		if len(parsedRedisCommandVal.internalMsg) == 2 {
+
+			// Handle subscription notify (push)
+			if err := handleInternalNotify(parsedRedisCommandVal.internalMsg, argocdWriter, logCtx); err != nil {
+				logCtx.WithError(err).Error("exit due to unable to handle subscription notify command")
+				return
+			}
+		}
+
+		parsedReceived := parsedRedisCommandVal.parsedReceived
+
+		forwardRawCommandToPrincipalRedis := true // whether to send the command to principal redis: false if the command has already been processed, true otherwise.
+
+		// If we received a 'subscribe' message from argo cd, in the exact expected format
+		if len(parsedReceived) == 2 && parsedReceived[0] == "subscribe" {
+
+			// Example command:
+			// 'subscribe' 'app|managed-resources|agent-managed_my-app|1.8.3'
+			// - format is: subscribe "(key to subscribe to)""
+			// - 'my-app' is name of Argo CD Application
+			// - 'agent-managed' is the namespace of 'my-app' Application (and 'agent-managed' also correspond to Argo CD agent on another cluster)
+
+			channelName := parsedReceived[1]
+
+			agentName, err := extractAgentNameFromRedisCommandKey(channelName, logCtx)
+			if err != nil {
+				logCtx.WithError(err).Error("exit due to unable to get agent name: " + channelName)
+				return
+			}
+
+			if agentName != "" { // We're only interested in handling subscribes that need to be forwarded to an agent redis
+
+				forwardRawCommandToPrincipalRedis = false
+
+				if err := rp.handleAgentSubscribe(connState, channelName, agentName, argocdWriter, logCtx); err != nil {
+					logCtx.WithError(err).Error("exit due to unable to handle agent subscribe")
+					return
+				}
+			}
+		}
+
+		// If we received a 'get' message from Argo CD...
+		if len(parsedReceived) == 2 && parsedReceived[0] == "get" {
+
+			// Determine if the command should be forwarded to agent (and which agent)
+			key := parsedReceived[1]
+
+			agentName, err := extractAgentNameFromRedisCommandKey(key, logCtx)
+			if err != nil {
+				logCtx.WithError(err).Error("exit due to unable to get agent name: " + key)
+				return
+			}
+
+			if agentName != "" { // We're only interested in forwarding get commands that are destined for agent redis
+
+				// agentName will be the agent namespace on principal cluster, so forward it to the corresponding argocd-agent instance on agent cluster
+
+				forwardRawCommandToPrincipalRedis = false
+
+				if err := rp.handleAgentGet(connState, key, argocdWriter, agentName, logCtx); err != nil {
+					logCtx.WithError(err).Error("exit due to unable to handle agent get")
+					return
+				}
+			}
+
+		}
+
+		// If the command we received was not 'get', 'subscribe', or 'internal-notify' (or if the 'get'/'subscribe' is known be principal-only), then just forward it directly to principal redis without modification.
+		if forwardRawCommandToPrincipalRedis {
+			rawReceived := parsedRedisCommandVal.rawReceived
+
+			for _, raw := range rawReceived {
+				if _, err := redisWriter.Write(([]byte)(raw + "\r\n")); err != nil {
+					logCtx.WithError(err).Error("exit due to write error:", err.Error())
+					return
+				}
+			}
+			if err := redisWriter.Flush(); err != nil {
+				logCtx.WithError(err).Error("exit due to flush error:", err.Error())
+				return
+			}
+		}
+	}
+}
+
+// handleInternalNotify	handle subscription notify (push) from agent
+func handleInternalNotify(vals []string, argocdWriter argoCDRedisWriter, logCtx *logrus.Entry) error {
+
+	if len(vals) != 2 {
+		return fmt.Errorf("unexpected internal message command format: %v", vals)
+	}
+
+	// Example command:
+	// internal-notify "(resp.Body.PushFromSubscribe.ChannelName)"
+
+	if vals[0] != constInternalNotify {
+		return fmt.Errorf("unexpected internal message command: %s", vals[0])
+	}
+
+	// We only support nil message subscription messages for now
+	channelName := vals[1]
+	channelNameBytes := ([]byte)(vals[1])
+
+	if channelName == "" {
+		return fmt.Errorf("channel name is empty")
+	}
+
+	logCtx = logCtx.WithField("channelName", channelName)
+
+	// Example response that we need to send to principal Argo CD redis:
+	// >3
+	// $7
+	// message  # 'message' type
+	// $49  # length of channel name in bytes
+	// app|managed-resources|agent-managed_my-app|1.8.3  # channel name
+	// $0  # no body data to the notify response
+	// (With each line ending with \r\n)
+
+	msg := fmt.Appendf(nil, ">3\r\n$7\r\nmessage\r\n$%d\r\n%s\r\n$0\r\n\r\n", len(channelNameBytes), channelName)
+
+	logCtx.Tracef("Wrote notify response to argo cd: '%s'", string(msg))
+
+	if err := argocdWriter.writeToArgoCDRedisSocket(logCtx, msg); err != nil {
+		logCtx.WithError(err).Error("unable to write response in handleInternalNotify")
+		return fmt.Errorf("unable to write response")
+	}
+
+	return nil
+}
+
+// handleAgentGet processes a redis get message that is destinated for a specific agent
+func (rp *RedisProxy) handleAgentGet(connState *connectionState, key string, argocdWriter argoCDRedisWriter, agentName string, logCtx *logrus.Entry) error {
+
+	rp.beginPingGoRoutineIfNeeded(connState, agentName, logCtx)
+
+	// Example of a redis get command request/response:
+	// (A->R) Wrote: *2
+	// (A->R) Wrote: $3
+	// (A->R) Wrote: get  # 'get ' type
+	// (A->R) Wrote: $52  # get key is 52 bytes
+	// (A->R) Wrote: cluster|info|https://kubernetes.default.svc|1.8.3.gz  # get key
+
+	// (R->A) Read and wrote: $177  # get response is 177 bytes
+	// (R->A) Read and wrote: (... binary data ...) # get resposne
+
+	logCtx = logCtx.WithField("getKey", key)
+
+	cmdBody := event.RedisCommandBody{
+		Get: &event.RedisCommandBodyGet{
+			Key: key,
+		},
+	}
+
+	agentName, err := extractAgentNameFromRedisCommandKey(key, logCtx)
+	if err != nil {
+		logCtx.WithError(err).Error("unable to get agent name: " + key)
+		return err
+	}
+
+	logCtx.Trace("sending get command to agent")
+
+	// This function will forward message to agent and await a response
+	response := rp.sendSynchronousMessageToAgentFn(agentName, connState.connUUID, cmdBody)
+	if response == nil {
+		logCtx.Error("no response from agent")
+		return fmt.Errorf("unexpected nil in get response")
+	}
+
+	if response.Get == nil {
+		logCtx.Error("received a redis response from agent, but get body was nil")
+		return fmt.Errorf("no get response in response command")
+	}
+
+	if response.Get.Error != "" {
+		logCtx.Error("received a redis response from agent, but an error occurred: " + response.Get.Error)
+		return fmt.Errorf("unexpected error: %s", response.Get.Error)
+
+	} else if !response.Get.CacheHit {
+
+		// Cache miss: no data for that key in agent redis
+
+		response := "-\r\n" // Cache miss is a simple redis null
+
+		logCtx.Tracef("Wrote GET response to argo cd: '%s'", response)
+
+		if err := argocdWriter.writeToArgoCDRedisSocket(logCtx, ([]byte)(response)); err != nil {
+			return err
+		}
+
+		return nil
+
+	} else {
+
+		// Cache hit: there was data for that key in agent redis, so forward back to principal Argo CD
+
+		// We sanitize the log string because it may contain confidential data, which we don't want to log.
+		logCtx.Tracef("Wrote GET response to argo cd: '%s' '%s'", key, sanitizeStringIfNonASCII(string(response.Get.Bytes)))
+
+		// Get response format is as described above
+		if err := argocdWriter.writeToArgoCDRedisSocket(logCtx, fmt.Appendf(nil, "$%d\r\n%s\r\n", len(response.Get.Bytes), response.Get.Bytes)); err != nil {
+			return err
+		}
+
+		return nil
+	}
+
+}
+
+// handleAgentSubscribe handles a subscription request from Argo CD to be forwarded to agent redis
+func (rp *RedisProxy) handleAgentSubscribe(connState *connectionState, channelName string, agentName string, argoCDWrite argoCDRedisWriter, logCtx *logrus.Entry) error {
+
+	rp.beginPingGoRoutineIfNeeded(connState, agentName, logCtx)
+
+	// Create the channel and start the goroutine for the channel that is responsible for reading asynchronous redis subscription responses from agents
+	if connState.connectionUUIDEventsChannel == nil {
+
+		logCtx.Trace("begun tracking by connection uuid")
+		connState.connectionUUIDEventsChannel = make(chan *cloudevents.Event)
+		subscriptionChannel, err := rp.ConnectionIDTracker.Track(connState.connUUID, agentName)
+		if err != nil {
+			logCtx.WithError(err).Error("Unable to track by connection uuid")
+			return fmt.Errorf("unable to track by connection UUID")
+		}
+
+		// Forward all events from 'subscriptionChannel' to 'connectionUUIDEventsChannel'
+		go func() {
+			defer close(connState.connectionUUIDEventsChannel)
+
+			for {
+				select {
+				case <-connState.connectionCtx.Done():
+					logCtx.Trace("cancelling connectionUUIDEventsChannel forwarding due to context cancelled")
+					return
+				case event := <-subscriptionChannel:
+					logCtx.Trace("received redis subscription event from agent, forwarding to connection channel")
+					connState.connectionUUIDEventsChannel <- event
+				}
+			}
+
+		}()
+	}
+
+	// Send synchronous subscribe message to begin the subscription.
+	cmdBody := event.RedisCommandBody{
+		Subscribe: &event.RedisCommandBodySubscribe{
+			ChannelName: channelName,
+		},
+	}
+
+	// This function will wait for a response
+	response := rp.sendSynchronousMessageToAgentFn(agentName, connState.connUUID, cmdBody)
+	if response == nil {
+		logCtx.Error("unexpected nil in get response")
+		return fmt.Errorf("unexpected nil in get response")
+	}
+
+	// Example response to subscribe, to send back to Argo CD:
+	// >3
+	// $9
+	// subscribe # 'subscribe' type message
+	// $49  # 49 bytes in channel name
+	// app|managed-resources|agent-managed_my-app|1.8.3  # channel name
+	// :1
+
+	// Send acknowledgment of subscribe back to Argo CD
+	msgToSend := fmt.Appendf(nil, ">3\r\n$9\r\nsubscribe\r\n$%d\r\n%s\r\n:1\r\n", len(([]byte)(channelName)), channelName)
+
+	logCtx.Tracef("(r->a) Wrote SUBSCRIBE response to argo cd: '%s': %s", channelName, msgToSend)
+	if err := argoCDWrite.writeToArgoCDRedisSocket(logCtx, msgToSend); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// beginPingGoRoutineIfNeeded starts a go routine that sends 'ping' messages to the agent for as long as the redis connection is active.
+// - Only 1 ping go routine is started per agent (name)
+// - This ensures that if principal or agent are restarted, that all redis connections on the other side are closed.
+func (rp *RedisProxy) beginPingGoRoutineIfNeeded(connState *connectionState, agentName string, logCtx *logrus.Entry) {
+
+	_, exists := connState.pingRoutineStarted[agentName]
+	if exists {
+		// Already started, so no-op
+		return
+	}
+
+	connState.pingRoutineStarted[agentName] = true
+
+	// Send 'ping' to the agent for as long as the redis connection is active.
+	go func() {
+
+		logCtx = logCtx.WithField("agent-name", agentName)
+
+		logCtx.Debug("Beginning ping thread")
+		for {
+			ticker := time.NewTicker(1 * time.Minute)
+
+			select {
+			case <-ticker.C:
+				logCtx.Trace("sending ping on ping thread")
+				cmdBody := event.RedisCommandBody{
+					Ping: &event.RedisCommandBodyPing{},
+				}
+
+				// sendSynchronousMessageToAgentFn waits up to X seconds for a respond to the message, and returns nil response if no response received.
+				response := rp.sendSynchronousMessageToAgentFn(agentName, connState.connUUID, cmdBody)
+				if response == nil {
+					logCtx.Error("unexpected nil in response in ping thread, cancelling connection context")
+					connState.connectionCancelFn()
+					return
+				}
+
+			case <-connState.connectionCtx.Done():
+				logCtx.Debug("ping thread terminated")
+				return
+			}
+		}
+
+	}()
+
+}
+
+// readNextMessageFromArgoCDOrInternal reads the next message from either the argo cd TCP-IP socket or the internal channel (used for subscription notify)
+func readNextMessageFromArgoCDOrInternal(connState *connectionState, receiverChan chan parsedRedisCommand, logCtx *logrus.Entry) parsedRedisCommand {
+
+	select {
+
+	case <-connState.connectionCtx.Done(): // Stop reading if the connection context is cancelled
+		return parsedRedisCommand{
+			connContextCancelled: true,
+		}
+
+	// Read messages from argo cd TCP-IP socket
+	case rcMessage := <-receiverChan:
+		return rcMessage
+
+	// Read internal (subscribe notify) messages sent to us by an agent
+	case channelMessage := <-connState.connectionUUIDEventsChannel:
+
+		// Get the resource out of the event
+		resp := &event.RedisResponse{}
+
+		err := channelMessage.DataAs(resp)
+		if err != nil {
+			logCtx.WithError(err).Error("Could not get data from event")
+			return parsedRedisCommand{err: err}
+		}
+		return parsedRedisCommand{internalMsg: []string{constInternalNotify, resp.Body.PushFromSubscribe.ChannelName}}
+	}
+}
+
+// generateParsedCommandDebugString is debug utility function
+func (prc *parsedRedisCommand) generateParsedCommandDebugString() string {
+
+	if prc.err != nil {
+		return fmt.Sprintf("error occurred: %v", prc.err)
+	}
+
+	if len(prc.internalMsg) > 0 {
+		return fmt.Sprintf("internal message: %v", prc.internalMsg)
+	}
+
+	res := "(a->r) "
+	for _, str := range prc.parsedReceived {
+		res += fmt.Sprintf("'%s' | ", sanitizeStringIfNonASCII(str))
+	}
+
+	return res
+
+}
+
+// sanitizeStringIfNonASCII: if the string is non-ascii (likely because it includes binary data), then only return the number of bytes of the string rather than the string itself
+// - This is not done for security reasons; it is only to avoid dumping binary data to logs.
+func sanitizeStringIfNonASCII(str string) string {
+	containsNonASCII := len(str) != utf8.RuneCountInString(str)
+
+	var res string
+
+	if !containsNonASCII {
+		res = str
+	} else {
+		res = fmt.Sprintf("( %d bytes )", len(str))
+	}
+
+	return res
+
+}
+
+// parsedRedisCommand is parsed commands (messages) from redis socket
+type parsedRedisCommand struct {
+	// err is non-nil if an error occurred during parsing
+	err error
+
+	// parseReceived is the parsed version of the redis message
+	// example: ["ping"]
+	parsedReceived []string
+
+	// rawReceived is the raw, unparsed version of the redis message, as transmitted on wire
+	// example: ["*1", "$4", "ping"]
+	rawReceived []string
+
+	// This struct is also used to communicate internal messages via this field: as of this writing, the only supported message that will be written to this field is:
+	// internal-notify (subscription channel)
+	internalMsg []string
+
+	// connContextCancelled indicated whether the connection context was cancelled (indicating that the underlying connection has been closed, and so no further processing is required)
+	connContextCancelled bool
+}
+
+// forwardTrafficSimple reads from 'r' and writes to 'argocdWriter'. Traffic is MITMed so that it can be output via debug.
+// - 'simple' in the sense that we read/write with any modification to that data.
+func forwardTrafficSimple(debugStr string, r *bufio.Reader, argocdWriter *argoCDRedisWriterInternal, logCtx *logrus.Entry) error {
+
+	// Maintains a record of bytes forwarded, so we can output via debug log
+	debugBuf := bytes.NewBuffer(make([]byte, 0))
+	debugWrite := bufio.NewWriter(debugBuf)
+	debugRead := bufio.NewReader(debugBuf)
+
+	buf := make([]byte, 4096)
+	for {
+
+		// Read from input
+		n, err := r.Read(buf)
+		if err != nil {
+			logCtx.WithError(err).Trace("unable to read from connection " + debugStr)
+			return err
+		}
+
+		// Write to output
+		if err := argocdWriter.writeToArgoCDRedisSocket(logCtx, buf[0:n]); err != nil {
+			logCtx.WithError(err).Trace("unable to write to connection " + debugStr)
+			return err
+		}
+
+		// Write to our debug buffer
+		if _, err := debugWrite.Write(buf[0:n]); err != nil {
+			logCtx.WithError(err).Debug("error returned by debugWrite Write " + debugStr)
+		}
+		if err := debugWrite.Flush(); err != nil {
+			logCtx.WithError(err).Debug("error returned by debugWrite Flush " + debugStr)
+		}
+
+		// Write any (read) strings to debug log
+		for {
+
+			writtenStr, err := debugRead.ReadString('\n')
+			if err != nil {
+				if err != io.EOF { // EOF means no \n was found, not that the connection has closed (that is handled elsewhere)
+					logCtx.WithError(err).Warn("unexpected error from redis debug output")
+				}
+				break
+			}
+
+			logCtx.Tracef("%s wrote '%d bytes'", debugStr, len(writtenStr))
+			// replace the above with this to output the actual text:
+			// logCtx.Tracef("%s wrote '%s'", debugStr, sanitizeString(writtenStr))
+			// This line is commented out by default to avoid logging confidential data to logs
+
+		}
+	}
+}
+
+// argoCDRedisWriter is wrapper over argoCDRedisWriterInternal (primarily to avoid writing to internal fields, and to allow mocking)
+type argoCDRedisWriter interface {
+	writeToArgoCDRedisSocket(logCtx *logrus.Entry, bytes []byte) error
+}
+
+// argoCDRedisWriterInternal is a simple wrapper around argo cd redis socket, which ensures that lock is owned while writing to argo cd server.
+type argoCDRedisWriterInternal struct {
+
+	// Use 'writeToArgoCDRedisSocket' function: these internal fields should not be called directly.
+
+	fromArgoCDWrite *bufio.Writer
+	argoCDWriteLock *sync.Mutex
+}
+
+// writeToArgoCDRedisSocket writes data back to Argo CD while owning mutex
+func (are *argoCDRedisWriterInternal) writeToArgoCDRedisSocket(logCtx *logrus.Entry, bytes []byte) error {
+
+	are.argoCDWriteLock.Lock()
+	defer are.argoCDWriteLock.Unlock()
+
+	_, err := are.fromArgoCDWrite.Write(bytes)
+	if err != nil {
+		log().WithError(err).Error("unable to write to Argo CD Redis socket")
+		return err
+	}
+
+	if err := are.fromArgoCDWrite.Flush(); err != nil {
+		logCtx.WithError(err).Info("unable to flush to Argo CD Redis socket")
+		return err
+	}
+
+	return nil
+}
+
+// establishConnectionToPrincipalRedis establishes a simple TCP-IP socket connection to principal's redis. (That is, we don't use go-redis client)
+func establishConnectionToPrincipalRedis(principalRedisAddress string, logCtx *logrus.Entry) (*net.TCPConn, error) {
+
+	var redisConn *net.TCPConn
+
+	addr, err := net.ResolveTCPAddr("tcp", principalRedisAddress)
+	if err != nil {
+		logCtx.WithError(err).WithField("redisAddress", principalRedisAddress).Error("Resolution error")
+		return nil, fmt.Errorf("unable to resolve address: %w", err)
+	}
+
+	// Dial the resolved address
+	redisConn, err = net.DialTCP("tcp", nil, addr)
+	if err != nil {
+		logCtx.WithError(err).WithField("redisAddress", principalRedisAddress).Error("Connection error")
+		return nil, fmt.Errorf("unable to connect to redis '%s': %w", principalRedisAddress, err)
+	}
+
+	return redisConn, nil
+}
+
+// Extract agent name from the key field of 'get' or 'subscribe' redis commands
+// If found, return name. If not found, return "" (with nil err).
+// If a field had an unexpected format, and error is returned.
+//
+// For example:
+// - If the key is 'app|managed-resources|agent-managed_my-app|1.8.3'
+// - The extracted agent name will be 'agent-managed'
+//   - This value comes from the third field, before the '_' character
+func extractAgentNameFromRedisCommandKey(redisKey string, logCtx *logrus.Entry) (string, error) {
+
+	// We only recognize agent names from these keys
+	if !strings.HasPrefix(redisKey, "app|managed-resources") && !strings.HasPrefix(redisKey, "app|resources-tree") {
+
+		if redisKey == "new-revoked-token" {
+			// 'new-revoked-token' is forwarded to principal
+			return "", nil
+		}
+
+		if strings.HasPrefix("mfst|", redisKey) {
+			// mfst| is forwarded to principal, but I think this may not be a permanent behaviour.
+			// Example key:
+			// - mfst|annotation:app.kubernetes.io/instance|agent-managed_my-app|(revision id)|guestbook|3093507789|1.8.3.gz
+			logCtx.Info("redirecting mfst| redis key to principal redis")
+			return "", nil
+		}
+
+		logCtx.Errorf("Unexpected redis key seen: '%s'. Redirecting to principal by default.", redisKey)
+
+		return "", nil
+	}
+
+	// Example keys:
+	// * app|managed-resources|my-app|1.8.3
+	// * app|resources-tree|my-app|1.8.3.gz
+	// * app|managed-resources|agent-managed_my-app|1.8.3
+	// * app|resources-tree|agent-managed_my-app|1.8.3.gz
+
+	splitByPipe := strings.Split(redisKey, "|")
+	if len(splitByPipe) != 4 {
+		errMsg := fmt.Sprintf("unexpected number of fields in expected key: '%s'", redisKey)
+		logCtx.Error(errMsg)
+		return "", fmt.Errorf("%s", errMsg)
+	}
+
+	namespaceAndName := splitByPipe[2]
+
+	// It is not possible to create a namespace name containing a '_' value, so this is a correct delimiter
+	if !strings.Contains(namespaceAndName, "_") {
+		errMsg := fmt.Sprintf("unexpected lack of '_' namespace/name separate: '%s'", redisKey)
+		logCtx.Error(errMsg)
+		return "", fmt.Errorf("%s", errMsg)
+	}
+
+	// namespace is the agent name
+	res := namespaceAndName[0:strings.Index(namespaceAndName, "_")]
+
+	return res, nil
+
+}
+
+func log() *logrus.Entry {
+	return logrus.WithField("module", "redisProxy")
+}

--- a/principal/redisproxy/redisproxy_test.go
+++ b/principal/redisproxy/redisproxy_test.go
@@ -1,3 +1,17 @@
+// Copyright 2025 The argocd-agent Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package redisproxy
 
 import (

--- a/principal/redisproxy/redisproxy_test.go
+++ b/principal/redisproxy/redisproxy_test.go
@@ -1,0 +1,410 @@
+package redisproxy
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/argoproj-labs/argocd-agent/internal/event"
+	cloudevents "github.com/cloudevents/sdk-go/v2"
+	"github.com/google/uuid"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_extractAgentNameFromRedisCommandKey(t *testing.T) {
+
+	logEntry := log()
+
+	type testEntry struct {
+		name          string
+		key           string
+		value         string
+		errorExpected bool
+	}
+
+	testEntries := []testEntry{
+		{
+			name:          "'app|managed-resources' with name/namespace",
+			key:           "app|managed-resources|agent-managed_my-app|1.8.3",
+			value:         "agent-managed",
+			errorExpected: false,
+		},
+		{
+			name:          "'app|resources-tree' with name/namespace",
+			key:           "app|resources-tree|agent-managed_my-app|1.8.3.gz",
+			value:         "agent-managed",
+			errorExpected: false,
+		},
+		{
+			name:          "'app|managed-resources' with only namespace",
+			key:           "app|managed-resources|my-app|1.8.3",
+			value:         "",
+			errorExpected: true,
+		},
+		{
+			name:          "'app|resources-tree' with only namespace",
+			key:           "app|resources-tree|my-app|1.8.3.gz",
+			value:         "",
+			errorExpected: true,
+		},
+		{
+			name:          "'app|resources-tree' with unexpected field format",
+			key:           "app|resources-tree|agent-managed_my-app|THIS FIELD IS UNEXPECTED|1.8.3.gz",
+			value:         "",
+			errorExpected: true,
+		},
+		{
+			name:          "mfst| key",
+			key:           "mfst|annotation:app.kubernetes.io/instance|agent-managed_my-app|(revision id)|guestbook|3093507789|1.8.3.gz",
+			value:         "",
+			errorExpected: false,
+		},
+		{
+			name:          "unexpected key should just return empty value, so it will be forwarded to principal",
+			key:           "some other unexpected key",
+			value:         "",
+			errorExpected: false,
+		},
+	}
+
+	for _, testEntry := range testEntries {
+
+		t.Run(testEntry.name, func(t *testing.T) {
+			res, err := extractAgentNameFromRedisCommandKey(testEntry.key, logEntry)
+
+			require.Equal(t, testEntry.value, res)
+			require.Equal(t, testEntry.errorExpected, err != nil, "err: %v", err)
+
+		})
+
+	}
+}
+
+// mockArgoCDRedisWriter is a mock implementation of argoCDRedisWriter interface for testing
+type mockArgoCDRedisWriter struct {
+	writeToArgoCDRedisSocketCalled bool
+	writtenBytes                   []byte
+	returnError                    error
+}
+
+func (m *mockArgoCDRedisWriter) writeToArgoCDRedisSocket(logCtx *logrus.Entry, bytes []byte) error {
+	m.writeToArgoCDRedisSocketCalled = true
+	m.writtenBytes = bytes
+	return m.returnError
+}
+
+func Test_handleInternalNotify(t *testing.T) {
+	logEntry := log()
+
+	t.Run("successful internal notify with valid command", func(t *testing.T) {
+		mockWriter := &mockArgoCDRedisWriter{}
+		channelName := "app|managed-resources|agent-managed_my-app|1.8.3"
+		vals := []string{constInternalNotify, channelName}
+
+		err := handleInternalNotify(vals, mockWriter, logEntry)
+
+		require.NoError(t, err)
+		require.True(t, mockWriter.writeToArgoCDRedisSocketCalled)
+
+		expectedMsg := fmt.Sprintf(">3\r\n$7\r\nmessage\r\n$%d\r\n%s\r\n$0\r\n\r\n", len([]byte(channelName)), channelName)
+		require.Equal(t, expectedMsg, string(mockWriter.writtenBytes))
+	})
+
+	t.Run("successful internal notify with different channel name", func(t *testing.T) {
+		mockWriter := &mockArgoCDRedisWriter{}
+		channelName := "app|resources-tree|test-agent_my-app|1.8.4.gz"
+		vals := []string{constInternalNotify, channelName}
+
+		err := handleInternalNotify(vals, mockWriter, logEntry)
+
+		require.NoError(t, err)
+		require.True(t, mockWriter.writeToArgoCDRedisSocketCalled)
+
+		expectedMsg := fmt.Sprintf(">3\r\n$7\r\nmessage\r\n$%d\r\n%s\r\n$0\r\n\r\n", len([]byte(channelName)), channelName)
+		require.Equal(t, expectedMsg, string(mockWriter.writtenBytes))
+	})
+
+	t.Run("error when command is not internal-notify", func(t *testing.T) {
+		mockWriter := &mockArgoCDRedisWriter{}
+		channelName := "app|managed-resources|agent-managed_my-app|1.8.3"
+		vals := []string{"invalid-command", channelName}
+
+		err := handleInternalNotify(vals, mockWriter, logEntry)
+
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "unexpected internal message command: invalid-command")
+		require.False(t, mockWriter.writeToArgoCDRedisSocketCalled)
+	})
+
+	t.Run("error when writeToArgoCDRedisSocket fails", func(t *testing.T) {
+		mockWriter := &mockArgoCDRedisWriter{
+			returnError: fmt.Errorf("write socket error"),
+		}
+		channelName := "app|managed-resources|agent-managed_my-app|1.8.3"
+		vals := []string{constInternalNotify, channelName}
+
+		err := handleInternalNotify(vals, mockWriter, logEntry)
+
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "unable to write response")
+		require.True(t, mockWriter.writeToArgoCDRedisSocketCalled)
+	})
+
+}
+
+// mockSendSynchronousMessageToAgentFunc is a mock implementation of sendSynchronousMessageToAgentFuncType
+type mockSendSynchronousMessageToAgentFunc struct {
+	callCount        int
+	lastAgentName    string
+	lastConnUUID     string
+	lastBody         event.RedisCommandBody
+	responseToReturn *event.RedisResponseBody
+}
+
+func (m *mockSendSynchronousMessageToAgentFunc) call(agentName string, connectionUUID string, body event.RedisCommandBody) *event.RedisResponseBody {
+	m.callCount++
+	m.lastAgentName = agentName
+	m.lastConnUUID = connectionUUID
+	m.lastBody = body
+	return m.responseToReturn
+}
+
+func Test_handleAgentGet(t *testing.T) {
+	logEntry := log()
+
+	t.Run("successful get with cache hit", func(t *testing.T) {
+		// Setup mocks
+		mockWriter := &mockArgoCDRedisWriter{}
+		mockSendFunc := &mockSendSynchronousMessageToAgentFunc{
+			responseToReturn: &event.RedisResponseBody{
+				Get: &event.RedisResponseBodyGet{
+					Bytes:    []byte("test-data"),
+					CacheHit: true,
+					Error:    "",
+				},
+			},
+		}
+
+		// Create RedisProxy instance
+		rp := &RedisProxy{
+			sendSynchronousMessageToAgentFn: mockSendFunc.call,
+		}
+
+		// Setup connection state
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		connState := &connectionState{
+			connectionCtx:      ctx,
+			connectionCancelFn: cancel,
+			connUUID:           "test-connection-uuid",
+			pingRoutineStarted: make(map[string]bool),
+		}
+
+		// Test data
+		key := "app|managed-resources|test-agent_my-app|1.8.3"
+		agentName := "test-agent"
+
+		// Call the function
+		err := rp.handleAgentGet(connState, key, mockWriter, agentName, logEntry)
+
+		// Assertions
+		require.NoError(t, err)
+		require.Equal(t, 1, mockSendFunc.callCount)
+		require.Equal(t, agentName, mockSendFunc.lastAgentName)
+		require.Equal(t, "test-connection-uuid", mockSendFunc.lastConnUUID)
+		require.NotNil(t, mockSendFunc.lastBody.Get)
+		require.Equal(t, key, mockSendFunc.lastBody.Get.Key)
+
+		// Check that the correct response was written
+		require.True(t, mockWriter.writeToArgoCDRedisSocketCalled)
+		expectedResponse := fmt.Sprintf("$%d\r\n%s\r\n", len([]byte("test-data")), "test-data")
+		require.Equal(t, expectedResponse, string(mockWriter.writtenBytes))
+	})
+
+	t.Run("successful get with empty cache hit", func(t *testing.T) {
+		// Setup mocks
+		mockWriter := &mockArgoCDRedisWriter{}
+		mockSendFunc := &mockSendSynchronousMessageToAgentFunc{
+			responseToReturn: &event.RedisResponseBody{
+				Get: &event.RedisResponseBodyGet{
+					Bytes:    []byte{},
+					CacheHit: true,
+					Error:    "",
+				},
+			},
+		}
+
+		// Create RedisProxy instance
+		rp := &RedisProxy{
+			sendSynchronousMessageToAgentFn: mockSendFunc.call,
+		}
+
+		// Setup connection state
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		connState := &connectionState{
+			connectionCtx:      ctx,
+			connectionCancelFn: cancel,
+			connUUID:           uuid.New().String(),
+			pingRoutineStarted: make(map[string]bool),
+		}
+
+		// Test data
+		key := "app|resources-tree|agent-managed_test-app|1.8.4.gz"
+		agentName := "agent-managed"
+
+		// Call the function
+		err := rp.handleAgentGet(connState, key, mockWriter, agentName, logEntry)
+
+		// Assertions
+		require.NoError(t, err)
+		require.Equal(t, 1, mockSendFunc.callCount)
+		require.True(t, mockWriter.writeToArgoCDRedisSocketCalled)
+		expectedResponse := "$0\r\n\r\n"
+		require.Equal(t, expectedResponse, string(mockWriter.writtenBytes))
+	})
+
+	t.Run("cache miss returns 'CacheHit: false', with empty error string", func(t *testing.T) {
+		// Setup mocks
+		mockWriter := &mockArgoCDRedisWriter{}
+		mockSendFunc := &mockSendSynchronousMessageToAgentFunc{
+			responseToReturn: &event.RedisResponseBody{
+				Get: &event.RedisResponseBodyGet{
+					Bytes:    nil,
+					CacheHit: false,
+					Error:    "",
+				},
+			},
+		}
+
+		// Create RedisProxy instance
+		rp := &RedisProxy{
+			sendSynchronousMessageToAgentFn: mockSendFunc.call,
+		}
+
+		// Setup connection state
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		connState := &connectionState{
+			connectionCtx:      ctx,
+			connectionCancelFn: cancel,
+			connUUID:           uuid.New().String(),
+			pingRoutineStarted: make(map[string]bool),
+		}
+
+		// Test data
+		key := "app|managed-resources|test-agent_my-app|1.8.3"
+		agentName := "test-agent"
+
+		// Call the function
+		err := rp.handleAgentGet(connState, key, mockWriter, agentName, logEntry)
+
+		// Assertions
+		require.NoError(t, err)
+		require.Equal(t, 1, mockSendFunc.callCount)
+		require.True(t, mockWriter.writeToArgoCDRedisSocketCalled)
+		expectedResponse := "-\r\n"
+		require.Equal(t, expectedResponse, string(mockWriter.writtenBytes))
+	})
+
+	t.Run("error from get response should be returned within Get body", func(t *testing.T) {
+		// Setup mocks
+		mockWriter := &mockArgoCDRedisWriter{}
+		mockSendFunc := &mockSendSynchronousMessageToAgentFunc{
+			responseToReturn: &event.RedisResponseBody{
+				Get: &event.RedisResponseBodyGet{
+					Bytes:    nil,
+					CacheHit: false,
+					Error:    "redis connection failed",
+				},
+			},
+		}
+
+		// Create RedisProxy instance
+		rp := &RedisProxy{
+			sendSynchronousMessageToAgentFn: mockSendFunc.call,
+		}
+
+		// Setup connection state
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		connState := &connectionState{
+			connectionCtx:      ctx,
+			connectionCancelFn: cancel,
+			connUUID:           uuid.New().String(),
+			pingRoutineStarted: make(map[string]bool),
+		}
+
+		// Test data
+		key := "app|managed-resources|test-agent_my-app|1.8.3"
+		agentName := "test-agent"
+
+		// Call the function
+		err := rp.handleAgentGet(connState, key, mockWriter, agentName, logEntry)
+
+		// Assertions
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "unexpected error: redis connection failed")
+		require.Equal(t, 1, mockSendFunc.callCount)
+		require.False(t, mockWriter.writeToArgoCDRedisSocketCalled)
+	})
+
+}
+
+func Test_handleAgentSubscribe(t *testing.T) {
+	logEntry := log()
+
+	t.Run("successful subscription", func(t *testing.T) {
+		// Setup mocks
+		mockWriter := &mockArgoCDRedisWriter{}
+		mockSendFunc := &mockSendSynchronousMessageToAgentFunc{
+			responseToReturn: &event.RedisResponseBody{
+				SubscribeResponse: &event.RedisResponseBodySubscribeResponse{
+					Error: "", // no error
+				},
+			},
+		}
+
+		// Create RedisProxy instance with nil tracker since we're ignoring channel logic
+		rp := &RedisProxy{
+			sendSynchronousMessageToAgentFn: mockSendFunc.call,
+			ConnectionIDTracker:             nil,
+		}
+
+		// Setup connection state
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		connState := &connectionState{
+			connectionCtx:               ctx,
+			connectionCancelFn:          cancel,
+			connUUID:                    "test-connection-uuid",
+			connectionUUIDEventsChannel: make(chan *cloudevents.Event, 1),
+			pingRoutineStarted:          make(map[string]bool),
+		}
+
+		// Test data
+		channelName := "app|managed-resources|test-agent_my-app|1.8.3"
+		agentName := "test-agent"
+
+		// Call the function
+		err := rp.handleAgentSubscribe(connState, channelName, agentName, mockWriter, logEntry)
+
+		// Assertions
+		require.NoError(t, err)
+		require.Equal(t, 1, mockSendFunc.callCount)
+		require.Equal(t, agentName, mockSendFunc.lastAgentName)
+		require.Equal(t, "test-connection-uuid", mockSendFunc.lastConnUUID)
+		require.NotNil(t, mockSendFunc.lastBody.Subscribe)
+		require.Equal(t, channelName, mockSendFunc.lastBody.Subscribe.ChannelName)
+
+		// Check that the correct response was written
+		require.True(t, mockWriter.writeToArgoCDRedisSocketCalled)
+		expectedResponse := fmt.Sprintf(">3\r\n$9\r\nsubscribe\r\n$%d\r\n%s\r\n:1\r\n", len([]byte(channelName)), channelName)
+		require.Equal(t, expectedResponse, string(mockWriter.writtenBytes))
+
+		// Check that ping routine was started
+		require.True(t, connState.pingRoutineStarted[agentName])
+	})
+
+}

--- a/principal/redisproxy/util.go
+++ b/principal/redisproxy/util.go
@@ -1,0 +1,133 @@
+package redisproxy
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"strconv"
+
+	"github.com/sirupsen/logrus"
+)
+
+// startArgoCDRedisEndpointReader reads redis commands from socket from Argo CD, parses them, and then writes them to channel
+func startArgoCDRedisEndpointReader(logCtx *logrus.Entry, fromArgoCDRead *bufio.Reader) chan parsedRedisCommand {
+
+	// fromArgoCDRead := bufio.NewReader(fromArgoCDConn)
+	receiverChan := make(chan parsedRedisCommand)
+
+	go func() {
+		defer close(receiverChan)
+		for {
+			// Read from Argo CD server input
+			parsedReceived, rawReceived, err := readRedisArray(fromArgoCDRead)
+			if err != nil {
+				logCtx.WithError(err).Error("unable to read array. Stopped reading redis endpoint input.")
+				receiverChan <- parsedRedisCommand{err: err}
+				return
+			}
+			// Write to channel
+			receiverChan <- parsedRedisCommand{parsedReceived: parsedReceived, rawReceived: rawReceived}
+
+		}
+	}()
+
+	return receiverChan
+
+}
+
+var ErrInvalidRequest = errors.New("invalid request")
+
+// readRedisArray reads a redis array from reader
+//
+// Returns:
+// - parsed redis fields from input (removing type information)
+// - raw redis input (includes type information)
+// - error
+//
+// This function originally from https://github.com/alicebob/miniredis (https://github.com/alicebob/miniredis/commit/e79bddcbd62ee0f3669cbcd43d75bab2a2d726ad), under MIT license
+func readRedisArray(rd *bufio.Reader) ([]string, []string, error) {
+	line, err := rd.ReadString('\n')
+	if err != nil {
+		return nil, nil, fmt.Errorf("readArray ReadString error: %v", err)
+	}
+	if len(line) < 3 {
+		return nil, nil, fmt.Errorf("readArray unexpected 'line' length")
+	}
+
+	switch line[0] {
+	default:
+		return nil, nil, fmt.Errorf("readArray unexpected line '%s'", line)
+	case '*':
+		var receivedRes []string
+
+		l, err := strconv.Atoi(line[1 : len(line)-2])
+		if err != nil {
+			return nil, nil, err
+		}
+		receivedRes = append(receivedRes, fmt.Sprintf("*%d", l))
+
+		// l can be -1
+		var fields []string
+		for ; l > 0; l-- {
+			s, received, err := readString(rd)
+			if err != nil {
+				return nil, nil, err
+			}
+			fields = append(fields, s)
+			receivedRes = append(receivedRes, received...)
+		}
+
+		return fields, receivedRes, nil
+	}
+}
+
+// readString reads redis simple or bulk string
+// Returns:
+// - parsed redis fields from input (removing type information)
+// - raw redis input (includes type information)
+// - error
+// This function originally from https://github.com/alicebob/miniredis (https://github.com/alicebob/miniredis/commit/e79bddcbd62ee0f3669cbcd43d75bab2a2d726ad), under MIT license
+func readString(rd *bufio.Reader) (string, []string, error) {
+	line, err := rd.ReadString('\n')
+	if err != nil {
+		return "", nil, err
+	}
+	if len(line) < 3 {
+		return "", nil, ErrInvalidRequest
+	}
+
+	switch line[0] {
+	default:
+		return "", nil, ErrInvalidRequest
+	case '+', '-', ':':
+		// +: simple string
+		// -: errors
+		// :: integer
+		// Simple line based replies.
+		return string(line[1 : len(line)-2]), []string{line}, nil // Consider adding a trim on this line
+	case '$':
+		// bulk strings are: `$5\r\nhello\r\n`
+		length, err := strconv.Atoi(line[1 : len(line)-2])
+		if err != nil {
+			return "", nil, err
+		}
+		if length < 0 {
+			// -1 is a nil response
+			return "", []string{fmt.Sprintf("$%d", length)}, nil
+		}
+		var (
+			buf = make([]byte, length+2)
+			pos = 0
+		)
+		for pos < length+2 {
+			n, err := rd.Read(buf[pos:])
+			if err != nil {
+				return "", nil, err
+			}
+			pos += n
+		}
+		resStr := string(buf[:length])
+
+		return resStr, []string{fmt.Sprintf("$%d", length), resStr}, nil
+	}
+}

--- a/principal/redisproxy/util.go
+++ b/principal/redisproxy/util.go
@@ -1,3 +1,17 @@
+// Copyright 2025 The argocd-agent Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package redisproxy
 
 import (

--- a/principal/redisproxy/util.go
+++ b/principal/redisproxy/util.go
@@ -20,8 +20,8 @@ func startArgoCDRedisEndpointReader(logCtx *logrus.Entry, fromArgoCDRead *bufio.
 			// Read from Argo CD server input
 			parsedReceived, rawReceived, err := readRedisArray(fromArgoCDRead)
 			if err != nil {
-				logCtx.WithError(err).Error("unable to read array. Stopped reading redis endpoint input.")
-				receiverChan <- parsedRedisCommand{err: err}
+				logCtx.WithError(err).Debug("unable to read from Argo CD redis endpoint input, usually due to closed connection")
+				// We don't need to send the 'err' back on the channel, as the close() call above will handle informing the channel consumer.
 				return
 			}
 			// Write to channel

--- a/principal/redisproxy/util.go
+++ b/principal/redisproxy/util.go
@@ -12,7 +12,6 @@ import (
 // startArgoCDRedisEndpointReader reads redis commands from socket from Argo CD, parses them, and then writes them to channel
 func startArgoCDRedisEndpointReader(logCtx *logrus.Entry, fromArgoCDRead *bufio.Reader) chan parsedRedisCommand {
 
-	// fromArgoCDRead := bufio.NewReader(fromArgoCDConn)
 	receiverChan := make(chan parsedRedisCommand)
 
 	go func() {

--- a/principal/tracker/tracking.go
+++ b/principal/tracker/tracking.go
@@ -1,0 +1,102 @@
+// Copyright 2024 The argocd-agent Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tracker
+
+import (
+	"fmt"
+	"sync"
+
+	cloudevents "github.com/cloudevents/sdk-go/v2"
+	"github.com/sirupsen/logrus"
+)
+
+type Tracker struct {
+	statemap requestState
+}
+
+func New() *Tracker {
+
+	var res Tracker
+	res.statemap.requests = make(map[string]*requestWrapper)
+
+	return &res
+}
+
+// requestWrapper holds information about a given request to be tracked.
+type requestWrapper struct {
+	// agentName is the name of the agent for which a resource is tracked
+	agentName string
+	// evCh is a channel where the requester expects the response to its
+	// requests is written to.
+	evCh chan *cloudevents.Event
+}
+
+// requestState holds all currently tracked requests
+type requestState struct {
+	mutex    sync.RWMutex
+	requests map[string]*requestWrapper
+}
+
+// Tracked returns the tracked event identified by resId
+func (p *Tracker) Tracked(eventID string) (string, chan *cloudevents.Event) {
+	p.statemap.mutex.RLock()
+	defer p.statemap.mutex.RUnlock()
+	r, ok := p.statemap.requests[eventID]
+	if !ok || r == nil {
+		return "", nil
+	}
+	return r.agentName, r.evCh
+}
+
+// Track starts tracking a resource request identified by its UUID for an agent
+// with the given name. It will return a channel the caller can use to read the
+// response event from.
+func (p *Tracker) Track(eventID string, agentName string) (<-chan *cloudevents.Event, error) {
+	p.statemap.mutex.Lock()
+	defer p.statemap.mutex.Unlock()
+	log().WithFields(logrus.Fields{"event_id": eventID, "agent": agentName}).Trace("Tracking new request")
+	_, ok := p.statemap.requests[eventID]
+	if ok {
+		return nil, fmt.Errorf("resource with ID %s already tracked", eventID)
+	}
+	ch := make(chan *cloudevents.Event)
+	p.statemap.requests[eventID] = &requestWrapper{agentName: agentName, evCh: ch}
+	return ch, nil
+}
+
+// StopTracking will stop tracking a particular resource and close any event
+// channel that may still be open.
+func (p *Tracker) StopTracking(eventID string) error {
+	p.statemap.mutex.Lock()
+	defer p.statemap.mutex.Unlock()
+	r, ok := p.statemap.requests[eventID]
+	if ok {
+		close(r.evCh)
+		logCtx := log().WithFields(logrus.Fields{
+			"event_id": eventID,
+			"agent":    r.agentName,
+		})
+		logCtx.Trace("Finished tracking request")
+		delete(p.statemap.requests, eventID)
+		return nil
+	} else {
+		log().WithField("event_id", eventID).Warn("Resource not tracked -- is this a bug?")
+		return fmt.Errorf("resource request %s not tracked", eventID)
+	}
+}
+
+func log() *logrus.Entry {
+	return logrus.WithField("module", "tracker")
+}

--- a/principal/tracker/tracking_test.go
+++ b/principal/tracker/tracking_test.go
@@ -1,0 +1,42 @@
+package tracker
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_Tracking(t *testing.T) {
+
+	tracker := Tracker{
+		statemap: requestState{
+			requests: map[string]*requestWrapper{},
+		},
+	}
+
+	ch, err := tracker.Track("123", "agent")
+	assert.NotNil(t, ch)
+	assert.NoError(t, err)
+	t.Run("Check that request is tracked", func(t *testing.T) {
+		agent, ch := tracker.Tracked("123")
+		assert.Equal(t, "agent", agent)
+		assert.NotNil(t, ch)
+	})
+	t.Run("Track existing request", func(t *testing.T) {
+		ch, err := tracker.Track("123", "agent")
+		assert.Nil(t, ch)
+		assert.ErrorContains(t, err, "already tracked")
+	})
+	t.Run("Stop tracking request", func(t *testing.T) {
+		err := tracker.StopTracking("123")
+		require.NoError(t, err)
+		// Can't stop tracking twice
+		err = tracker.StopTracking("123")
+		require.Error(t, err)
+		// It's now untracked
+		agent, ch := tracker.Tracked("123")
+		assert.Empty(t, agent)
+		assert.Nil(t, ch)
+	})
+}

--- a/test/e2e2/fixture/fixture.go
+++ b/test/e2e2/fixture/fixture.go
@@ -75,18 +75,19 @@ func (suite *BaseSuite) TearDownTest() {
 	suite.Require().Nil(err)
 }
 
-func ensureDeletion(ctx context.Context, kclient KubeClient, app KubeObject) error {
-	err := kclient.Delete(ctx, app, metav1.DeleteOptions{})
+// EnsureDeletion will issue a delete for a namespace-scoped K8s resource, then wait for it to no longer exist
+func EnsureDeletion(ctx context.Context, kclient KubeClient, obj KubeObject) error {
+	err := kclient.Delete(ctx, obj, metav1.DeleteOptions{})
 	if errors.IsNotFound(err) {
-		// application is already deleted
+		// object is already deleted
 		return nil
 	} else if err != nil {
 		return err
 	}
 
-	key := types.NamespacedName{Name: app.GetName(), Namespace: app.GetNamespace()}
+	key := types.NamespacedName{Name: obj.GetName(), Namespace: obj.GetNamespace()}
 	for count := 0; count < 120; count++ {
-		err := kclient.Get(ctx, key, app, metav1.GetOptions{})
+		err := kclient.Get(ctx, key, obj, metav1.GetOptions{})
 		if errors.IsNotFound(err) {
 			return nil
 		} else if err == nil {
@@ -96,7 +97,7 @@ func ensureDeletion(ctx context.Context, kclient KubeClient, app KubeObject) err
 		}
 	}
 
-	return fmt.Errorf("ensureDeletion: timeout waiting for deletion of %s/%s", key.Namespace, key.Name)
+	return fmt.Errorf("EnsureDeletion: timeout waiting for deletion of %s/%s", key.Namespace, key.Name)
 }
 
 func CleanUp(ctx context.Context, principalClient KubeClient, managedAgentClient KubeClient, autonomousAgentClient KubeClient) error {
@@ -114,7 +115,7 @@ func CleanUp(ctx context.Context, principalClient KubeClient, managedAgentClient
 		return err
 	}
 	for _, app := range list.Items {
-		err = ensureDeletion(ctx, principalClient, &app)
+		err = EnsureDeletion(ctx, principalClient, &app)
 		if err != nil {
 			return err
 		}
@@ -127,7 +128,7 @@ func CleanUp(ctx context.Context, principalClient KubeClient, managedAgentClient
 		return err
 	}
 	for _, app := range list.Items {
-		err = ensureDeletion(ctx, autonomousAgentClient, &app)
+		err = EnsureDeletion(ctx, autonomousAgentClient, &app)
 		if err != nil {
 			return err
 		}
@@ -140,7 +141,7 @@ func CleanUp(ctx context.Context, principalClient KubeClient, managedAgentClient
 		return err
 	}
 	for _, app := range list.Items {
-		err = ensureDeletion(ctx, managedAgentClient, &app)
+		err = EnsureDeletion(ctx, managedAgentClient, &app)
 		if err != nil {
 			return err
 		}
@@ -153,7 +154,7 @@ func CleanUp(ctx context.Context, principalClient KubeClient, managedAgentClient
 		return err
 	}
 	for _, app := range list.Items {
-		err = ensureDeletion(ctx, principalClient, &app)
+		err = EnsureDeletion(ctx, principalClient, &app)
 		if err != nil {
 			return err
 		}
@@ -209,11 +210,11 @@ func CleanUp(ctx context.Context, principalClient KubeClient, managedAgentClient
 
 	// Delete any left over namespaces
 	ns := corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "guestbook"}}
-	err = ensureDeletion(ctx, managedAgentClient, &ns)
+	err = EnsureDeletion(ctx, managedAgentClient, &ns)
 	if err != nil {
 		return err
 	}
-	err = ensureDeletion(ctx, autonomousAgentClient, &ns)
+	err = EnsureDeletion(ctx, autonomousAgentClient, &ns)
 	if err != nil {
 		return err
 	}

--- a/test/e2e2/fixture/fixture.go
+++ b/test/e2e2/fixture/fixture.go
@@ -170,7 +170,7 @@ func CleanUp(ctx context.Context, principalClient KubeClient, managedAgentClient
 		if appProject.Name == appproject.DefaultAppProjectName {
 			continue
 		}
-		err = ensureDeletion(ctx, principalClient, &appProject)
+		err = EnsureDeletion(ctx, principalClient, &appProject)
 		if err != nil {
 			return err
 		}
@@ -186,7 +186,7 @@ func CleanUp(ctx context.Context, principalClient KubeClient, managedAgentClient
 		if appProject.Name == appproject.DefaultAppProjectName {
 			continue
 		}
-		err = ensureDeletion(ctx, autonomousAgentClient, &appProject)
+		err = EnsureDeletion(ctx, autonomousAgentClient, &appProject)
 		if err != nil {
 			return err
 		}
@@ -202,7 +202,7 @@ func CleanUp(ctx context.Context, principalClient KubeClient, managedAgentClient
 		if appProject.Name == appproject.DefaultAppProjectName {
 			continue
 		}
-		err = ensureDeletion(ctx, managedAgentClient, &appProject)
+		err = EnsureDeletion(ctx, managedAgentClient, &appProject)
 		if err != nil {
 			return err
 		}

--- a/test/e2e2/redis_proxy_test.go
+++ b/test/e2e2/redis_proxy_test.go
@@ -1,0 +1,624 @@
+// Copyright 2025 The argocd-agent Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package e2e2
+
+import (
+	"bufio"
+	"context"
+	"crypto/tls"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/argoproj-labs/argocd-agent/test/e2e2/fixture"
+
+	argocdclient "github.com/argoproj/argo-cd/v2/pkg/apiclient"
+	"github.com/argoproj/argo-cd/v2/pkg/apiclient/application"
+	sessionpkg "github.com/argoproj/argo-cd/v2/pkg/apiclient/session"
+	"github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
+	"github.com/argoproj/gitops-engine/pkg/health"
+	"github.com/stretchr/testify/suite"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+type RedisProxyTestSuite struct {
+	fixture.BaseSuite
+}
+
+func (suite *RedisProxyTestSuite) Test_RedisProxy_ManagedAgent_Argo() {
+	requires := suite.Require()
+
+	t := suite.T()
+
+	// Get the Argo server endpoint to use
+	argoEndpoint, err := fixture.GetArgoCDServerEndpoint(suite.PrincipalClient)
+	requires.NoError(err)
+
+	// Read admin secret from principal's cluster
+	password, err := fixture.GetInitialAdminSecret(suite.PrincipalClient)
+	requires.NoError(err)
+
+	// Create a managed application in the principal's cluster
+	appOnPrincipal := v1alpha1.Application{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-app",
+			Namespace: "agent-managed",
+		},
+		Spec: v1alpha1.ApplicationSpec{
+			Project: "default",
+			Source: &v1alpha1.ApplicationSource{
+				RepoURL:        "https://github.com/argoproj/argocd-example-apps",
+				TargetRevision: "HEAD",
+				Path:           "kustomize-guestbook",
+			},
+			Destination: v1alpha1.ApplicationDestination{
+				Name:      "agent-managed",
+				Namespace: "guestbook",
+			},
+			SyncPolicy: &v1alpha1.SyncPolicy{
+				Automated: &v1alpha1.SyncPolicyAutomated{},
+				SyncOptions: v1alpha1.SyncOptions{
+					"CreateNamespace=true",
+				},
+			},
+		},
+	}
+
+	err = suite.PrincipalClient.Create(suite.Ctx, &appOnPrincipal, metav1.CreateOptions{})
+	requires.NoError(err)
+
+	argocdClient, sessionToken, closer, err := createArgoCDAPIClient(suite.Ctx, argoEndpoint, password)
+	requires.NoError(err)
+	defer closer.Close()
+
+	closer, appClient, err := argocdClient.NewApplicationClient()
+	requires.NoError(err)
+	defer closer.Close()
+
+	syncAppWithAutoResync(&appOnPrincipal, appClient, &suite.BaseSuite)
+
+	cancellableContext, cancelFunc := context.WithCancel(suite.Ctx)
+	defer cancelFunc()
+
+	resourceTreeURL := "https://" + argoEndpoint + "/api/v1/stream/applications/" + appOnPrincipal.Name + "/resource-tree?appNamespace=" + appOnPrincipal.Namespace
+
+	// Wait for sucessful connection to event source
+	var msgChan chan string
+	requires.Eventually(func() bool {
+		var err error
+		msgChan, err = streamFromEventSourceNew(cancellableContext, resourceTreeURL, sessionToken, t)
+		if err != nil {
+			t.Logf("streamFromEventSource returned error: %v", err)
+			return false
+		}
+		return true
+
+	}, 5*time.Minute, 5*time.Second)
+
+	requires.NotNil(msgChan)
+
+	// Find pod on managed-agent client
+
+	var podList corev1.PodList
+	err = suite.ManagedAgentClient.List(suite.Ctx, "guestbook", &podList, metav1.ListOptions{})
+	requires.NoError(err)
+
+	requires.True(len(podList.Items) == 1, "should only be one kustomize-guestbook pod")
+
+	// Locate guestbook pod
+	var oldPod corev1.Pod
+	for idx := range podList.Items {
+		pod := podList.Items[idx]
+		if strings.Contains(pod.Name, "kustomize-guestbook-ui") {
+			oldPod = pod
+			break
+		}
+	}
+	requires.NotEmpty(oldPod.Name)
+
+	// Ensure that the pod appears in the resource tree value returned by Argo CD server (this will only be true if redis proxy is working)
+	tree, err := appClient.ResourceTree(suite.Ctx, &application.ResourcesQuery{
+		ApplicationName: &appOnPrincipal.Name,
+		AppNamespace:    &appOnPrincipal.Namespace,
+		Project:         &appOnPrincipal.Spec.Project,
+	})
+	requires.NoError(err)
+
+	requires.NotNil(tree)
+
+	matchFound := false
+	for _, node := range tree.Nodes {
+		if node.Kind == "Pod" && node.Name == oldPod.Name {
+			matchFound = true
+			break
+		}
+	}
+	requires.True(matchFound)
+
+	// Delete pod on managed agent cluster
+	err = suite.ManagedAgentClient.Delete(suite.Ctx, &oldPod, metav1.DeleteOptions{})
+	requires.NoError(err)
+
+	// Wait for new pod to be created, to replace the old one that was deleted
+	var newPod corev1.Pod
+	requires.Eventually(func() bool {
+		var podList corev1.PodList
+		err = suite.ManagedAgentClient.List(suite.Ctx, "guestbook", &podList, metav1.ListOptions{})
+		requires.NoError(err)
+
+		for idx := range podList.Items {
+			pod := podList.Items[idx]
+			if strings.Contains(pod.Name, "kustomize-guestbook-ui") && newPod.Name != oldPod.Name {
+				newPod = pod
+				break
+			}
+		}
+
+		return newPod.Name != ""
+
+	}, time.Second*30, time.Second*5)
+
+	// Verify the name of the new pod exists in what has been sent from the channel (this will only be true if redis proxy subscription is working)
+	requires.Eventually(func() bool {
+		for {
+			// drain channel looking for name of new pod
+			select {
+			case msg := <-msgChan:
+				t.Log("Processing message:", msg)
+				if strings.Contains(msg, newPod.Name) {
+					t.Log("new pod name found:", newPod.Name)
+					return true
+				}
+			default:
+				return false
+			}
+		}
+	}, time.Second*30, time.Second*5)
+
+	// Ensure that the pod appears in the new resource tree value returned by Argo CD server
+	tree, err = appClient.ResourceTree(suite.Ctx, &application.ResourcesQuery{
+		ApplicationName: &appOnPrincipal.Name,
+		AppNamespace:    &appOnPrincipal.Namespace,
+		Project:         &appOnPrincipal.Spec.Project,
+	})
+	requires.NoError(err)
+	requires.NotNil(tree)
+
+	matchFound = false
+	for _, node := range tree.Nodes {
+		if node.Kind == "Pod" && node.Name == newPod.Name {
+			matchFound = true
+			break
+		}
+	}
+	requires.True(matchFound)
+
+}
+
+func (suite *RedisProxyTestSuite) Test_RedisProxy_AutonomousAgent_Argo() {
+	requires := suite.Require()
+
+	t := suite.T()
+
+	// Get the Argo server endpoint to use
+	argoEndpoint, err := fixture.GetArgoCDServerEndpoint(suite.PrincipalClient)
+	requires.NoError(err)
+
+	// Read admin secret from principal's cluster
+	password, err := fixture.GetInitialAdminSecret(suite.PrincipalClient)
+	requires.NoError(err)
+
+	// Create a autonomous agent application in the principal's cluster
+	appOnAutonomous := v1alpha1.Application{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-app",
+			Namespace: "argocd",
+		},
+		Spec: v1alpha1.ApplicationSpec{
+			Project: "default",
+			Source: &v1alpha1.ApplicationSource{
+				RepoURL:        "https://github.com/argoproj/argocd-example-apps",
+				TargetRevision: "HEAD",
+				Path:           "kustomize-guestbook",
+			},
+			Destination: v1alpha1.ApplicationDestination{
+				Server:    "https://kubernetes.default.svc",
+				Namespace: "guestbook",
+			},
+			SyncPolicy: &v1alpha1.SyncPolicy{
+				Automated: &v1alpha1.SyncPolicyAutomated{},
+				SyncOptions: v1alpha1.SyncOptions{
+					"CreateNamespace=true",
+				},
+			},
+		},
+	}
+
+	err = suite.AutonomousAgentClient.Create(suite.Ctx, &appOnAutonomous, metav1.CreateOptions{})
+	requires.NoError(err)
+
+	argocdClient, sessionToken, closer, err := createArgoCDAPIClient(suite.Ctx, argoEndpoint, password)
+	requires.NoError(err)
+	defer closer.Close()
+
+	closer, appClient, err := argocdClient.NewApplicationClient()
+	requires.NoError(err)
+	defer closer.Close()
+
+	// Sync the app
+	appOnPrincipal := v1alpha1.Application{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-app",
+			Namespace: "agent-autonomous",
+		},
+	}
+
+	syncAppWithAutoResync(&appOnPrincipal, appClient, &suite.BaseSuite)
+
+	cancellableContext, cancelFunc := context.WithCancel(suite.Ctx)
+	defer cancelFunc()
+
+	// Stream resource tree events for the application
+	resourceTreeURL := "https://" + argoEndpoint + "/api/v1/stream/applications/" + appOnPrincipal.Name + "/resource-tree?appNamespace=" + appOnPrincipal.Namespace
+
+	t.Log("beginning stream", time.Now())
+
+	// Wait for sucessful connection to event source
+	var msgChan chan string
+	requires.Eventually(func() bool {
+		var err error
+		msgChan, err = streamFromEventSourceNew(cancellableContext, resourceTreeURL, sessionToken, t)
+		if err != nil {
+			t.Logf("streamFromEventSource returned error: %v", err)
+			return false
+		}
+		return true
+
+	}, 5*time.Minute, 5*time.Second)
+
+	requires.NotNil(msgChan)
+
+	// Find pod of deployed Application, on autonomous cluster
+
+	var podList corev1.PodList
+	err = suite.AutonomousAgentClient.List(suite.Ctx, "guestbook", &podList, metav1.ListOptions{})
+	requires.NoError(err)
+
+	requires.True(len(podList.Items) == 1, "should only be one kustomize-guestbook pod")
+
+	// Locate guestbook pod
+	var oldPod corev1.Pod
+	for idx := range podList.Items {
+		pod := podList.Items[idx]
+		if strings.Contains(pod.Name, "kustomize-guestbook-ui") {
+			oldPod = pod
+			break
+		}
+	}
+	requires.NotEmpty(oldPod.Name)
+
+	var tree *v1alpha1.ApplicationTree
+	requires.Eventually(func() bool {
+		var err error
+		// Ensure that the pod appears in the resource tree value returned by Argo CD server
+		tree, err = appClient.ResourceTree(suite.Ctx, &application.ResourcesQuery{
+			ApplicationName: &appOnPrincipal.Name,
+			AppNamespace:    &appOnPrincipal.Namespace,
+			Project:         &appOnPrincipal.Spec.Project,
+		})
+		if err != nil {
+			t.Log(err)
+			return false
+		}
+
+		return true
+
+	}, time.Second*60, time.Second*5)
+
+	requires.NotNil(tree)
+
+	matchFound := false
+	for _, node := range tree.Nodes {
+		if node.Kind == "Pod" && node.Name == oldPod.Name {
+			matchFound = true
+			break
+		}
+	}
+	requires.True(matchFound)
+
+	t.Log("deleting pod", time.Now())
+
+	// Delete pod on managed agent cluster
+	err = suite.AutonomousAgentClient.Delete(suite.Ctx, &oldPod, metav1.DeleteOptions{})
+	requires.NoError(err)
+
+	// Wait for new pod to be created, to replace the old one that was deleted
+	var newPod corev1.Pod
+	requires.Eventually(func() bool {
+		var podList corev1.PodList
+		err = suite.AutonomousAgentClient.List(suite.Ctx, "guestbook", &podList, metav1.ListOptions{})
+		requires.NoError(err)
+
+		for idx := range podList.Items {
+			pod := podList.Items[idx]
+			if strings.Contains(pod.Name, "kustomize-guestbook-ui") && newPod.Name != oldPod.Name {
+				newPod = pod
+				break
+			}
+		}
+
+		return newPod.Name != ""
+
+	}, time.Second*30, time.Second*5)
+
+	// Verify the name of the new pod exists in what has been sent on the subscribe channel
+
+	requires.Eventually(func() bool {
+		for {
+			// drain channel looking for name of new pod
+			select {
+			case msg := <-msgChan:
+				t.Log("Processing message:", msg)
+				if strings.Contains(msg, newPod.Name) {
+					t.Log("new pod name found:", newPod.Name)
+					return true
+				}
+			default:
+				return false
+			}
+		}
+	}, time.Second*30, time.Second*5)
+
+	// Ensure that the pod appears in the new resource tree value returned by Argo CD server
+	tree, err = appClient.ResourceTree(suite.Ctx, &application.ResourcesQuery{
+		ApplicationName: &appOnPrincipal.Name,
+		AppNamespace:    &appOnPrincipal.Namespace,
+		Project:         &appOnPrincipal.Spec.Project,
+	})
+	requires.NoError(err)
+	requires.NotNil(tree)
+
+	matchFound = false
+	for _, node := range tree.Nodes {
+		if node.Kind == "Pod" && node.Name == newPod.Name {
+			matchFound = true
+			break
+		}
+	}
+	requires.True(matchFound)
+}
+
+func syncAppWithAutoResync(app *v1alpha1.Application, appClient application.ApplicationServiceClient, suite *fixture.BaseSuite) {
+
+	requires := suite.Require()
+
+	// Wait until the app is synced and healthy
+	retries := 0
+	requires.Eventually(func() bool {
+		err := suite.PrincipalClient.Get(suite.Ctx, types.NamespacedName{Namespace: app.Namespace, Name: app.Name}, app, metav1.GetOptions{})
+		if err != nil {
+			suite.T().Logf("Error on get: %v", err)
+			return false
+		}
+
+		if app.Status.Sync.Status == v1alpha1.SyncStatusCodeSynced && app.Status.Health.Status == health.HealthStatusHealthy {
+			return true
+		} else {
+			// Sometimes, the sync hangs on the workload cluster. We trigger
+			// a sync every 5th or so retry.
+			if retries > 0 && retries%5 == 0 {
+				suite.T().Logf("Triggering re-sync")
+
+				_, err := appClient.Sync(suite.Ctx, &application.ApplicationSyncRequest{
+					Name:         &app.Name,
+					AppNamespace: &app.Namespace,
+				})
+				if err != nil {
+					suite.T().Logf("Error on sync: %v", err)
+					return true
+				}
+			}
+			retries += 1
+		}
+		return false
+	}, 60*time.Second, 1*time.Second)
+
+}
+
+func createArgoCDAPIClient(ctx context.Context, argoServerEndpoint string, password string) (argocdclient.Client, string, io.Closer, error) {
+	var token string
+
+	clientOpts := &argocdclient.ClientOptions{
+		ServerAddr: argoServerEndpoint,
+		Insecure:   true,
+		AuthToken:  password,
+	}
+
+	client, err := argocdclient.NewClient(clientOpts)
+	if err != nil {
+		return nil, "", nil, fmt.Errorf("unable to create new Argo CD client: %v", err)
+	}
+
+	closer, sessionClient, err := client.NewSessionClient()
+	if err != nil {
+		return nil, "", nil, fmt.Errorf("unable to create new Argo CD session client: %v", err)
+	}
+
+	sessionResponse, err := sessionClient.Create(ctx, &sessionpkg.SessionCreateRequest{Username: "admin", Password: password})
+	if err != nil {
+		return nil, "", nil, fmt.Errorf("unable to create invoke session client: %v", err)
+	}
+	token = sessionResponse.Token
+
+	clientOpts = &argocdclient.ClientOptions{
+		ServerAddr: argoServerEndpoint,
+		Insecure:   true,
+		AuthToken:  token,
+	}
+
+	client, err = argocdclient.NewClient(clientOpts)
+	if err != nil {
+		return nil, "", nil, fmt.Errorf("unable to create new argocd client: %v", err)
+	}
+
+	return client, token, closer, nil
+
+}
+
+// streamFromEventSource connections to event source API at given URL (using given token), and sends received data back on channel
+func streamFromEventSourceNew(ctx context.Context, eventSourceAPIURL string, sessionToken string, t *testing.T) (chan string, error) {
+
+	msgChan := make(chan string)
+
+	go func() {
+
+		connect := func(client *http.Client, req *http.Request) bool {
+			resp, err := client.Do(req)
+			if err != nil {
+				t.Logf("Error performing request: %v", err)
+
+				return strings.Contains(err.Error(), "context canceled")
+			}
+
+			defer resp.Body.Close()
+
+			reader := bufio.NewReader(resp.Body)
+			for {
+				line, err := reader.ReadString('\n')
+				if err != nil {
+					t.Logf("Error reading from stream: %v", err)
+
+					return strings.Contains(err.Error(), "context canceled")
+				}
+
+				if strings.HasPrefix(line, "data:") {
+					data := strings.TrimSpace(strings.TrimPrefix(line, "data:"))
+					select {
+					case <-ctx.Done():
+						t.Log("Context is complete")
+						return true
+					default:
+						msgChan <- data
+					}
+
+				}
+			}
+		}
+
+		for {
+
+			req, err := http.NewRequest("GET", eventSourceAPIURL, nil)
+			if err != nil {
+				t.Errorf("Error creating request: %v", err)
+				return
+			}
+			req.Header.Set("Accept", "text/event-stream") // server sent event mime type
+
+			req = req.WithContext(ctx)
+
+			cookie := &http.Cookie{
+				Name:  "argocd.token",
+				Value: sessionToken, // session token
+			}
+			req.AddCookie(cookie)
+
+			tr := &http.Transport{
+				TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+			}
+			client := &http.Client{Transport: tr}
+
+			contextCancelled := connect(client, req)
+
+			if contextCancelled {
+				t.Log("context cancelled on event source stream")
+				return
+			} else {
+				time.Sleep(250 * time.Millisecond)
+			}
+		}
+
+	}()
+
+	return msgChan, nil
+}
+
+// streamFromEventSource connections to event source API at given URL (using given token), and sends received data back on channel
+// func streamFromEventSourceOld(ctx context.Context, eventSourceAPIURL string, sessionToken string, t *testing.T) (chan string, error) {
+
+// 	msgChan := make(chan string)
+
+// 	req, err := http.NewRequest("GET", eventSourceAPIURL, nil)
+// 	if err != nil {
+// 		t.Logf("Error creating request: %v", err)
+// 		return nil, fmt.Errorf("error creating request: %v", err)
+// 	}
+// 	req.Header.Set("Accept", "text/event-stream") // server sent event mime type
+
+// 	req = req.WithContext(ctx)
+
+// 	cookie := &http.Cookie{
+// 		Name:  "argocd.token",
+// 		Value: sessionToken, // session token
+// 	}
+// 	req.AddCookie(cookie)
+
+// 	tr := &http.Transport{
+// 		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+// 	}
+// 	client := &http.Client{Transport: tr}
+
+// 	go func() {
+// 		resp, err := client.Do(req)
+// 		if err != nil {
+// 			t.Logf("Error performing request: %v", err)
+// 			return
+// 		}
+
+// 		defer resp.Body.Close()
+
+// 		reader := bufio.NewReader(resp.Body)
+// 		for {
+// 			line, err := reader.ReadString('\n')
+// 			if err != nil {
+// 				t.Logf("Error reading from stream: %v", err)
+// 				return
+// 			}
+
+// 			if strings.HasPrefix(line, "data:") {
+// 				data := strings.TrimSpace(strings.TrimPrefix(line, "data:"))
+// 				select {
+// 				case <-ctx.Done():
+// 					t.Log("Context is complete")
+// 					return
+// 				default:
+// 					msgChan <- data
+// 				}
+
+// 			}
+// 		}
+
+// 	}()
+
+// 	return msgChan, nil
+// }
+
+func TestRedisProxyTestSuite(t *testing.T) {
+	suite.Run(t, new(RedisProxyTestSuite))
+}


### PR DESCRIPTION
**What does this PR do / why we need it**:

Implementation TL;DR:
- Principal agent now contains a redis proxy, which acts as an intermediary/broker for redis traffic.
- Principal Argo CD connects to principal redis proxy, rather than directly to Principal Argo CD Redis.
- Principal agent listens and reads for traffic on redis port:
	- If redis commands `subscribe`, or `get` are received from principal Argo CD:
		- AND those commands are subscribe/get specifically for an argo agent, then redirect message to agent via event message
		- Otherwise, forward to principal redis (and return response to Argo CD)
	- For all other redis commands, forward it to principal redis (and return response to Argo CD)
- Agents running on agent clusters will receive redis messages from principal, see above.
	- These will be either get or subscribe messages.
- These messages are forwarded to agent redis, and the response returns back through agent event machinery

Notes:
- I cloned `principal/resourceproxy/tracking.go` into a new package, `principal/tracking`.
	- This tracking functionality is useful for tracking redis sync calls as well.
	- I think we should refactor resourceproxy to use `principal/tracking` (since it's the same API), and delete the original file, but I've left that out of this PR to reduce merge friction.
	- Happy to do it as part of a separate PR, presuming you all agree.
- More info on Redis wire protocol is [here](https://redis.io/docs/latest/develop/reference/protocol-spec/#sets)
- I had to disable parallel running of go tests for `make test`: 
    - Why? There are now multiple separate packages that call `(principal) Server.Start()`, which listens on Redis port, which causes 'port already in use' errors. (`pkg/client/remote_test.go` and `principal/listen_test.go`).


**Which issue(s) this PR fixes**:

Fixes #344

**How to test changes / Special notes to the reviewer**:


**Checklist**

* [ ] Documentation update is required by this PR (and has been updated) OR no documentation update is required.

