### PR TITLE
feat: Helm chart for installation

### DIFF
--- a/charts/README.md
+++ b/charts/README.md
@@ -1,0 +1,200 @@
+# ArgoCD Agent Helm Charts
+
+This directory contains Helm charts for deploying the ArgoCD Agent components:
+
+- `argocd-agent-principal` - The principal component that manages agent connections
+- `argocd-agent-agent` - The agent component that runs on remote clusters
+
+## Prerequisites
+
+- Kubernetes cluster
+- Helm 3.0+
+- ArgoCD running in the cluster (for the principal)
+
+## Installation
+
+### Installing the Principal
+
+The principal should be installed in the same cluster as ArgoCD:
+
+```bash
+helm install argocd-agent-principal ./argocd-agent-principal \
+  --namespace argocd \
+  --create-namespace
+```
+
+### Installing the Agent
+
+The agent should be installed in remote clusters that will be managed by ArgoCD:
+
+```bash
+helm install argocd-agent-agent ./argocd-agent-agent \
+  --namespace argocd \
+  --create-namespace \
+  --set agent.server.address=<principal-server-address>
+```
+
+## Configuration
+
+### Principal Configuration
+
+Key configuration options for the principal:
+
+```yaml
+principal:
+  # Network configuration
+  listenHost: ""
+  listenPort: "8443"
+  
+  # ArgoCD namespace management
+  namespace: "argocd"
+  allowedNamespaces: ""
+  
+  # TLS configuration
+  tls:
+    secretName: "argocd-agent-principal-tls"
+    server:
+      allowGenerate: "false"  # Set to "true" for development only
+    clientCert:
+      require: "false"
+  
+  # Authentication
+  auth: "userpass:/app/config/userpass/passwd"
+```
+
+### Agent Configuration
+
+Key configuration options for the agent:
+
+```yaml
+agent:
+  # Operation mode
+  mode: "autonomous"
+  
+  # Server connection
+  server:
+    address: "argocd-agent-principal.example.com"
+    port: "443"
+  
+  # TLS configuration
+  tls:
+    clientInsecure: "false"  # Set to "true" for development only
+    rootCaSecretName: "argocd-agent-ca"
+    secretName: "argocd-agent-client-tls"
+  
+  # Authentication
+  creds: "userpass:/app/config/creds/userpass.creds"
+```
+
+## TLS Certificate Management
+
+Both components require TLS certificates for secure communication:
+
+### Principal Certificates
+
+- `argocd-agent-principal-tls` - Server certificate for the principal
+- `argocd-agent-ca` - CA certificate for validating agent connections
+- `argocd-agent-jwt` - JWT signing key
+
+### Agent Certificates
+
+- `argocd-agent-client-tls` - Client certificate for agent authentication
+- `argocd-agent-ca` - CA certificate for validating the principal
+
+### Development Setup
+
+For development and testing, you can enable certificate generation:
+
+```yaml
+# Principal values
+principal:
+  tls:
+    server:
+      allowGenerate: "true"
+  jwt:
+    allowGenerate: "true"
+
+# Agent values
+agent:
+  tls:
+    clientInsecure: "true"
+```
+
+## Authentication
+
+### Username/Password Authentication
+
+Create secrets for authentication:
+
+```bash
+# Principal userpass secret
+kubectl create secret generic argocd-agent-principal-userpass \
+  --from-literal=passwd=<encrypted-password-file> \
+  --namespace argocd
+
+# Agent userpass secret
+kubectl create secret generic <release-name>-argocd-agent-agent-userpass \
+  --from-literal=credentials=<encrypted-credentials-file> \
+  --namespace argocd
+```
+
+### Mutual TLS Authentication
+
+For mTLS authentication, configure the principal to require client certificates:
+
+```yaml
+principal:
+  tls:
+    clientCert:
+      require: "true"
+      matchSubject: "true"
+  auth: "mtls:CN=(.+)"
+```
+
+## Monitoring
+
+Both charts expose metrics endpoints:
+
+- Principal: Port 8000
+- Agent: Port 8181
+
+Metrics services are created automatically and can be scraped by Prometheus.
+
+## Upgrading
+
+To upgrade the charts:
+
+```bash
+helm upgrade argocd-agent-principal ./argocd-agent-principal
+helm upgrade argocd-agent-agent ./argocd-agent-agent
+```
+
+## Uninstallation
+
+To remove the components:
+
+```bash
+helm uninstall argocd-agent-principal
+helm uninstall argocd-agent-agent
+```
+
+## Troubleshooting
+
+### Common Issues
+
+1. **Connection Issues**: Verify network connectivity and TLS certificates
+2. **Authentication Failures**: Check secret creation and credential formats
+3. **Permission Errors**: Verify RBAC permissions and service account configuration
+
+### Logs
+
+Check component logs:
+
+```bash
+kubectl logs -n argocd deployment/argocd-agent-principal
+kubectl logs -n argocd deployment/argocd-agent-agent
+```
+
+## Values Reference
+
+See the `values.yaml` files in each chart directory for complete configuration options. 

