### PR TITLE
test(e2e): Fix flaky test for ClusterCacheInfo validation

### DIFF
--- a/test/e2e/clusterinfo_test.go
+++ b/test/e2e/clusterinfo_test.go
@@ -42,31 +42,31 @@ func TestClusterTestSuite(t *testing.T) {
 }
 
 func (suite *ClusterInfoTestSuite) SetupTest() {
-	if !fixture.IsProcessRunning(PrincipalName) {
+	if !fixture.IsProcessRunning(fixture.PrincipalName) {
 		// Start the principal if it is not running and wait for it to be ready
-		suite.Require().NoError(fixture.StartProcess(PrincipalName))
-		fixture.CheckReadiness(suite.T(), PrincipalName)
+		suite.Require().NoError(fixture.StartProcess(fixture.PrincipalName))
+		fixture.CheckReadiness(suite.T(), fixture.PrincipalName)
 	} else {
 		// If principal is already running, verify that it is ready
-		fixture.CheckReadiness(suite.T(), PrincipalName)
+		fixture.CheckReadiness(suite.T(), fixture.PrincipalName)
 	}
 
-	if !fixture.IsProcessRunning(AgentManagedName) {
+	if !fixture.IsProcessRunning(fixture.AgentManagedName) {
 		// Start the agent if it is not running and wait for it to be ready
-		suite.Require().NoError(fixture.StartProcess(AgentManagedName))
-		fixture.CheckReadiness(suite.T(), AgentManagedName)
+		suite.Require().NoError(fixture.StartProcess(fixture.AgentManagedName))
+		fixture.CheckReadiness(suite.T(), fixture.AgentManagedName)
 	} else {
 		// If agent is already running, verify that it is ready
-		fixture.CheckReadiness(suite.T(), AgentManagedName)
+		fixture.CheckReadiness(suite.T(), fixture.AgentManagedName)
 	}
 
-	if !fixture.IsProcessRunning(AgentAutonomousName) {
+	if !fixture.IsProcessRunning(fixture.AgentAutonomousName) {
 		// Start the agent if it is not running and wait for it to be ready
-		suite.Require().NoError(fixture.StartProcess(AgentAutonomousName))
-		fixture.CheckReadiness(suite.T(), AgentAutonomousName)
+		suite.Require().NoError(fixture.StartProcess(fixture.AgentAutonomousName))
+		fixture.CheckReadiness(suite.T(), fixture.AgentAutonomousName)
 	} else {
 		// If agent is already running, verify that it is ready
-		fixture.CheckReadiness(suite.T(), AgentAutonomousName)
+		fixture.CheckReadiness(suite.T(), fixture.AgentAutonomousName)
 	}
 
 	suite.BaseSuite.SetupTest()
@@ -81,33 +81,33 @@ func (suite *ClusterInfoTestSuite) Test_ClusterInfo_Managed() {
 	requires.Eventually(func() bool {
 		return fixture.HasConnectionStatus(os.Getenv(fixture.ManagedAgentServerKey), appv1.ConnectionState{
 			Status:  appv1.ConnectionStatusSuccessful,
-			Message: fmt.Sprintf(message, AgentManagedName, "connected"),
+			Message: fmt.Sprintf(message, fixture.AgentManagedName, "connected"),
 		})
 	}, 30*time.Second, 1*time.Second)
 
 	// Stop the agent
-	err := fixture.StopProcess(AgentManagedName)
+	err := fixture.StopProcess(fixture.AgentManagedName)
 	requires.NoError(err)
 
 	// Verify that connection status is updated when agent is disconnected
 	requires.Eventually(func() bool {
 		return fixture.HasConnectionStatus(os.Getenv(fixture.ManagedAgentServerKey), appv1.ConnectionState{
 			Status:     appv1.ConnectionStatusFailed,
-			Message:    fmt.Sprintf(message, AgentManagedName, "disconnected"),
+			Message:    fmt.Sprintf(message, fixture.AgentManagedName, "disconnected"),
 			ModifiedAt: &metav1.Time{Time: time.Now()},
 		})
 	}, 30*time.Second, 1*time.Second)
 
 	// Restart the agent
-	err = fixture.StartProcess(AgentManagedName)
+	err = fixture.StartProcess(fixture.AgentManagedName)
 	requires.NoError(err)
-	fixture.CheckReadiness(suite.T(), AgentManagedName)
+	fixture.CheckReadiness(suite.T(), fixture.AgentManagedName)
 
 	// Verify that connection status is updated again when agent is re-connected
 	requires.Eventually(func() bool {
 		return fixture.HasConnectionStatus(os.Getenv(fixture.ManagedAgentServerKey), appv1.ConnectionState{
 			Status:     appv1.ConnectionStatusSuccessful,
-			Message:    fmt.Sprintf(message, AgentManagedName, "connected"),
+			Message:    fmt.Sprintf(message, fixture.AgentManagedName, "connected"),
 			ModifiedAt: &metav1.Time{Time: time.Now()},
 		})
 	}, 30*time.Second, 1*time.Second)
@@ -120,33 +120,33 @@ func (suite *ClusterInfoTestSuite) Test_ClusterInfo_Autonomous() {
 	requires.Eventually(func() bool {
 		return fixture.HasConnectionStatus(os.Getenv(fixture.AutonomousAgentServerKey), appv1.ConnectionState{
 			Status:  appv1.ConnectionStatusSuccessful,
-			Message: fmt.Sprintf(message, AgentAutonomousName, "connected"),
+			Message: fmt.Sprintf(message, fixture.AgentAutonomousName, "connected"),
 		})
 	}, 30*time.Second, 1*time.Second)
 
 	// Stop the agent
-	err := fixture.StopProcess(AgentAutonomousName)
+	err := fixture.StopProcess(fixture.AgentAutonomousName)
 	requires.NoError(err)
 
 	// Verify that connection status is updated when agent is disconnected
 	requires.Eventually(func() bool {
 		return fixture.HasConnectionStatus(os.Getenv(fixture.AutonomousAgentServerKey), appv1.ConnectionState{
 			Status:     appv1.ConnectionStatusFailed,
-			Message:    fmt.Sprintf(message, AgentAutonomousName, "disconnected"),
+			Message:    fmt.Sprintf(message, fixture.AgentAutonomousName, "disconnected"),
 			ModifiedAt: &metav1.Time{Time: time.Now()},
 		})
 	}, 30*time.Second, 1*time.Second)
 
 	// Restart the agent
-	err = fixture.StartProcess(AgentAutonomousName)
+	err = fixture.StartProcess(fixture.AgentAutonomousName)
 	requires.NoError(err)
-	fixture.CheckReadiness(suite.T(), AgentAutonomousName)
+	fixture.CheckReadiness(suite.T(), fixture.AgentAutonomousName)
 
 	// Verify that connection status is updated again when agent is re-connected
 	requires.Eventually(func() bool {
 		return fixture.HasConnectionStatus(os.Getenv(fixture.AutonomousAgentServerKey), appv1.ConnectionState{
 			Status:     appv1.ConnectionStatusSuccessful,
-			Message:    fmt.Sprintf(message, AgentAutonomousName, "connected"),
+			Message:    fmt.Sprintf(message, fixture.AgentAutonomousName, "connected"),
 			ModifiedAt: &metav1.Time{Time: time.Now()},
 		})
 	}, 30*time.Second, 1*time.Second)
@@ -222,17 +222,17 @@ func (suite *ClusterInfoTestSuite) Test_ClusterCacheInfo() {
 	requires.Eventually(func() bool {
 		return fixture.HasConnectionStatus(os.Getenv(fixture.ManagedAgentServerKey), appv1.ConnectionState{
 			Status:  appv1.ConnectionStatusSuccessful,
-			Message: fmt.Sprintf(message, AgentManagedName, "connected"),
+			Message: fmt.Sprintf(message, fixture.AgentManagedName, "connected"),
 		})
 	}, 30*time.Second, 1*time.Second)
 
 	// Step 8:
 	// Disconnect agent and verify that connection status is changed to Failed
-	requires.NoError(fixture.StopProcess(AgentManagedName))
+	requires.NoError(fixture.StopProcess(fixture.AgentManagedName))
 	requires.Eventually(func() bool {
 		return fixture.HasConnectionStatus(os.Getenv(fixture.ManagedAgentServerKey), appv1.ConnectionState{
 			Status:     appv1.ConnectionStatusFailed,
-			Message:    fmt.Sprintf(message, AgentManagedName, "disconnected"),
+			Message:    fmt.Sprintf(message, fixture.AgentManagedName, "disconnected"),
 			ModifiedAt: &metav1.Time{Time: time.Now()},
 		})
 	}, 60*time.Second, 2*time.Second)
@@ -249,13 +249,13 @@ func (suite *ClusterInfoTestSuite) Test_ClusterCacheInfo() {
 
 	// Step 10:
 	// Reconnect agent and verify that connection status and cluster cache info are updated again with correct values
-	requires.NoError(fixture.StartProcess(AgentManagedName))
-	fixture.CheckReadiness(suite.T(), AgentManagedName)
+	requires.NoError(fixture.StartProcess(fixture.AgentManagedName))
+	fixture.CheckReadiness(suite.T(), fixture.AgentManagedName)
 
 	requires.Eventually(func() bool {
 		return fixture.HasConnectionStatus(os.Getenv(fixture.ManagedAgentServerKey), appv1.ConnectionState{
 			Status:     appv1.ConnectionStatusSuccessful,
-			Message:    fmt.Sprintf(message, AgentManagedName, "connected"),
+			Message:    fmt.Sprintf(message, fixture.AgentManagedName, "connected"),
 			ModifiedAt: &metav1.Time{Time: time.Now()},
 		})
 	}, 60*time.Second, 2*time.Second)

--- a/test/e2e/fixture/fixture.go
+++ b/test/e2e/fixture/fixture.go
@@ -87,7 +87,7 @@ func (suite *BaseSuite) SetupTest() {
 			suite.T().Log(err)
 		}
 		return err == nil && len(project.Annotations) > 0 && project.Annotations["created"] == now
-	}, 10*time.Second, 1*time.Second)
+	}, 30*time.Second, 1*time.Second)
 
 	suite.T().Logf("Test begun at: %v", time.Now())
 }
@@ -280,5 +280,15 @@ func CleanUp(ctx context.Context, principalClient KubeClient, managedAgentClient
 		return err
 	}
 
+	return resetManagedAgentClusterInfo()
+}
+
+// resetManagedAgentClusterInfo resets the cluster info in the redis cache for the managed agent
+func resetManagedAgentClusterInfo() error {
+	// Reset cluster info in redis cache
+	if err := getCacheInstance(AgentManagedName).SetClusterInfo(AgentClusterServerURL, &argoapp.ClusterInfo{}); err != nil {
+		fmt.Println("resetManagedAgentClusterInfo: error", err)
+		return err
+	}
 	return nil
 }

--- a/test/e2e/fixture/toxyproxy.go
+++ b/test/e2e/fixture/toxyproxy.go
@@ -123,5 +123,5 @@ func CheckReadiness(t require.TestingT, compName string) {
 		}
 		defer resp.Body.Close()
 		return resp.StatusCode == http.StatusOK
-	}, 60*time.Second, 1*time.Second)
+	}, 120*time.Second, 2*time.Second)
 }


### PR DESCRIPTION
This PR is to modify the validation of ClusterCacheInfo.

The test fails sometimes because of delay in ClusterCacheInfo update by Argo CD. 
Here is the scenario when test fails:

1) At 1st second `ClusterCacheInfo` is refreshed by Argo CD periodic update (every 10 seconds).
2) 5th second, app is created by a test, but cache is yet to be refreshed in next iteration.

3) 10th second, cache is refreshed and now it has app count 1.
4) 15th second, last test completed and app is deleted, but again cache is yet to be refreshed on 20 second.
5) 18th second, `Test_ClusterCacheInfo` started and it fetched current number of apps from agent cache (appCountBefore) which is still set to 1 from last iteration (on 10th second).

6) 20th second, cache refreshed and application count is now set to 0 (based on last test).
7) Now a new application is created by `Test_ClusterCacheInfo` and it is assuming that no of apps in cache would be 1+1=2 (appCountBefore + new app), but actually it is 0+1, hence the test case fails here expecting no of app to be 2.

The easiest fix is to wait for Argo CD to refresh cache before starting the `Test_ClusterCacheInfo` test to allow Argo CD to refresh the cache. 
