### PR TITLE
Improve using release branches for manifests

### DIFF
--- a/docs/getting-started/kubernetes/index.md
+++ b/docs/getting-started/kubernetes/index.md
@@ -62,19 +62,19 @@ kubectl create namespace argocd --context <control-plane-context>
 
 ### 1.2 Install Argo CD on Control Plane
 
-Install a customized Argo CD instance that excludes components that will run on workload clusters:
+Install a customized Argo CD instance that excludes components that will run on workload clusters replacing <release-branch> with the release you wish to use:
 
 ```bash
 # Apply the principal-specific Argo CD configuration
 kubectl apply -n argocd \
-  -k 'https://github.com/argoproj-labs/argocd-agent/install/kubernetes/argo-cd/principal?ref=main' \
+  -k 'https://github.com/argoproj-labs/argocd-agent/install/kubernetes/argo-cd/principal?ref=<release-branch>' \
   --context <control-plane-context>
 ```
 
 This configuration includes:
 
 - ✅ **argocd-server** (API and UI)
-- ✅ **argocd-dex-server** (SSO, if needed)  
+- ✅ **argocd-dex-server** (SSO, if needed)
 - ✅ **argocd-redis** (state storage)
 - ✅ **argocd-repo-server** (Git repository access)
 - ❌ **argocd-application-controller** (runs on workload clusters only)
@@ -160,9 +160,11 @@ argocd-agentctl jwt create-key \
 
 ### 3.1 Deploy Principal Component
 
+Change <release-branch> to the release you wish to use:
+
 ```bash
 kubectl apply -n argocd \
-  -k 'https://github.com/argoproj-labs/argocd-agent/install/kubernetes/principal?ref=main' \
+  -k 'https://github.com/argoproj-labs/argocd-agent/install/kubernetes/principal?ref=<release-branch>' \
   --context <control-plane-context>
 ```
 
@@ -184,7 +186,7 @@ The principal's gRPC service needs to be accessible from workload clusters:
 kubectl patch svc argocd-agent-principal -n argocd --context <control-plane-context> \
   --patch '{"spec":{"type":"LoadBalancer"}}'
 
-# Option 2: NodePort  
+# Option 2: NodePort
 kubectl patch svc argocd-agent-principal -n argocd --context <control-plane-context> \
   --patch '{"spec":{"type":"NodePort","ports":[{"port":8443,"nodePort":30443}]}}'
 ```
@@ -221,15 +223,17 @@ kubectl create namespace argocd --context <workload-cluster-context>
 
 ### 4.3 Install Argo CD on Workload Cluster
 
+Replace <release-branch> with the release you wish to use:
+
 ```bash
 # For managed agents
 kubectl apply -n argocd \
-  -k 'https://github.com/argoproj-labs/argocd-agent/install/kubernetes/argo-cd/agent-managed?ref=main' \
+  -k 'https://github.com/argoproj-labs/argocd-agent/install/kubernetes/argo-cd/agent-managed?ref=<release-branch>' \
   --context <workload-cluster-context>
 
 # For autonomous agents (alternative)
 # kubectl apply -n argocd \
-#   -k 'https://github.com/argoproj-labs/argocd-agent/install/kubernetes/argo-cd/agent-autonomous?ref=main' \
+#   -k 'https://github.com/argoproj-labs/argocd-agent/install/kubernetes/argo-cd/agent-autonomous?ref=<release-branch>' \
 #   --context <workload-cluster-context>
 ```
 
@@ -291,9 +295,11 @@ kubectl get secret argocd-agent-ca -n argocd --context <workload-cluster-context
 
 ### 5.4 Deploy Agent
 
+Replace <release-branch> with the version of the release you wish to use:
+
 ```bash
 kubectl apply -n argocd \
