### PR TITLE
fix: follow what Argo CD does and set the rolebinding namespace to argocd

### DIFF
--- a/install/kubernetes/agent/agent-clusterrolebinding.yaml
+++ b/install/kubernetes/agent/agent-clusterrolebinding.yaml
@@ -13,4 +13,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: argocd-agent-agent
-  namespace: default
+  namespace: argocd

--- a/install/kubernetes/agent/agent-rolebinding.yaml
+++ b/install/kubernetes/agent/agent-rolebinding.yaml
@@ -13,4 +13,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: argocd-agent-agent
-  namespace: default
+  namespace: argocd

--- a/install/kubernetes/principal/principal-clusterrolebinding.yaml
+++ b/install/kubernetes/principal/principal-clusterrolebinding.yaml
@@ -13,4 +13,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: argocd-agent-principal
-  namespace: default
+  namespace: argocd

--- a/install/kubernetes/principal/principal-rolebinding.yaml
+++ b/install/kubernetes/principal/principal-rolebinding.yaml
@@ -13,4 +13,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: argocd-agent-principal
-  namespace: default
+  namespace: argocd


### PR DESCRIPTION
**What does this PR do / why we need it**:
Follow what Argo CD does and set the rolebinding namespace to argocd for both principal and agent

See https://github.com/argoproj-labs/argocd-agent/pull/542#issuecomment-3253788558 for more details.

This default ns has been pretty annoying when setting up the argocd-agent env for some time now. Following the setup/installation steps is arguably the hardest part of this project, so we should make it as simple as possible for beginners.

**Which issue(s) this PR fixes**:

Fixes https://github.com/argoproj-labs/argocd-agent/issues/403

**How to test changes / Special notes to the reviewer**:


**Checklist**

* [x] Documentation update is required by this PR (and has been updated) OR no documentation update is required.

