### PR TITLE
fix(cli): Respect principal namespace flag when issuing certificates

### DIFF
--- a/cmd/ctl/ca.go
+++ b/cmd/ctl/ca.go
@@ -395,7 +395,7 @@ func NewPKIIssuePrincipalCommand() *cobra.Command {
 		Short: "Issue a TLS certificate for the principal",
 		Use:   "principal",
 		Run: func(cmd *cobra.Command, args []string) {
-			issueAndSaveSecret(globalOpts.principalContext, "argocd-agent-principal-tls", "argocd", upsert, func(c *x509.Certificate, pk crypto.PrivateKey) (string, string, error) {
+			issueAndSaveSecret(globalOpts.principalContext, "argocd-agent-principal-tls", globalOpts.principalNamespace, upsert, func(c *x509.Certificate, pk crypto.PrivateKey) (string, string, error) {
 				return tlsutil.GenerateServerCertificate("argocd-agent-principal", c, pk, ips, dns)
 			})
 		},
@@ -421,7 +421,7 @@ func NewPKIIssueResourceProxyCommand() *cobra.Command {
 				fmt.Println("Please pass at least one of --ips or --dns options or use --no-san to create certificate without SAN")
 				os.Exit(1)
 			}
-			issueAndSaveSecret(globalOpts.principalContext, "argocd-agent-resource-proxy-tls", "argocd", upsert, func(c *x509.Certificate, pk crypto.PrivateKey) (string, string, error) {
+			issueAndSaveSecret(globalOpts.principalContext, "argocd-agent-resource-proxy-tls", globalOpts.principalNamespace, upsert, func(c *x509.Certificate, pk crypto.PrivateKey) (string, string, error) {
 				return tlsutil.GenerateServerCertificate("argocd-agent-resource-proxy", c, pk, ips, dns)
 			})
 		},


### PR DESCRIPTION
**What does this PR do / why we need it**:

The `pki issue` command of `argocd-agentctl` would not respect the `--principal-namespace` flag when creating the secrets holding the certificates, and instead use `argocd` as the hardcoded namespace.

**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:


**Checklist**

* [ ] Documentation update is required by this PR (and has been updated) OR no documentation update is required.

