### PR TITLE
fix: add missing agent configurations in helm chart

### DIFF
--- a/install/helm-repo/argocd-agent-agent/templates/agent-deployment.yaml
+++ b/install/helm-repo/argocd-agent-agent/templates/agent-deployment.yaml
@@ -115,6 +115,60 @@ spec:
                 name: argocd-agent-params
                 key: agent.redis.address
                 optional: true
+          - name: ARGOCD_AGENT_KEEP_ALIVE_PING_INTERVAL
+            valueFrom:
+              configMapKeyRef:
+                name: argocd-agent-params
+                key: agent.keep-alive.interval
+                optional: true
+          - name: REDIS_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: {{ .Values.argoCdRedisSecretName }}
+                key: {{ .Values.argoCdRedisPasswordKey }}
+                optional: true
+          - name: REDIS_USERNAME
+            valueFrom:
+              configMapKeyRef:
+                name: argocd-agent-params
+                key: agent.redis.username
+                optional: true
+          - name: ARGOCD_PRINCIPAL_LOG_FORMAT
+            valueFrom:
+              configMapKeyRef:
+                name: argocd-agent-params
+                key: agent.log.format
+                optional: true
+          - name: ARGOCD_AGENT_ENABLE_WEBSOCKET
+            valueFrom:
+              configMapKeyRef:
+                name: argocd-agent-params
+                key: agent.websocket.enabled
+                optional: true
+          - name: ARGOCD_AGENT_ENABLE_COMPRESSION
+            valueFrom:
+              configMapKeyRef:
+                name: argocd-agent-params
+                key: agent.compression.enabled
+                optional: true
+          - name: ARGOCD_AGENT_PPROF_PORT
+            valueFrom:
+              configMapKeyRef:
+                name: argocd-agent-params
+                key: agent.pprof.port
+                optional: true
+          - name: ARGOCD_AGENT_ENABLE_RESOURCE_PROXY
+            valueFrom:
+              configMapKeyRef:
+                name: argocd-agent-params
+                key: agent.resource-proxy.enabled
+                optional: true
+          - name: ARGOCD_AGENT_CACHE_REFRESH_INTERVAL
+            valueFrom:
+              configMapKeyRef:
+                name: argocd-agent-params
+                key: agent.cache.refresh-interval
+                optional: true
           name: argocd-agent-agent
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}

--- a/install/helm-repo/argocd-agent-agent/templates/agent-params-cm.yaml
+++ b/install/helm-repo/argocd-agent-agent/templates/agent-params-cm.yaml
@@ -20,6 +20,12 @@ data:
   #   extracting the agent ID from client cert subject.
   # Default: ""
   agent.creds: {{ .Values.auth }}
+  # agent.tls.secret-name: Name of the secret containing the TLS certificate.
+  # Default: "argocd-agent-client-tls"
+  agent.tls.secret-name: {{ .Values.tlsSecretName | quote }}
+  # agent.tls.root-ca-secret-name: Name of the secret containing the root CA certificate.
+  # Default: "argocd-agent-principal-ca"
+  agent.tls.root-ca-secret-name: {{ .Values.tlsRootCASecretName | quote }}
   # agent.tls.client.insecure: Whether to skip the validation of the remote TLS
   # credentials. Insecure. Do only use for development purposes.
   # Default: false
@@ -60,3 +66,27 @@ data:
   # agent.redis.address: The address of the Redis server.
   # Default: "argocd-redis:6379"
   agent.redis.address: {{ .Values.redisAddress | quote }}
