### PR TITLE
feat: CLI command to propagate CA cert to agents

### DIFF
--- a/internal/config/constants.go
+++ b/internal/config/constants.go
@@ -8,6 +8,10 @@ package config
 // configuration for the principal's Certificate Authority
 const SecretNamePrincipalCA = "argocd-agent-ca"
 
+// SecretNameAgentCA is the name of the secret containing the TLS
+// configuration for the agent's Certificate Authority
+const SecretNameAgentCA = "argocd-agent-ca"
+
 // SecretNamePrincipalTLS is the name of the secret containing the TLS
 // configuration for the principal's gRPC service.
 const SecretNamePrincipalTLS = "argocd-agent-principal-tls"


### PR DESCRIPTION
**What does this PR do / why we need it**:

Adds a new CLI command `pki propagate` that propagates the principal's PKI CA certificate to the specified agent.

This will ease setup for people testing out the agent.

**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:

1. Initialize a new PKI for the principal: `argocd-agentctl pki init --principal-context vcluster-control-plane`
2. Propagate CA certificate to agent: `argocd-agentctl pki propagate --principal-context vcluster-control-plane --agent-context vcluster-agent-managed`
3. Check that secret `argocd-agent-ca` has been created in `vcluster-agent-managed` context's namespace `argocd` (by default) and that the field `ca.crt` holds the principal's PKI CA certificate.

**Checklist**

* [ ] Documentation update is required by this PR (and has been updated) OR no documentation update is required.

