### PR TITLE
fix: module logger should respect the CLI log flags

### DIFF
--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -23,7 +23,6 @@ package logging
 import (
 	"fmt"
 	"io"
-	"os"
 	"strings"
 
 	"github.com/sirupsen/logrus"
@@ -56,13 +55,8 @@ const (
 var defaultLogger *logrus.Logger
 
 func init() {
-	// Initialize the default logger with sensible defaults
-	defaultLogger = logrus.New()
-	defaultLogger.SetLevel(logrus.InfoLevel)
-	defaultLogger.SetFormatter(&logrus.TextFormatter{
-		FullTimestamp: true,
-	})
-	defaultLogger.SetOutput(os.Stdout)
+	// Use the process-wide standard logger so that CLI flags and InitLogging() apply here too
+	defaultLogger = logrus.StandardLogger()
 }
 
 // SetupLogging configures the global logger with the provided options


### PR DESCRIPTION
**What does this PR do / why we need it**:

The module logger creates a new logrus instance that is not configured by the CLI flags. This hides certain trace-level logs because it uses the info level by default. The PR updates the default logger defined in internal/logging to use the standard logger so that all the CLI flags apply here.


**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:

1. Add a trace-level log (`log().Trace`) in agent/principal
2. The trace log is not displayed because the module logger uses the info level.


**Checklist**

* [ ] Documentation update is required by this PR (and has been updated) OR no documentation update is required.

