### PR TITLE
fix: Setting Use for shell completion

### DIFF
--- a/cmd/ctl/main.go
+++ b/cmd/ctl/main.go
@@ -40,6 +40,7 @@ func NewRootCommand() *cobra.Command {
 	command := &cobra.Command{
 		Short: "Inspect and manipulate argocd-agent configuration",
 		Long:  cliDescription,
+		Use:   "argocd-agentctl",
 		Run: func(cmd *cobra.Command, args []string) {
 			_ = cmd.Usage()
 			os.Exit(1)


### PR DESCRIPTION
**What does this PR do / why we need it**:

Running `source <(argocd agentctl completion bash)` errors out. This PR fixes the issue.

**Which issue(s) this PR fixes**:

Fixes #583 

