### PR TITLE
test(e2e): Restore idempotency of e2e tests

### DIFF
--- a/test/e2e/fixture/argoclient.go
+++ b/test/e2e/fixture/argoclient.go
@@ -432,6 +432,7 @@ func (c *ArgoRestClient) ListApplications() (*v1alpha1.ApplicationList, error) {
 func (c *ArgoRestClient) DeleteApplication(name string) error {
 	reqURL := c.url()
 	reqURL.Path = fmt.Sprintf("/api/v1/applications/%s", name)
+	reqURL.RawQuery = "cascade=false"
 
 	req, err := http.NewRequest(http.MethodDelete, reqURL.String(), nil)
 	if err != nil {

--- a/test/e2e/fixture/fixture.go
+++ b/test/e2e/fixture/fixture.go
@@ -107,19 +107,19 @@ func (suite *BaseSuite) TearDownTest() {
 
 // EnsureDeletion will issue a delete for a namespace-scoped K8s resource, then wait for it to no longer exist
 func EnsureDeletion(ctx context.Context, kclient KubeClient, obj KubeObject) error {
-	err := kclient.Delete(ctx, obj, metav1.DeleteOptions{})
-	if errors.IsNotFound(err) {
-		// object is already deleted
-		return nil
-	} else if err != nil {
-		return err
-	}
-
 	// Wait for the object to be deleted  for 60 seconds
 	// - Primarily this will be waiting for the finalizer to be removed, so that the object is deleted
 	key := types.NamespacedName{Name: obj.GetName(), Namespace: obj.GetNamespace()}
 	for count := 0; count < 60; count++ {
-		err := kclient.Get(ctx, key, obj, metav1.GetOptions{})
+		err := kclient.Delete(ctx, obj, metav1.DeleteOptions{})
+		if errors.IsNotFound(err) {
+			// object is already deleted
+			return nil
+		} else if err != nil {
+			return err
+		}
+
+		err = kclient.Get(ctx, key, obj, metav1.GetOptions{})
 		if errors.IsNotFound(err) {
 			return nil
 		} else if err == nil {
@@ -161,19 +161,6 @@ func CleanUp(ctx context.Context, principalClient KubeClient, managedAgentClient
 	// Remove any previously configured env variables from the config file
 	os.Remove(EnvVariablesFromE2EFile)
 
-	// Delete all managed applications from the principal
-	list = argoapp.ApplicationList{}
-	err = principalClient.List(ctx, "agent-managed", &list, metav1.ListOptions{})
-	if err != nil {
-		return err
-	}
-	for _, app := range list.Items {
-		err = EnsureDeletion(ctx, principalClient, &app)
-		if err != nil {
-			return err
-		}
-	}
-
 	// Delete all applications from the autonomous agent
 	list = argoapp.ApplicationList{}
 	err = autonomousAgentClient.List(ctx, "argocd", &list, metav1.ListOptions{})
@@ -182,6 +169,19 @@ func CleanUp(ctx context.Context, principalClient KubeClient, managedAgentClient
 	}
 	for _, app := range list.Items {
 		err = EnsureDeletion(ctx, autonomousAgentClient, &app)
+		if err != nil {
+			return err
+		}
+	}
+
+	// Delete all managed applications from the principal
+	list = argoapp.ApplicationList{}
+	err = principalClient.List(ctx, "agent-managed", &list, metav1.ListOptions{})
+	if err != nil {
+		return err
+	}
+	for _, app := range list.Items {
+		err = EnsureDeletion(ctx, principalClient, &app)
 		if err != nil {
 			return err
 		}
@@ -213,24 +213,8 @@ func CleanUp(ctx context.Context, principalClient KubeClient, managedAgentClient
 		}
 	}
 
-	// Delete all appProjects from the principal
-	appProjectList := argoapp.AppProjectList{}
-	err = principalClient.List(ctx, "argocd", &appProjectList, metav1.ListOptions{})
-	if err != nil {
-		return err
-	}
-	for _, appProject := range appProjectList.Items {
-		if appProject.Name == appproject.DefaultAppProjectName {
-			continue
-		}
-		err = EnsureDeletion(ctx, principalClient, &appProject)
-		if err != nil {
-			return err
-		}
-	}
-
 	// Delete all appProjects from the autonomous agent
-	appProjectList = argoapp.AppProjectList{}
+	appProjectList := argoapp.AppProjectList{}
 	err = autonomousAgentClient.List(ctx, "argocd", &appProjectList, metav1.ListOptions{})
 	if err != nil {
 		return err
@@ -240,6 +224,23 @@ func CleanUp(ctx context.Context, principalClient KubeClient, managedAgentClient
 			continue
 		}
 		err = EnsureDeletion(ctx, autonomousAgentClient, &appProject)
+		if err != nil {
+			return err
+		}
+	}
+
+	// Delete all appProjects from the principal
+	appProjectList = argoapp.AppProjectList{}
+	err = principalClient.List(ctx, "argocd", &appProjectList, metav1.ListOptions{})
+	if err != nil {
+		return err
+	}
+	for _, appProject := range appProjectList.Items {
+		if appProject.Name == appproject.DefaultAppProjectName {
+			continue
+		}
+		fmt.Println("Deleting appProject", appProject.Name)
+		err = EnsureDeletion(ctx, principalClient, &appProject)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
**What does this PR do / why we need it**:

The idempotent of the e2e tests (i.e., the ability to run the same test twice in succession) have been compromised recently. This PR restores this ability and also fixes a (rare) race during cleanup.

**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:


**Checklist**

* [ ] Documentation update is required by this PR (and has been updated) OR no documentation update is required.