--- a/charts/argocd-agent-agent/Chart.yaml
+++ b/charts/argocd-agent-agent/Chart.yaml
@@ -1,0 +1,14 @@
+apiVersion: v2
+name: argocd-agent-agent
+description: A Helm chart for ArgoCD Agent
+type: application
+version: 0.1.0
+appVersion: "latest"
+home: https://github.com/argoproj-labs/argocd-agent
+keywords:
+  - argocd
+  - agent
+  - kubernetes
+maintainers:
+  - name: ArgoProj Labs
+    url: https://github.com/argoproj-labs 

--- a/charts/argocd-agent-agent/templates/_helpers.tpl
+++ b/charts/argocd-agent-agent/templates/_helpers.tpl
@@ -1,0 +1,75 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "argocd-agent-agent.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "argocd-agent-agent.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "argocd-agent-agent.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "argocd-agent-agent.labels" -}}
+helm.sh/chart: {{ include "argocd-agent-agent.chart" . }}
+{{ include "argocd-agent-agent.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "argocd-agent-agent.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "argocd-agent-agent.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/part-of: argocd-agent
+app.kubernetes.io/component: agent
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "argocd-agent-agent.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "argocd-agent-agent.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create the namespace to use
+*/}}
+{{- define "argocd-agent-agent.namespace" -}}
+{{- if .Values.namespaceOverride }}
+{{- .Values.namespaceOverride }}
+{{- else }}
+{{- .Release.Namespace }}
+{{- end }}
+{{- end }} 

--- a/charts/argocd-agent-agent/templates/clusterrole.yaml
+++ b/charts/argocd-agent-agent/templates/clusterrole.yaml
@@ -1,0 +1,21 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "argocd-agent-agent.fullname" . }}
+  labels:
+    {{- include "argocd-agent-agent.labels" . | nindent 4 }}
+rules:
+- apiGroups:
+  - argoproj.io
+  resources:
+  - applications
+  - applicationsets
+  - appprojects
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete 

--- a/charts/argocd-agent-agent/templates/clusterrolebinding.yaml
+++ b/charts/argocd-agent-agent/templates/clusterrolebinding.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "argocd-agent-agent.fullname" . }}
+  labels:
+    {{- include "argocd-agent-agent.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "argocd-agent-agent.fullname" . }}
+subjects:
+- kind: ServiceAccount
+  name: {{ include "argocd-agent-agent.serviceAccountName" . }}
+  namespace: {{ include "argocd-agent-agent.namespace" . }} 

--- a/charts/argocd-agent-agent/templates/configmap.yaml
+++ b/charts/argocd-agent-agent/templates/configmap.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "argocd-agent-agent.fullname" . }}-params
+  namespace: {{ include "argocd-agent-agent.namespace" . }}
+  labels:
+    {{- include "argocd-agent-agent.labels" . | nindent 4 }}
+data:
+  agent.mode: {{ .Values.agent.mode | quote }}
+  agent.creds: {{ .Values.agent.creds | quote }}
+  agent.tls.client.insecure: {{ .Values.agent.tls.clientInsecure | quote }}
+  agent.tls.root-ca-secret-name: {{ .Values.agent.tls.rootCaSecretName | quote }}
+  agent.tls.root-ca-path: {{ .Values.agent.tls.rootCaPath | quote }}
+  agent.tls.secret-name: {{ .Values.agent.tls.secretName | quote }}
+  agent.tls.client.cert-path: {{ .Values.agent.tls.client.certPath | quote }}
+  agent.tls.client.key-path: {{ .Values.agent.tls.client.keyPath | quote }}
+  agent.log.level: {{ .Values.agent.logLevel | quote }}
+  agent.namespace: {{ .Values.agent.namespace | quote }}
+  agent.server.address: {{ .Values.agent.server.address | quote }}
+  agent.server.port: {{ .Values.agent.server.port | quote }}
+  agent.metrics.port: {{ .Values.agent.metricsPort | quote }} 

