### PR TITLE
chore(dev-env): Tweak example/test apps to use resource proxy as destination

### DIFF
--- a/hack/dev-env/apps/autonomous-guestbook.yaml
+++ b/hack/dev-env/apps/autonomous-guestbook.yaml
@@ -10,7 +10,7 @@ spec:
     targetRevision: HEAD
     path: kustomize-guestbook
   destination:
-    server: https://kubernetes.default.svc
+    name: in-cluster
     namespace: guestbook
   syncPolicy:
     syncOptions:

--- a/hack/dev-env/apps/managed-guestbook.yaml
+++ b/hack/dev-env/apps/managed-guestbook.yaml
@@ -10,7 +10,7 @@ spec:
     targetRevision: HEAD
     path: kustomize-guestbook
   destination:
-    server: https://kubernetes.default.svc
+    name: agent-managed
     namespace: guestbook
   syncPolicy:
     syncOptions:


### PR DESCRIPTION
**What does this PR do / why we need it**:

This PR modifies the example apps to a) use resource proxy as destination in case of the managed agent app, and b) both Applications to use names instead of URLs.

**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:


**Checklist**

* [ ] Documentation update is required by this PR (and has been updated) OR no documentation update is required.

