### PR TITLE
fix(e2e): wait for components to be ready after restart

### DIFF
--- a/test/e2e/repository_test.go
+++ b/test/e2e/repository_test.go
@@ -15,6 +15,7 @@
 package e2e
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -116,7 +117,15 @@ func (suite *RepositoryTestSuite) Test_Repository_Managed() {
 	requires.Eventually(func() bool {
 		repository := corev1.Secret{}
 		err := suite.ManagedAgentClient.Get(suite.Ctx, key, &repository, metav1.GetOptions{})
-		return err == nil && string(repository.Data["url"]) == updatedRepo
+		if err != nil {
+			fmt.Println("error getting repository", err)
+			return false
+		}
+		if string(repository.Data["url"]) != updatedRepo {
+			fmt.Println("repository url does not match", string(repository.Data["url"]), updatedRepo)
+			return false
+		}
+		return true
 	}, 30*time.Second, 1*time.Second, "GET repository from managed-agent")
 
 	// Delete the repository on the principal


### PR DESCRIPTION
**What does this PR do / why we need it**:
1. Wait for the agent/principal to be ready after the restart
2. Add extra print statements to debug failures

Tested it locally with repetitions and the tests didn't fail. This should hopefully resolve the intermittent failing e2e tests.

**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:


**Checklist**

* [ ] Documentation update is required by this PR (and has been updated) OR no documentation update is required.