--- a/charts/argocd-agent-agent/templates/deployment.yaml
+++ b/charts/argocd-agent-agent/templates/deployment.yaml
@@ -1,0 +1,166 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "argocd-agent-agent.fullname" . }}
+  namespace: {{ include "argocd-agent-agent.namespace" . }}
+  labels:
+    {{- include "argocd-agent-agent.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "argocd-agent-agent.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "argocd-agent-agent.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "argocd-agent-agent.serviceAccountName" . }}
+      containers:
+        - name: {{ .Chart.Name }}
+          args:
+            - agent
+          env:
+          - name: ARGOCD_AGENT_REMOTE_SERVER
+            valueFrom:
+              configMapKeyRef:
+                name: {{ include "argocd-agent-agent.fullname" . }}-params
+                key: agent.server.address
+                optional: true
+          - name: ARGOCD_AGENT_REMOTE_PORT
+            valueFrom:
+              configMapKeyRef:
+                name: {{ include "argocd-agent-agent.fullname" . }}-params
+                key: agent.server.port
+                optional: true
+          - name: ARGOCD_AGENT_LOG_LEVEL
+            valueFrom:
+              configMapKeyRef:
+                name: {{ include "argocd-agent-agent.fullname" . }}-params
+                key: agent.log.level
+                optional: true
+          - name: ARGOCD_AGENT_NAMESPACE
+            valueFrom:
+              configMapKeyRef:
+                name: {{ include "argocd-agent-agent.fullname" . }}-params
+                key: agent.namespace
+                optional: true
+          - name: ARGOCD_AGENT_TLS_SECRET_NAME
+            valueFrom:
+              configMapKeyRef:
+                name: {{ include "argocd-agent-agent.fullname" . }}-params
+                key: agent.tls.secret-name
+                optional: true
+          - name: ARGOCD_AGENT_TLS_CLIENT_CERT_PATH
+            valueFrom:
+              configMapKeyRef:
+                name: {{ include "argocd-agent-agent.fullname" . }}-params
+                key: agent.tls.client.cert-path
+                optional: true
+          - name: ARGOCD_AGENT_TLS_CLIENT_KEY_PATH
+            valueFrom:
+              configMapKeyRef:
+                name: {{ include "argocd-agent-agent.fullname" . }}-params
+                key: agent.tls.client.key-path
+                optional: true
+          - name: ARGOCD_AGENT_TLS_INSECURE
+            valueFrom:
+              configMapKeyRef:
+                name: {{ include "argocd-agent-agent.fullname" . }}-params
+                key: agent.tls.client.insecure
+                optional: true
+          - name: ARGOCD_AGENT_TLS_ROOT_CA_SECRET_NAME
+            valueFrom:
+              configMapKeyRef:
+                name: {{ include "argocd-agent-agent.fullname" . }}-params
+                key: agent.tls.root-ca-secret-name
+                optional: true
+          - name: ARGOCD_AGENT_TLS_ROOT_CA_PATH
+            valueFrom:
+              configMapKeyRef:
+                name: {{ include "argocd-agent-agent.fullname" . }}-params
+                key: agent.tls.root-ca-path
+                optional: true
+          - name: ARGOCD_AGENT_MODE
+            valueFrom:
+              configMapKeyRef:
+                name: {{ include "argocd-agent-agent.fullname" . }}-params
+                key: agent.mode
+                optional: true
+          - name: ARGOCD_AGENT_CREDS
+            valueFrom:
+              configMapKeyRef:
+                name: {{ include "argocd-agent-agent.fullname" . }}-params
+                key: agent.creds
+                optional: true
+          - name: ARGOCD_AGENT_METRICS_PORT
+            valueFrom:
+              configMapKeyRef:
+                name: {{ include "argocd-agent-agent.fullname" . }}-params
+                key: agent.metrics.port
+                optional: true
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: metrics
+              containerPort: 8000
+              protocol: TCP
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: userpass-passwd
+              mountPath: /app/config/creds
+            - name: client-tls
+              mountPath: /app/config/tls
+            - name: ca-cert
+              mountPath: /app/config/ca
+      volumes:
+      - name: userpass-passwd
+        secret:
+          secretName: {{ include "argocd-agent-agent.fullname" . }}-userpass
+          items:
+          - key: credentials
+            path: userpass.creds
+          optional: true
+      - name: client-tls
+        secret:
+          secretName: {{ .Values.agent.tls.secretName }}
+          items:
+          - key: tls.crt
+            path: tls.crt
+          - key: tls.key
+            path: tls.key
+          optional: true
+      - name: ca-cert
+        secret:
+          secretName: {{ .Values.agent.tls.rootCaSecretName }}
+          items:
+          - key: ca.crt
+            path: ca.crt
+          optional: true
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }} 

