### PR TITLE
fix: Return error from create app project

### DIFF
--- a/internal/manager/appproject/appproject.go
+++ b/internal/manager/appproject/appproject.go
@@ -160,7 +160,7 @@ func createAppProject(ctx context.Context, m *AppProjectManager, project *v1alph
 		}
 		return created, nil
 	}
-	return nil, nil
+	return nil, err
 }
 
 func (m *AppProjectManager) Get(ctx context.Context, name, namespace string) (*v1alpha1.AppProject, error) {


### PR DESCRIPTION
**What does this PR do / why we need it**:
Principal panics if create app project fails due to an error. This was due to error not being passed correctly from the createAppProjectMethod.
**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:


**Checklist**

* [ ] Documentation update is required by this PR (and has been updated) OR no documentation update is required.

