### PR TITLE
fix: cascaded delete on Application should clean up all managed-agent app resources

### DIFF
--- a/agent/outbound.go
+++ b/agent/outbound.go
@@ -127,11 +127,6 @@ func (a *Agent) addAppDeletionToQueue(app *v1alpha1.Application) {
 		return
 	}
 
-	// Only send the deletion event when we're in autonomous mode
-	if !a.mode.IsAutonomous() {
-		return
-	}
-
 	q.Add(a.emitter.ApplicationEvent(event.Delete, app))
 	logCtx.WithField("sendq_len", q.Len()).Debugf("Added app delete event to send queue")
 }

--- a/agent/outbound_test.go
+++ b/agent/outbound_test.go
@@ -146,6 +146,10 @@ func Test_addAppDeletionToQueue(t *testing.T) {
 		require.False(t, a.appManager.IsManaged("agent/guestbook"))
 	})
 	t.Run("Deletion event for unmanaged application", func(t *testing.T) {
+		a := newAgent(t)
+		a.remote.SetClientID("agent")
+		a.mode = types.AgentModeAutonomous
+
 		app := &v1alpha1.Application{ObjectMeta: v1.ObjectMeta{Name: "guestbook", Namespace: "agent"}}
 		// App must be already managed for event to be generated
 		a.addAppDeletionToQueue(app)

--- a/agent/outbound_test.go
+++ b/agent/outbound_test.go
@@ -138,10 +138,11 @@ func Test_addAppDeletionToQueue(t *testing.T) {
 		defer func() {
 			a.mode = types.AgentModeAutonomous
 		}()
-		// App must be already managed for event to be generated
+		// Delete events will be sent for managed applications on managed agent, whether or not the application is managed.
 		_ = a.appManager.Manage("agent/guestbook")
-		a.addAppDeletionToQueue(app)
 		require.Equal(t, 0, a.queues.SendQ(defaultQueueName).Len())
+		a.addAppDeletionToQueue(app)
+		require.Equal(t, 1, a.queues.SendQ(defaultQueueName).Len())
 		require.False(t, a.appManager.IsManaged("agent/guestbook"))
 	})
 	t.Run("Deletion event for unmanaged application", func(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -36,6 +36,7 @@ require (
 	k8s.io/api v0.32.2
 	k8s.io/apimachinery v0.32.2
 	k8s.io/client-go v0.32.2
+	k8s.io/utils v0.0.0-20241210054802-24370beab758
 )
 
 require (
@@ -188,7 +189,6 @@ require (
 	k8s.io/kube-openapi v0.0.0-20250304201544-e5f78fe3ede9 // indirect
 	k8s.io/kubectl v0.32.2 // indirect
 	k8s.io/kubernetes v1.32.2 // indirect
-	k8s.io/utils v0.0.0-20241210054802-24370beab758 // indirect
 	oras.land/oras-go/v2 v2.5.0 // indirect
 	sigs.k8s.io/json v0.0.0-20241010143419-9aa6b5e7a4b3 // indirect
 	sigs.k8s.io/kustomize/api v0.18.0 // indirect

--- a/internal/manager/application/application_test.go
+++ b/internal/manager/application/application_test.go
@@ -143,6 +143,7 @@ func Test_ManagerUpdateManaged(t *testing.T) {
 					"bar":                       "foo",
 					manager.SourceUIDAnnotation: "random_uid",
 				},
+				Finalizers: []string{"test-finalizer"},
 			},
 			Spec: v1alpha1.ApplicationSpec{
 				Source: &v1alpha1.ApplicationSource{
@@ -223,6 +224,10 @@ func Test_ManagerUpdateManaged(t *testing.T) {
 
 		// Labels and annotations must be in sync with incoming
 		require.Equal(t, incoming.Labels, updated.Labels)
+
+		// Finalizers must be in sync
+		require.Equal(t, incoming.Finalizers, updated.Finalizers)
+
 		// Non-refresh annotations must be in sync with incoming
 		require.Equal(t, incoming.Annotations["bar"], updated.Annotations["bar"])
 		// Refresh annotation must not be removed
@@ -232,6 +237,7 @@ func Test_ManagerUpdateManaged(t *testing.T) {
 		// Spec must be in sync with incoming
 		require.Equal(t, incoming.Spec, updated.Spec)
 	})
+
 }
 
 func Test_ManagerUpdateStatus(t *testing.T) {

--- a/principal/callbacks.go
+++ b/principal/callbacks.go
@@ -69,15 +69,6 @@ func (s *Server) updateAppCallback(old *v1alpha1.Application, new *v1alpha1.Appl
 		"event":            "application_update",
 		"application_name": old.Name,
 	})
-	if len(new.Finalizers) > 0 && len(new.Finalizers) != len(old.Finalizers) {
-		tmp, err := s.appManager.RemoveFinalizers(s.ctx, new)
-		if err != nil {
-			logCtx.WithError(err).Warnf("Could not remove finalizer")
-		} else {
-			logCtx.Debug("Removed finalizer")
-			new = tmp
-		}
-	}
 	if s.appManager.IsChangeIgnored(new.QualifiedName(), new.ResourceVersion) {
 		logCtx.WithField("resource_version", new.ResourceVersion).Debugf("Resource version has already been seen")
 		return

--- a/principal/event.go
+++ b/principal/event.go
@@ -228,6 +228,7 @@ func (s *Server) processApplicationEvent(ctx context.Context, agentName string, 
 
 		} else if agentMode.IsManaged() {
 
+			incoming.SetNamespace(agentName)
 			app, err := s.appManager.Get(ctx, incoming.Name, incoming.Namespace)
 			if err != nil {
 				if kerrors.IsNotFound(err) {

--- a/test/e2e2/delete_test.go
+++ b/test/e2e2/delete_test.go
@@ -100,8 +100,13 @@ func (suite *DeleteTestSuite) Test_CascadeDeleteOnManagedAgent() {
 
 	t.Log("Ensure that finalizers and deletion timestamp are synced to managed-agent")
 	requires.Eventually(func() bool {
-		app := argoapp.Application{}
-		err := suite.ManagedAgentClient.Get(suite.Ctx, fixture.ToNamespacedName(&appOnPrincipal), &app, metav1.GetOptions{})
+		app := argoapp.Application{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      appOnPrincipal.Name,
+				Namespace: "argocd",
+			},
+		}
+		err := suite.ManagedAgentClient.Get(suite.Ctx, fixture.ToNamespacedName(&app), &app, metav1.GetOptions{})
 		return err == nil && app.DeletionTimestamp != nil && len(app.Finalizers) > 0
 	}, 60*time.Second, 1*time.Second)
 

--- a/test/e2e2/delete_test.go
+++ b/test/e2e2/delete_test.go
@@ -1,0 +1,140 @@
+// Copyright 2025 The argocd-agent Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package e2e2
+
+import (
+	"testing"
+	"time"
+
+	"github.com/argoproj-labs/argocd-agent/test/e2e2/fixture"
+
+	"github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
+	argoapp "github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
+	"github.com/stretchr/testify/suite"
+	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type DeleteTestSuite struct {
+	fixture.BaseSuite
+}
+
+func (suite *DeleteTestSuite) Test_CascadeDeleteOnManagedAgent() {
+	requires := suite.Require()
+
+	t := suite.T()
+
+	t.Log("Create a managed application in the principal's cluster")
+	appOnPrincipal := v1alpha1.Application{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-app",
+			Namespace: "agent-managed",
+		},
+		Spec: v1alpha1.ApplicationSpec{
+			Project: "default",
+			Source: &v1alpha1.ApplicationSource{
+				RepoURL:        "https://github.com/argoproj/argocd-example-apps",
+				TargetRevision: "HEAD",
+				Path:           "kustomize-guestbook",
+			},
+			Destination: v1alpha1.ApplicationDestination{
+				Name:      "agent-managed",
+				Namespace: "guestbook",
+			},
+			SyncPolicy: &v1alpha1.SyncPolicy{
+				Automated: &v1alpha1.SyncPolicyAutomated{},
+				SyncOptions: v1alpha1.SyncOptions{
+					"CreateNamespace=true",
+				},
+			},
+		},
+	}
+
+	err := ensureAppExistsAndIsSyncedAndHealthy(&appOnPrincipal, suite.PrincipalClient, &suite.BaseSuite)
+	requires.NoError(err)
+
+	t.Log("'kustomize-guestbook-ui' Deployment should exist on managed-agent")
+	depl := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "kustomize-guestbook-ui", Namespace: "guestbook"}}
+	requires.Eventually(func() bool {
+		err := suite.ManagedAgentClient.Get(suite.Ctx, fixture.ToNamespacedName(depl), depl, metav1.GetOptions{})
+		return err == nil
+	}, 60*time.Second, 1*time.Second)
+
+	t.Log("Add a finalizer to the Deployment to keep it from being deleted")
+	depl.Finalizers = append(depl.Finalizers, "test-e2e/my-test-finalizer")
+	err = suite.ManagedAgentClient.Update(suite.Ctx, depl, metav1.UpdateOptions{})
+	requires.NoError(err)
+
+	// Ensure that finalizer is removed from Deployment if the test ends prematurely
+	defer func() {
+		err = suite.ManagedAgentClient.Get(suite.Ctx, fixture.ToNamespacedName(depl), depl, metav1.GetOptions{})
+		if err == nil { // If the Deployment still exists
+			depl.Finalizers = nil // Remove the finalizer
+			err = suite.ManagedAgentClient.Update(suite.Ctx, depl, metav1.UpdateOptions{})
+			requires.NoError(err)
+		}
+	}()
+
+	t.Log("Simulate cascade deletion from Argo CD: Add a resources-finalizer to principal, then delete it (which sets deletion timestamp)")
+	err = suite.PrincipalClient.EnsureApplicationUpdate(suite.Ctx, fixture.ToNamespacedName(&appOnPrincipal), func(a *v1alpha1.Application) error {
+		a.Finalizers = append(appOnPrincipal.Finalizers, "resources-finalizer.argocd.argoproj.io")
+		return nil
+	}, metav1.UpdateOptions{})
+	requires.NoError(err)
+
+	err = suite.PrincipalClient.Delete(suite.Ctx, &appOnPrincipal, metav1.DeleteOptions{})
+	requires.NoError(err)
+
+	t.Log("Ensure that finalizers and deletion timestamp are synced to managed-agent")
+	requires.Eventually(func() bool {
+		app := argoapp.Application{}
+		err := suite.ManagedAgentClient.Get(suite.Ctx, fixture.ToNamespacedName(&appOnPrincipal), &app, metav1.GetOptions{})
+		return err == nil && app.DeletionTimestamp != nil && len(app.Finalizers) > 0
+	}, 60*time.Second, 1*time.Second)
+
+	t.Log("Remove finalizer from the Deployment, so that it may proceed with being deleted")
+	err = suite.ManagedAgentClient.Get(suite.Ctx, fixture.ToNamespacedName(depl), depl, metav1.GetOptions{})
+	requires.NoError(err)
+
+	depl.Finalizers = nil
+	err = suite.ManagedAgentClient.Update(suite.Ctx, depl, metav1.UpdateOptions{})
+	requires.NoError(err)
+
+	t.Log("Verify managed agent application is eventually deleted")
+	requires.Eventually(func() bool {
+		app := argoapp.Application{}
+		err := suite.ManagedAgentClient.Get(suite.Ctx, fixture.ToNamespacedName(&appOnPrincipal), &app, metav1.GetOptions{})
+		return err != nil && errors.IsNotFound(err)
+	}, 60*time.Second, 1*time.Second)
+
+	t.Log("Verify guestbook Deployment is deleted from managed-agent cluster, which proves it is a cascaded delete")
+	requires.Eventually(func() bool {
+		err := suite.ManagedAgentClient.Get(suite.Ctx, fixture.ToNamespacedName(depl), depl, metav1.GetOptions{})
+		return err != nil && errors.IsNotFound(err)
+	}, 60*time.Second, 1*time.Second)
+
+	t.Log("Verify principal application is deleted")
+	requires.Eventually(func() bool {
+		app := argoapp.Application{}
+		err := suite.PrincipalClient.Get(suite.Ctx, fixture.ToNamespacedName(&appOnPrincipal), &app, metav1.GetOptions{})
+		return err != nil && errors.IsNotFound(err)
+	}, 60*time.Second, 1*time.Second)
+
+}
+
+func TestDeleteTestSuite(t *testing.T) {
+	suite.Run(t, new(DeleteTestSuite))
+}


### PR DESCRIPTION
**What does this PR do / why we need it**:
- At present, if you perform a cascade delete on an Argo CD Application from principal, the child resources of that Application will not be deleted on managed-agent.
- This is due to the following, which have been rectified: 
    - The Argo CD Application deletion `.metadata.finalizer` was being removed by principal
    - Deletion events for managed-agent were not being sent by agent
    - Deletion events for managed-agent were not being processed by principal
- Plus updated unit/E2E tests

**Which issue(s) this PR fixes**:

Fixes #443

