### PR TITLE
feat(cli): Print more information in `pki inspect` command

### DIFF
--- a/cmd/ctl/ca.go
+++ b/cmd/ctl/ca.go
@@ -47,6 +47,19 @@ OR TO PROTECT ANY KIND OF DATA.
 You have been warned.
 */
 
+// certificateSummary is a summary of a certificate.
+type certificateSummary struct {
+	Subject   string   `json:"subject" yaml:"subject" text:"Subject"`
+	KeyType   string   `json:"keyType" yaml:"keyType" text:"Key type"`
+	KeyLength int      `json:"keyLength" yaml:"keyLength" text:"Key length"`
+	NotBefore string   `json:"notBefore" yaml:"notBefore" text:"Not valid before"`
+	NotAfter  string   `json:"notAfter" yaml:"notAfter" text:"Not valid after"`
+	Checksum  string   `json:"sha256" yaml:"sha256" text:"Checksum"`
+	IPs       []string `json:"ips,omitempty" yaml:"ips,omitempty" text:"IPs,omitempty"`
+	DNS       []string `json:"dns,omitempty" yaml:"dns,omitempty" text:"DNS,omitempty"`
+	Warnings  []string `json:"warnings,omitempty" yaml:"warnings,omitempty" text:"Warnings,omitempty"`
+}
+
 func NewPKICommand() *cobra.Command {
 	command := &cobra.Command{
 		Short: "!!NON-PROD!! Inspect and manage the principal's PKI",
@@ -199,14 +212,11 @@ func NewPKIInspectCommand() *cobra.Command {
 		full      bool
 		outFormat string
 	)
-	type summary struct {
-		Subject   string   `json:"subject" yaml:"subject" text:"Subject"`
-		KeyType   string   `json:"keyType" yaml:"keyType" text:"Key type"`
-		KeyLength int      `json:"keyLength" yaml:"keyLength" text:"Key length"`
-		NotBefore string   `json:"notBefore" yaml:"notBefore" text:"Not valid before"`
-		NotAfter  string   `json:"notAfter" yaml:"notAfter" text:"Not valid after"`
-		Checksum  string   `json:"sha256" yaml:"sha256" text:"Checksum"`
-		Warnings  []string `json:"warnings,omitempty" yaml:"warnings,omitempty" text:"Warnings,omitempty"`
+
+	type inspectSummary struct {
+		CA            certificateSummary `json:"ca,omitempty" yaml:"ca,omitempty" text:"CA,omitempty"`
+		Principal     certificateSummary `json:"principal,omitempty" yaml:"principal,omitempty" text:"Principal,omitempty"`
+		ResourceProxy certificateSummary `json:"resourceProxy,omitempty" yaml:"resourceProxy,omitempty" text:"Resource Proxy,omitempty"`
 	}
 	command := &cobra.Command{
 		Short: "NON-PROD!! Inspect the configured PKI",
@@ -217,39 +227,15 @@ func NewPKIInspectCommand() *cobra.Command {
 			if err != nil {
 				cmdutil.Fatal("Error creating Kubernetes client: %v", err)
 			}
-			tlsCert, err := tlsutil.TLSCertFromSecret(ctx, clt.Clientset, globalOpts.principalNamespace, config.SecretNamePrincipalCA)
-			if err != nil {
-				cmdutil.Fatal("Could not read CA from secret: %v", err)
-			}
-			if len(tlsCert.Certificate[0]) == 0 {
-				cmdutil.Fatal("No certificate in data")
-			}
-			cert, err := x509.ParseCertificate(tlsCert.Certificate[0])
-			if err != nil {
-				cmdutil.Fatal("Could not parse x509 data: %v", err)
-			}
 
-			key, ok := tlsCert.PrivateKey.(*rsa.PrivateKey)
-			if !ok {
-				cmdutil.Fatal("Not an RSA private key")
-			}
+			caSum := readAndSummarizeCertificate(ctx, clt, globalOpts.principalNamespace, config.SecretNamePrincipalCA, true)
+			resourceProxySum := readAndSummarizeCertificate(ctx, clt, globalOpts.principalNamespace, "argocd-agent-resource-proxy-tls", false)
+			principalSum := readAndSummarizeCertificate(ctx, clt, globalOpts.principalNamespace, "argocd-agent-principal-tls", false)
 
-			warnings := []string{}
-			if !cert.IsCA {
-				warnings = append(warnings, "- Is not a CA certificate")
-			}
-			if !cert.BasicConstraintsValid {
-				warnings = append(warnings, "- Basic constraints are invalid")
-			}
-
-			sum := summary{
-				Subject:   cert.Subject.String(),
-				KeyType:   "RSA",
-				KeyLength: key.Size() * 8,
-				NotBefore: cert.NotBefore.Format(time.RFC1123Z),
-				NotAfter:  cert.NotAfter.Format(time.RFC1123Z),
-				Checksum:  fmt.Sprintf("%x", sha256.Sum256(cert.Raw)),
-				Warnings:  warnings,
+			sum := inspectSummary{
+				CA:            caSum,
+				Principal:     principalSum,
+				ResourceProxy: resourceProxySum,
 			}
 
 			out, err := cmdutil.MarshalStruct(sum, outFormat)
@@ -545,4 +531,44 @@ func issueAndSaveSecret(outContext, outName, outNamespace string, upsert bool, i
 		fmt.Printf("Secret %s/%s created\n", outNamespace, outName)
 	}
 
+}
+
+func readAndSummarizeCertificate(ctx context.Context, clt *kube.KubernetesClient, namespace, name string, isCA bool) certificateSummary {
+	cert, err := tlsutil.TLSCertFromSecret(ctx, clt.Clientset, namespace, name)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return certificateSummary{}
+		} else {
+			cmdutil.Fatal("Error getting certificate: %v", err)
+		}
+	}
+	parsedCert, err := x509.ParseCertificate(cert.Certificate[0])
+	if err != nil {
+		cmdutil.Fatal("Could not parse certificate: %v", err)
+	}
+
+	warnings := []string{}
+	if !parsedCert.IsCA && isCA {
+		warnings = append(warnings, "This is not a CA certificate")
+	}
+	if !parsedCert.BasicConstraintsValid {
+		warnings = append(warnings, "Basic constraints are invalid")
+	}
+	ips := []string{}
+	for _, ip := range parsedCert.IPAddresses {
+		ips = append(ips, ip.String())
+	}
+	sum := certificateSummary{
+		Subject:   parsedCert.Subject.String(),
+		KeyType:   "RSA",
+		KeyLength: parsedCert.PublicKey.(*rsa.PublicKey).N.BitLen(),
+		NotBefore: parsedCert.NotBefore.Format(time.RFC1123Z),
+		NotAfter:  parsedCert.NotAfter.Format(time.RFC1123Z),
+		Checksum:  fmt.Sprintf("%x", sha256.Sum256(parsedCert.Raw)),
+		IPs:       ips,
+		DNS:       parsedCert.DNSNames,
+		Warnings:  warnings,
+	}
+
+	return sum
 }

--- a/cmd/ctl/ca.go
+++ b/cmd/ctl/ca.go
@@ -549,7 +549,7 @@ func readAndSummarizeCertificate(ctx context.Context, clt *kube.KubernetesClient
 	}
 	parsedCert, err := x509.ParseCertificate(cert.Certificate[0])
 	if err != nil {
-		return certificateSummary{}, fmt.Errorf("Could not parse certificate: %v", err)
+		return certificateSummary{}, fmt.Errorf("could not parse certificate: %v", err)
 	}
 
 	warnings := []string{}

--- a/cmd/ctl/ca_test.go
+++ b/cmd/ctl/ca_test.go
@@ -1,0 +1,349 @@
+// Copyright 2025 The argocd-agent Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"math/big"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/argoproj-labs/argocd-agent/internal/kube"
+	fakekube "github.com/argoproj-labs/argocd-agent/test/fake/kube"
+	"github.com/argoproj-labs/argocd-agent/test/fake/testcerts"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestReadAndSummarizeCertificate(t *testing.T) {
+	ctx := context.TODO()
+	namespace := "test-namespace"
+	secretName := "test-secret"
+
+	t.Run("Certificate not found", func(t *testing.T) {
+		// Create fake client with no secrets
+		fakeClient := fakekube.NewFakeClientsetWithResources()
+		client := &kube.KubernetesClient{
+			Clientset: fakeClient,
+		}
+
+		summary := readAndSummarizeCertificate(ctx, client, namespace, secretName, false)
+
+		// Should return empty summary for not found
+		assert.Empty(t, summary.Subject)
+		assert.Empty(t, summary.KeyType)
+		assert.Zero(t, summary.KeyLength)
+		assert.Empty(t, summary.NotBefore)
+		assert.Empty(t, summary.NotAfter)
+		assert.Empty(t, summary.Checksum)
+		assert.Empty(t, summary.IPs)
+		assert.Empty(t, summary.DNS)
+		assert.Empty(t, summary.Warnings)
+	})
+
+	t.Run("Valid CA certificate", func(t *testing.T) {
+		// Create CA certificate template
+		caTemplate := x509.Certificate{
+			SerialNumber: big.NewInt(1),
+			Subject: pkix.Name{
+				CommonName:   "Test CA",
+				Organization: []string{"Test Org"},
+			},
+			KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+			ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageAny},
+			BasicConstraintsValid: true,
+			IsCA:                  true,
+			NotBefore:             time.Now().Add(-1 * time.Hour),
+			NotAfter:              time.Now().Add(24 * time.Hour),
+		}
+
+		// Generate certificate
+		certPEM, keyPEM := testcerts.CreateSelfSignedCert(t, "rsa", caTemplate)
+
+		// Create secret with the certificate
+		secret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      secretName,
+				Namespace: namespace,
+			},
+			Type: corev1.SecretTypeTLS,
+			Data: map[string][]byte{
+				"tls.crt": certPEM,
+				"tls.key": keyPEM,
+			},
+		}
+
+		fakeClient := fakekube.NewFakeClientsetWithResources(secret)
+		client := &kube.KubernetesClient{
+			Clientset: fakeClient,
+		}
+
+		summary := readAndSummarizeCertificate(ctx, client, namespace, secretName, true)
+
+		// Verify certificate summary
+		assert.Contains(t, summary.Subject, "Test CA")
+		assert.Equal(t, "RSA", summary.KeyType)
+		assert.Equal(t, 2048, summary.KeyLength) // RSA 2048 is used by testcerts
+		assert.NotEmpty(t, summary.NotBefore)
+		assert.NotEmpty(t, summary.NotAfter)
+		assert.NotEmpty(t, summary.Checksum)
+		assert.Empty(t, summary.Warnings) // Should be no warnings for valid CA
+	})
+
+	t.Run("Valid non-CA certificate with IP and DNS", func(t *testing.T) {
+		// Create server certificate template with SAN
+		serverTemplate := x509.Certificate{
+			SerialNumber: big.NewInt(2),
+			Subject: pkix.Name{
+				CommonName: "test-server.example.com",
+			},
+			KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+			ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+			BasicConstraintsValid: true,
+			IsCA:                  false,
+			NotBefore:             time.Now().Add(-1 * time.Hour),
+			NotAfter:              time.Now().Add(24 * time.Hour),
+			IPAddresses:           []net.IP{net.ParseIP("127.0.0.1"), net.ParseIP("192.168.1.1")},
+			DNSNames:              []string{"localhost", "test-server.example.com"},
+		}
+
+		certPEM, keyPEM := testcerts.CreateSelfSignedCert(t, "rsa", serverTemplate)
+
+		secret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      secretName,
+				Namespace: namespace,
+			},
+			Type: corev1.SecretTypeTLS,
+			Data: map[string][]byte{
+				"tls.crt": certPEM,
+				"tls.key": keyPEM,
+			},
+		}
+
+		fakeClient := fakekube.NewFakeClientsetWithResources(secret)
+		client := &kube.KubernetesClient{
+			Clientset: fakeClient,
+		}
+
+		summary := readAndSummarizeCertificate(ctx, client, namespace, secretName, false)
+
+		// Verify certificate summary
+		assert.Contains(t, summary.Subject, "test-server.example.com")
+		assert.Equal(t, "RSA", summary.KeyType)
+		assert.Equal(t, 2048, summary.KeyLength)
+		assert.NotEmpty(t, summary.NotBefore)
+		assert.NotEmpty(t, summary.NotAfter)
+		assert.NotEmpty(t, summary.Checksum)
+		assert.Contains(t, summary.IPs, "127.0.0.1")
+		assert.Contains(t, summary.IPs, "192.168.1.1")
+		assert.Contains(t, summary.DNS, "localhost")
+		assert.Contains(t, summary.DNS, "test-server.example.com")
+		assert.Empty(t, summary.Warnings) // Should be no warnings for valid server cert
+	})
+
+	t.Run("Non-CA certificate expected to be CA", func(t *testing.T) {
+		// Create non-CA certificate
+		nonCATemplate := x509.Certificate{
+			SerialNumber: big.NewInt(3),
+			Subject: pkix.Name{
+				CommonName: "Not a CA",
+			},
+			KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+			ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+			BasicConstraintsValid: true,
+			IsCA:                  false,
+			NotBefore:             time.Now().Add(-1 * time.Hour),
+			NotAfter:              time.Now().Add(24 * time.Hour),
+		}
+
+		certPEM, keyPEM := testcerts.CreateSelfSignedCert(t, "rsa", nonCATemplate)
+
+		secret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      secretName,
+				Namespace: namespace,
+			},
+			Type: corev1.SecretTypeTLS,
+			Data: map[string][]byte{
+				"tls.crt": certPEM,
+				"tls.key": keyPEM,
+			},
+		}
+
+		fakeClient := fakekube.NewFakeClientsetWithResources(secret)
+		client := &kube.KubernetesClient{
+			Clientset: fakeClient,
+		}
+
+		summary := readAndSummarizeCertificate(ctx, client, namespace, secretName, true)
+
+		// Should have warning about not being a CA
+		assert.Contains(t, summary.Warnings, "This is not a CA certificate")
+		assert.Contains(t, summary.Subject, "Not a CA")
+	})
+
+	t.Run("Certificate with invalid basic constraints", func(t *testing.T) {
+		// Create certificate with invalid basic constraints
+		invalidTemplate := x509.Certificate{
+			SerialNumber: big.NewInt(4),
+			Subject: pkix.Name{
+				CommonName: "Invalid Constraints",
+			},
+			KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+			ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+			BasicConstraintsValid: false, // Invalid basic constraints
+			IsCA:                  false,
+			NotBefore:             time.Now().Add(-1 * time.Hour),
+			NotAfter:              time.Now().Add(24 * time.Hour),
+		}
+
+		certPEM, keyPEM := testcerts.CreateSelfSignedCert(t, "rsa", invalidTemplate)
+
+		secret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      secretName,
+				Namespace: namespace,
+			},
+			Type: corev1.SecretTypeTLS,
+			Data: map[string][]byte{
+				"tls.crt": certPEM,
+				"tls.key": keyPEM,
+			},
+		}
+
+		fakeClient := fakekube.NewFakeClientsetWithResources(secret)
+		client := &kube.KubernetesClient{
+			Clientset: fakeClient,
+		}
+
+		summary := readAndSummarizeCertificate(ctx, client, namespace, secretName, false)
+
+		// Should have warning about invalid basic constraints
+		assert.Contains(t, summary.Warnings, "Basic constraints are invalid")
+		assert.Contains(t, summary.Subject, "Invalid Constraints")
+	})
+
+	t.Run("Certificate with both CA and constraint warnings", func(t *testing.T) {
+		// Create non-CA certificate with invalid constraints, expected to be CA
+		bothIssuesTemplate := x509.Certificate{
+			SerialNumber: big.NewInt(5),
+			Subject: pkix.Name{
+				CommonName: "Both Issues",
+			},
+			KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+			ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+			BasicConstraintsValid: false, // Invalid
+			IsCA:                  false, // Not CA
+			NotBefore:             time.Now().Add(-1 * time.Hour),
+			NotAfter:              time.Now().Add(24 * time.Hour),
+		}
+
+		certPEM, keyPEM := testcerts.CreateSelfSignedCert(t, "rsa", bothIssuesTemplate)
+
+		secret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      secretName,
+				Namespace: namespace,
+			},
+			Type: corev1.SecretTypeTLS,
+			Data: map[string][]byte{
+				"tls.crt": certPEM,
+				"tls.key": keyPEM,
+			},
+		}
+
+		fakeClient := fakekube.NewFakeClientsetWithResources(secret)
+		client := &kube.KubernetesClient{
+			Clientset: fakeClient,
+		}
+
+		summary := readAndSummarizeCertificate(ctx, client, namespace, secretName, true) // expecting CA
+
+		// Should have both warnings
+		assert.Contains(t, summary.Warnings, "This is not a CA certificate")
+		assert.Contains(t, summary.Warnings, "Basic constraints are invalid")
+		assert.Len(t, summary.Warnings, 2)
+	})
+
+	t.Run("Secret with invalid certificate data", func(t *testing.T) {
+		// Create secret with invalid certificate data
+		secret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      secretName,
+				Namespace: namespace,
+			},
+			Type: corev1.SecretTypeTLS,
+			Data: map[string][]byte{
+				"tls.crt": []byte("invalid certificate data"),
+				"tls.key": []byte("invalid key data"),
+			},
+		}
+
+		// The function should call cmdutil.Fatal for parsing errors,
+		// but since we can't easily test Fatal calls without refactoring,
+		// we'll skip this test case for now. In a real scenario, we might
+		// want to refactor the function to return errors instead of calling Fatal.
+		_ = secret
+		t.Skip("Skipping test for invalid certificate data as it calls cmdutil.Fatal")
+	})
+
+	t.Run("Empty certificate data", func(t *testing.T) {
+		// Create secret with empty certificate data
+		secret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      secretName,
+				Namespace: namespace,
+			},
+			Type: corev1.SecretTypeTLS,
+			Data: map[string][]byte{
+				"tls.crt": []byte(""),
+				"tls.key": []byte(""),
+			},
+		}
+
+		// Similar to above, this would trigger an error that calls cmdutil.Fatal
+		_ = secret
+		t.Skip("Skipping test for empty certificate data as it calls cmdutil.Fatal")
+	})
+}
+
+func TestReadAndSummarizeCertificate_GetSecretError(t *testing.T) {
+	// Test that we can verify error handling, although most errors result in Fatal calls
+	ctx := context.TODO()
+	namespace := "test-namespace"
+
+	t.Run("Network error accessing secret", func(t *testing.T) {
+		// This would be challenging to test without a more sophisticated mock
+		// that can simulate network errors. For now, we test the not found case
+		// which is the one case that doesn't call Fatal.
+
+		fakeClient := fakekube.NewFakeClientsetWithResources()
+		client := &kube.KubernetesClient{
+			Clientset: fakeClient,
+		}
+
+		summary := readAndSummarizeCertificate(ctx, client, namespace, "non-existent-secret", false)
+
+		// Should return empty summary when secret is not found
+		assert.Empty(t, summary.Subject)
+		assert.Empty(t, summary.KeyType)
+		assert.Zero(t, summary.KeyLength)
+	})
+}


### PR DESCRIPTION
**What does this PR do / why we need it**:

The `pki inspect` command now prints information about principal's and resource proxy's certificate along with the CA certificate. This eases troubleshooting and information gathering for admins.

**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:


**Checklist**

* [ ] Documentation update is required by this PR (and has been updated) OR no documentation update is required.