--- a/charts/argocd-agent-agent/templates/metrics-service.yaml
+++ b/charts/argocd-agent-agent/templates/metrics-service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "argocd-agent-agent.fullname" . }}-metrics
+  namespace: {{ include "argocd-agent-agent.namespace" . }}
+  labels:
+    {{- include "argocd-agent-agent.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.metricsService.type }}
+  ports:
+    - port: {{ .Values.metricsService.port }}
+      targetPort: metrics
+      protocol: TCP
+      name: metrics
+  selector:
+    {{- include "argocd-agent-agent.selectorLabels" . | nindent 4 }} 

--- a/charts/argocd-agent-agent/templates/role.yaml
+++ b/charts/argocd-agent-agent/templates/role.yaml
@@ -1,0 +1,72 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "argocd-agent-agent.fullname" . }}
+  namespace: {{ include "argocd-agent-agent.namespace" . }}
+  labels:
+    {{- include "argocd-agent-agent.labels" . | nindent 4 }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete 

--- a/charts/argocd-agent-agent/templates/rolebinding.yaml
+++ b/charts/argocd-agent-agent/templates/rolebinding.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "argocd-agent-agent.fullname" . }}
+  namespace: {{ include "argocd-agent-agent.namespace" . }}
+  labels:
+    {{- include "argocd-agent-agent.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "argocd-agent-agent.fullname" . }}
+subjects:
+- kind: ServiceAccount
+  name: {{ include "argocd-agent-agent.serviceAccountName" . }}
+  namespace: {{ include "argocd-agent-agent.namespace" . }} 

--- a/charts/argocd-agent-agent/templates/serviceaccount.yaml
+++ b/charts/argocd-agent-agent/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "argocd-agent-agent.serviceAccountName" . }}
+  namespace: {{ include "argocd-agent-agent.namespace" . }}
+  labels:
+    {{- include "argocd-agent-agent.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }} 

--- a/charts/argocd-agent-agent/values.yaml
+++ b/charts/argocd-agent-agent/values.yaml
@@ -1,0 +1,94 @@
+# Default values for argocd-agent-agent
+# This is a YAML-formatted file.
+
+# Image configuration
+image:
+  repository: ghcr.io/argoproj-labs/argocd-agent/argocd-agent
+  pullPolicy: Always
+  tag: "latest"
+
+# Replica count
+replicaCount: 1
+
+# ServiceAccount configuration
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+# Pod annotations
+podAnnotations: {}
+
+# Pod security context
+podSecurityContext: {}
+
+# Container security context
+securityContext:
+  capabilities:
+    drop:
+    - ALL
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  runAsNonRoot: true
+  seccompProfile:
+    type: RuntimeDefault
+
+# Metrics service configuration
+metricsService:
+  type: ClusterIP
+  port: 8000
+
+# Agent configuration parameters
+agent:
+  # The mode this agent should operate in. Valid values are "autonomous" or "managed".
+  mode: "autonomous"
+  # Valid credential identifier for this agent.
+  creds: "userpass:/app/config/creds/userpass.creds"
+  # The log level the agent should use. Valid values are trace, debug, info, warn and error.
+  logLevel: "info"
+  # The namespace the agent should operate and manage the Argo CD resources in.
+  namespace: "argocd"
+  # The port the metrics server should listen on.
+  metricsPort: "8181"
+  
+  # Server configuration
+  server:
+    # The remote address of the principal to connect to. Can be a DNS name, an IPv4 address or an IPv6 address.
+    address: "argocd-agent-principal.example.com"
+    # The remote port of the principal to connect to.
+    port: "443"
+  
+  # TLS configuration
+  tls:
+    # Whether to skip the validation of the remote TLS credentials. Insecure. Do only use for development purposes.
+    clientInsecure: "false"
+    # The name of the secret containing the certificates for the TLS root certificate authority used to validate the remote principal.
+    rootCaSecretName: "argocd-agent-ca"
+    # The path to a file containing the certificates for the TLS root certificate authority used to validate the remote principal.
+    rootCaPath: ""
+    # The name of the secret containing the agent certificate.
+    secretName: "argocd-agent-client-tls"
+    client:
+      # Path to a file containing the agent's TLS client certificate.
+      certPath: ""
+      # Path to a file containing the agent's TLS client private key.
+      keyPath: ""
+
+# Resources configuration
+resources: {}
+
+# Node selector
+nodeSelector: {}
+
+# Tolerations
+tolerations: []
+
+# Affinity
+affinity: {}
+
+# Namespace where the chart will be deployed
+namespaceOverride: "" 

--- a/charts/argocd-agent-principal/Chart.yaml
+++ b/charts/argocd-agent-principal/Chart.yaml
@@ -1,0 +1,15 @@
+apiVersion: v2
+name: argocd-agent-principal
+description: A Helm chart for ArgoCD Agent Principal
+type: application
+version: 0.1.0
+appVersion: "latest"
+home: https://github.com/argoproj-labs/argocd-agent
+keywords:
+  - argocd
+  - agent
+  - principal
+  - kubernetes
+maintainers:
+  - name: ArgoProj Labs
+    url: https://github.com/argoproj-labs 

--- a/charts/argocd-agent-principal/templates/_helpers.tpl
+++ b/charts/argocd-agent-principal/templates/_helpers.tpl
@@ -1,0 +1,75 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "argocd-agent-principal.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "argocd-agent-principal.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "argocd-agent-principal.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "argocd-agent-principal.labels" -}}
+helm.sh/chart: {{ include "argocd-agent-principal.chart" . }}
+{{ include "argocd-agent-principal.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "argocd-agent-principal.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "argocd-agent-principal.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/part-of: argocd-agent
+app.kubernetes.io/component: principal
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "argocd-agent-principal.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "argocd-agent-principal.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create the namespace to use
+*/}}
+{{- define "argocd-agent-principal.namespace" -}}
+{{- if .Values.namespaceOverride }}
+{{- .Values.namespaceOverride }}
+{{- else }}
+{{- .Release.Namespace }}
+{{- end }}
+{{- end }} 

--- a/charts/argocd-agent-principal/templates/clusterrole.yaml
+++ b/charts/argocd-agent-principal/templates/clusterrole.yaml
@@ -1,0 +1,28 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "argocd-agent-principal.fullname" . }}
+  labels:
+    {{- include "argocd-agent-principal.labels" . | nindent 4 }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+- apiGroups:
+  - argoproj.io
+  resources:
+  - applications
+  - applicationsets
+  - appprojects
+  verbs:
+  - get
+  - list
+  - watch 

--- a/charts/argocd-agent-principal/templates/clusterrolebinding.yaml
+++ b/charts/argocd-agent-principal/templates/clusterrolebinding.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "argocd-agent-principal.fullname" . }}
+  labels:
+    {{- include "argocd-agent-principal.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "argocd-agent-principal.fullname" . }}
+subjects:
+- kind: ServiceAccount
+  name: {{ include "argocd-agent-principal.serviceAccountName" . }}
+  namespace: {{ include "argocd-agent-principal.namespace" . }} 

--- a/charts/argocd-agent-principal/templates/configmap.yaml
+++ b/charts/argocd-agent-principal/templates/configmap.yaml
@@ -1,0 +1,34 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "argocd-agent-principal.fullname" . }}-params
+  namespace: {{ include "argocd-agent-principal.namespace" . }}
+  labels:
+    {{- include "argocd-agent-principal.labels" . | nindent 4 }}
+data:
+  principal.listen.host: {{ .Values.principal.listenHost | quote }}
+  principal.listen.port: {{ .Values.principal.listenPort | quote }}
+  principal.log.level: {{ .Values.principal.logLevel | quote }}
+  principal.metrics.port: {{ .Values.principal.metricsPort | quote }}
+  principal.namespace: {{ .Values.principal.namespace | quote }}
+  principal.allowed-namespaces: {{ .Values.principal.allowedNamespaces | quote }}
+  principal.namespace-create.enable: {{ .Values.principal.namespaceCreate.enable | quote }}
+  principal.namespace-create.pattern: {{ .Values.principal.namespaceCreate.pattern | quote }}
+  principal.namespace-create.labels: {{ .Values.principal.namespaceCreate.labels | quote }}
+  principal.tls.secret-name: {{ .Values.principal.tls.secretName | quote }}
+  principal.tls.server.cert-path: {{ .Values.principal.tls.server.certPath | quote }}
+  principal.tls.server.key-path: {{ .Values.principal.tls.server.keyPath | quote }}
+  principal.tls.server.allow-generate: {{ .Values.principal.tls.server.allowGenerate | quote }}
+  principal.tls.client-cert.require: {{ .Values.principal.tls.clientCert.require | quote }}
+  principal.tls.server.root-ca-secret-name: {{ .Values.principal.tls.server.rootCaSecretName | quote }}
+  principal.tls.server.root-ca-path: {{ .Values.principal.tls.server.rootCaPath | quote }}
+  principal.tls.client-cert.match-subject: {{ .Values.principal.tls.clientCert.matchSubject | quote }}
+  principal.resource-proxy.secret-name: {{ .Values.principal.resourceProxy.secretName | quote }}
+  principal.resource-proxy.tls.cert-path: {{ .Values.principal.resourceProxy.tls.certPath | quote }}
+  principal.resource-proxy.tls.key-path: {{ .Values.principal.resourceProxy.tls.keyPath | quote }}
+  principal.resource-proxy.ca.secret-name: {{ .Values.principal.resourceProxy.ca.secretName | quote }}
+  principal.resource-proxy.ca.path: {{ .Values.principal.resourceProxy.ca.path | quote }}
+  principal.jwt.allow-generate: {{ .Values.principal.jwt.allowGenerate | quote }}
+  principal.jwt.secret-name: {{ .Values.principal.jwt.secretName | quote }}
+  principal.jwt.key-path: {{ .Values.principal.jwt.keyPath | quote }}
+  principal.auth: {{ .Values.principal.auth | quote }} 

