### PR TITLE
docs: Enable mermaid plugin for mkdocs

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -16,6 +16,11 @@ markdown_extensions:
 - toc:
     permalink: true
     toc_depth: 3
+- pymdownx.superfences:
+    custom_fences:
+    - name: mermaid
+      class: mermaid
+      format: !!python/name:pymdownx.superfences.fence_code_format
 nav:
   - Overview: index.md
   - Features:


### PR DESCRIPTION
**What does this PR do / why we need it**:

Enables the mermaid plugin for mkdocs-material to support rendering of [diagrams](https://squidfunk.github.io/mkdocs-material/reference/diagrams/) in the documentation.

**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:


**Checklist**

* [ ] Documentation update is required by this PR (and has been updated) OR no documentation update is required.

