### PR TITLE
chore(dev-env): install the latest argocd version

### DIFF
--- a/hack/dev-env/setup-vcluster-env.sh
+++ b/hack/dev-env/setup-vcluster-env.sh
@@ -119,7 +119,8 @@ apply() {
         sed -i.bak -e "/loadBalancerIP/s/192\.168\.56/${LB_NETWORK}/" $TMP_DIR/agent-autonomous/redis-service.yaml
     fi
 
-    LATEST_RELEASE_TAG=`curl -s "https://api.github.com/repos/argoproj/argo-cd/releases/latest" | jq -r .tag_name`
+    # Get the most recent version of Argo CD from the releases page
+    LATEST_RELEASE_TAG=`curl -s "https://api.github.com/repos/argoproj/argo-cd/releases" | jq -r '.[].tag_name' | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -1`
     sed -i.bak -e "s/LatestReleaseTag/${LATEST_RELEASE_TAG}/" $TMP_DIR/control-plane/kustomization.yaml
     sed -i.bak -e "s/LatestReleaseTag/${LATEST_RELEASE_TAG}/" $TMP_DIR/agent-autonomous/kustomization.yaml
     sed -i.bak -e "s/LatestReleaseTag/${LATEST_RELEASE_TAG}/" $TMP_DIR/agent-managed/kustomization.yaml


### PR DESCRIPTION
**What does this PR do / why we need it**:
Currently, we install the argocd version that is marked as latest in the upstream argocd repository. The latest release could also be a patch release of an older version and may not always be the most recent minor version. For example, v3.0.13 is marked as the latest even though v3.1.1 exists. This could break some of the e2e tests (ResourceAction) since we test with an older version.

https://github.com/argoproj-labs/argocd-agent/blob/main/hack/dev-env/setup-vcluster-env.sh#L122

**Alternate solution**: We fix the argocd version 

**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:


**Checklist**

* [ ] Documentation update is required by this PR (and has been updated) OR no documentation update is required.

