### PR TITLE
chore: port HTTP/2 downgrade test to current e2e test framework

### DIFF
--- a/hack/dev-env/start-agent-managed.sh
+++ b/hack/dev-env/start-agent-managed.sh
@@ -27,6 +27,7 @@ export ARGOCD_AGENT_REMOTE_PORT=${ARGOCD_AGENT_REMOTE_PORT:-8443}
 E2E_ENV_FILE="/tmp/argocd-agent-e2e"
 if [ -f "$E2E_ENV_FILE" ]; then
     source "$E2E_ENV_FILE"
+    export ARGOCD_PRINCIPAL_ENABLE_WEBSOCKET=${ARGOCD_PRINCIPAL_ENABLE_WEBSOCKET:-false}
 fi
 
 go run github.com/argoproj-labs/argocd-agent/cmd/argocd-agent agent \

--- a/hack/dev-env/start-principal.sh
+++ b/hack/dev-env/start-principal.sh
@@ -35,6 +35,13 @@ if test "${ARGOCD_PRINCIPAL_REDIS_SERVER_ADDRESS}" = ""; then
        export ARGOCD_PRINCIPAL_REDIS_SERVER_ADDRESS
 fi
 
+# Point the principal to the e2e test configuration if it exists
+E2E_ENV_FILE="/tmp/argocd-agent-e2e"
+if [ -f "$E2E_ENV_FILE" ]; then
+    source "$E2E_ENV_FILE"
+    export ARGOCD_PRINCIPAL_ENABLE_WEBSOCKET=${ARGOCD_PRINCIPAL_ENABLE_WEBSOCKET:-false}
+fi
+
 SCRIPTPATH="$( cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
 go run github.com/argoproj-labs/argocd-agent/cmd/argocd-agent principal \
 	--allowed-namespaces '*' \

--- a/test/e2e/fixture/toxyproxy.go
+++ b/test/e2e/fixture/toxyproxy.go
@@ -125,3 +125,23 @@ func CheckReadiness(t require.TestingT, compName string) {
 		return resp.StatusCode == http.StatusOK
 	}, 120*time.Second, 2*time.Second)
 }
+
+func IsNotReady(t require.TestingT, compName string) {
+	healthzAddr := "http://localhost:8002/healthz"
+	if compName == "agent-managed" {
+		healthzAddr = "http://localhost:8001/healthz"
+	}
+
+	if compName == "principal" {
+		healthzAddr = "http://localhost:8003/healthz"
+	}
+
+	require.Never(t, func() bool {
+		resp, err := http.Get(healthzAddr)
+		if err != nil {
+			return false
+		}
+		defer resp.Body.Close()
+		return resp.StatusCode == http.StatusOK
+	}, 10*time.Second, 1*time.Second)
+}

