### PR TITLE
fix: Add missing configurations in manifests

### DIFF
--- a/install/kubernetes/agent/agent-deployment.yaml
+++ b/install/kubernetes/agent/agent-deployment.yaml
@@ -105,6 +105,36 @@ spec:
                 name: argocd-agent-params
                 key: agent.healthz.port
                 optional: true
+          - name: ARGOCD_PRINCIPAL_LOG_FORMAT
+            valueFrom:
+              configMapKeyRef:
+                name: argocd-agent-params
+                key: agent.log.format
+                optional: true
+          - name: ARGOCD_AGENT_ENABLE_WEBSOCKET
+            valueFrom:
+              configMapKeyRef:
+                name: argocd-agent-params
+                key: agent.websocket.enable
+                optional: true
+          - name: ARGOCD_AGENT_ENABLE_COMPRESSION
+            valueFrom:
+              configMapKeyRef:
+                name: argocd-agent-params
+                key: agent.compression.enable
+                optional: true
+          - name: ARGOCD_AGENT_KEEP_ALIVE_PING_INTERVAL
+            valueFrom:
+              configMapKeyRef:
+                name: argocd-agent-params
+                key: agent.keep-alive.interval
+                optional: true
+          - name: ARGOCD_AGENT_PPROF_PORT
+            valueFrom:
+              configMapKeyRef:
+                name: argocd-agent-params
+                key: agent.pprof.port
+                optional: true
           - name: REDIS_PASSWORD
             valueFrom:
               secretKeyRef:

--- a/install/kubernetes/agent/agent-params-cm.yaml
+++ b/install/kubernetes/agent/agent-params-cm.yaml
@@ -61,4 +61,23 @@ data:
   # agent.healthz.port: The port the health check server should listen on.
   # Default: 8002
   agent.healthz.port: "8002"
+  # agent.log.format: The log format agent should use. Valid values are
+  # "json" or "text".
+  # Default: "text"
+  agent.log.format: "text"
+  # agent.websocket.enable: Whether to use the websocket to stream events to the
+  # principal.
+  # Default: false
+  agent.websocket.enable: "false"
+  # agent.compression.enable: Whether to use compression while sending data
+  # between Principal and Agent using gRPC
+  # Default: false
+  agent.compression.enable: "false"
+  # agent.keep-alive.interval: The interval at which the agent should send
+  # a ping to the principal to keep the connection alive.
+  # Default: 0
+  agent.keep-alive.interval: "0"
+  # agent.pprof.port: The port the pprof server should listen on.
+  # Default: 0
+  agent.pprof.port: "0"
   

--- a/install/kubernetes/principal/principal-deployment.yaml
+++ b/install/kubernetes/principal/principal-deployment.yaml
@@ -153,7 +153,7 @@ spec:
                 name: argocd-agent-params
                 key: principal.resource-proxy.ca.secret-name
                 optional: true
-          - name: ARGOCD_PRINCIPAL_RESOURCE_PROXY_CA_PATH
+          - name: ARGOCD_PRINCIPAL_RESOURCE_PROXY_TLS_CA_PATH
             valueFrom:
               configMapKeyRef:
                 name: argocd-agent-params
@@ -182,6 +182,42 @@ spec:
               configMapKeyRef:
                 name: argocd-agent-params
                 key: principal.auth
+                optional: true
+          - name: ARGOCD_PRINCIPAL_LOG_FORMAT
+            valueFrom:
+              configMapKeyRef:
+                name: argocd-agent-params
+                key: principal.log.format
+                optional: true
+          - name: ARGOCD_PRINCIPAL_ENABLE_WEBSOCKET
+            valueFrom:
+              configMapKeyRef:
+                name: argocd-agent-params
+                key: principal.websocket.enable
+                optional: true
+          - name: ARGOCD_PRINCIPAL_REDIS_COMPRESSION_TYPE
+            valueFrom:
+              configMapKeyRef:
+                name: argocd-agent-params
+                key: principal.redis.compression.type
+                optional: true
+          - name: ARGOCD_PRINCIPAL_ENABLE_RESOURCE_PROXY
+            valueFrom:
+              configMapKeyRef:
+                name: argocd-agent-params
+                key: principal.resource-proxy.enable
+                optional: true
+          - name: ARGOCD_PRINCIPAL_KEEP_ALIVE_MIN_INTERVAL
+            valueFrom:
+              configMapKeyRef:
+                name: argocd-agent-params
+                key: principal.keep-alive.min-interval
+                optional: true
+          - name: ARGOCD_PRINCIPAL_PPROF_PORT
+            valueFrom:
+              configMapKeyRef:
+                name: argocd-agent-params
+                key: principal.pprof.port
                 optional: true
           - name: REDIS_PASSWORD
             valueFrom:

--- a/install/kubernetes/principal/principal-params-cm.yaml
+++ b/install/kubernetes/principal/principal-params-cm.yaml
@@ -115,3 +115,25 @@ data:
   #   extracting the agent ID from client cert subject.
   # Default: userpass:_path_to_encrypted_creds_
   principal.auth: "mtls:CN=([^,]+)"
+  # principal.log.format: The log format principal should use. Valid values are
+  # "json" or "text".
+  # Default: "text"
+  principal.log.format: "text"
+  # principal.websocket.enable: Whether to use the websocket to stream events to the
+  # agent.
+  # Default: false
+  principal.websocket.enable: "false"
+  # principal.redis.compression.type: The compression type to use for the Redis
+  # connection.
+  # Default: "gzip"
+  principal.redis.compression.type: "gzip"
+  # principal.resource-proxy.enable: Whether to enable the resource proxy.
+  # Default: true
+  principal.resource-proxy.enable: "true"
+  # principal.keep-alive.min-interval: Drop agent connections that send keepalive pings 
+  # more often than the specified interval.
+  # Default: 0
+  principal.keep-alive.min-interval: "0"
+  # principal.pprof.port: The port the pprof server will listen on.
+  # Default: 0
+  principal.pprof.port: "0"


### PR DESCRIPTION
This PR is to add few missing configurations in ConfigMap and Deployment manifests for both Agent and Principal.