+  # agent.redis.username: The username for Redis authentication.
+  # Default: ""
+  agent.redis.username: {{ .Values.redisUsername | quote }}
+  # agent.keep-alive.interval: The keep-alive interval for connections
+  # Default: "30s"
+  agent.keep-alive.interval: {{ .Values.keepAliveInterval | quote }}
+  # agent.log.format: The log format for the agent (text or json).
+  # Default: "text"
+  agent.log.format: {{ .Values.logFormat | quote }}
+  # agent.websocket.enabled: Whether to enable WebSocket connections.
+  # Default: false
+  agent.websocket.enabled: {{ .Values.enableWebSocket | quote }}
+  # agent.compression.enabled: Whether to enable gRPC compression.
+  # Default: false
+  agent.compression.enabled: {{ .Values.enableCompression | quote }}
+  # agent.pprof.port: Port for pprof server (0 disables pprof).
+  # Default: 0
+  agent.pprof.port: {{ .Values.pprofPort | quote }}
+  # agent.resource-proxy.enabled: Whether to enable resource proxy.
+  # Default: true
+  agent.resource-proxy.enabled: {{ .Values.enableResourceProxy | quote }}
+  # agent.cache.refresh-interval: Cache refresh interval.
+  # Default: "10s"
+  agent.cache.refresh-interval: {{ .Values.cacheRefreshInterval | quote }}

--- a/install/helm-repo/argocd-agent-agent/values.yaml
+++ b/install/helm-repo/argocd-agent-agent/values.yaml
@@ -20,6 +20,8 @@ image:
 replicaCount: 1
 # -- Name of the TLS Secret containing client cert/key for mTLS.
 tlsSecretName: "argocd-agent-client-tls"
+# -- Name of the Secret containing root CA certificate.
+tlsRootCASecretName: "argocd-agent-ca"
 # -- Name of the Secret containing agent username/password (if used).
 userPasswordSecretName: "argocd-agent-agent-userpass"
 # -- Resource requests and limits for the agent Pod.
@@ -94,6 +96,8 @@ agentMode: "autonomous"
 auth: "mtls:any"
 # -- Log level for the agent.
 logLevel: "info"
+# -- Log format for the agent (text or json).
+logFormat: "text"
 # -- Principal server address (hostname or host:port).
 server: "principal.server.address.com"
 # -- Principal server port.
@@ -106,9 +110,29 @@ tlsClientInSecure: "false"
 healthzPort: "8002"
 # -- Redis address used by the agent.
 redisAddress: "argocd-redis:6379"
-
+# -- Redis username for authentication.
+redisUsername: ""
+# -- ArgoCD Redis password secret name.
+argoCdRedisSecretName: "argocd-redis"
+# -- ArgoCD Redis password key.
+argoCdRedisPasswordKey: "auth"
+# -- Whether to enable WebSocket connections.
+enableWebSocket: false
+# -- Whether to enable gRPC compression.
+enableCompression: false
+# -- Port for pprof server (0 disables pprof).
+pprofPort: 0
+# -- Whether to enable resource proxy.
+enableResourceProxy: true
+# -- Cache refresh interval.
+cacheRefreshInterval: "10s"
+# -- Keep-alive interval for connections.
+keepAliveInterval: "50s"
+# -- Path to the TLS client key.
 tlsClientKeyPath: "/app/config/tls/tls.key"
+# -- Path to the TLS client certificate.
 tlsClientCertPath: "/app/config/tls/tls.crt"
+# -- Path to the TLS root CA certificate.
 tlsRootCAPath: "/app/config/tls/ca.crt"
 
 networkPolicy:


### PR DESCRIPTION
This PR is to add few missing agent configurations from helm chart. They are not essential, but if in cases they need to be changed then we need to make those configurable via helm chart. To fetch Redis password, secret and key names are now configurable. In case users want to use secret `argocd-redis-initial-password` instead of `argocd-redis` they can configure that in agent deployment.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added TLS certificate and root CA configuration support for secure communications
  * Introduced Redis authentication with username configuration options
  * Added performance tuning parameters including keep-alive interval and cache refresh settings
  * Enabled new operational toggles for WebSocket, compression, and resource proxy features
  * Added configurable logging format and diagnostic pprof port support

<!-- end of auto-generated comment: release notes by coderabbit.ai -->