--- a/test/e2e/websocket_test.go
+++ b/test/e2e/websocket_test.go
@@ -1,0 +1,151 @@
+// Copyright 2025 The argocd-agent Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/argoproj-labs/argocd-agent/internal/config"
+	"github.com/argoproj-labs/argocd-agent/internal/tlsutil"
+	"github.com/argoproj-labs/argocd-agent/test/e2e/fixture"
+	"github.com/argoproj-labs/argocd-agent/test/proxy"
+	"github.com/stretchr/testify/suite"
+	"k8s.io/client-go/kubernetes"
+)
+
+type HTTP1DowngradeTestSuite struct {
+	fixture.BaseSuite
+}
+
+func (suite *HTTP1DowngradeTestSuite) TearDownTest() {
+	suite.BaseSuite.TearDownTest()
+	requires := suite.Require()
+
+	if _, err := os.Stat(fixture.EnvVariablesFromE2EFile); err == nil {
+		requires.NoError(os.Remove(fixture.EnvVariablesFromE2EFile))
+		fixture.RestartAgent(suite.T(), "agent-managed")
+		fixture.RestartAgent(suite.T(), "agent-autonomous")
+	}
+
+	// Ensure that all the components are running after runnings the tests
+	if !fixture.IsProcessRunning("process") {
+		err := fixture.StartProcess("principal")
+		requires.NoError(err)
+		fixture.CheckReadiness(suite.T(), "principal")
+	}
+
+	if !fixture.IsProcessRunning("agent-managed") {
+		err := fixture.StartProcess("agent-managed")
+		requires.NoError(err)
+		fixture.CheckReadiness(suite.T(), "agent-managed")
+	}
+
+	if !fixture.IsProcessRunning("agent-autonomous") {
+		err := fixture.StartProcess("agent-autonomous")
+		requires.NoError(err)
+		fixture.CheckReadiness(suite.T(), "agent-autonomous")
+	}
+}
+
+func (suite *HTTP1DowngradeTestSuite) Test_WithHTTP1Downgrade() {
+	requires := suite.Require()
+
+	// Verify that the agent has connected to the principal
+	fixture.CheckReadiness(suite.T(), "agent-managed")
+
+	// Create a reverse proxy that downgrades the incoming requests to HTTP/1.1
+	hostPort := func(host string, port int) string {
+		return fmt.Sprintf("%s:%d", host, port)
+	}
+
+	principalClient, err := kubernetes.NewForConfig(suite.PrincipalClient.Config)
+	requires.NoError(err)
+
+	agentClient, err := kubernetes.NewForConfig(suite.ManagedAgentClient.Config)
+	requires.NoError(err)
+
+	ctx := context.Background()
+
+	// Load the principal's certificate for incoming connections (agent → proxy)
+	principalServerCert, err := tlsutil.TLSCertFromSecret(ctx, principalClient, "argocd", config.SecretNamePrincipalTLS)
+	requires.NoError(err)
+
+	// Load the agent's client certificate for outgoing connections (proxy → principal)
+	agentClientCert, err := tlsutil.TLSCertFromSecret(ctx, agentClient, "argocd", config.SecretNameAgentClientCert)
+	requires.NoError(err)
+
+	proxyPort := 9091
+	principalPort := 8443
+
+	// Configure the proxy with TLS certificates
+	http1Proxy := proxy.StartHTTP2DowngradingProxy(suite.T(), hostPort("", proxyPort), hostPort("", principalPort), agentClientCert, principalServerCert)
+	defer http1Proxy.Close()
+
+	// The agent must connect to the principal via the proxy and explicitly disable WebSocket
+	envVar := fmt.Sprintf(`ARGOCD_AGENT_REMOTE_PORT=%d
+ARGOCD_AGENT_ENABLE_WEBSOCKET=false
+ARGOCD_PRINCIPAL_ENABLE_WEBSOCKET=false`, proxyPort)
+	err = os.WriteFile(fixture.EnvVariablesFromE2EFile, []byte(envVar+"\n"), 0644)
+	requires.NoError(err)
+
+	defer func() {
+		if err := os.Remove(fixture.EnvVariablesFromE2EFile); err != nil {
+			suite.T().Errorf("failed to remove env file: %v", err)
+		}
+
+		// Restart the agent process
+		fixture.RestartAgent(suite.T(), "agent-managed")
+
+		// Give some time for the agent to be ready
+		fixture.CheckReadiness(suite.T(), "agent-managed")
+
+		// Restart the principal process
+		fixture.RestartAgent(suite.T(), "principal")
+
+		// Give some time for the principal to be ready
+		fixture.CheckReadiness(suite.T(), "principal")
+	}()
+
+	// Restart the agent process
+	fixture.RestartAgent(suite.T(), "agent-managed")
+
+	// Agent should not be able to connect to the principal when the Websocket is disabled because the
+	// proxy downgrades the requests to HTTP/1.1
+	fixture.IsNotReady(suite.T(), "agent-managed")
+
+	// Restart the principal and the agent with the Websocket enabled
+	envVar = fmt.Sprintf(`ARGOCD_AGENT_REMOTE_PORT=%d
+ARGOCD_AGENT_ENABLE_WEBSOCKET=true
+ARGOCD_PRINCIPAL_ENABLE_WEBSOCKET=true`, proxyPort)
+	err = os.WriteFile(fixture.EnvVariablesFromE2EFile, []byte(envVar+"\n"), 0644)
+	requires.NoError(err)
+
+	fixture.RestartAgent(suite.T(), "principal")
+
+	fixture.RestartAgent(suite.T(), "agent-managed")
+
+	// Give some time for the principal to be ready
+	fixture.CheckReadiness(suite.T(), "principal")
+
+	// Give some time for the agent to be ready
+	fixture.CheckReadiness(suite.T(), "agent-managed")
+}
+
+func TestHTTP1DowngradeTestSuite(t *testing.T) {
+	suite.Run(t, new(HTTP1DowngradeTestSuite))
+}

