### PR TITLE
fix:  tlsClientInSecure field fails to set value using --set true/false

### DIFF
--- a/install/helm-repo/argocd-agent-agent/values.schema.json
+++ b/install/helm-repo/argocd-agent-agent/values.schema.json
@@ -140,9 +140,11 @@
       "description": "Agent metrics port (env/config value)"
     },
     "tlsClientInSecure": {
-      "type": "string",
-      "enum": ["true", "false"],
-      "description": "Whether to skip TLS verification for client (string)"
+      "anyOf": [
+        { "type": "string", "enum": ["true", "false"] },
+        { "type": "boolean" }
+      ],
+      "description": "Whether to skip TLS verification for client (can be boolean or string)"
     },
     "healthzPort": {
       "type": "string",


### PR DESCRIPTION
**What does this PR do / why we need it**:
previously when setting tlsClientInSecure field value to true/false was throwing error `- at '/tlsClientInSecure': got boolean, want string` 
This PR updates the schema to fix this issue and lets user set values for tlsClientInSecure field.

```
helm install argocd-agent argocd-agent-agent-0.1.0.tgz --version 0.1.0 --set logLevel="debug" --set agentMode=${mode} --set server=$svc --set namespaceOverride=argocd --set tlsClientInSecure=true
Error: INSTALLATION FAILED: values don't meet the specifications of the schema(s) in the following chart(s):
argocd-agent-agent:
- at '/tlsClientInSecure': got boolean, want string
```

**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:


**Checklist**

* [ ] Documentation update is required by this PR (and has been updated) OR no documentation update is required.

