### PR TITLE
fix: Better transformation of AppProjects from autonomous agents

### DIFF
--- a/hack/dev-env/apps/autonomous-guestbook.yaml
+++ b/hack/dev-env/apps/autonomous-guestbook.yaml
@@ -4,7 +4,7 @@ metadata:
   name: guestbook
   namespace: argocd
 spec:
-  project: default
+  project: test-project
   source:
     repoURL: https://github.com/argoproj/argocd-example-apps
     targetRevision: HEAD

--- a/hack/dev-env/apps/autonomous-project.yaml
+++ b/hack/dev-env/apps/autonomous-project.yaml
@@ -4,6 +4,9 @@ metadata:
   name: test-project
   namespace: argocd
 spec:
+  clusterResourceWhitelist:
+  - group: ''
+    kind: Namespace
   destinations:
   - namespace: 'guestbook'
     name: 'in-cluster'

--- a/hack/dev-env/apps/autonomous-project.yaml
+++ b/hack/dev-env/apps/autonomous-project.yaml
@@ -1,0 +1,13 @@
+apiVersion: argoproj.io/v1alpha1
+kind: AppProject
+metadata:
+  name: test-project
+  namespace: argocd
+spec:
+  destinations:
+  - namespace: 'guestbook'
+    name: 'in-cluster'
+    server: 'https://kubernetes.default.svc'
+  sourceRepos:
+  - '*'
+

--- a/principal/event.go
+++ b/principal/event.go
@@ -24,7 +24,6 @@ import (
 	"github.com/argoproj-labs/argocd-agent/internal/event"
 	"github.com/argoproj-labs/argocd-agent/internal/kube"
 	"github.com/argoproj-labs/argocd-agent/internal/manager"
-	"github.com/argoproj-labs/argocd-agent/internal/manager/appproject"
 	"github.com/argoproj-labs/argocd-agent/internal/metrics"
 	"github.com/argoproj-labs/argocd-agent/internal/namedlock"
 	"github.com/argoproj-labs/argocd-agent/internal/resync"
@@ -150,11 +149,9 @@ func (s *Server) processApplicationEvent(ctx context.Context, agentName string, 
 		}
 
 		// AppProjects from the autonomous agents are prefixed with the agent name
-		if incoming.Spec.Project != appproject.DefaultAppProjectName {
-			incoming.Spec.Project, err = agentPrefixedProjectName(incoming.Spec.Project, agentName)
-			if err != nil {
-				return fmt.Errorf("could not prefix project name: %w", err)
-			}
+		incoming.Spec.Project, err = agentPrefixedProjectName(incoming.Spec.Project, agentName)
+		if err != nil {
+			return fmt.Errorf("could not prefix project name: %w", err)
 		}
 
 		// Set the destination name to the cluster mapping for the agent

--- a/principal/event.go
+++ b/principal/event.go
@@ -293,10 +293,17 @@ func (s *Server) processAppProjectEvent(ctx context.Context, agentName string, e
 
 	// AppProjects coming from different autonomous agents could have the same name,
 	// so we prefix the project name with the agent name
-	if agentMode.IsAutonomous() && incoming.Name != appproject.DefaultAppProjectName {
+	if agentMode.IsAutonomous() {
 		incoming.Name, err = agentPrefixedProjectName(incoming.Name, agentName)
 		if err != nil {
 			return fmt.Errorf("could not prefix project name: %w", err)
+		}
+		// Set the source namespaces to allow the agent's namespace on the principal
+		incoming.Spec.SourceNamespaces = []string{agentName}
+		// Set all destinations to point to the agent cluster
+		for i := range incoming.Spec.Destinations {
+			incoming.Spec.Destinations[i].Name = agentName
+			incoming.Spec.Destinations[i].Server = "*"
 		}
 	}
 

--- a/principal/event_test.go
+++ b/principal/event_test.go
@@ -312,7 +312,7 @@ func Test_UpdateEvents(t *testing.T) {
 		assert.Equal(t, "foo", napp.Spec.Destination.Name)
 		assert.Equal(t, "", napp.Spec.Destination.Server)
 		assert.Nil(t, napp.Operation)
-		assert.Equal(t, "default", napp.Spec.Project)
+		assert.Equal(t, "foo-default", napp.Spec.Project)
 		assert.Equal(t, v1alpha1.SyncStatusCodeSynced, napp.Status.Sync.Status)
 	})
 

--- a/test/e2e2/basic_test.go
+++ b/test/e2e2/basic_test.go
@@ -169,6 +169,7 @@ func (suite *BasicTestSuite) Test_AgentAutonomous() {
 	requires.NoError(err)
 	app.Spec.Destination.Name = "agent-autonomous"
 	app.Spec.Destination.Server = ""
+	app.Spec.Project = "agent-autonomous-default"
 	requires.Equal(&app.Spec, &papp.Spec)
 
 	// Modify the application on the autonomous-agent and ensure the change is

--- a/test/e2e2/resync_test.go
+++ b/test/e2e2/resync_test.go
@@ -504,6 +504,7 @@ func (suite *ResyncTestSuite) createAutonomousApp() *argoapp.Application {
 	requires.NoError(err)
 	app.Spec.Destination.Name = "agent-autonomous"
 	app.Spec.Destination.Server = ""
+	app.Spec.Project = "agent-autonomous-default"
 	requires.Equal(&app.Spec, &papp.Spec)
 
 	return &app

--- a/test/e2e2/sync_test.go
+++ b/test/e2e2/sync_test.go
@@ -245,6 +245,7 @@ func (suite *SyncTestSuite) Test_SyncAutonomous() {
 	requires.NoError(err)
 	app.Spec.Destination.Name = "agent-autonomous"
 	app.Spec.Destination.Server = ""
+	app.Spec.Project = "agent-autonomous-default"
 	requires.Equal(&app.Spec, &papp.Spec)
 
 	// Modify the application on the autonomous-agent and ensure the change is


### PR DESCRIPTION
**What does this PR do / why we need it**:

This PR correctly applies transformations to `.spec.sourceNamespaces` and `.spec.destinations` when an AppProject is synced from an autonomous agent to the principal.

Also, it will not treat the `default` AppProject synced from an autonomous agent in a special way anymore.

**Which issue(s) this PR fixes**:

Fixes #496
Fixes #497

**How to test changes / Special notes to the reviewer**:


**Checklist**

* [ ] Documentation update is required by this PR (and has been updated) OR no documentation update is required.

