### PR TITLE
chore: Add teardown-e2e to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,9 @@ setup-e2e: cli
 	./hack/dev-env/gen-creds.sh
 	./hack/dev-env/create-agent-config.sh
 
+teardown-e2e:
+	./hack/dev-env/setup-vcluster-env.sh delete
+
 .PHONY: start-e2e
 start-e2e: cli install-goreman
 	./hack/dev-env/start-e2e.sh


### PR DESCRIPTION
**What does this PR do / why we need it**:

This adds a target named `teardown-e2e` to the Makefile, which will completely remove any traces of the e2e environment from a cluster.

**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:


**Checklist**

* [ ] Documentation update is required by this PR (and has been updated) OR no documentation update is required.

