### PR TITLE
feat: add Redis Proxy disable option for test environment

### DIFF
--- a/principal/options.go
+++ b/principal/options.go
@@ -75,6 +75,7 @@ type ServerOptions struct {
 	redisPassword          string
 	redisCompressionType   cacheutil.RedisCompressionType
 	healthzPort            int
+	redisProxyDisabled     bool
 	informerSyncTimeout    time.Duration
 }
 
@@ -413,6 +414,14 @@ func WithAutoNamespaceCreate(enabled bool, pattern string, labels map[string]str
 func WithWebSocket(enableWebSocket bool) ServerOption {
 	return func(o *Server) error {
 		o.enableWebSocket = enableWebSocket
+		return nil
+	}
+}
+
+// WithRedisProxyDisabled disables the Redis proxy for testing.
+func WithRedisProxyDisabled() ServerOption {
+	return func(o *Server) error {
+		o.options.redisProxyDisabled = true
 		return nil
 	}
 }

--- a/principal/options_test.go
+++ b/principal/options_test.go
@@ -98,3 +98,10 @@ func Test_WithMinimumTLSVersion(t *testing.T) {
 		}
 	})
 }
+
+func Test_WithRedisProxyDisabled(t *testing.T) {
+	s := &Server{options: &ServerOptions{}}
+	err := WithRedisProxyDisabled()(s)
+	assert.NoError(t, err)
+	assert.True(t, s.options.redisProxyDisabled)
+}

--- a/principal/server.go
+++ b/principal/server.go
@@ -337,7 +337,9 @@ func NewServer(ctx context.Context, kubeClient *kube.KubernetesClient, namespace
 		s.resourceProxyListenAddr = defaultResourceProxyListenerAddr
 	}
 
-	s.redisProxy = redisproxy.New(defaultRedisProxyListenerAddr, s.options.redisAddress, s.sendSynchronousRedisMessageToAgent)
+	if !s.options.redisProxyDisabled {
+		s.redisProxy = redisproxy.New(defaultRedisProxyListenerAddr, s.options.redisAddress, s.sendSynchronousRedisMessageToAgent)
+	}
 
 	// Instantiate our ResourceProxy to intercept Kubernetes requests from Argo
 	// CD's API server.


### PR DESCRIPTION
**What does this PR do / why we need it**:

This PR adds a `WithRedisProxyDisabled()` option that allows the principal server to selectively disable the Redis proxy. Currently, the principal always creates the Redis proxy by default, but in test environments or certain scenarios, the Redis proxy may be unnecessary or may even complicate testing. This option enables running the principal without the Redis proxy, allowing test code to be written more simply and clearly.


**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:

A new unit test, `Test_WithRedisProxyDisabled`, has been added to verify that the option is set correctly.


**Checklist**

* [ ] Documentation update is required by this PR (and has been updated) OR no documentation update is required.