-  -k 'https://github.com/argoproj-labs/argocd-agent/install/kubernetes/agent?ref=main' \
+  -k 'https://github.com/argoproj-labs/argocd-agent/install/kubernetes/agent?ref=<release-branch>' \
   --context <workload-cluster-context>
 ```
 
@@ -324,7 +330,7 @@ kubectl logs -n argocd deployment/argocd-agent-agent --context <workload-cluster
 
 # Expected output:
 # INFO[0001] Starting argocd-agent (agent) v0.1.0 (ns=argocd, mode=managed, auth=mtls)
-# INFO[0002] Authentication successful  
+# INFO[0002] Authentication successful
 # INFO[0003] Connected to argocd-agent-principal v0.1.0
 ```
 
@@ -389,7 +395,7 @@ Access the Argo CD UI to see your agent and its applications!
 
 ### Security Hardening
 1. **Replace development certificates** with production-grade PKI
-2. **Configure proper RBAC** in Argo CD  
+2. **Configure proper RBAC** in Argo CD
 3. **Set up network policies** to restrict traffic
 4. **Enable audit logging** for compliance
 

--- a/docs/getting-started/openshift/index.md
+++ b/docs/getting-started/openshift/index.md
@@ -162,9 +162,9 @@ Run this command while connected to principal
 argocd-agentctl pki issue agent <agent-name> --principal-context <principal context> --agent-context <workload context> --agent-namespace argocd --upsert
 ```
 
-Apply the installation manifests for argocd agent
+Apply the installation manifests for argocd agent replacing <release-branch> with the release that you wish to use:
 ```
-oc apply -n argocd -k 'https://github.com/argoproj-labs/argocd-agent/install/kubernetes/agent?ref=main'
+oc apply -n argocd -k 'https://github.com/argoproj-labs/argocd-agent/install/kubernetes/agent?ref=<release-branch>'
 ```
 This should create all the required agent related resources.
 

--- a/docs/getting-started/openshift/index.md
+++ b/docs/getting-started/openshift/index.md
@@ -64,7 +64,7 @@ spec:
   argoCDAgent:
     principal:
       enabled: true
-      allowedNamespaces: 
+      allowedNamespaces:
         - "*"
       jwtAllowGenerate: true
       auth: "mtls:CN=([^,]+)"
@@ -72,7 +72,7 @@ spec:
       image: "ghcr.io/argoproj-labs/argocd-agent/argocd-agent:latest"
   sourceNamespaces:
     - "agent-managed"
-    - "agent-autonomous"  					
+    - "agent-autonomous"
 ```
 
 The above CR should create all the necessary resource for Argo CD as well as argocd-agent principal in argocd namespace.
@@ -83,10 +83,10 @@ Create argocd-redis secret, because principal looks for it to fetch redis authen
 oc create secret generic argocd-redis -n argocd --from-literal=auth="$(oc get secret argocd-redis-initial-password -n argocd -o jsonpath='{.data.admin\.password}' | base64 -d)"
 ```
 
-## Setting up agent workload cluster 
+## Setting up agent workload cluster
 
-### Configure Argo CD for Agent 
- 
+### Configure Argo CD for Agent
+
 Argo CD instance on Agent cluster
 
 Creating Argo CD instance for Workload/spoke cluster.
@@ -100,14 +100,14 @@ Creating Argo CD instance for Workload/spoke cluster.
       enabled: false
 ```
 
-Create redis secret using below command for agent deployment 
+Create redis secret using below command for agent deployment
 ```
 kubectl create secret generic argocd-redis -n <workload namespace> --from-literal=auth="$(kubectl get secret argocd-redis-initial-password -n <argocd-namespace> -o jsonpath='{.data.admin\.password}' | base64 -d)"
 ```
 
 ### Configure Agent in managed mode
 
-Before installing agent resources create 
+Before installing agent resources create
 - a TLS secret containing the issued certificate for agent
 
 Create the PKI on the agent:
@@ -116,9 +116,9 @@ Run this command while connected to principal
 argocd-agentctl pki issue agent <agent-name>  --principal-context <principal context> --agent-context <workload context> --agent-namespace <workload namespace> --upsert
 ```
 
-Apply the installation manifests for Argo CD-agent agent
+Apply the installation manifests for Argo CD-agent agent, change <release-branch> to the release you want to deploy:
 ```
