### PR TITLE
refactor: Remove --version flags from commands in favour of version command

### DIFF
--- a/cmd/argocd-agent/agent.go
+++ b/cmd/argocd-agent/agent.go
@@ -30,7 +30,6 @@ import (
 	"github.com/argoproj-labs/argocd-agent/internal/auth/userpass"
 	"github.com/argoproj-labs/argocd-agent/internal/config"
 	"github.com/argoproj-labs/argocd-agent/internal/env"
-	"github.com/argoproj-labs/argocd-agent/internal/version"
 	"github.com/argoproj-labs/argocd-agent/pkg/client"
 	"github.com/argoproj-labs/argocd-agent/pkg/types"
 	"github.com/sirupsen/logrus"
@@ -52,8 +51,6 @@ func NewAgentRunCommand() *cobra.Command {
 		namespace         string
 		agentMode         string
 		creds             string
-		showVersion       bool
-		versionFormat     string
 		tlsSecretName     string
 		tlsClientCrt      string
 		tlsClientKey      string
@@ -74,10 +71,6 @@ func NewAgentRunCommand() *cobra.Command {
 		Use:   "agent",
 		Short: "Run the argocd-agent agent component",
 		Run: func(c *cobra.Command, args []string) {
-			if showVersion {
-				cmdutil.PrintVersion(version.New("argocd-agent"), versionFormat)
-				os.Exit(0)
-			}
 			ctx, cancelFn := context.WithCancel(context.Background())
 			defer cancelFn()
 
@@ -267,8 +260,6 @@ func NewAgentRunCommand() *cobra.Command {
 
 	command.Flags().StringVar(&kubeConfig, "kubeconfig", "", "Path to a kubeconfig file to use")
 	command.Flags().StringVar(&kubeContext, "kubecontext", "", "Override the default kube context")
-	command.Flags().BoolVar(&showVersion, "version", false, "Display version information and exit")
-	command.Flags().StringVar(&versionFormat, "version-format", "text", "Output version information in format: text, json, json-indent")
 	return command
 }
 

--- a/cmd/argocd-agent/principal.go
+++ b/cmd/argocd-agent/principal.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"net/http"
 	_ "net/http/pprof"
-	"os"
 	"regexp"
 	"runtime"
 	"strings"
@@ -35,7 +34,6 @@ import (
 	"github.com/argoproj-labs/argocd-agent/internal/kube"
 	"github.com/argoproj-labs/argocd-agent/internal/labels"
 	"github.com/argoproj-labs/argocd-agent/internal/tlsutil"
-	"github.com/argoproj-labs/argocd-agent/internal/version"
 	"github.com/argoproj-labs/argocd-agent/principal"
 	cacheutil "github.com/argoproj/argo-cd/v3/util/cache"
 
@@ -78,8 +76,6 @@ func NewPrincipalRunCommand() *cobra.Command {
 		resourceProxyKeyPath      string
 		resourceProxyCaSecretName string
 		resourceProxyCAPath       string
-		showVersion               bool
-		versionFormat             string
 
 		// Minimum time duration for agent to wait before sending next keepalive ping to principal
 		// if agent sends ping more often than specified interval then connection will be dropped
@@ -94,11 +90,6 @@ func NewPrincipalRunCommand() *cobra.Command {
 		Use:   "principal",
 		Short: "Run the argocd-agent principal component",
 		Run: func(c *cobra.Command, args []string) {
-			if showVersion {
-				cmdutil.PrintVersion(version.New("argocd-agent"), versionFormat)
-				os.Exit(0)
-			}
-
 			ctx, cancelFn := context.WithCancel(context.Background())
 			defer cancelFn()
 
@@ -382,8 +373,6 @@ func NewPrincipalRunCommand() *cobra.Command {
 
 	command.Flags().StringVar(&kubeConfig, "kubeconfig", "", "Path to a kubeconfig file to use")
 	command.Flags().StringVar(&kubeContext, "kubecontext", "", "Override the default kube context")
-	command.Flags().BoolVar(&showVersion, "version", false, "Display version information and exit")
-	command.Flags().StringVar(&versionFormat, "version-format", "text", "Output version information in format: text, json, json-indent")
 
 	return command
 

--- a/docs/configuration/agent/configuration.md
+++ b/docs/configuration/agent/configuration.md
@@ -261,24 +261,7 @@ The recommended approach for production deployments is to use ConfigMap entries 
 - **Default**: `""` (uses current context)
 - **Example**: `"my-cluster-context"`
 
-### Version Information
 
-#### Version
-- **Command Line Flag**: `--version`
-- **Environment Variable**: *(Not available)*
-- **ConfigMap Entry**: *(Not available in ConfigMap)*
-- **Description**: Display version information and exit
-- **Type**: Boolean
-- **Default**: `false`
-
-#### Version Format
-- **Command Line Flag**: `--version-format`
-- **Environment Variable**: *(Not available)*
-- **ConfigMap Entry**: *(Not available in ConfigMap)*
-- **Description**: Output version information in specified format
-- **Type**: String
-- **Default**: `"text"`
-- **Valid Values**: `"text"`, `"json"`, `"json-indent"`
 
 ## Configuration Examples
 

--- a/docs/configuration/principal/configuration.md
+++ b/docs/configuration/principal/configuration.md
@@ -377,24 +377,7 @@ The recommended approach for production deployments is to use ConfigMap entries 
 - **Default**: `""` (uses current context)
 - **Example**: `"my-cluster-context"`
 
-### Version Information
 
-#### Version
-- **Command Line Flag**: `--version`
-- **Environment Variable**: *(Not available)*
-- **ConfigMap Entry**: *(Not available in ConfigMap)*
-- **Description**: Display version information and exit
-- **Type**: Boolean
-- **Default**: `false`
-
-#### Version Format
-- **Command Line Flag**: `--version-format`
-- **Environment Variable**: *(Not available)*
-- **ConfigMap Entry**: *(Not available in ConfigMap)*
-- **Description**: Output version information in specified format
-- **Type**: String
-- **Default**: `"text"`
-- **Valid Values**: `"text"`, `"json"`, `"json-indent"`
 
 ## Configuration Examples
 


### PR DESCRIPTION
**What does this PR do / why we need it**:

The `version` command was introduced with the unification of the agent and the principal commands. 

This PR is a follow-up to cleanup the remaining `--version` flag, and its related siblings.

**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:


**Checklist**

* [ ] Documentation update is required by this PR (and has been updated) OR no documentation update is required.

