### PR TITLE
fix(cli): Allow DNS names for resource proxy host in agent config

### DIFF
--- a/cmd/ctl/agent.go
+++ b/cmd/ctl/agent.go
@@ -443,7 +443,7 @@ func serverURL(address, agentName string) (string, error) {
 		}
 		addr := tok[0]
 		port := tok[1]
-		if len(validation.NameIsDNSLabel(addr, false)) > 0 {
+		if len(validation.NameIsDNSSubdomain(addr, false)) > 0 {
 			return "", fmt.Errorf("invalid address: %s", address)
 		}
 		if _, err := strconv.ParseUint(port, 10, 16); err != nil {

--- a/cmd/ctl/agent.go
+++ b/cmd/ctl/agent.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"net/netip"
 	"os"
+	"strconv"
 	"strings"
 	"syscall"
 	"text/tabwriter"
@@ -42,6 +43,7 @@ import (
 	"gopkg.in/yaml.v3"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/validation"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -434,7 +436,19 @@ func clusterSecretName(agentName string) string {
 func serverURL(address, agentName string) (string, error) {
 	_, err := netip.ParseAddrPort(address)
 	if err != nil {
-		return "", err
+		// We now have a host:port address, so we need to validate the host
+		tok := strings.SplitN(address, ":", 2)
+		if len(tok) != 2 {
+			return "", fmt.Errorf("invalid address: %s", address)
+		}
+		addr := tok[0]
+		port := tok[1]
+		if len(validation.NameIsDNSLabel(addr, false)) > 0 {
+			return "", fmt.Errorf("invalid address: %s", address)
+		}
+		if _, err := strconv.ParseUint(port, 10, 16); err != nil {
+			return "", fmt.Errorf("invalid port: %s", port)
+		}
 	}
 	if !session.IsValidClientID(agentName) {
 		return "", fmt.Errorf("invalid agent name")

--- a/cmd/ctl/agent_test.go
+++ b/cmd/ctl/agent_test.go
@@ -1,0 +1,243 @@
+// Copyright 2025 The argocd-agent Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_serverURL(t *testing.T) {
+	testCases := []struct {
+		name        string
+		address     string
+		agentName   string
+		expected    string
+		expectError bool
+		errorMsg    string
+	}{
+		// Valid IP:port addresses
+		{
+			name:      "valid IPv4 address with port",
+			address:   "192.168.1.100:8080",
+			agentName: "test-agent",
+			expected:  "https://192.168.1.100:8080?agentName=test-agent",
+		},
+		{
+			name:      "valid IPv6 address with port",
+			address:   "[::1]:8080",
+			agentName: "test-agent",
+			expected:  "https://[::1]:8080?agentName=test-agent",
+		},
+		{
+			name:      "valid localhost IP with port",
+			address:   "127.0.0.1:9090",
+			agentName: "my-agent",
+			expected:  "https://127.0.0.1:9090?agentName=my-agent",
+		},
+
+		// Valid DNS names with ports
+		{
+			name:      "valid DNS name with port",
+			address:   "example.com:8080",
+			agentName: "test-agent",
+			expected:  "https://example.com:8080?agentName=test-agent",
+		},
+		{
+			name:      "valid subdomain with port",
+			address:   "api.example.com:443",
+			agentName: "prod-agent",
+			expected:  "https://api.example.com:443?agentName=prod-agent",
+		},
+		{
+			name:      "valid localhost DNS with port",
+			address:   "localhost:8080",
+			agentName: "dev-agent",
+			expected:  "https://localhost:8080?agentName=dev-agent",
+		},
+
+		// Valid agent names
+		{
+			name:      "agent name with hyphens",
+			address:   "192.168.1.100:8080",
+			agentName: "test-agent-123",
+			expected:  "https://192.168.1.100:8080?agentName=test-agent-123",
+		},
+		{
+			name:      "agent name with dots",
+			address:   "192.168.1.100:8080",
+			agentName: "test.agent.name",
+			expected:  "https://192.168.1.100:8080?agentName=test.agent.name",
+		},
+		{
+			name:      "numeric agent name",
+			address:   "192.168.1.100:8080",
+			agentName: "123",
+			expected:  "https://192.168.1.100:8080?agentName=123",
+		},
+
+		// Invalid addresses - missing port
+		{
+			name:        "address without port",
+			address:     "192.168.1.100",
+			agentName:   "test-agent",
+			expectError: true,
+			errorMsg:    "invalid address: 192.168.1.100",
+		},
+		{
+			name:        "DNS name without port",
+			address:     "example.com",
+			agentName:   "test-agent",
+			expectError: true,
+			errorMsg:    "invalid address: example.com",
+		},
+
+		// Invalid addresses - invalid port
+		{
+			name:        "invalid port - too large",
+			address:     "192.168.1.100:70000",
+			agentName:   "test-agent",
+			expectError: true,
+			errorMsg:    "invalid port: 70000",
+		},
+		{
+			name:        "invalid port - negative",
+			address:     "192.168.1.100:-1",
+			agentName:   "test-agent",
+			expectError: true,
+			errorMsg:    "invalid port: -1",
+		},
+		{
+			name:        "invalid port - non-numeric",
+			address:     "192.168.1.100:abc",
+			agentName:   "test-agent",
+			expectError: true,
+			errorMsg:    "invalid port: abc",
+		},
+		{
+			name:      "valid port zero",
+			address:   "192.168.1.100:0",
+			agentName: "test-agent",
+			expected:  "https://192.168.1.100:0?agentName=test-agent",
+		},
+
+		// Invalid addresses - malformed DNS
+		{
+			name:        "invalid DNS with underscore",
+			address:     "invalid_host:8080",
+			agentName:   "test-agent",
+			expectError: true,
+			errorMsg:    "invalid address: invalid_host:8080",
+		},
+		{
+			name:        "invalid DNS with spaces",
+			address:     "invalid host:8080",
+			agentName:   "test-agent",
+			expectError: true,
+			errorMsg:    "invalid address: invalid host:8080",
+		},
+		{
+			name:        "empty address",
+			address:     "",
+			agentName:   "test-agent",
+			expectError: true,
+			errorMsg:    "invalid address: ",
+		},
+
+		// Invalid agent names
+		{
+			name:        "empty agent name",
+			address:     "192.168.1.100:8080",
+			agentName:   "",
+			expectError: true,
+			errorMsg:    "invalid agent name",
+		},
+		{
+			name:        "agent name with underscores",
+			address:     "192.168.1.100:8080",
+			agentName:   "test_agent",
+			expectError: true,
+			errorMsg:    "invalid agent name",
+		},
+		{
+			name:        "agent name with spaces",
+			address:     "192.168.1.100:8080",
+			agentName:   "test agent",
+			expectError: true,
+			errorMsg:    "invalid agent name",
+		},
+		{
+			name:        "agent name with uppercase",
+			address:     "192.168.1.100:8080",
+			agentName:   "TestAgent",
+			expectError: true,
+			errorMsg:    "invalid agent name",
+		},
+		{
+			name:        "agent name starting with hyphen",
+			address:     "192.168.1.100:8080",
+			agentName:   "-test-agent",
+			expectError: true,
+			errorMsg:    "invalid agent name",
+		},
+		{
+			name:        "agent name ending with hyphen",
+			address:     "192.168.1.100:8080",
+			agentName:   "test-agent-",
+			expectError: true,
+			errorMsg:    "invalid agent name",
+		},
+		{
+			name:        "agent name too long",
+			address:     "192.168.1.100:8080",
+			agentName:   "a" + string(make([]byte, 255)), // 256 characters
+			expectError: true,
+			errorMsg:    "invalid agent name",
+		},
+
+		// Edge cases
+		{
+			name:        "colon in address without port",
+			address:     "192.168.1.100:",
+			agentName:   "test-agent",
+			expectError: true,
+			errorMsg:    "invalid port: ",
+		},
+		{
+			name:        "multiple colons in address",
+			address:     "192.168.1.100:8080:extra",
+			agentName:   "test-agent",
+			expectError: true,
+			errorMsg:    "invalid port: 8080:extra",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result, err := serverURL(tc.address, tc.agentName)
+
+			if tc.expectError {
+				require.Error(t, err, "Expected error for test case: %s", tc.name)
+				assert.Contains(t, err.Error(), tc.errorMsg, "Error message should contain expected text")
+				assert.Empty(t, result, "Result should be empty when error occurs")
+			} else {
+				require.NoError(t, err, "Expected no error for test case: %s", tc.name)
+				assert.Equal(t, tc.expected, result, "Result should match expected URL")
+			}
+		})
+	}
+}


### PR DESCRIPTION
**What does this PR do / why we need it**:

The `agent create` command of the `argocd-agentctl` CLI takes a `--resource-proxy-server` parameter to specify the location of the resource server. The value given is validated, and needed to be a valid IP address and port combination. However, in the cluster, the hostname is most likely to be specified as DNS name, i.e. the name of the service of the resource proxy's endpoint.

**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:

Create an agent configuration that points the RP to a DNS name, e.g.

```
argocd-agentctl agent create --resource-proxy-server resource-proxy:9090 agent-test
```

**Checklist**

* [ ] Documentation update is required by this PR (and has been updated) OR no documentation update is required.