--- a/charts/argocd-agent-principal/templates/deployment.yaml
+++ b/charts/argocd-agent-principal/templates/deployment.yaml
@@ -1,0 +1,267 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "argocd-agent-principal.fullname" . }}
+  namespace: {{ include "argocd-agent-principal.namespace" . }}
+  labels:
+    {{- include "argocd-agent-principal.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "argocd-agent-principal.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "argocd-agent-principal.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "argocd-agent-principal.serviceAccountName" . }}
+      containers:
+        - name: {{ .Chart.Name }}
+          args:
+            - principal
+          env:
+          - name: ARGOCD_PRINCIPAL_LISTEN_HOST
+            valueFrom:
+              configMapKeyRef:
+                name: {{ include "argocd-agent-principal.fullname" . }}-params
+                key: principal.listen.host
+                optional: true
+          - name: ARGOCD_PRINCIPAL_LISTEN_PORT
+            valueFrom:
+              configMapKeyRef:
+                name: {{ include "argocd-agent-principal.fullname" . }}-params
+                key: principal.listen.port
+                optional: true
+          - name: ARGOCD_PRINCIPAL_LOG_LEVEL
+            valueFrom:
+              configMapKeyRef:
+                name: {{ include "argocd-agent-principal.fullname" . }}-params
+                key: principal.log.level
+                optional: true
+          - name: ARGOCD_PRINCIPAL_METRICS_PORT
+            valueFrom:
+              configMapKeyRef:
+                name: {{ include "argocd-agent-principal.fullname" . }}-params
+                key: principal.metrics.port
+                optional: true
+          - name: ARGOCD_PRINCIPAL_NAMESPACE
+            valueFrom:
+              configMapKeyRef:
+                name: {{ include "argocd-agent-principal.fullname" . }}-params
+                key: principal.namespace
+                optional: true
+          - name: ARGOCD_PRINCIPAL_ALLOWED_NAMESPACES
+            valueFrom:
+              configMapKeyRef:
+                name: {{ include "argocd-agent-principal.fullname" . }}-params
+                key: principal.allowed-namespaces
+                optional: true
+          - name: ARGOCD_PRINCIPAL_NAMESPACE_CREATE_ENABLE
+            valueFrom:
+              configMapKeyRef:
+                name: {{ include "argocd-agent-principal.fullname" . }}-params
+                key: principal.namespace-create.enable
+                optional: true
+          - name: ARGOCD_PRINCIPAL_NAMESPACE_CREATE_PATTERN
+            valueFrom:
+              configMapKeyRef:
+                name: {{ include "argocd-agent-principal.fullname" . }}-params
+                key: principal.namespace-create.pattern
+                optional: true
+          - name: ARGOCD_PRINCIPAL_NAMESPACE_CREATE_LABELS
+            valueFrom:
+              configMapKeyRef:
+                name: {{ include "argocd-agent-principal.fullname" . }}-params
+                key: principal.namespace-create.labels
+                optional: true
+          - name: ARGOCD_PRINCIPAL_TLS_SECRET_NAME
+            valueFrom:
+              configMapKeyRef:
+                name: {{ include "argocd-agent-principal.fullname" . }}-params
+                key: principal.tls.secret-name
+                optional: true
+          - name: ARGOCD_PRINCIPAL_TLS_SERVER_CERT_PATH
+            valueFrom:
+              configMapKeyRef:
+                name: {{ include "argocd-agent-principal.fullname" . }}-params
+                key: principal.tls.server.cert-path
+                optional: true
+          - name: ARGOCD_PRINCIPAL_TLS_SERVER_KEY_PATH
+            valueFrom:
+              configMapKeyRef:
+                name: {{ include "argocd-agent-principal.fullname" . }}-params
+                key: principal.tls.server.key-path
+                optional: true
+          - name: ARGOCD_PRINCIPAL_TLS_SERVER_ALLOW_GENERATE
+            valueFrom:
+              configMapKeyRef:
+                name: {{ include "argocd-agent-principal.fullname" . }}-params
+                key: principal.tls.server.allow-generate
+                optional: true
+          - name: ARGOCD_PRINCIPAL_TLS_CLIENT_CERT_REQUIRE
+            valueFrom:
+              configMapKeyRef:
+                name: {{ include "argocd-agent-principal.fullname" . }}-params
+                key: principal.tls.client-cert.require
+                optional: true
+          - name: ARGOCD_PRINCIPAL_TLS_SERVER_ROOT_CA_SECRET_NAME
+            valueFrom:
+              configMapKeyRef:
+                name: {{ include "argocd-agent-principal.fullname" . }}-params
+                key: principal.tls.server.root-ca-secret-name
+                optional: true
+          - name: ARGOCD_PRINCIPAL_TLS_SERVER_ROOT_CA_PATH
+            valueFrom:
+              configMapKeyRef:
+                name: {{ include "argocd-agent-principal.fullname" . }}-params
+                key: principal.tls.server.root-ca-path
+                optional: true
+          - name: ARGOCD_PRINCIPAL_TLS_CLIENT_CERT_MATCH_SUBJECT
+            valueFrom:
+              configMapKeyRef:
+                name: {{ include "argocd-agent-principal.fullname" . }}-params
+                key: principal.tls.client-cert.match-subject
+                optional: true
+          - name: ARGOCD_PRINCIPAL_RESOURCE_PROXY_SECRET_NAME
+            valueFrom:
+              configMapKeyRef:
+                name: {{ include "argocd-agent-principal.fullname" . }}-params
+                key: principal.resource-proxy.secret-name
+                optional: true
+          - name: ARGOCD_PRINCIPAL_RESOURCE_PROXY_TLS_CERT_PATH
+            valueFrom:
+              configMapKeyRef:
+                name: {{ include "argocd-agent-principal.fullname" . }}-params
+                key: principal.resource-proxy.tls.cert-path
+                optional: true
+          - name: ARGOCD_PRINCIPAL_RESOURCE_PROXY_TLS_KEY_PATH
+            valueFrom:
+              configMapKeyRef:
+                name: {{ include "argocd-agent-principal.fullname" . }}-params
+                key: principal.resource-proxy.tls.key-path
+                optional: true
+          - name: ARGOCD_PRINCIPAL_RESOURCE_PROXY_CA_SECRET_NAME
+            valueFrom:
+              configMapKeyRef:
+                name: {{ include "argocd-agent-principal.fullname" . }}-params
+                key: principal.resource-proxy.ca.secret-name
+                optional: true
+          - name: ARGOCD_PRINCIPAL_RESOURCE_PROXY_CA_PATH
+            valueFrom:
+              configMapKeyRef:
+                name: {{ include "argocd-agent-principal.fullname" . }}-params
+                key: principal.resource-proxy.ca.path
+                optional: true
+          - name: ARGOCD_PRINCIPAL_JWT_ALLOW_GENERATE
+            valueFrom:
+              configMapKeyRef:
+                name: {{ include "argocd-agent-principal.fullname" . }}-params
+                key: principal.jwt.allow-generate
+                optional: true
+          - name: ARGOCD_PRINCIPAL_JWT_SECRET_NAME
+            valueFrom:
+              configMapKeyRef:
+                name: {{ include "argocd-agent-principal.fullname" . }}-params
+                key: principal.jwt.secret-name
+                optional: true
+          - name: ARGOCD_PRINCIPAL_JWT_KEY_PATH
+            valueFrom:
+              configMapKeyRef:
+                name: {{ include "argocd-agent-principal.fullname" . }}-params
+                key: principal.jwt.key-path
+                optional: true
+          - name: ARGOCD_PRINCIPAL_AUTH
+            valueFrom:
+              configMapKeyRef:
+                name: {{ include "argocd-agent-principal.fullname" . }}-params
+                key: principal.auth
+                optional: true
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: principal
+              containerPort: 8443
+              protocol: TCP
+            - name: metrics
+              containerPort: 8000
+              protocol: TCP
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: jwt-secret
+              mountPath: /app/config/jwt
+            - name: userpass-passwd
+              mountPath: /app/config/userpass
+            - name: principal-tls
+              mountPath: /app/config/tls
+            - name: ca-cert
+              mountPath: /app/config/ca
+            - name: resource-proxy-tls
+              mountPath: /app/config/resource-proxy
+      volumes:
+      - name: jwt-secret
+        secret:
+          secretName: {{ .Values.principal.jwt.secretName }}
+          items:
+          - key: jwt.key
+            path: jwt.key
+          optional: true
+      - name: userpass-passwd
+        secret:
+          secretName: argocd-agent-principal-userpass
+          items:
+          - key: passwd
+            path: passwd
+          optional: true
+      - name: principal-tls
+        secret:
+          secretName: {{ .Values.principal.tls.secretName }}
+          items:
+          - key: tls.crt
+            path: tls.crt
+          - key: tls.key
+            path: tls.key
+          optional: true
+      - name: ca-cert
+        secret:
+          secretName: {{ .Values.principal.tls.server.rootCaSecretName }}
+          items:
+          - key: ca.crt
+            path: ca.crt
+          optional: true
+      - name: resource-proxy-tls
+        secret:
+          secretName: {{ .Values.principal.resourceProxy.secretName }}
+          items:
+          - key: tls.crt
+            path: tls.crt
+          - key: tls.key
+            path: tls.key
+          optional: true
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }} 