--- a/test/proxy/proxy.go
+++ b/test/proxy/proxy.go
@@ -42,23 +42,12 @@ func StartHTTP2DowngradingProxy(t *testing.T, addr string, target string, agentC
 }
 
 func downgradeToHTTP1Handler(target string, agentCert tls.Certificate) http.Handler {
-	printHeaders := func(header http.Header) {
-		for name, values := range header {
-			for _, value := range values {
-				fmt.Printf("%s: %s\n", name, value)
-			}
-		}
-	}
-
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		fmt.Printf("Intercepting a %s request to %s\n", req.Method, req.URL)
 
 		// Check if this is a gRPC request
 		isGRPC := req.Header.Get("Content-Type") == "application/grpc"
 		fmt.Printf("Is gRPC request: %t, Protocol: %s\n", isGRPC, req.Proto)
-
-		fmt.Println("Request Headers:")
-		printHeaders(req.Header)
 
 		// Downgrade all requests to HTTP/1.1
 		if req.Proto == "HTTP/2.0" {

--- a/test/proxy/proxy.go
+++ b/test/proxy/proxy.go
@@ -2,24 +2,17 @@ package proxy
 
 import (
 	"crypto/tls"
-	"crypto/x509"
 	"fmt"
 	"log"
-	"math/big"
 	"net"
 	"net/http"
 	"net/http/httputil"
-	"path"
 	"testing"
-
-	"github.com/argoproj-labs/argocd-agent/test/fake/testcerts"
 )
 
-// Start a reverse proxy that downgrades the incoming HTTP/2 requests to HTTP/1.1
-func StartHTTP2DowngradingProxy(t *testing.T, addr string, target string) *http.Server {
-	tempDir := t.TempDir()
-	basePath := path.Join(tempDir, "certs")
-	testcerts.WriteSelfSignedCert(t, "rsa", basePath, x509.Certificate{SerialNumber: big.NewInt(1)})
+// StartHTTP2DowngradingProxy starts a proxy that downgrades HTTP/2.0 to HTTP/1.1
+// This simulates a real HTTP/1.1-only proxy environment.
+func StartHTTP2DowngradingProxy(t *testing.T, addr string, target string, agentClientCert, principalServerCert tls.Certificate) *http.Server {
 
 	lis, err := net.Listen("tcp", addr)
 	if err != nil {
@@ -28,19 +21,27 @@ func StartHTTP2DowngradingProxy(t *testing.T, addr string, target string) *http.
 
 	server := &http.Server{
 		TLSConfig: &tls.Config{
-			InsecureSkipVerify: true,
+			// Use principal's server certificate for incoming connections
+			// This makes the agent think it's connecting to the real principal
+			Certificates: []tls.Certificate{principalServerCert},
+			NextProtos:   []string{"h2", "http/1.1"},
 		},
-		Handler: downgradeToHTTP1Handler(target),
+		Handler: downgradeToHTTP1Handler(target, agentClientCert),
 		Addr:    lis.Addr().String(),
 	}
 
 	//nolint:errcheck
-	go server.ServeTLS(lis, basePath+".crt", basePath+".key")
+	go func() {
+		tlsListener := tls.NewListener(lis, server.TLSConfig)
+		if err := server.Serve(tlsListener); err != nil {
+			log.Printf("Proxy server error: %v", err)
+		}
+	}()
 
 	return server
 }
 
-func downgradeToHTTP1Handler(target string) http.Handler {
+func downgradeToHTTP1Handler(target string, agentCert tls.Certificate) http.Handler {
 	printHeaders := func(header http.Header) {
 		for name, values := range header {
 			for _, value := range values {
@@ -48,38 +49,62 @@ func downgradeToHTTP1Handler(target string) http.Handler {
 			}
 		}
 	}
-	return &httputil.ReverseProxy{
-		Director: func(req *http.Request) {
-			fmt.Println("Intercepting a request")
-			req.URL.Host = target
-			if req.URL.Scheme == "" {
-				req.URL.Scheme = "https"
-			}
 
-			// Request is downgraded to HTTP/1.1
+	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		fmt.Printf("Intercepting a %s request to %s\n", req.Method, req.URL)
+
+		// Check if this is a gRPC request
+		isGRPC := req.Header.Get("Content-Type") == "application/grpc"
+		fmt.Printf("Is gRPC request: %t, Protocol: %s\n", isGRPC, req.Proto)
+
+		fmt.Println("Request Headers:")
+		printHeaders(req.Header)
+
+		// Downgrade all requests to HTTP/1.1
+		if req.Proto == "HTTP/2.0" {
+			fmt.Println("Downgrading request from HTTP/2.0 to HTTP/1.1")
 			req.ProtoMajor, req.ProtoMinor, req.Proto = 1, 1, "HTTP/1.1"
+		}
 
-			// Log headers for debugging
-			fmt.Println("Request Headers:")
-			printHeaders(req.Header)
-		},
-		Transport: &http.Transport{
-			TLSClientConfig: &tls.Config{
-				InsecureSkipVerify: true,
+		// For WebSocket upgrade requests, allow them through
+		if req.Header.Get("Upgrade") == "websocket" {
+			fmt.Println("Allowing WebSocket upgrade request")
+		} else if isGRPC && req.Proto == "HTTP/1.1" {
+			fmt.Println("Forwarding downgraded gRPC request over HTTP/1.1")
+		}
+
+		// Use reverse proxy with HTTP/1.1 enforcement
+		proxy := &httputil.ReverseProxy{
+			Director: func(req *http.Request) {
+				req.URL.Host = target
+				if req.URL.Scheme == "" {
+					req.URL.Scheme = "https"
+				}
+
+				// Ensure the request is downgraded to HTTP/1.1
+				req.ProtoMajor, req.ProtoMinor, req.Proto = 1, 1, "HTTP/1.1"
+
+				fmt.Printf("Proxying %s request to %s (downgraded to %s)\n", req.Method, req.URL, req.Proto)
 			},
-			ForceAttemptHTTP2: false,
-		},
-		ModifyResponse: func(res *http.Response) error {
-			// Ensure the response is sent as HTTP/1.1
-			res.ProtoMajor = 1
-			res.ProtoMinor = 1
-			res.Proto = "HTTP/1.1"
+			Transport: &http.Transport{
+				TLSClientConfig: &tls.Config{
+					InsecureSkipVerify: true,
+					// Use agent's certificate for outgoing connections
+					// This makes the principal think it's connecting to the real agent
+					Certificates: []tls.Certificate{agentCert},
+				},
+				ForceAttemptHTTP2: false,
+			},
+			ModifyResponse: func(res *http.Response) error {
+				if res != nil {
+					// Ensure response is also HTTP/1.1
+					res.ProtoMajor, res.ProtoMinor, res.Proto = 1, 1, "HTTP/1.1"
+					fmt.Printf("Response: %s (proto: %s)\n", res.Status, res.Proto)
+				}
+				return nil
+			},
+		}
 
-			// Log response headers for debugging
-			fmt.Println("Response Headers:")
-			printHeaders(res.Header)
-
-			return nil
-		},
-	}
+		proxy.ServeHTTP(w, req)
+	})
 }


### PR DESCRIPTION
**What does this PR do / why we need it**:

Port an old e2e test to our current e2e test framework. The test verifies that the agent can connect to the principal via gRPC over websocket when the intermediate proxy downgrades the HTTP/2 request to HTTP/1.1. 

**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:


**Checklist**

* [ ] Documentation update is required by this PR (and has been updated) OR no documentation update is required.

