### PR TITLE
fix: close redis proxy connection ID tracker on goroutine end

### DIFF
--- a/principal/event.go
+++ b/principal/event.go
@@ -377,6 +377,11 @@ func (s *Server) processRedisEventResponse(ctx context.Context, logCtx *logrus.E
 		// PushFromSubscribe is asynchronous, so we can't use event id tracker to find the corresponding channel.
 		// - We instead use connection id, which maps directly to the connection from Argo CD
 		trAgent, evChan := s.redisProxy.ConnectionIDTracker.Tracked(resReq.ConnectionUUID)
+		if evChan == nil {
+			logCtx.Debug("connection UUID is no longer in connectionIDTracker, likely the principal connection has closed")
+			return nil
+		}
+
 		if trAgent != agentName {
 			err := fmt.Errorf("agent mismap between event and tracking for PushFromSubscribe: '%s' '%s' '%s'", trAgent, agentName, resReq.ConnectionUUID)
 			return err

--- a/principal/redisproxy/redisproxy.go
+++ b/principal/redisproxy/redisproxy.go
@@ -458,6 +458,11 @@ func (rp *RedisProxy) handleAgentSubscribe(connState *connectionState, channelNa
 		// Forward all events from 'subscriptionChannel' to 'connectionUUIDEventsChannel'
 		go func() {
 			defer close(connState.connectionUUIDEventsChannel)
+			defer func() {
+				if err := rp.ConnectionIDTracker.StopTracking(connState.connUUID); err != nil {
+					logCtx.WithError(err).Error("connection ID tracker reported an unexpected error. At this stage of the goroutine lifecycle, the resource should still necessarily be tracked.")
+				}
+			}()
 
 			for {
 				select {


### PR DESCRIPTION
**What does this PR do / why we need it**:

As originally reported on internal Slack back in July (pre-redis-proxy-PR merge), @jannfis  reported the following redis-proxy-related error message while interacting with Argo CD UI:

`
14:07:00        principal | time="2025-07-08T14:07:00Z" level=error msg="unable to process redis event response" error="error waiting for response to be read: context deadline exceeded" # (...)
`

It was investigated at the time and determined to only be a logging/lack-of-cleanup issue. That is still correct. 

Here is what I wrote at the time:
> * Re: *'error waiting for response to be read: context deadline exceeded'*:
> * This functionally here is correct, but logging can be improved.
> * This error is printed when an event is sent from agent back to principal, but principal argo cd has ALREADY CLOSED the redis connection.
>     * You can verify this by finding a log line where this error is reported, and grepping for the connection uuid (e.g. `cat log.txt | grep "35cc699a-d3e9-4c37-a605-c66a5e6b211c`) and inevitably you will see the connection was previously closed.
>     * This will stop once the agent redis connection is cleaned up due to inactivity.
> * This can be improved by some simple logic to ignore events for closed connections on principal.
> * I've NOT fixed this as part of this PR: I recommend handling it as part of a separate PR.

Well this is that 'separate PR' :smile: . 

This PR:
- Ensures that the connection tracker lifecycle is cleaned up at the appropriate spot
- The log message now logs at debug level (rather than error) and with a more accurate message
- (If I knew it was this easy to fix, I would have included it in the original PR :smile: )

**Checklist**

* [ ] Documentation update is required by this PR (and has been updated) OR no documentation update is required.

