### PR TITLE
test: wait for resource action to be available

### DIFF
--- a/test/e2e/fixture/argoclient.go
+++ b/test/e2e/fixture/argoclient.go
@@ -182,9 +182,21 @@ func (c *ArgoRestClient) RunResourceAction(app *v1alpha1.Application, action, gr
 		"version", version,
 		"kind", kind,
 	)
-	reqURL.Path = fmt.Sprintf("/api/v1/applications/%s/resource/actions", app.Name)
+	reqURL.Path = fmt.Sprintf("/api/v1/applications/%s/resource/actions/v2", app.Name)
 
-	reqBody, err := json.Marshal(action)
+	// Based on Argo CD Swagger: https://cd.apps.argoproj.io/swagger-ui#tag/ApplicationService/operation/ApplicationService_RunResourceActionV2
+	requestBody := map[string]interface{}{
+		"action":       action,
+		"appNamespace": app.Namespace,
+		"group":        group,
+		"kind":         kind,
+		"name":         name,
+		"namespace":    namespace,
+		"project":      app.Spec.Project,
+		"resourceName": name,
+		"version":      version,
+	}
+	reqBody, err := json.Marshal(requestBody)
 	if err != nil {
 		return err
 	}

--- a/test/e2e/rp_test.go
+++ b/test/e2e/rp_test.go
@@ -370,6 +370,18 @@ func (suite *ResourceProxyTestSuite) Test_ResourceProxy_ResourceActions() {
 	}, 60*time.Second, 1*time.Second)
 	requires.NoError(err)
 
+	requires.Eventually(func() bool {
+		actions, err := argoClient.ListResourceActions(&app, "apps", "v1", "Deployment", "guestbook", "kustomize-guestbook-ui")
+		requires.NoError(err)
+
+		for _, action := range actions {
+			if action == "test" {
+				return true
+			}
+		}
+		return false
+	}, 30*time.Second, 1*time.Second)
+
 	// Execute the action
 	err = argoClient.RunResourceAction(&app, "test",
 		"apps", "v1", "Deployment", "guestbook", "kustomize-guestbook-ui")

--- a/test/run-e2e.sh
+++ b/test/run-e2e.sh
@@ -71,4 +71,6 @@ if test "${AGENT_E2E_AUTONOMOUS_CLUSTER_SERVER}" = ""; then
        export AGENT_E2E_AUTONOMOUS_CLUSTER_SERVER
 fi
 
-go test -count=1 -v -race -timeout 30m github.com/argoproj-labs/argocd-agent/test/e2e
+# go test -count=1 -v -race -timeout 30m github.com/argoproj-labs/argocd-agent/test/e2e
+
+go test -v -race github.com/argoproj-labs/argocd-agent/test/e2e -run TestResourceProxyTestSuite/Test_ResourceProxy_ResourceActions

--- a/test/run-e2e.sh
+++ b/test/run-e2e.sh
@@ -71,6 +71,4 @@ if test "${AGENT_E2E_AUTONOMOUS_CLUSTER_SERVER}" = ""; then
        export AGENT_E2E_AUTONOMOUS_CLUSTER_SERVER
 fi
 
-# go test -count=1 -v -race -timeout 30m github.com/argoproj-labs/argocd-agent/test/e2e
-
-go test -v -race github.com/argoproj-labs/argocd-agent/test/e2e -run TestResourceProxyTestSuite/Test_ResourceProxy_ResourceActions
+go test -count=1 -v -race -timeout 30m github.com/argoproj-labs/argocd-agent/test/e2e


### PR DESCRIPTION
**What does this PR do / why we need it**:

* The e2e test should wait for the resource action to be available. This could prevent a race condition where the test executes the resource action before Argo CD discovers the action.

* Switch to resource action API version V2

**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:


**Checklist**

* [ ] Documentation update is required by this PR (and has been updated) OR no documentation update is required.

