### PR TITLE
feat: Ability to toggle resource proxy per agent

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -90,6 +90,9 @@ type Agent struct {
 
 	// redisProxyMsgHandler manages redis connection state for agent
 	redisProxyMsgHandler *redisProxyMsgHandler
+
+	// enableResourceProxy determines if the agent should proxy resources to the principal
+	enableResourceProxy bool
 }
 
 const defaultQueueName = "default"

--- a/agent/options.go
+++ b/agent/options.go
@@ -92,3 +92,10 @@ func WithRedisPassword(password string) AgentOption {
 		return nil
 	}
 }
+
+func WithEnableResourceProxy(enable bool) AgentOption {
+	return func(o *Agent) error {
+		o.enableResourceProxy = enable
+		return nil
+	}
+}

--- a/agent/resource.go
+++ b/agent/resource.go
@@ -33,6 +33,11 @@ var ErrUnmanaged = errors.New("resource not managed by app")
 //     scoped.
 //   - Request for a list of available APIs
 func (a *Agent) processIncomingResourceRequest(ev *event.Event) error {
+	// If resource proxy is disabled, we return an error immediately.
+	if !a.enableResourceProxy {
+		return fmt.Errorf("resource proxy is disabled in agent configuration")
+	}
+
 	rreq, err := ev.ResourceRequest()
 	if err != nil {
 		return err

--- a/cmd/argocd-agent/agent.go
+++ b/cmd/argocd-agent/agent.go
@@ -39,29 +39,30 @@ import (
 // NewAgentRunCommand returns a new agent run command.
 func NewAgentRunCommand() *cobra.Command {
 	var (
-		serverAddress     string
-		serverPort        int
-		logLevel          string
-		logFormat         string
-		insecure          bool
-		rootCASecretName  string
-		rootCAPath        string
-		kubeConfig        string
-		kubeContext       string
-		namespace         string
-		agentMode         string
-		creds             string
-		tlsSecretName     string
-		tlsClientCrt      string
-		tlsClientKey      string
-		enableWebSocket   bool
-		metricsPort       int
-		healthzPort       int
-		enableCompression bool
-		pprofPort         int
-		redisAddr         string
-		redisUsername     string
-		redisPassword     string
+		serverAddress       string
+		serverPort          int
+		logLevel            string
+		logFormat           string
+		insecure            bool
+		rootCASecretName    string
+		rootCAPath          string
+		kubeConfig          string
+		kubeContext         string
+		namespace           string
+		agentMode           string
+		creds               string
+		tlsSecretName       string
+		tlsClientCrt        string
+		tlsClientKey        string
+		enableWebSocket     bool
+		metricsPort         int
+		healthzPort         int
+		enableCompression   bool
+		pprofPort           int
+		redisAddr           string
+		redisUsername       string
+		redisPassword       string
+		enableResourceProxy bool
 
 		// Time interval for agent to principal ping
 		// Ex: "30m", "1h" or "1h20m10s". Valid time units are "s", "m", "h".
@@ -172,6 +173,8 @@ func NewAgentRunCommand() *cobra.Command {
 			agentOpts = append(agentOpts, agent.WithRedisUsername(redisUsername))
 			agentOpts = append(agentOpts, agent.WithRedisPassword(redisPassword))
 
+			agentOpts = append(agentOpts, agent.WithEnableResourceProxy(enableResourceProxy))
+
 			if metricsPort > 0 {
 				agentOpts = append(agentOpts, agent.WithMetricsPort(metricsPort))
 			}
@@ -257,6 +260,9 @@ func NewAgentRunCommand() *cobra.Command {
 	command.Flags().IntVar(&pprofPort, "pprof-port",
 		env.NumWithDefault("ARGOCD_AGENT_PPROF_PORT", cmdutil.ValidPort, 0),
 		"Port the pprof server will listen on")
+	command.Flags().BoolVar(&enableResourceProxy, "enable-resource-proxy",
+		env.BoolWithDefault("ARGOCD_AGENT_ENABLE_RESOURCE_PROXY", true),
+		"Enable resource proxy")
 
 	command.Flags().StringVar(&kubeConfig, "kubeconfig", "", "Path to a kubeconfig file to use")
 	command.Flags().StringVar(&kubeContext, "kubecontext", "", "Override the default kube context")

--- a/docs/configuration/agent/configuration.md
+++ b/docs/configuration/agent/configuration.md
@@ -241,6 +241,21 @@ The recommended approach for production deployments is to use ConfigMap entries 
 - **Default**: `""` (empty)
 - **Example**: `"redis-password"`
 
+### Resource Proxy Configuration
+
+#### Enable Resource Proxy
+- **Command Line Flag**: `--enable-resource-proxy`
+- **Environment Variable**: `ARGOCD_AGENT_ENABLE_RESOURCE_PROXY`
+- **ConfigMap Entry**: *(Not available in ConfigMap)*
+- **Description**: Enable the resource proxy to allow access to live resources on this agent cluster from the principal
+- **Type**: Boolean
+- **Default**: `true`
+- **Example**: `"true"`
+- **Use Cases for Disabling**:
+  - Security policies that require restricted resource access
+  - Performance optimization when live resource viewing is not needed
+  - Troubleshooting resource proxy related issues
+
 ### Kubernetes Configuration
 
 #### Kubeconfig
@@ -272,7 +287,8 @@ argocd-agent agent \
   --server-port=8443 \
   --agent-mode=autonomous \
   --namespace=argocd \
-  --log-level=info
+  --log-level=info \
+  --enable-resource-proxy=true
 ```
 
 ### Using Environment Variables
@@ -282,6 +298,7 @@ export ARGOCD_AGENT_REMOTE_PORT=8443
 export ARGOCD_AGENT_MODE=autonomous
 export ARGOCD_AGENT_NAMESPACE=argocd
 export ARGOCD_AGENT_LOG_LEVEL=info
+export ARGOCD_AGENT_ENABLE_RESOURCE_PROXY=true
 argocd-agent agent
 ```
 
@@ -313,4 +330,20 @@ The ConfigMap should be mounted to the agent container and the parameters will b
 - Store sensitive configuration like credentials in Kubernetes Secrets, not ConfigMaps
 - Use mutual TLS (`mtls`) authentication when possible for enhanced security
 - Regularly rotate TLS certificates and authentication credentials
-- Restrict network access to the agent's metrics and health endpoints 
+- Restrict network access to the agent's metrics and health endpoints
+- Consider disabling resource proxy (`--enable-resource-proxy=false`) if live resource access is not required for enhanced security isolation
+
+## Resource Proxy Considerations
+
+When the resource proxy is **enabled** (default):
+- Users can view live resources for applications on this agent cluster through the Argo CD UI
+- The agent processes resource requests from the principal and proxies them to the local Kubernetes API
+- All resource access is limited to resources managed by Argo CD applications
+
+When the resource proxy is **disabled**:
+- Live resource viewing will not work for applications on this agent cluster
+- The Argo CD UI will show application status but not allow inspection of individual resources
+- Application synchronization and management operations continue to work normally
+- Reduces attack surface and network communication between principal and agent
+
+For detailed information about how the resource proxy works and additional configuration options, see the [Live Resources](../../user-guide/live-resources.md) user guide. 

--- a/docs/user-guide/live-resources.md
+++ b/docs/user-guide/live-resources.md
@@ -66,7 +66,25 @@ argocd-agent principal \
 
 ### Agent Configuration
 
-**No additional configuration is required on the agent side.** The agent automatically processes resource requests received from the principal through the standard event queue mechanism.
+The resource proxy is **enabled by default** on the agent and requires no additional configuration in most cases. However, it can be disabled if live resource access is not needed.
+
+#### Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `ARGOCD_AGENT_ENABLE_RESOURCE_PROXY` | `true` | Enable/disable resource proxy processing on the agent |
+
+#### Command Line Options
+
+```bash
+# Disable resource proxy on the agent
+argocd-agent agent --enable-resource-proxy=false
+
+# Enable resource proxy (default behavior)
+argocd-agent agent --enable-resource-proxy=true
+```
+
+**Note**: When disabled, the agent will not process resource requests from the principal, making live resource viewing unavailable for applications on this agent cluster.
 
 ## Supported Operations
 
@@ -263,6 +281,8 @@ curl -k --cert client.crt --key client.key \
 
 ## Related Documentation
 
+- [Agent Configuration](../configuration/agent/configuration.md#resource-proxy-configuration) - Agent resource proxy configuration options
+- [Principal Configuration](../configuration/principal/configuration.md#resource-proxy-configuration) - Principal resource proxy configuration options
 - [Application Synchronization](./applications.md) - How Applications are managed
 - [Agent Modes](../concepts/agent-modes/) - Understanding managed vs autonomous modes
 - [Architecture](../concepts/architecture.md) - Overall system architecture 

--- a/install/kubernetes/agent/agent-deployment.yaml
+++ b/install/kubernetes/agent/agent-deployment.yaml
@@ -140,6 +140,12 @@ spec:
               secretKeyRef:
                 name: argocd-redis
                 key: auth
+          - name: ARGOCD_AGENT_ENABLE_RESOURCE_PROXY
+            valueFrom:
+              configMapKeyRef:
+                name: argocd-agent-params
+                key: agent.resource-proxy.enable
+                optional: true
           image: argocd-agent
           imagePullPolicy: Always
           name: argocd-agent-agent

--- a/install/kubernetes/agent/agent-params-cm.yaml
+++ b/install/kubernetes/agent/agent-params-cm.yaml
@@ -80,4 +80,6 @@ data:
   # agent.pprof.port: The port the pprof server should listen on.
   # Default: 0
   agent.pprof.port: "0"
-  
+  # agent.resource-proxy.enable: Whether to enable the resource proxy.
+  # Default: true
+  agent.resource-proxy.enable: "true"


### PR DESCRIPTION
**What does this PR do / why we need it**:

This PR introduces a flag `--enable-resource-proxy` to the agent component. The flag defaults to `true`. If set to `false`, the agent will not provide any local resources through the resource proxy, effectively disabling the resource proxy functionality.

**Which issue(s) this PR fixes**:

Fixes #480

**How to test changes / Special notes to the reviewer**:

**Checklist**

* [ ] Documentation update is required by this PR (and has been updated) OR no documentation update is required.

