### PR TITLE
fix: allow egress to kube-system for DNS resolution in redis connection

### DIFF
--- a/install/kubernetes/agent/agent-networkpolicy-redis.yaml
+++ b/install/kubernetes/agent/agent-networkpolicy-redis.yaml
@@ -16,4 +16,13 @@ spec:
     ports:
     - port: 6379
       protocol: TCP
+  - to:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: kube-system
+    ports:
+    - port: 53
+      protocol: UDP
+    - port: 53
+      protocol: TCP
 

--- a/install/kubernetes/principal/principal-networkpolicy-redis.yaml
+++ b/install/kubernetes/principal/principal-networkpolicy-redis.yaml
@@ -16,4 +16,13 @@ spec:
     ports:
     - port: 6379
       protocol: TCP
+  - to:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: kube-system
+    ports:
+    - port: 53
+      protocol: UDP
+    - port: 53
+      protocol: TCP
 


### PR DESCRIPTION
**What does this PR do / why we need it**:
This PR resolves the issue where the argocd-agent Pod failed to connect to the argocd-redis service due to blocked DNS egress traffic.
The previous NetworkPolicy did not allow UDP/TCP port 53 access to the CoreDNS service running in the kube-system namespace, causing repeated `dial tcp: lookup argocd-redis: i/o timeout` errors.
This update explicitly permits egress to kube-system for DNS resolution, ensuring that cluster-local services (argocd-redis) can be properly resolved.

**Which issue(s) this PR fixes**:

Fixes #611 

**How to test changes / Special notes to the reviewer**:
1. Deploy argocd-agent in a multi-cluster setup.

2. Before applying this PR, observe that argocd-agent and principal fails DNS lookup:
```bash
# command
kubectl logs -n argocd deployment/argocd-agent-<principal-or-agent> --context kind-<principal-or-agent-cluster-name>

# result
redis: connection pool: failed to dial after 5 attempts: dial tcp: lookup argocd-redis: i/o timeout
```

4. Apply this PR (updated NetworkPolicy).
Verify successful name resolution and Redis connection:
```bash
# command
kubectl exec -n argocd deploy/argocd-agent-agent -- getent hosts argocd-redis

# result (can find)
10.103.173.211    argocd-redis.argocd.svc.cluster.local  argocd-redis.argocd.svc.cluster.local argocd-redis
```

**Checklist**

* [x] Documentation update is required by this PR (and has been updated) OR no documentation update is required.

