### PR TITLE
feat: informer sync timeout configuration for principal

### DIFF
--- a/principal/listen_test.go
+++ b/principal/listen_test.go
@@ -152,6 +152,7 @@ func Test_Serve(t *testing.T) {
 		WithListenerAddress("127.0.0.1"),
 		WithShutDownGracePeriod(2*time.Second),
 		WithGRPC(true),
+		WithInformerSyncTimeout(5*time.Second),
 	)
 	require.NoError(t, err)
 	errch := make(chan error)

--- a/principal/options.go
+++ b/principal/options.go
@@ -75,6 +75,7 @@ type ServerOptions struct {
 	redisPassword          string
 	redisCompressionType   cacheutil.RedisCompressionType
 	healthzPort            int
+	informerSyncTimeout    time.Duration
 }
 
 type ServerOption func(o *Server) error
@@ -82,12 +83,13 @@ type ServerOption func(o *Server) error
 // defaultOptions returns a set of default options for the server
 func defaultOptions() *ServerOptions {
 	return &ServerOptions{
-		port:            443,
-		address:         "",
-		tlsMinVersion:   tls.VersionTLS13,
-		unauthMethods:   make(map[string]bool),
-		eventProcessors: 10,
-		rootCa:          x509.NewCertPool(),
+		port:                443,
+		address:             "",
+		tlsMinVersion:       tls.VersionTLS13,
+		unauthMethods:       make(map[string]bool),
+		eventProcessors:     10,
+		rootCa:              x509.NewCertPool(),
+		informerSyncTimeout: 60 * time.Second,
 	}
 }
 
@@ -411,6 +413,14 @@ func WithAutoNamespaceCreate(enabled bool, pattern string, labels map[string]str
 func WithWebSocket(enableWebSocket bool) ServerOption {
 	return func(o *Server) error {
 		o.enableWebSocket = enableWebSocket
+		return nil
+	}
+}
+
+// WithInformerSyncTimeout sets the informer sync timeout duration.
+func WithInformerSyncTimeout(timeout time.Duration) ServerOption {
+	return func(o *Server) error {
+		o.options.informerSyncTimeout = timeout
 		return nil
 	}
 }

--- a/principal/options_test.go
+++ b/principal/options_test.go
@@ -17,9 +17,17 @@ package principal
 import (
 	"crypto/tls"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
+
+func Test_WithInformerSyncTimeout(t *testing.T) {
+	s := &Server{options: &ServerOptions{}}
+	err := WithInformerSyncTimeout(5 * time.Second)(s)
+	assert.NoError(t, err)
+	assert.Equal(t, 5*time.Second, s.options.informerSyncTimeout)
+}
 
 func Test_WithPort(t *testing.T) {
 	ports := []struct {

--- a/principal/server.go
+++ b/principal/server.go
@@ -508,17 +508,22 @@ func (s *Server) Start(ctx context.Context, errch chan error) error {
 
 	s.events = event.NewEventSource(s.options.serverName)
 
-	if err := s.appManager.EnsureSynced(waitForSyncedDuration); err != nil {
+	syncTimeout := s.options.informerSyncTimeout
+	if syncTimeout == 0 {
+		syncTimeout = waitForSyncedDuration
+	}
+
+	if err := s.appManager.EnsureSynced(syncTimeout); err != nil {
 		return fmt.Errorf("unable to sync Application informer: %w", err)
 	}
 	log().Infof("Application informer synced and ready")
 
-	if err := s.projectManager.EnsureSynced(waitForSyncedDuration); err != nil {
+	if err := s.projectManager.EnsureSynced(syncTimeout); err != nil {
 		return fmt.Errorf("unable to sync AppProject informer: %w", err)
 	}
 	log().Infof("AppProject informer synced and ready")
 
-	if err := s.repoManager.EnsureSynced(waitForSyncedDuration); err != nil {
+	if err := s.repoManager.EnsureSynced(syncTimeout); err != nil {
 		return fmt.Errorf("unable to sync Repository informer: %w", err)
 	}
 	log().Infof("Repository informer synced and ready")
@@ -534,11 +539,10 @@ func (s *Server) Start(ctx context.Context, errch chan error) error {
 		log().Infof("Resource proxy is disabled")
 	}
 
-	err = s.clusterMgr.Start()
-	if err != nil {
-		return err
+	if err := s.clusterMgr.Start(); err != nil {
+		return fmt.Errorf("unable to start cluster manager with informer sync timeout %v: %w", syncTimeout, err)
 	}
-	if err := s.namespaceManager.EnsureSynced(waitForSyncedDuration); err != nil {
+	if err := s.namespaceManager.EnsureSynced(syncTimeout); err != nil {
 		return fmt.Errorf("unable to sync Namespace informer: %w", err)
 	}
 	log().Infof("Namespace informer synced and ready")

--- a/principal/server_test.go
+++ b/principal/server_test.go
@@ -96,6 +96,20 @@ func Test_NewServer(t *testing.T) {
 		assert.Error(t, err)
 		assert.Nil(t, s)
 	})
+
+	t.Run("Informer sync timeout should be configurable", func(t *testing.T) {
+		s, err := NewServer(context.TODO(), kube.NewKubernetesFakeClientWithApps(testNamespace), testNamespace, WithGeneratedTokenSigningKey(), WithInformerSyncTimeout(10*time.Second))
+		assert.NoError(t, err)
+		assert.NotNil(t, s)
+		assert.Equal(t, 10*time.Second, s.options.informerSyncTimeout)
+	})
+
+	t.Run("Informer sync timeout should default to 60s when not set", func(t *testing.T) {
+		s, err := NewServer(context.TODO(), kube.NewKubernetesFakeClientWithApps(testNamespace), testNamespace, WithGeneratedTokenSigningKey())
+		assert.NoError(t, err)
+		assert.NotNil(t, s)
+		assert.Equal(t, 60*time.Second, s.options.informerSyncTimeout)
+	})
 }
 
 func Test_handleResyncOnConnect(t *testing.T) {


### PR DESCRIPTION
**What does this PR do / why we need it**:

In large clusters, there can be many resources, and informer synchronization may take longer.
To address this, an --informer-sync-timeout flag is added to adjust the wait time for informer sync.
In test environments, the timeout can be set short for quick failure detection.
This allows flexible configuration instead of a hardcoded timeout.

**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:

- Applied to Application, AppProject, Repository, and Namespace informers
- Timeout can be set via the WithInformerSyncTimeout() option
- If not set, the default timeout is 60 seconds
- Unit tests verify timeout settings and default behavior



**Checklist**

* [ ] Documentation update is required by this PR (and has been updated) OR no documentation update is required.