--- a/charts/argocd-agent-principal/templates/metrics-service.yaml
+++ b/charts/argocd-agent-principal/templates/metrics-service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "argocd-agent-principal.fullname" . }}-metrics
+  namespace: {{ include "argocd-agent-principal.namespace" . }}
+  labels:
+    {{- include "argocd-agent-principal.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.metricsService.type }}
+  ports:
+    - port: {{ .Values.metricsService.port }}
+      targetPort: metrics
+      protocol: TCP
+      name: metrics
+  selector:
+    {{- include "argocd-agent-principal.selectorLabels" . | nindent 4 }} 

--- a/charts/argocd-agent-principal/templates/role.yaml
+++ b/charts/argocd-agent-principal/templates/role.yaml
@@ -1,0 +1,35 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "argocd-agent-principal.fullname" . }}
+  namespace: {{ include "argocd-agent-principal.namespace" . }}
+  labels:
+    {{- include "argocd-agent-principal.labels" . | nindent 4 }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - get
+  - list
+  - watch 

--- a/charts/argocd-agent-principal/templates/rolebinding.yaml
+++ b/charts/argocd-agent-principal/templates/rolebinding.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "argocd-agent-principal.fullname" . }}
+  namespace: {{ include "argocd-agent-principal.namespace" . }}
+  labels:
+    {{- include "argocd-agent-principal.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "argocd-agent-principal.fullname" . }}
+subjects:
+- kind: ServiceAccount
+  name: {{ include "argocd-agent-principal.serviceAccountName" . }}
+  namespace: {{ include "argocd-agent-principal.namespace" . }} 

--- a/charts/argocd-agent-principal/templates/service.yaml
+++ b/charts/argocd-agent-principal/templates/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "argocd-agent-principal.fullname" . }}
+  namespace: {{ include "argocd-agent-principal.namespace" . }}
+  labels:
+    {{- include "argocd-agent-principal.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: principal
+      protocol: TCP
+      name: principal
+  selector:
+    {{- include "argocd-agent-principal.selectorLabels" . | nindent 4 }} 

--- a/charts/argocd-agent-principal/templates/serviceaccount.yaml
+++ b/charts/argocd-agent-principal/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "argocd-agent-principal.serviceAccountName" . }}
+  namespace: {{ include "argocd-agent-principal.namespace" . }}
+  labels:
+    {{- include "argocd-agent-principal.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }} 

--- a/charts/argocd-agent-principal/values.yaml
+++ b/charts/argocd-agent-principal/values.yaml
@@ -1,0 +1,135 @@
+# Default values for argocd-agent-principal
+# This is a YAML-formatted file.
+
+# Image configuration
+image:
+  repository: ghcr.io/argoproj-labs/argocd-agent/argocd-agent
+  pullPolicy: Always
+  tag: "latest"
+
+# Replica count
+replicaCount: 1
+
+# ServiceAccount configuration
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+# Pod annotations
+podAnnotations: {}
+
+# Pod security context
+podSecurityContext: {}
+
+# Container security context
+securityContext:
+  capabilities:
+    drop:
+    - ALL
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  runAsNonRoot: true
+  seccompProfile:
+    type: RuntimeDefault
+
+# Service configuration
+service:
+  type: ClusterIP
+  port: 8443
+
+# Metrics service configuration
+metricsService:
+  type: ClusterIP
+  port: 8000
+
+# Principal configuration parameters
+principal:
+  # The interface address to listen on. Leave empty for all interfaces.
+  listenHost: ""
+  # The port the gRPC server should listen on.
+  listenPort: "8443"
+  # The logging level to use. One of trace, debug, info, warn or error.
+  logLevel: info
+  # The port the metrics server should listen on.
+  metricsPort: "8000"
+  # The namespace the principal will operate in. If left blank, the namespace where the pod is running in will be used.
+  namespace: "argocd"
+  # A list of namespaces the principal shall watch and process Argo CD resources in. Separate entries using commas.
+  allowedNamespaces: ""
+  
+  # Namespace creation configuration
+  namespaceCreate:
+    # Whether the principal is allowed to create namespaces for agents if they don't exist yet.
+    enable: "false"
+    # A regexp pattern to restrict the names of namespaces to be created. If empty, all patterns are allowed.
+    pattern: ""
+    # A set of labels to apply to namespaces created for agents.
+    labels: ""
+  
+  # TLS configuration
+  tls:
+    # The name of the secret containing the TLS certificate and key.
+    secretName: "argocd-agent-principal-tls"
+    server:
+      # Path to the TLS certificate to be used by the gRPC server.
+      certPath: ""
+      # Path to the TLS private key to be used by the gRPC server.
+      keyPath: ""
+      # Whether to allow the principal to generate its own set of TLS cert and key on startup when none are configured.
+      allowGenerate: "false"
+      # The name of the secret containing the root CA TLS certificate.
+      rootCaSecretName: "argocd-agent-ca"
+      # Path to a TLS root certificate authority to be used to validate agent's client certificates against.
+      rootCaPath: ""
+    clientCert:
+      # Whether to require client certs from agents upon connection.
+      require: "false"
+      # Whether to match the subject field in a client certificate presented by an agent to the agent's name.
+      matchSubject: "false"
+  
+  # Resource proxy configuration
+  resourceProxy:
+    # The name of the secret containing the TLS certificate and key for the resource proxy.
+    secretName: "argocd-agent-resource-proxy-tls"
+    tls:
+      # Path to the TLS certificate to be used by the resource proxy.
+      certPath: ""
+      # Path to the TLS private key to be used by the resource proxy.
+      keyPath: ""
+    ca:
+      # The name of the secret containing the CA certificate for the resource proxy.
+      secretName: "argocd-agent-ca"
+      # Path to the CA certificate to be used by the resource proxy.
+      path: ""
+  
+  # JWT configuration
+  jwt:
+    # Whether to allow the principal to generate its own private key for signing JWT tokens.
+    allowGenerate: "false"
+    # The name of the secret containing the JWT signing key.
+    secretName: "argocd-agent-jwt"
+    # Path to the private key to be used for signing JWT tokens.
+    keyPath: ""
+  
+  # Authentication configuration
+  auth: "userpass:/app/config/userpass/passwd"
+
+# Resources configuration
+resources: {}
+
+# Node selector
+nodeSelector: {}
+
+# Tolerations
+tolerations: []
+
+# Affinity
+affinity: {}
+
+# Namespace where the chart will be deployed
+namespaceOverride: "" 


### PR DESCRIPTION
**What does this PR do / why we need it**:

This PR introduces two Helm charts, one for installing the principal and one for installing the agent.

It should make installation of both much, much easier.

**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:

* Copy the values file from the chart you want to install to a temporary location and make appropriate changes: `cp charts/argocd-agent-principal/values.yaml /tmp/principal-values.yaml`
* Install the chart (I use template + kubectl apply instead of install): `helm template --values /tmp/principal-values.yaml argocd-agent-principal ./charts/argocd-agent-principal | kubectl --context vcluster-control-plane -n argocd -f -`

**Checklist**

* [ ] Documentation update is required by this PR (and has been updated) OR no documentation update is required.

