### PR TITLE
fix: Make volume mounts optional for agent and principal deployments

### DIFF
--- a/install/kubernetes/agent/agent-deployment.yaml
+++ b/install/kubernetes/agent/agent-deployment.yaml
@@ -125,3 +125,4 @@ spec:
           items:
           - key: credentials
             path: userpass.creds
+          optional: true

--- a/install/kubernetes/principal/principal-deployment.yaml
+++ b/install/kubernetes/principal/principal-deployment.yaml
@@ -208,9 +208,11 @@ spec:
           items:
           - key: passwd
             path: passwd
+          optional: true
       - name: jwt-secret
         secret:
           secretName: argocd-agent-jwt
           items:
           - key: jwt.key
             path: jwt.key
+          optional: true


### PR DESCRIPTION
**What does this PR do / why we need it**:

The agent and the principal both can read credentials from a file. For the pods, we mount these files from a secret.

However, this has changed from being mandatory to optional, since both can read directly from Kubernetes secrets now. For this reason, the volume mounts will now be optional, too.

**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:


**Checklist**

* [ ] Documentation update is required by this PR (and has been updated) OR no documentation update is required.

