### PR TITLE
chore: disable unsupported redis subcommand to suppress warning

### DIFF
--- a/agent/inbound_redis.go
+++ b/agent/inbound_redis.go
@@ -27,6 +27,7 @@ import (
 	"github.com/argoproj-labs/argocd-agent/internal/logging/logfields"
 	rediscache "github.com/go-redis/cache/v9"
 	"github.com/redis/go-redis/v9"
+	"github.com/redis/go-redis/v9/maintnotifications"
 	"github.com/sirupsen/logrus"
 )
 
@@ -341,6 +342,9 @@ func (a *Agent) getRedisClientAndCache() (*redis.Client, *rediscache.Cache, erro
 		MaxRetries: 3,
 		TLSConfig:  tlsConfig,
 		Username:   a.redisProxyMsgHandler.redisUsername,
+		MaintNotificationsConfig: &maintnotifications.Config{
+			Mode: maintnotifications.ModeDisabled,
+		},
 	}
 
 	client := redis.NewClient(opts)

--- a/internal/argocd/cluster/cluster.go
+++ b/internal/argocd/cluster/cluster.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/argoproj-labs/argocd-agent/internal/event"
 	"github.com/redis/go-redis/v9"
+	"github.com/redis/go-redis/v9/maintnotifications"
 	"github.com/sirupsen/logrus"
 
 	appv1 "github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
@@ -166,7 +167,13 @@ func (m *Manager) setClusterInfo(clusterServer, agentName, clusterName string, c
 // NewClusterCacheInstance creates a new cache instance with Redis connection
 func NewClusterCacheInstance(redisAddress, redisPassword string, redisCompressionType cacheutil.RedisCompressionType) (*appstatecache.Cache, error) {
 
-	redisOptions := &redis.Options{Addr: redisAddress, Password: redisPassword}
+	redisOptions := &redis.Options{
+		Addr:     redisAddress,
+		Password: redisPassword,
+		MaintNotificationsConfig: &maintnotifications.Config{
+			Mode: maintnotifications.ModeDisabled,
+		},
+	}
 	redisClient := redis.NewClient(redisOptions)
 
 	clusterCache := appstatecache.NewCache(cacheutil.NewCache(

--- a/test/e2e/fixture/cluster.go
+++ b/test/e2e/fixture/cluster.go
@@ -23,6 +23,7 @@ import (
 	cacheutil "github.com/argoproj/argo-cd/v3/util/cache"
 	appstatecache "github.com/argoproj/argo-cd/v3/util/cache/appstate"
 	"github.com/redis/go-redis/v9"
+	"github.com/redis/go-redis/v9/maintnotifications"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -163,9 +164,15 @@ func getCacheInstance(source string, clusterDetails *ClusterDetails) *appstateca
 	case PrincipalName:
 		redisOptions.Addr = clusterDetails.PrincipalRedisAddr
 		redisOptions.Password = clusterDetails.PrincipalRedisPassword
+		redisOptions.MaintNotificationsConfig = &maintnotifications.Config{
+			Mode: maintnotifications.ModeDisabled,
+		}
 	case AgentManagedName:
 		redisOptions.Addr = clusterDetails.ManagedAgentRedisAddr
 		redisOptions.Password = clusterDetails.ManagedAgentRedisPassword
+		redisOptions.MaintNotificationsConfig = &maintnotifications.Config{
+			Mode: maintnotifications.ModeDisabled,
+		}
 	default:
 		panic(fmt.Sprintf("invalid source: %s", source))
 	}


### PR DESCRIPTION
**What does this PR do / why we need it**:

We're seeing this error message in unit tests:
```
redis: 2025/11/11 11:18:17 redis.go:478: auto mode fallback: maintnotifications disabled due to handshake error: ERR unknown subcommand 'maint_notifications'. Try CLIENT HELP.
```
This is due to a recent change in go-redis, which is described here: https://github.com/redis/go-redis/issues/3536

Fix is just to disable maint_notifications as this is currently not actionable by us.

**How to test changes / Special notes to the reviewer**:
N/A

**Checklist**

* [ ] Documentation update is required by this PR (and has been updated) OR no documentation update is required.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Disabled Redis maintenance notifications across internal components to optimize system performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->