### PR TITLE
chore: add pre-sync hook job for e2e test

### DIFF
--- a/test/data/pre-sync/kustomization.yaml
+++ b/test/data/pre-sync/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- https://github.com/argoproj/argocd-example-apps//kustomize-guestbook?ref=master
+- pre-sync-job.yaml

--- a/test/data/pre-sync/pre-sync-job.yaml
+++ b/test/data/pre-sync/pre-sync-job.yaml
@@ -1,0 +1,17 @@
+# A pre-sync hook that keeps the sync operation pending for 20 minutes.
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: before
+  annotations:
+    argocd.argoproj.io/hook: PreSync
+    argocd.argoproj.io/hook-delete-policy: HookSucceeded
+spec:
+  template:
+    spec:
+      containers:
+      - name: sleep
+        image: alpine:latest
+        command: ["sleep", "20m"]
+      restartPolicy: Never
+  backoffLimit: 0


### PR DESCRIPTION
**What does this PR do / why we need it**:

I'm trying to simulate an [e2e test scenario](https://github.com/argoproj-labs/argocd-agent/pull/630) where we can terminate a sync operation. A pre-sync hook can keep the sync operation in progress. The [upstream example](https://github.com/argoproj/argocd-example-apps/blob/master/pre-post-sync/pre-sync-job.yaml) keeps the pre-sync hook running only for 10 seconds. Using that example in e2e may lead to race conditions. We need a hook that can keep the sync operation in progress for a sufficiently long duration. 

This PR adds an example pre-sync hook that we can use in the e2e tests.

**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:


**Checklist**

* [ ] Documentation update is required by this PR (and has been updated) OR no documentation update is required.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test fixture files for pre-sync job validation and Kustomize manifest configuration scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->