### PR TITLE
fix: Remove username/password from CLI's create agent function

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,6 @@ require (
 	golang.org/x/crypto v0.42.0
 	golang.org/x/net v0.44.0
 	golang.org/x/sync v0.17.0
-	golang.org/x/term v0.35.0
 	golang.stackrox.io/grpc-http1 v0.4.0
 	google.golang.org/genproto/googleapis/api v0.0.0-20250707201910-8d1bb00bc6a7
 	google.golang.org/grpc v1.75.1
@@ -171,6 +170,7 @@ require (
 	go.yaml.in/yaml/v2 v2.4.2 // indirect
 	golang.org/x/oauth2 v0.30.0 // indirect
 	golang.org/x/sys v0.36.0 // indirect
+	golang.org/x/term v0.35.0 // indirect
 	golang.org/x/text v0.29.0 // indirect
 	golang.org/x/time v0.12.0 // indirect
 	google.golang.org/genproto v0.0.0-20240213162025-012b6fc9bca9 // indirect

--- a/hack/dev-env/create-agent-config.sh
+++ b/hack/dev-env/create-agent-config.sh
@@ -80,8 +80,6 @@ for agent in ${AGENTS}; do
 	if ! ${AGENTCTL} agent inspect ${agent} >/dev/null 2>&1; then
 		echo "  -> Creating cluster secret for agent configuration"
 		${AGENTCTL} agent create ${agent} \
-			--resource-proxy-username ${agent} \
-			--resource-proxy-password ${agent} \
 			--resource-proxy-server ${ARGOCD_AGENT_RESOURCE_PROXY}:9090
 	else
 		echo "  -> Reusing existing cluster secret for agent configuration"


### PR DESCRIPTION
**What does this PR do / why we need it**:

The `argocd-agentctl agent create` command asks for a username and password. However, these are NOPs, as neither is used anywhere for authentication or other purposes. It's best to remove them, to prevent confusion.

**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:


**Checklist**

* [x] Documentation update is required by this PR (and has been updated) OR no documentation update is required.

