### PR TITLE
feat: add health check endpoint for principal

### DIFF
--- a/cmd/argocd-agent/principal.go
+++ b/cmd/argocd-agent/principal.go
@@ -88,6 +88,7 @@ func NewPrincipalRunCommand() *cobra.Command {
 
 		redisAddress         string
 		redisCompressionType string
+		healthzPort          int
 	)
 	var command = &cobra.Command{
 		Use:   "principal",
@@ -251,6 +252,7 @@ func NewPrincipalRunCommand() *cobra.Command {
 			opts = append(opts, principal.WithWebSocket(enableWebSocket))
 			opts = append(opts, principal.WithKeepAliveMinimumInterval(keepAliveMinimumInterval))
 			opts = append(opts, principal.WithRedis(redisAddress, redisCompressionType))
+			opts = append(opts, principal.WithHealthzPort(healthzPort))
 
 			s, err := principal.NewServer(ctx, kubeConfig, namespace, opts...)
 			if err != nil {
@@ -374,6 +376,9 @@ func NewPrincipalRunCommand() *cobra.Command {
 	command.Flags().IntVar(&pprofPort, "pprof-port",
 		env.NumWithDefault("ARGOCD_PRINCIPAL_PPROF_PORT", cmdutil.ValidPort, 0),
 		"Port the pprof server will listen on")
+	command.Flags().IntVar(&healthzPort, "healthz-port",
+		env.NumWithDefault("ARGOCD_PRINCIPAL_HEALTH_CHECK_PORT", cmdutil.ValidPort, 8003),
+		"Port the health check server will listen on")
 
 	command.Flags().StringVar(&kubeConfig, "kubeconfig", "", "Path to a kubeconfig file to use")
 	command.Flags().StringVar(&kubeContext, "kubecontext", "", "Override the default kube context")

--- a/install/kubernetes/agent/agent-deployment.yaml
+++ b/install/kubernetes/agent/agent-deployment.yaml
@@ -99,12 +99,20 @@ spec:
                 name: argocd-agent-params
                 key: agent.metrics.port
                 optional: true
+          - name: ARGOCD_AGENT_HEALTH_CHECK_PORT
+            valueFrom:
+              configMapKeyRef:
+                name: argocd-agent-params
+                key: agent.healthz.port
+                optional: true
           image: argocd-agent
           imagePullPolicy: Always
           name: argocd-agent-agent
           ports:
             - containerPort: 8000
               name: metrics
+            - containerPort: 8002
+              name: healthz
           securityContext:
             capabilities:
               drop:

--- a/install/kubernetes/agent/agent-healthz-service.yaml
+++ b/install/kubernetes/agent/agent-healthz-service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+      app.kubernetes.io/name: argocd-agent-agent
+      app.kubernetes.io/part-of: argocd-agent
+      app.kubernetes.io/component: agent
+  name: argocd-agent-agent-healthz
+spec:
+  ports:
+    - name: healthz
+      protocol: TCP
+      port: 8002
+      targetPort: 8002
+  selector:
+    app.kubernetes.io/name: argocd-agent-agent 

--- a/install/kubernetes/agent/agent-params-cm.yaml
+++ b/install/kubernetes/agent/agent-params-cm.yaml
@@ -58,4 +58,7 @@ data:
   # agent.metrics.port: The port the metrics server should listen on.
   # Default: 8181
   agent.metrics.port: "8181"
+  # agent.healthz.port: The port the health check server should listen on.
+  # Default: 8002
+  agent.healthz.port: "8002"
   

--- a/install/kubernetes/agent/kustomization.yaml
+++ b/install/kubernetes/agent/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
 - agent-deployment.yaml
 - agent-params-cm.yaml
 - agent-metrics-service.yaml
+- agent-healthz-service.yaml
 
 images:
 - name: argocd-agent

--- a/install/kubernetes/principal/kustomization.yaml
+++ b/install/kubernetes/principal/kustomization.yaml
@@ -8,6 +8,7 @@ resources:
 - principal-service.yaml
 - principal-params-cm.yaml
 - principal-metrics-service.yaml
+- principal-healthz-service.yaml
 
 images:
 - name: argocd-agent

--- a/install/kubernetes/principal/principal-deployment.yaml
+++ b/install/kubernetes/principal/principal-deployment.yaml
@@ -45,6 +45,12 @@ spec:
                 name: argocd-agent-params
                 key: principal.metrics.port
                 optional: true
+          - name: ARGOCD_PRINCIPAL_HEALTH_CHECK_PORT
+            valueFrom:
+              configMapKeyRef:
+                name: argocd-agent-params
+                key: principal.healthz.port
+                optional: true
           - name: ARGOCD_PRINCIPAL_NAMESPACE
             valueFrom:
               configMapKeyRef:
@@ -186,6 +192,8 @@ spec:
               name: principal
             - containerPort: 8000
               name: metrics
+            - containerPort: 8003
+              name: healthz
           securityContext:
             capabilities:
               drop:

--- a/install/kubernetes/principal/principal-healthz-service.yaml
+++ b/install/kubernetes/principal/principal-healthz-service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/name: argocd-agent-principal
+    app.kubernetes.io/part-of: argocd-agent
+    app.kubernetes.io/component: principal
+  name: argocd-agent-principal-healthz
+spec:
+  ports:
+    - name: healthz
+      protocol: TCP
+      port: 8003
+      targetPort: 8003
+  selector:
+    app.kubernetes.io/name: argocd-agent-principal 

--- a/install/kubernetes/principal/principal-params-cm.yaml
+++ b/install/kubernetes/principal/principal-params-cm.yaml
@@ -17,6 +17,9 @@ data:
   # principal.metrics.port: The port the metrics server should listen on.
   # Default: 8000
   principal.metrics.port: "8000"
+  # principal.healthz.port: The port the health check server should listen on.
+  # Default: 8003
+  principal.healthz.port: "8003"
   # principal.namespace: The namespace the principal will operate in. If left
   # blank, the namespace where the pod is running in will be used.
   # Default: "argocd"

--- a/principal/options.go
+++ b/principal/options.go
@@ -73,6 +73,7 @@ type ServerOptions struct {
 	clientCertSubjectMatch bool
 	redisAddress           string
 	redisCompressionType   cacheutil.RedisCompressionType
+	healthzPort            int
 }
 
 type ServerOption func(o *Server) error
@@ -444,5 +445,16 @@ func WithRedis(redisAddress, redisCompressionTypeStr string) ServerOption {
 		o.options.redisAddress = redisAddress
 
 		return nil
+	}
+}
+
+func WithHealthzPort(port int) ServerOption {
+	return func(o *Server) error {
+		if port > 0 && port < 32768 {
+			o.options.healthzPort = port
+			return nil
+		} else {
+			return fmt.Errorf("invalid port: %d", port)
+		}
 	}
 }

--- a/test/e2e2/fixture/toxyproxy.go
+++ b/test/e2e2/fixture/toxyproxy.go
@@ -64,7 +64,7 @@ func SetupToxiproxy(t require.TestingT, agentName string, proxyAddress string) (
 		RestartAgent(t, agentName)
 
 		// Give some time for the agent to be ready
-		WaitForAgent(t, agentName)
+		CheckReadiness(t, agentName)
 	}
 
 	return proxy, cleanup, nil
@@ -106,10 +106,14 @@ func RestartAgent(t require.TestingT, agentName string) {
 	}, 30*time.Second, 1*time.Second)
 }
 
-func WaitForAgent(t require.TestingT, agentName string) {
+func CheckReadiness(t require.TestingT, compName string) {
 	healthzAddr := "http://localhost:8002/healthz"
-	if agentName == "agent-managed" {
+	if compName == "agent-managed" {
 		healthzAddr = "http://localhost:8001/healthz"
+	}
+
+	if compName == "principal" {
+		healthzAddr = "http://localhost:8003/healthz"
 	}
 
 	require.Eventually(t, func() bool {
@@ -119,5 +123,5 @@ func WaitForAgent(t require.TestingT, agentName string) {
 		}
 		defer resp.Body.Close()
 		return resp.StatusCode == http.StatusOK
-	}, 30*time.Second, 1*time.Second)
+	}, 60*time.Second, 1*time.Second)
 }

--- a/test/e2e2/resync_test.go
+++ b/test/e2e2/resync_test.go
@@ -281,7 +281,7 @@ func (suite *ResyncTestSuite) Test_ResyncUpdatesOnAgentStartupAutonomous() {
 	err = fixture.StartProcess("agent-autonomous")
 	requires.NoError(err)
 
-	fixture.WaitForAgent(suite.T(), "agent-autonomous")
+	fixture.CheckReadiness(suite.T(), "agent-autonomous")
 
 	requires.Eventually(func() bool {
 		app := argoapp.Application{}


### PR DESCRIPTION
This PR is to add health check endpoint to principal, which can be used to verify server readiness. This would fix the issue https://github.com/argoproj-labs/argocd-agent/issues/422, where principal is not fully started but tests still executed which causes test failure.
This PR also exposes health check via a service for both Principal and Agent.