### PR TITLE
feat: Selectively prevent resources from being synced

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -28,6 +28,7 @@ import (
 	kubeappproject "github.com/argoproj-labs/argocd-agent/internal/backend/kubernetes/appproject"
 	kubenamespace "github.com/argoproj-labs/argocd-agent/internal/backend/kubernetes/namespace"
 	kuberepository "github.com/argoproj-labs/argocd-agent/internal/backend/kubernetes/repository"
+	"github.com/argoproj-labs/argocd-agent/internal/config"
 	"github.com/argoproj-labs/argocd-agent/internal/event"
 	"github.com/argoproj-labs/argocd-agent/internal/informer"
 	"github.com/argoproj-labs/argocd-agent/internal/kube"
@@ -171,10 +172,10 @@ func NewAgent(ctx context.Context, client *kube.KubernetesClient, namespace stri
 
 	// appListFunc and watchFunc are anonymous functions for the informer
 	appListFunc := func(ctx context.Context, opts v1.ListOptions) (runtime.Object, error) {
-		return client.ApplicationsClientset.ArgoprojV1alpha1().Applications(a.namespace).List(ctx, opts)
+		return client.ApplicationsClientset.ArgoprojV1alpha1().Applications(a.namespace).List(ctx, config.SkipSyncSelector())
 	}
 	appWatchFunc := func(ctx context.Context, opts v1.ListOptions) (watch.Interface, error) {
-		return client.ApplicationsClientset.ArgoprojV1alpha1().Applications(a.namespace).Watch(ctx, opts)
+		return client.ApplicationsClientset.ArgoprojV1alpha1().Applications(a.namespace).Watch(ctx, config.SkipSyncSelector())
 	}
 
 	appInformerOptions := []informer.InformerOption[*v1alpha1.Application]{
@@ -213,11 +214,11 @@ func NewAgent(ctx context.Context, client *kube.KubernetesClient, namespace stri
 	appManagerOpts = append(appManagerOpts, application.WithAllowUpsert(allowUpsert))
 
 	projListFunc := func(ctx context.Context, opts v1.ListOptions) (runtime.Object, error) {
-		return client.ApplicationsClientset.ArgoprojV1alpha1().AppProjects(a.namespace).List(ctx, opts)
+		return client.ApplicationsClientset.ArgoprojV1alpha1().AppProjects(a.namespace).List(ctx, config.SkipSyncSelector())
 	}
 
 	projWatchFunc := func(ctx context.Context, opts v1.ListOptions) (watch.Interface, error) {
-		return client.ApplicationsClientset.ArgoprojV1alpha1().AppProjects(a.namespace).Watch(ctx, opts)
+		return client.ApplicationsClientset.ArgoprojV1alpha1().AppProjects(a.namespace).Watch(ctx, config.SkipSyncSelector())
 	}
 
 	projInformerOptions := []informer.InformerOption[*v1alpha1.AppProject]{
@@ -253,10 +254,10 @@ func NewAgent(ctx context.Context, client *kube.KubernetesClient, namespace stri
 
 	repoInformerOptions := []informer.InformerOption[*corev1.Secret]{
 		informer.WithListHandler[*corev1.Secret](func(ctx context.Context, opts v1.ListOptions) (runtime.Object, error) {
-			return client.Clientset.CoreV1().Secrets(a.namespace).List(ctx, opts)
+			return client.Clientset.CoreV1().Secrets(a.namespace).List(ctx, config.SkipSyncSelector())
 		}),
 		informer.WithWatchHandler[*corev1.Secret](func(ctx context.Context, opts v1.ListOptions) (watch.Interface, error) {
-			return client.Clientset.CoreV1().Secrets(a.namespace).Watch(ctx, opts)
+			return client.Clientset.CoreV1().Secrets(a.namespace).Watch(ctx, config.SkipSyncSelector())
 		}),
 		informer.WithAddHandler[*corev1.Secret](a.handleRepositoryCreation),
 		informer.WithUpdateHandler[*corev1.Secret](a.handleRepositoryUpdate),

--- a/agent/connection_test.go
+++ b/agent/connection_test.go
@@ -24,7 +24,7 @@ import (
 )
 
 func TestResyncOnStart(t *testing.T) {
-	a := newAgent(t)
+	a, _ := newAgent(t)
 	a.emitter = event.NewEventSource("test")
 	a.kubeClient.RestConfig = &rest.Config{}
 	logCtx := log()

--- a/agent/filters.go
+++ b/agent/filters.go
@@ -29,7 +29,7 @@ func (a *Agent) DefaultAppFilterChain() *filter.Chain[*v1alpha1.Application] {
 
 	// Admit based on namespace of the application
 	fc.AppendAdmitFilter(func(app *v1alpha1.Application) bool {
-		if !glob.MatchStringInList(append([]string{a.namespace}, a.options.namespaces...), app.Namespace, glob.REGEXP) {
+		if !glob.MatchStringInList(append([]string{a.namespace}, a.allowedNamespaces...), app.Namespace, glob.REGEXP) {
 			log().Warnf("namespace not allowed: %s", app.QualifiedName())
 			return false
 		}

--- a/agent/filters.go
+++ b/agent/filters.go
@@ -15,6 +15,7 @@
 package agent
 
 import (
+	"github.com/argoproj-labs/argocd-agent/internal/config"
 	"github.com/argoproj-labs/argocd-agent/internal/filter"
 	"github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
 	"github.com/argoproj/argo-cd/v3/util/glob"
@@ -36,6 +37,14 @@ func (a *Agent) DefaultAppFilterChain() *filter.Chain[*v1alpha1.Application] {
 		// 	log().Warnf("App is not managed: %s", app.QualifiedName())
 		// 	return false
 		// }
+		return true
+	})
+
+	// Ignore applications that have the skip sync label
+	fc.AppendAdmitFilter(func(app *v1alpha1.Application) bool {
+		if v, ok := app.Labels[config.SkipSyncLabel]; ok && v == "true" {
+			return false
+		}
 		return true
 	})
 

--- a/agent/filters_test.go
+++ b/agent/filters_test.go
@@ -1,0 +1,251 @@
+// Copyright 2024 The argocd-agent Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package agent
+
+import (
+	"context"
+	"testing"
+
+	"github.com/argoproj-labs/argocd-agent/internal/config"
+	"github.com/argoproj-labs/argocd-agent/pkg/client"
+	fakekube "github.com/argoproj-labs/argocd-agent/test/fake/kube"
+	"github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestDefaultAppFilterChain_SkipSyncLabel(t *testing.T) {
+	kubec := fakekube.NewKubernetesFakeClientWithApps("argocd")
+	remote, err := client.NewRemote("127.0.0.1", 8080)
+	require.NoError(t, err)
+	agent, err := NewAgent(context.TODO(), kubec, "argocd", WithRemote(remote))
+	require.NoError(t, err)
+
+	filterChain := agent.DefaultAppFilterChain()
+
+	tests := []struct {
+		name     string
+		app      *v1alpha1.Application
+		expected bool
+	}{
+		{
+			name: "Application without skip sync label should be admitted",
+			app: &v1alpha1.Application{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-app",
+					Namespace: "argocd",
+					Labels:    map[string]string{},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "Application with skip sync label set to false should be admitted",
+			app: &v1alpha1.Application{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-app",
+					Namespace: "argocd",
+					Labels: map[string]string{
+						config.SkipSyncLabel: "false",
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "Application with skip sync label set to empty string should be admitted",
+			app: &v1alpha1.Application{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-app",
+					Namespace: "argocd",
+					Labels: map[string]string{
+						config.SkipSyncLabel: "",
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "Application with skip sync label set to true should be rejected",
+			app: &v1alpha1.Application{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-app",
+					Namespace: "argocd",
+					Labels: map[string]string{
+						config.SkipSyncLabel: "true",
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "Application with skip sync label set to TRUE (case sensitive) should be admitted",
+			app: &v1alpha1.Application{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-app",
+					Namespace: "argocd",
+					Labels: map[string]string{
+						config.SkipSyncLabel: "TRUE",
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "Application with skip sync label and other labels should be rejected when skip sync is true",
+			app: &v1alpha1.Application{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-app",
+					Namespace: "argocd",
+					Labels: map[string]string{
+						config.SkipSyncLabel:           "true",
+						"app.kubernetes.io/name":       "test-app",
+						"app.kubernetes.io/instance":   "prod",
+						"app.kubernetes.io/managed-by": "argocd",
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "Application in wrong namespace with skip sync label should be rejected (namespace filter takes precedence)",
+			app: &v1alpha1.Application{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-app",
+					Namespace: "wrong-namespace",
+					Labels: map[string]string{
+						config.SkipSyncLabel: "false",
+					},
+				},
+			},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := filterChain.Admit(tt.app)
+			assert.Equal(t, tt.expected, result, "Filter result should match expected value")
+		})
+	}
+}
+
+func TestDefaultAppFilterChain_NamespaceAndSkipSyncInteraction(t *testing.T) {
+	kubec := fakekube.NewKubernetesFakeClientWithApps("argocd")
+	remote, err := client.NewRemote("127.0.0.1", 8080)
+	require.NoError(t, err)
+
+	// Create agent with multiple allowed namespaces
+	agent, err := NewAgent(context.TODO(), kubec, "argocd",
+		WithRemote(remote),
+		WithAllowedNamespaces("argocd", "apps", "staging"))
+	require.NoError(t, err)
+
+	filterChain := agent.DefaultAppFilterChain()
+
+	tests := []struct {
+		name     string
+		app      *v1alpha1.Application
+		expected bool
+		reason   string
+	}{
+		{
+			name: "App in allowed namespace without skip sync label should be admitted",
+			app: &v1alpha1.Application{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-app",
+					Namespace: "apps",
+				},
+			},
+			expected: true,
+			reason:   "Namespace is allowed, no skip sync label",
+		},
+		{
+			name: "App in allowed namespace with skip sync=true should be rejected",
+			app: &v1alpha1.Application{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-app",
+					Namespace: "staging",
+					Labels: map[string]string{
+						config.SkipSyncLabel: "true",
+					},
+				},
+			},
+			expected: false,
+			reason:   "Skip sync label takes effect even in allowed namespace",
+		},
+		{
+			name: "App in disallowed namespace with skip sync=false should be rejected",
+			app: &v1alpha1.Application{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-app",
+					Namespace: "production",
+					Labels: map[string]string{
+						config.SkipSyncLabel: "false",
+					},
+				},
+			},
+			expected: false,
+			reason:   "Namespace filter rejects before skip sync filter",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := filterChain.Admit(tt.app)
+			assert.Equal(t, tt.expected, result, tt.reason)
+		})
+	}
+}
+
+func TestDefaultAppFilterChain_ProcessChange(t *testing.T) {
+	kubec := fakekube.NewKubernetesFakeClientWithApps("argocd")
+	remote, err := client.NewRemote("127.0.0.1", 8080)
+	require.NoError(t, err)
+	agent, err := NewAgent(context.TODO(), kubec, "argocd", WithRemote(remote))
+	require.NoError(t, err)
+
+	filterChain := agent.DefaultAppFilterChain()
+
+	oldApp := &v1alpha1.Application{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-app",
+			Namespace: "argocd",
+			Labels: map[string]string{
+				config.SkipSyncLabel: "false",
+			},
+		},
+	}
+
+	newApp := &v1alpha1.Application{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-app",
+			Namespace: "argocd",
+			Labels: map[string]string{
+				config.SkipSyncLabel: "true",
+			},
+		},
+	}
+
+	// Test that change processing works (no change filters are currently implemented)
+	result := filterChain.ProcessChange(oldApp, newApp)
+	assert.True(t, result, "ProcessChange should return true when no change filters are defined")
+}
+
+func init() {
+	logrus.SetLevel(logrus.TraceLevel)
+}

--- a/agent/inbound_test.go
+++ b/agent/inbound_test.go
@@ -41,7 +41,7 @@ import (
 )
 
 func Test_CreateApplication(t *testing.T) {
-	a := newAgent(t)
+	a, _ := newAgent(t)
 	be := backend_mocks.NewApplication(t)
 	var err error
 	a.appManager, err = application.NewApplicationManager(be, "argocd", application.WithAllowUpsert(true))
@@ -88,7 +88,7 @@ func Test_CreateApplication(t *testing.T) {
 }
 
 func Test_ProcessIncomingAppWithUIDMismatch(t *testing.T) {
-	a := newAgent(t)
+	a, _ := newAgent(t)
 	a.mode = types.AgentModeManaged
 	evs := event.NewEventSource("test")
 	var be *backend_mocks.Application
@@ -345,7 +345,7 @@ func Test_ProcessIncomingAppWithUIDMismatch(t *testing.T) {
 }
 
 func Test_ProcessIncomingAppProjectWithUIDMismatch(t *testing.T) {
-	a := newAgent(t)
+	a, _ := newAgent(t)
 	a.mode = types.AgentModeManaged
 	evs := event.NewEventSource("test")
 	var be *backend_mocks.AppProject
@@ -694,7 +694,7 @@ func Test_ProcessIncomingAppProjectWithUIDMismatch(t *testing.T) {
 }
 
 func Test_UpdateApplication(t *testing.T) {
-	a := newAgent(t)
+	a, _ := newAgent(t)
 	be := backend_mocks.NewApplication(t)
 	var err error
 	a.appManager, err = application.NewApplicationManager(be, "argocd", application.WithAllowUpsert(true))
@@ -785,7 +785,7 @@ func Test_UpdateApplication(t *testing.T) {
 }
 
 func Test_CreateAppProject(t *testing.T) {
-	a := newAgent(t)
+	a, _ := newAgent(t)
 	be := backend_mocks.NewAppProject(t)
 	var err error
 	a.projectManager, err = appproject.NewAppProjectManager(be, "argocd", appproject.WithAllowUpsert(true))
@@ -848,7 +848,7 @@ func Test_CreateAppProject(t *testing.T) {
 }
 
 func Test_UpdateAppProject(t *testing.T) {
-	a := newAgent(t)
+	a, _ := newAgent(t)
 	be := backend_mocks.NewAppProject(t)
 	var err error
 	a.projectManager, err = appproject.NewAppProjectManager(be, "argocd", appproject.WithAllowUpsert(true))
@@ -932,7 +932,7 @@ func Test_ProcessIncomingRepositoryWithUIDMismatch(t *testing.T) {
 
 	createAgent := func(t *testing.T) (*Agent, *backend_mocks.Repository) {
 		t.Helper()
-		a := newAgent(t)
+		a, _ := newAgent(t)
 		a.mode = types.AgentModeManaged
 		be := backend_mocks.NewRepository(t)
 		a.repoManager = repository.NewManager(be, "argocd", true)
@@ -1156,7 +1156,7 @@ func Test_ProcessIncomingRepositoryWithUIDMismatch(t *testing.T) {
 }
 
 func Test_CreateRepository(t *testing.T) {
-	a := newAgent(t)
+	a, _ := newAgent(t)
 	be := backend_mocks.NewRepository(t)
 	repoMgr := repository.NewManager(be, "argocd", true)
 	repoMgr.ManagedResources = manager.NewManagedResources()
@@ -1209,7 +1209,7 @@ func Test_CreateRepository(t *testing.T) {
 }
 
 func Test_UpdateRepository(t *testing.T) {
-	a := newAgent(t)
+	a, _ := newAgent(t)
 	be := backend_mocks.NewRepository(t)
 	repoMgr := repository.NewManager(be, "argocd", true)
 	repoMgr.ManagedResources = manager.NewManagedResources()
@@ -1272,7 +1272,7 @@ func Test_UpdateRepository(t *testing.T) {
 }
 
 func Test_processIncomingResourceResyncEvent(t *testing.T) {
-	a := newAgent(t)
+	a, _ := newAgent(t)
 	a.kubeClient.RestConfig = &rest.Config{}
 	a.namespace = "test"
 	a.context = context.Background()

--- a/agent/outbound_test.go
+++ b/agent/outbound_test.go
@@ -20,7 +20,7 @@ import (
 )
 
 func Test_addAppCreationToQueue(t *testing.T) {
-	a := newAgent(t)
+	a, _ := newAgent(t)
 	a.remote.SetClientID("agent")
 	a.emitter = event.NewEventSource("principal")
 
@@ -86,7 +86,7 @@ func Test_addAppCreationToQueue(t *testing.T) {
 }
 
 func Test_addAppUpdateToQueue(t *testing.T) {
-	a := newAgent(t)
+	a, _ := newAgent(t)
 	a.remote.SetClientID("agent")
 	a.emitter = event.NewEventSource("principal")
 
@@ -126,7 +126,7 @@ func Test_addAppUpdateToQueue(t *testing.T) {
 }
 
 func Test_addAppDeletionToQueue(t *testing.T) {
-	a := newAgent(t)
+	a, _ := newAgent(t)
 	a.remote.SetClientID("agent")
 	a.emitter = event.NewEventSource("principal")
 
@@ -153,7 +153,7 @@ func Test_addAppDeletionToQueue(t *testing.T) {
 		require.False(t, a.appManager.IsManaged("agent/guestbook"))
 	})
 	t.Run("Deletion event for unmanaged application", func(t *testing.T) {
-		a := newAgent(t)
+		a, _ := newAgent(t)
 		a.remote.SetClientID("agent")
 		a.mode = types.AgentModeAutonomous
 
@@ -167,7 +167,7 @@ func Test_addAppDeletionToQueue(t *testing.T) {
 }
 
 func Test_deleteNamespaceCallback(t *testing.T) {
-	a := newAgent(t)
+	a, _ := newAgent(t)
 	a.remote.SetClientID("agent")
 	a.emitter = event.NewEventSource("principal")
 	err := a.queues.Create("agent")
@@ -188,7 +188,7 @@ func Test_deleteNamespaceCallback(t *testing.T) {
 }
 
 func Test_addAppProjectCreationToQueue(t *testing.T) {
-	a := newAgent(t)
+	a, _ := newAgent(t)
 	a.remote.SetClientID("agent")
 	a.emitter = event.NewEventSource("principal")
 
@@ -255,7 +255,7 @@ func Test_addAppProjectCreationToQueue(t *testing.T) {
 }
 
 func Test_addAppProjectUpdateToQueue(t *testing.T) {
-	a := newAgent(t)
+	a, _ := newAgent(t)
 	a.remote.SetClientID("agent")
 	a.emitter = event.NewEventSource("principal")
 
@@ -337,7 +337,7 @@ func Test_addAppProjectUpdateToQueue(t *testing.T) {
 }
 
 func Test_addAppProjectDeletionToQueue(t *testing.T) {
-	a := newAgent(t)
+	a, _ := newAgent(t)
 	a.remote.SetClientID("agent")
 	a.emitter = event.NewEventSource("principal")
 
@@ -422,7 +422,7 @@ func Test_addClusterCacheInfoUpdateToQueue(t *testing.T) {
 }
 
 func Test_handleRepositoryCreation(t *testing.T) {
-	a := newAgent(t)
+	a, _ := newAgent(t)
 	a.remote.SetClientID("agent")
 	a.emitter = event.NewEventSource("principal")
 
@@ -493,7 +493,7 @@ func Test_handleRepositoryCreation(t *testing.T) {
 }
 
 func Test_handleRepositoryUpdate(t *testing.T) {
-	a := newAgent(t)
+	a, _ := newAgent(t)
 	a.remote.SetClientID("agent")
 	a.emitter = event.NewEventSource("principal")
 
@@ -577,7 +577,7 @@ func Test_handleRepositoryUpdate(t *testing.T) {
 }
 
 func Test_handleRepositoryDeletion(t *testing.T) {
-	a := newAgent(t)
+	a, _ := newAgent(t)
 	a.remote.SetClientID("agent")
 	a.emitter = event.NewEventSource("principal")
 

--- a/internal/backend/kubernetes/repository/filters_test.go
+++ b/internal/backend/kubernetes/repository/filters_test.go
@@ -1,0 +1,260 @@
+// Copyright 2024 The argocd-agent Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package repository
+
+import (
+	"testing"
+
+	"github.com/argoproj-labs/argocd-agent/internal/config"
+	"github.com/argoproj/argo-cd/v3/common"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestDefaultFilterChain_RepositoryFiltering(t *testing.T) {
+	namespace := "argocd"
+	filterChain := DefaultFilterChain(namespace)
+
+	tests := []struct {
+		name     string
+		secret   *corev1.Secret
+		expected bool
+		reason   string
+	}{
+		{
+			name: "Valid repository secret should be admitted",
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-repo",
+					Namespace: namespace,
+					Labels: map[string]string{
+						common.LabelKeySecretType: common.LabelValueSecretTypeRepository,
+					},
+				},
+				Data: map[string][]byte{
+					"project": []byte("default"),
+					"url":     []byte("https://github.com/example/repo.git"),
+				},
+			},
+			expected: true,
+			reason:   "Valid repository secret with all required fields",
+		},
+		{
+			name: "Repository secret with skip sync label=true should be filtered by informer (not this filter)",
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-repo",
+					Namespace: namespace,
+					Labels: map[string]string{
+						common.LabelKeySecretType: common.LabelValueSecretTypeRepository,
+						config.SkipSyncLabel:      "true",
+					},
+				},
+				Data: map[string][]byte{
+					"project": []byte("default"),
+					"url":     []byte("https://github.com/example/repo.git"),
+				},
+			},
+			expected: true,
+			reason:   "DefaultFilterChain only validates repository format, skip sync filtering happens at informer level",
+		},
+		{
+			name: "Repository secret in wrong namespace should be rejected",
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-repo",
+					Namespace: "wrong-namespace",
+					Labels: map[string]string{
+						common.LabelKeySecretType: common.LabelValueSecretTypeRepository,
+					},
+				},
+				Data: map[string][]byte{
+					"project": []byte("default"),
+					"url":     []byte("https://github.com/example/repo.git"),
+				},
+			},
+			expected: false,
+			reason:   "Repository secret in wrong namespace should be rejected",
+		},
+		{
+			name: "Secret without repository label should be rejected",
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-secret",
+					Namespace: namespace,
+					Labels:    map[string]string{},
+				},
+				Data: map[string][]byte{
+					"project": []byte("default"),
+					"url":     []byte("https://github.com/example/repo.git"),
+				},
+			},
+			expected: false,
+			reason:   "Secret without repository type label should be rejected",
+		},
+		{
+			name: "Repository secret without project data should be rejected",
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-repo",
+					Namespace: namespace,
+					Labels: map[string]string{
+						common.LabelKeySecretType: common.LabelValueSecretTypeRepository,
+					},
+				},
+				Data: map[string][]byte{
+					"url": []byte("https://github.com/example/repo.git"),
+				},
+			},
+			expected: false,
+			reason:   "Repository secret without project data should be rejected",
+		},
+		{
+			name: "Repository secret with empty project should be rejected",
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-repo",
+					Namespace: namespace,
+					Labels: map[string]string{
+						common.LabelKeySecretType: common.LabelValueSecretTypeRepository,
+					},
+				},
+				Data: map[string][]byte{
+					"project": []byte(""),
+					"url":     []byte("https://github.com/example/repo.git"),
+				},
+			},
+			expected: false,
+			reason:   "Repository secret with empty project should be rejected",
+		},
+		{
+			name: "Repository secret with nil data should be rejected",
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-repo",
+					Namespace: namespace,
+					Labels: map[string]string{
+						common.LabelKeySecretType: common.LabelValueSecretTypeRepository,
+					},
+				},
+				Data: nil,
+			},
+			expected: false,
+			reason:   "Repository secret with nil data should be rejected",
+		},
+		{
+			name: "Repository secret with nil labels should be rejected",
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-repo",
+					Namespace: namespace,
+					Labels:    nil,
+				},
+				Data: map[string][]byte{
+					"project": []byte("default"),
+					"url":     []byte("https://github.com/example/repo.git"),
+				},
+			},
+			expected: false,
+			reason:   "Repository secret with nil labels should be rejected",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := filterChain.Admit(tt.secret)
+			assert.Equal(t, tt.expected, result, tt.reason)
+		})
+	}
+}
+
+func TestIsValidRepositorySecret(t *testing.T) {
+	namespace := "argocd"
+
+	tests := []struct {
+		name     string
+		secret   *corev1.Secret
+		expected bool
+		reason   string
+	}{
+		{
+			name: "Valid repository secret",
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-repo",
+					Namespace: namespace,
+					Labels: map[string]string{
+						common.LabelKeySecretType: common.LabelValueSecretTypeRepository,
+					},
+				},
+				Data: map[string][]byte{
+					"project": []byte("my-project"),
+					"url":     []byte("https://github.com/example/repo.git"),
+				},
+			},
+			expected: true,
+			reason:   "Should accept valid repository secret",
+		},
+		{
+			name: "Repository secret with skip sync label (should still be valid at this level)",
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-repo",
+					Namespace: namespace,
+					Labels: map[string]string{
+						common.LabelKeySecretType: common.LabelValueSecretTypeRepository,
+						config.SkipSyncLabel:      "true",
+					},
+				},
+				Data: map[string][]byte{
+					"project": []byte("my-project"),
+					"url":     []byte("https://github.com/example/repo.git"),
+				},
+			},
+			expected: true,
+			reason:   "isValidRepositorySecret doesn't check skip sync label - that's handled by informer",
+		},
+		{
+			name: "Wrong secret type",
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-secret",
+					Namespace: namespace,
+					Labels: map[string]string{
+						common.LabelKeySecretType: "cluster",
+					},
+				},
+				Data: map[string][]byte{
+					"project": []byte("my-project"),
+				},
+			},
+			expected: false,
+			reason:   "Should reject non-repository secrets",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := isValidRepositorySecret(tt.secret, namespace)
+			assert.Equal(t, tt.expected, result, tt.reason)
+		})
+	}
+}
+
+func init() {
+	logrus.SetLevel(logrus.TraceLevel)
+}

--- a/internal/config/constants.go
+++ b/internal/config/constants.go
@@ -27,3 +27,6 @@ const SecretNameAgentClientCert = "argocd-agent-client-tls"
 // SecretNameJWT is the name of the secret containing the JWT signing key
 // for the principal.
 const SecretNameJWT = "argocd-agent-jwt"
+
+// SkipSyncLabel is the label used to skip sync for an application.
+const SkipSyncLabel = "argocd-agent.argoproj-labs.io/ignore-sync"

--- a/internal/config/selectors.go
+++ b/internal/config/selectors.go
@@ -1,0 +1,14 @@
+package config
+
+import (
+	"fmt"
+
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// SkipSyncSelector returns a ListOptions that excludes resources with the skip sync label
+func SkipSyncSelector() v1.ListOptions {
+	return v1.ListOptions{
+		LabelSelector: fmt.Sprintf("%s!=%s", SkipSyncLabel, "true"),
+	}
+}

--- a/internal/config/selectors_test.go
+++ b/internal/config/selectors_test.go
@@ -1,0 +1,53 @@
+// Copyright 2024 The argocd-agent Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestSkipSyncSelector(t *testing.T) {
+	selector := SkipSyncSelector()
+
+	// The selector should exclude resources with the skip sync label set to "true"
+	expectedLabelSelector := "argocd-agent.argoproj-labs.io/ignore-sync!=true"
+
+	assert.Equal(t, expectedLabelSelector, selector.LabelSelector,
+		"SkipSyncSelector should create a label selector that excludes resources with skip sync label set to true")
+
+	// Verify it's a proper ListOptions
+	assert.IsType(t, v1.ListOptions{}, selector,
+		"SkipSyncSelector should return a v1.ListOptions")
+}
+
+func TestSkipSyncSelector_Integration(t *testing.T) {
+	// This test verifies that the selector would work correctly with Kubernetes API
+	selector := SkipSyncSelector()
+
+	// The selector should be non-empty
+	assert.NotEmpty(t, selector.LabelSelector,
+		"Label selector should not be empty")
+
+	// The selector should not have any other fields set by default
+	assert.Empty(t, selector.FieldSelector,
+		"Field selector should be empty by default")
+	assert.Empty(t, selector.ResourceVersion,
+		"Resource version should be empty by default")
+	assert.Nil(t, selector.TimeoutSeconds,
+		"Timeout seconds should be nil by default")
+}

--- a/principal/server_filter_test.go
+++ b/principal/server_filter_test.go
@@ -1,0 +1,263 @@
+// Copyright 2024 The argocd-agent Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package principal
+
+import (
+	"testing"
+
+	"github.com/argoproj-labs/argocd-agent/internal/config"
+	"github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestServer_DefaultAppFilterChain_SkipSyncLabel(t *testing.T) {
+	server := &Server{
+		options: &ServerOptions{
+			namespaces: []string{"argocd", "apps"},
+		},
+	}
+
+	filterChain := server.defaultAppFilterChain()
+
+	tests := []struct {
+		name     string
+		app      *v1alpha1.Application
+		expected bool
+	}{
+		{
+			name: "Application without skip sync label should be admitted",
+			app: &v1alpha1.Application{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-app",
+					Namespace: "argocd",
+					Labels:    map[string]string{},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "Application with skip sync label set to false should be admitted",
+			app: &v1alpha1.Application{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-app",
+					Namespace: "argocd",
+					Labels: map[string]string{
+						config.SkipSyncLabel: "false",
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "Application with skip sync label set to empty string should be admitted",
+			app: &v1alpha1.Application{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-app",
+					Namespace: "argocd",
+					Labels: map[string]string{
+						config.SkipSyncLabel: "",
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "Application with skip sync label set to true should be rejected",
+			app: &v1alpha1.Application{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-app",
+					Namespace: "argocd",
+					Labels: map[string]string{
+						config.SkipSyncLabel: "true",
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "Application with skip sync label set to TRUE (case sensitive) should be admitted",
+			app: &v1alpha1.Application{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-app",
+					Namespace: "argocd",
+					Labels: map[string]string{
+						config.SkipSyncLabel: "TRUE",
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "Application with skip sync label and other labels should be rejected when skip sync is true",
+			app: &v1alpha1.Application{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-app",
+					Namespace: "argocd",
+					Labels: map[string]string{
+						config.SkipSyncLabel:           "true",
+						"app.kubernetes.io/name":       "test-app",
+						"app.kubernetes.io/instance":   "prod",
+						"app.kubernetes.io/managed-by": "argocd",
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "Application in wrong namespace with skip sync label should be rejected (namespace filter takes precedence)",
+			app: &v1alpha1.Application{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-app",
+					Namespace: "wrong-namespace",
+					Labels: map[string]string{
+						config.SkipSyncLabel: "false",
+					},
+				},
+			},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := filterChain.Admit(tt.app)
+			assert.Equal(t, tt.expected, result, "Filter result should match expected value")
+		})
+	}
+}
+
+func TestServer_DefaultAppFilterChain_NamespaceAndSkipSyncInteraction(t *testing.T) {
+	server := &Server{
+		options: &ServerOptions{
+			namespaces: []string{"argocd", "apps", "staging"},
+		},
+	}
+
+	filterChain := server.defaultAppFilterChain()
+
+	tests := []struct {
+		name     string
+		app      *v1alpha1.Application
+		expected bool
+		reason   string
+	}{
+		{
+			name: "App in allowed namespace without skip sync label should be admitted",
+			app: &v1alpha1.Application{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-app",
+					Namespace: "apps",
+				},
+			},
+			expected: true,
+			reason:   "Namespace is allowed, no skip sync label",
+		},
+		{
+			name: "App in allowed namespace with skip sync=true should be rejected",
+			app: &v1alpha1.Application{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-app",
+					Namespace: "staging",
+					Labels: map[string]string{
+						config.SkipSyncLabel: "true",
+					},
+				},
+			},
+			expected: false,
+			reason:   "Skip sync label takes effect even in allowed namespace",
+		},
+		{
+			name: "App in disallowed namespace with skip sync=false should be rejected",
+			app: &v1alpha1.Application{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-app",
+					Namespace: "production",
+					Labels: map[string]string{
+						config.SkipSyncLabel: "false",
+					},
+				},
+			},
+			expected: false,
+			reason:   "Namespace filter rejects before skip sync filter",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := filterChain.Admit(tt.app)
+			assert.Equal(t, tt.expected, result, tt.reason)
+		})
+	}
+}
+
+func TestServer_DefaultAppFilterChain_EdgeCases(t *testing.T) {
+	server := &Server{
+		options: &ServerOptions{
+			namespaces: []string{"argocd"},
+		},
+	}
+
+	filterChain := server.defaultAppFilterChain()
+
+	tests := []struct {
+		name     string
+		app      *v1alpha1.Application
+		expected bool
+		reason   string
+	}{
+		{
+			name: "Application with nil Labels map should be admitted",
+			app: &v1alpha1.Application{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-app",
+					Namespace: "argocd",
+					Labels:    nil,
+				},
+			},
+			expected: true,
+			reason:   "Nil labels map should not cause issues",
+		},
+		{
+			name: "Application with multiple skip sync related labels (only exact match matters)",
+			app: &v1alpha1.Application{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-app",
+					Namespace: "argocd",
+					Labels: map[string]string{
+						config.SkipSyncLabel:                   "false",
+						config.SkipSyncLabel + "-custom":       "true",
+						"custom-" + config.SkipSyncLabel:       "true",
+						"argocd-agent.argoproj-labs.io/custom": "true",
+					},
+				},
+			},
+			expected: true,
+			reason:   "Only exact label match should be considered",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := filterChain.Admit(tt.app)
+			assert.Equal(t, tt.expected, result, tt.reason)
+		})
+	}
+}
+
+func init() {
+	logrus.SetLevel(logrus.TraceLevel)
+}

--- a/test/e2e/skip_sync_test.go
+++ b/test/e2e/skip_sync_test.go
@@ -1,0 +1,287 @@
+// Copyright 2024 The argocd-agent Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package e2e
+
+import (
+	"testing"
+	"time"
+
+	"github.com/argoproj-labs/argocd-agent/internal/config"
+	"github.com/argoproj-labs/argocd-agent/test/e2e/fixture"
+	"github.com/argoproj/argo-cd/v3/common"
+	argoapp "github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
+	"github.com/stretchr/testify/suite"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type SkipSyncTestSuite struct {
+	fixture.BaseSuite
+}
+
+func (suite *SkipSyncTestSuite) Test_Application_SkipSync() {
+	requires := suite.Require()
+
+	// Create an Application on the principal's cluster with skip sync label
+	app := argoapp.Application{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "skip-sync-app",
+			Namespace: "argocd",
+			Labels: map[string]string{
+				config.SkipSyncLabel: "true",
+			},
+		},
+		Spec: argoapp.ApplicationSpec{
+			Project: "default",
+			Source: &argoapp.ApplicationSource{
+				RepoURL: "https://github.com/argoproj/argocd-example-apps.git",
+				Path:    "guestbook",
+			},
+			Destination: argoapp.ApplicationDestination{
+				Server:    "https://kubernetes.default.svc",
+				Namespace: "default",
+			},
+		},
+	}
+
+	err := suite.PrincipalClient.Create(suite.Ctx, &app, metav1.CreateOptions{})
+	requires.NoError(err)
+
+	appKey := fixture.ToNamespacedName(&app)
+
+	// Ensure the Application is NOT pushed to the managed-agent (should be filtered out)
+	suite.Require().Never(func() bool {
+		app := argoapp.Application{}
+		err := suite.ManagedAgentClient.Get(suite.Ctx, appKey, &app, metav1.GetOptions{})
+		return err == nil
+	}, 15*time.Second, 1*time.Second, "Application with skip sync label should not be synced to agent")
+
+	// Verify the Application still exists on the principal
+	principalApp := argoapp.Application{}
+	err = suite.PrincipalClient.Get(suite.Ctx, appKey, &principalApp, metav1.GetOptions{})
+	requires.NoError(err)
+	requires.Equal("skip-sync-app", principalApp.Name)
+}
+
+func (suite *SkipSyncTestSuite) Test_Application_SkipSync_False() {
+	requires := suite.Require()
+
+	// Create an Application on the principal's cluster with skip sync label set to false
+	app := argoapp.Application{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "no-skip-sync-app",
+			Namespace: "argocd",
+			Labels: map[string]string{
+				config.SkipSyncLabel: "false",
+			},
+		},
+		Spec: argoapp.ApplicationSpec{
+			Project: "default",
+			Source: &argoapp.ApplicationSource{
+				RepoURL: "https://github.com/argoproj/argocd-example-apps.git",
+				Path:    "guestbook",
+			},
+			Destination: argoapp.ApplicationDestination{
+				Server:    "https://kubernetes.default.svc",
+				Namespace: "default",
+			},
+		},
+	}
+
+	err := suite.PrincipalClient.Create(suite.Ctx, &app, metav1.CreateOptions{})
+	requires.NoError(err)
+
+	appKey := fixture.ToNamespacedName(&app)
+
+	// Ensure the Application IS pushed to the managed-agent (skip sync is false)
+	requires.Eventually(func() bool {
+		app := argoapp.Application{}
+		err := suite.ManagedAgentClient.Get(suite.Ctx, appKey, &app, metav1.GetOptions{})
+		return err == nil
+	}, 30*time.Second, 1*time.Second, "Application with skip sync=false should be synced to agent")
+}
+
+func (suite *SkipSyncTestSuite) Test_AppProject_SkipSync() {
+	requires := suite.Require()
+
+	// Create an AppProject on the principal's cluster with skip sync label
+	appProject := argoapp.AppProject{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "skip-sync-project",
+			Namespace: "argocd",
+			Labels: map[string]string{
+				config.SkipSyncLabel: "true",
+			},
+		},
+		Spec: argoapp.AppProjectSpec{
+			Destinations: []argoapp.ApplicationDestination{
+				{
+					Namespace: "*",
+					Name:      "agent-*",
+				},
+			},
+			SourceNamespaces: []string{"agent-*"},
+		},
+	}
+
+	err := suite.PrincipalClient.Create(suite.Ctx, &appProject, metav1.CreateOptions{})
+	requires.NoError(err)
+
+	projKey := fixture.ToNamespacedName(&appProject)
+
+	// Ensure the AppProject is NOT pushed to the managed-agent
+	suite.Require().Never(func() bool {
+		appProject := argoapp.AppProject{}
+		err := suite.ManagedAgentClient.Get(suite.Ctx, projKey, &appProject, metav1.GetOptions{})
+		return err == nil
+	}, 15*time.Second, 1*time.Second, "AppProject with skip sync label should not be synced to agent")
+
+	// Verify the AppProject still exists on the principal
+	principalProject := argoapp.AppProject{}
+	err = suite.PrincipalClient.Get(suite.Ctx, projKey, &principalProject, metav1.GetOptions{})
+	requires.NoError(err)
+	requires.Equal("skip-sync-project", principalProject.Name)
+}
+
+func (suite *SkipSyncTestSuite) Test_Repository_SkipSync() {
+	requires := suite.Require()
+
+	// First create a valid AppProject that would normally allow repository sync
+	appProject := argoapp.AppProject{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "repo-project",
+			Namespace: "argocd",
+		},
+		Spec: argoapp.AppProjectSpec{
+			Destinations: []argoapp.ApplicationDestination{
+				{
+					Namespace: "*",
+					Name:      "agent-*",
+				},
+			},
+			SourceNamespaces: []string{"agent-*"},
+		},
+	}
+
+	err := suite.PrincipalClient.Create(suite.Ctx, &appProject, metav1.CreateOptions{})
+	requires.NoError(err)
+
+	projKey := fixture.ToNamespacedName(&appProject)
+
+	// Wait for the AppProject to be synced to the agent
+	requires.Eventually(func() bool {
+		appProject := argoapp.AppProject{}
+		err := suite.ManagedAgentClient.Get(suite.Ctx, projKey, &appProject, metav1.GetOptions{})
+		return err == nil
+	}, 30*time.Second, 1*time.Second, "AppProject should be synced to agent first")
+
+	// Create a Repository on the principal's cluster with skip sync label
+	sourceRepo := corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "skip-sync-repo",
+			Namespace: "argocd",
+			Labels: map[string]string{
+				common.LabelKeySecretType: common.LabelValueSecretTypeRepository,
+				config.SkipSyncLabel:      "true",
+			},
+		},
+		Data: map[string][]byte{
+			"project": []byte("repo-project"),
+			"url":     []byte("https://github.com/example/repo.git"),
+		},
+	}
+
+	err = suite.PrincipalClient.Create(suite.Ctx, &sourceRepo, metav1.CreateOptions{})
+	requires.NoError(err)
+
+	repoKey := fixture.ToNamespacedName(&sourceRepo)
+
+	// Ensure the Repository is NOT pushed to the managed-agent
+	suite.Require().Never(func() bool {
+		repository := corev1.Secret{}
+		err := suite.ManagedAgentClient.Get(suite.Ctx, repoKey, &repository, metav1.GetOptions{})
+		return err == nil
+	}, 15*time.Second, 1*time.Second, "Repository with skip sync label should not be synced to agent")
+
+	// Verify the Repository still exists on the principal
+	principalRepo := corev1.Secret{}
+	err = suite.PrincipalClient.Get(suite.Ctx, repoKey, &principalRepo, metav1.GetOptions{})
+	requires.NoError(err)
+	requires.Equal("skip-sync-repo", principalRepo.Name)
+}
+
+func (suite *SkipSyncTestSuite) Test_Application_SkipSync_Update() {
+	requires := suite.Require()
+
+	// Create an Application on the principal's cluster without skip sync label
+	app := argoapp.Application{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "update-skip-sync-app",
+			Namespace: "argocd",
+		},
+		Spec: argoapp.ApplicationSpec{
+			Project: "default",
+			Source: &argoapp.ApplicationSource{
+				RepoURL: "https://github.com/argoproj/argocd-example-apps.git",
+				Path:    "guestbook",
+			},
+			Destination: argoapp.ApplicationDestination{
+				Server:    "https://kubernetes.default.svc",
+				Namespace: "default",
+			},
+		},
+	}
+
+	err := suite.PrincipalClient.Create(suite.Ctx, &app, metav1.CreateOptions{})
+	requires.NoError(err)
+
+	appKey := fixture.ToNamespacedName(&app)
+
+	// Ensure the Application IS pushed to the managed-agent initially
+	requires.Eventually(func() bool {
+		app := argoapp.Application{}
+		err := suite.ManagedAgentClient.Get(suite.Ctx, appKey, &app, metav1.GetOptions{})
+		return err == nil
+	}, 30*time.Second, 1*time.Second, "Application should be synced to agent initially")
+
+	// Update the Application to add the skip sync label
+	err = suite.PrincipalClient.EnsureApplicationUpdate(suite.Ctx, appKey, func(app *argoapp.Application) error {
+		if app.Labels == nil {
+			app.Labels = make(map[string]string)
+		}
+		app.Labels[config.SkipSyncLabel] = "true"
+		return nil
+	}, metav1.UpdateOptions{})
+	requires.NoError(err)
+
+	// Ensure the Application is removed from the managed-agent after the update
+	requires.Eventually(func() bool {
+		app := argoapp.Application{}
+		err := suite.ManagedAgentClient.Get(suite.Ctx, appKey, &app, metav1.GetOptions{})
+		return err != nil && errors.IsNotFound(err)
+	}, 30*time.Second, 1*time.Second, "Application should be removed from agent after adding skip sync label")
+
+	// Verify the Application still exists on the principal with the skip sync label
+	principalApp := argoapp.Application{}
+	err = suite.PrincipalClient.Get(suite.Ctx, appKey, &principalApp, metav1.GetOptions{})
+	requires.NoError(err)
+	requires.Equal("update-skip-sync-app", principalApp.Name)
+	requires.Equal("true", principalApp.Labels[config.SkipSyncLabel])
+}
+
+func TestSkipSyncTestSuite(t *testing.T) {
+	suite.Run(t, new(SkipSyncTestSuite))
+}


### PR DESCRIPTION
**What does this PR do / why we need it**:

These changes let users put a label on resources (Applications, AppProjects and repository configurations) and the principal and agent will ignore these resources, i.e. not perform any sync actions whatsoever with them.

The label is `argocd-agent.argoproj-labs.io/skip-sync` and it needs to be set to `"true"` to take effect.

This lets you, temporarily or permanently, disable updates on these resources.

**Which issue(s) this PR fixes**:

Fixes #490

**How to test changes / Special notes to the reviewer**:

Unit and e2e tests have been generally generated by Cursor.

**Checklist**

* [ ] Documentation update is required by this PR (and has been updated) OR no documentation update is required.

