### PR TITLE
fix: don't compare source UID for apps on autonomous agents

### DIFF
--- a/agent/inbound_test.go
+++ b/agent/inbound_test.go
@@ -91,11 +91,6 @@ func Test_ProcessIncomingAppWithUIDMismatch(t *testing.T) {
 
 	// oldApp is the app that is already present on the agent
 	oldApp := incomingApp.DeepCopy()
-	oldApp.Annotations = map[string]string{
-		manager.SourceUIDAnnotation: "old_uid",
-	}
-	a.appManager.Manage(oldApp.QualifiedName())
-	defer a.appManager.ClearManaged()
 
 	incomingApp.UID = ktypes.UID("new_uid")
 
@@ -109,6 +104,12 @@ func Test_ProcessIncomingAppWithUIDMismatch(t *testing.T) {
 
 	configureManager := func(t *testing.T, mode manager.ManagerMode) {
 		t.Helper()
+		oldApp.Annotations = map[string]string{
+			manager.SourceUIDAnnotation: "old_uid",
+		}
+		a.appManager.Manage(oldApp.QualifiedName())
+		defer a.appManager.ClearManaged()
+
 		be = backend_mocks.NewApplication(t)
 		var err error
 		a.appManager, err = application.NewApplicationManager(be, "argocd", application.WithAllowUpsert(true),

--- a/agent/inbound_test.go
+++ b/agent/inbound_test.go
@@ -107,12 +107,12 @@ func Test_ProcessIncomingAppWithUIDMismatch(t *testing.T) {
 		manager.SourceUIDAnnotation: string(incomingApp.UID),
 	}
 
-	configureManager := func(t *testing.T) {
+	configureManager := func(t *testing.T, mode manager.ManagerMode) {
 		t.Helper()
 		be = backend_mocks.NewApplication(t)
 		var err error
 		a.appManager, err = application.NewApplicationManager(be, "argocd", application.WithAllowUpsert(true),
-			application.WithRole(manager.ManagerRoleAgent), application.WithMode(manager.ManagerModeManaged))
+			application.WithRole(manager.ManagerRoleAgent), application.WithMode(mode))
 		require.NoError(t, err)
 		require.NotNil(t, a)
 
@@ -140,7 +140,7 @@ func Test_ProcessIncomingAppWithUIDMismatch(t *testing.T) {
 	}
 
 	t.Run("Create: Old app with diff UID must be deleted before creating the incoming app", func(t *testing.T) {
-		configureManager(t)
+		configureManager(t, manager.ManagerModeManaged)
 		defer unsetMocks(t)
 		a.appManager.Manage(oldApp.QualifiedName())
 		defer a.appManager.ClearManaged()
@@ -166,7 +166,7 @@ func Test_ProcessIncomingAppWithUIDMismatch(t *testing.T) {
 	})
 
 	t.Run("Create: Old app with the same UID must be updated", func(t *testing.T) {
-		configureManager(t)
+		configureManager(t, manager.ManagerModeManaged)
 		defer unsetMocks(t)
 		a.appManager.Manage(oldApp.QualifiedName())
 		defer a.appManager.ClearManaged()
@@ -197,7 +197,7 @@ func Test_ProcessIncomingAppWithUIDMismatch(t *testing.T) {
 	})
 
 	t.Run("Update: Old app with diff UID must be deleted and a new app must be created", func(t *testing.T) {
-		configureManager(t)
+		configureManager(t, manager.ManagerModeManaged)
 		defer unsetMocks(t)
 		a.appManager.Manage(oldApp.QualifiedName())
 		defer a.appManager.ClearManaged()
@@ -225,7 +225,7 @@ func Test_ProcessIncomingAppWithUIDMismatch(t *testing.T) {
 	})
 
 	t.Run("Update: incoming app must be created if it doesn't exist while handling update event", func(t *testing.T) {
-		configureManager(t)
+		configureManager(t, manager.ManagerModeManaged)
 		defer unsetMocks(t)
 		a.appManager.Manage(oldApp.QualifiedName())
 		defer a.appManager.ClearManaged()
@@ -261,8 +261,48 @@ func Test_ProcessIncomingAppWithUIDMismatch(t *testing.T) {
 		require.Equal(t, newApp, latestApp)
 	})
 
+	t.Run("Update: Don't compare source UID for the autonomous agent", func(t *testing.T) {
+		configureManager(t, manager.ManagerModeAutonomous)
+		defer unsetMocks(t)
+		a.appManager.Manage(oldApp.QualifiedName())
+		defer a.appManager.ClearManaged()
+
+		a.mode = types.AgentModeAutonomous
+		defer func() {
+			a.mode = types.AgentModeManaged
+		}()
+
+		// Create a fake sync operation for the autonomous agent app.
+		newApp := incomingApp.DeepCopy()
+		newApp.Operation = &v1alpha1.Operation{
+			Sync: &v1alpha1.SyncOperation{
+				Revision: "1.0.0",
+			},
+		}
+
+		updateMock.Unset()
+		updateMock = be.On("Update", mock.Anything, mock.Anything).Return(newApp, nil)
+
+		ev := event.New(evs.ApplicationEvent(event.SpecUpdate, newApp), event.TargetApplication)
+		err := a.processIncomingApplication(ev)
+		require.Nil(t, err)
+
+		// Check if the API calls were made in the same order:
+		expectedCalls := []string{"Get", "SupportsPatch", "Update"}
+		gotCalls := []string{}
+		for _, call := range be.Calls {
+			gotCalls = append(gotCalls, call.Method)
+		}
+		require.Equal(t, expectedCalls, gotCalls)
+
+		appInterface := be.Calls[2].ReturnArguments[0]
+		latestApp, ok := appInterface.(*v1alpha1.Application)
+		require.True(t, ok)
+		require.Equal(t, newApp.Operation, latestApp.Operation)
+	})
+
 	t.Run("Delete: Old app with diff UID must be deleted", func(t *testing.T) {
-		configureManager(t)
+		configureManager(t, manager.ManagerModeManaged)
 		defer unsetMocks(t)
 		a.appManager.Manage(oldApp.QualifiedName())
 		defer a.appManager.ClearManaged()

--- a/test/e2e2/sync_test.go
+++ b/test/e2e2/sync_test.go
@@ -216,8 +216,8 @@ func (suite *SyncTestSuite) Test_SyncAutonomous() {
 		return err == nil && app.Status.Sync.Status == argoapp.SyncStatusCodeOutOfSync
 	}, 60*time.Second, 1*time.Second)
 
-	// Sync the app
-	err = fixture.SyncApplication(suite.Ctx, agentKey, suite.AutonomousAgentClient)
+	// Sync the app from the control plane
+	err = fixture.SyncApplication(suite.Ctx, principalKey, suite.PrincipalClient)
 	requires.NoError(err)
 
 	// Wait for the app on the autonomous-agent to become synced


### PR DESCRIPTION
**What does this PR do / why we need it**:
We don't add source UID annotations for resources on autonomous agents since it is the source of truth. However, when the control plane sends update events due to sync/refresh, the agent used to look for this annotation and discard the event. This PR fixes this issue by only comparing the source UID for managed agents.


**Which issue(s) this PR fixes**:

Fixes #446 

**How to test changes / Special notes to the reviewer**:


**Checklist**

* [ ] Documentation update is required by this PR (and has been updated) OR no documentation update is required.