-oc apply -n $(workload-namespace) -k 'https://github.com/argoproj-labs/argocd-agent/install/kubernetes/agent?ref=main'
+oc apply -n $(workload-namespace) -k 'https://github.com/argoproj-labs/argocd-agent/install/kubernetes/agent?ref=<release-branch>'
 ```
 This should create all the required agent related resources.
 
@@ -129,7 +129,7 @@ kubectl patch clusterrolebinding argocd-agent-agent --type='json' -p='[{"op": "r
 ```
 
 
-Update the configMap with name `argocd-agent-params`  with parameters related to agent.mode,agent.creds, agent.namespace, agent.server.address.	
+Update the configMap with name `argocd-agent-params`  with parameters related to agent.mode,agent.creds, agent.namespace, agent.server.address.
 ```
   agent.keep-alive-ping-interval: 50s
   agent.mode: managed
@@ -147,13 +147,13 @@ Update the configMap with name `argocd-agent-params`  with parameters related to
   agent.tls.root-ca-secret-name: argocd-agent-ca
   agent.tls.secret-name: argocd-agent-client-tls
 ```
-Also Update RBAC, rolebinding/clusterrolebinding with `workload-namespace`, if pod is facing rbac issues. 
+Also Update RBAC, rolebinding/clusterrolebinding with `workload-namespace`, if pod is facing rbac issues.
 
 
 
 ### Configure Agent in Autonomous mode
 
-Before installing agent resources create 
+Before installing agent resources create
 Create a TLS secret containing the issued certificate for agent
 
 Create the PKI on the agent:
@@ -179,7 +179,7 @@ Update the configMap with name `argocd-agent-params`  with parameters related to
 ```
 data:
   agent.keep-alive-ping-interval: 50s
-  agent.tls.client.insecure: 'false' 
+  agent.tls.client.insecure: 'false'
   agent.server.port: '443'
   agent.tls.root-ca-path: ''
   agent.tls.client.cert-path: ''
@@ -196,7 +196,7 @@ data:
 ```
 
 
-#### Troubleshooting 
+#### Troubleshooting
 ___
 
 1. If pod fails to come up with error

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -59,11 +59,11 @@ fi
 echo "*** generating new manifests"
 (
 	cd install/kubernetes/agent
-	kustomize edit set image ghcr.io/argoproj-labs/argocd-agent/argocd-agent=quay.io/argoprojlabs/argocd-agent:${TARGET_TAG}
+	kustomize edit set image argocd-agent=quay.io/argoprojlabs/argocd-agent:${TARGET_TAG}
 )
 (
 	cd install/kubernetes/principal
-	kustomize edit set image ghcr.io/argoproj-labs/argocd-agent/argocd-agent=quay.io/argoprojlabs/argocd-agent:${TARGET_TAG}
+	kustomize edit set image argocd-agent=quay.io/argoprojlabs/argocd-agent:${TARGET_TAG}
 )
 
 echo "*** committing changes to release branch"


### PR DESCRIPTION
**What does this PR do / why we need it**:

This PR makes a small improvement to the docs when using release branches:

1. The installation docs for Kubernetes and OpenShift have been updated to call out using a <release-branch> instead of main
2. The release.sh script has been tweaked so that it doesn't generate redundant image updates which could be confusing to users. For example if you look here notice that the images are updated twice in the kustomization.yaml (https://github.com/argoproj-labs/argocd-agent/blob/release-0.4/install/kubernetes/agent/kustomization.yaml#L16)

Note my editor automatically removes trailing spaces so let me know if you want those changes excluded, I can redo the PR in a different editor to avoid this.

**Which issue(s) this PR fixes**:

**How to test changes / Special notes to the reviewer**:

I tested manually by running the kustomize command, not sure how to test release.sh without creating a release.

**Checklist**

* [ ] Documentation update is required by this PR (and has been updated) OR no documentation update is required.

