### PR TITLE
fix: don't remove default project on restart

### DIFF
--- a/agent/connection.go
+++ b/agent/connection.go
@@ -275,7 +275,7 @@ func (a *Agent) resyncOnStart(logCtx *logrus.Entry) error {
 			return err
 		}
 
-		resyncHandler := resync.NewRequestHandler(dynClient, sendQ, a.emitter, a.resources, logCtx, manager.ManagerRoleAgent)
+		resyncHandler := resync.NewRequestHandler(dynClient, sendQ, a.emitter, a.resources, logCtx, manager.ManagerRoleAgent, a.namespace)
 		go resyncHandler.SendRequestUpdates(a.context)
 
 		// Agent should request SyncedResourceList from the principal to detect deleted

--- a/agent/inbound.go
+++ b/agent/inbound.go
@@ -385,7 +385,7 @@ func (a *Agent) processIncomingResourceResyncEvent(ev *event.Event) error {
 		return fmt.Errorf("send queue not found for the default queue pair")
 	}
 
-	resyncHandler := resync.NewRequestHandler(dynClient, sendQ, a.emitter, a.resources, logCtx, manager.ManagerRoleAgent)
+	resyncHandler := resync.NewRequestHandler(dynClient, sendQ, a.emitter, a.resources, logCtx, manager.ManagerRoleAgent, a.namespace)
 
 	switch ev.Type() {
 	case event.SyncedResourceList:
@@ -419,8 +419,6 @@ func (a *Agent) processIncomingResourceResyncEvent(ev *event.Event) error {
 		if err != nil {
 			return err
 		}
-
-		incoming.Namespace = a.namespace
 
 		return resyncHandler.ProcessRequestUpdateEvent(a.context, a.remote.ClientID(), incoming)
 	case event.EventRequestResourceResync:

--- a/internal/resync/resync_test.go
+++ b/internal/resync/resync_test.go
@@ -246,6 +246,7 @@ func Test_generateSpecChecksum(t *testing.T) {
 func Test_ProcessRequestUpdateEvent(t *testing.T) {
 	ctx := context.Background()
 	handler := createFakeHandler(t)
+	handler.namespace = "default"
 
 	t.Run("return nil if resource exists and checksum matches", func(t *testing.T) {
 		resource := fakeUnresApp()
@@ -328,7 +329,7 @@ func createFakeHandler(t *testing.T) *RequestHandler {
 
 	dynClient := fake.NewSimpleDynamicClient(&runtime.Scheme{})
 	res := resources.NewResources()
-	return NewRequestHandler(dynClient, queues.SendQ(agentName), evs, res, logrus.NewEntry(logrus.New()), manager.ManagerRoleAgent)
+	return NewRequestHandler(dynClient, queues.SendQ(agentName), evs, res, logrus.NewEntry(logrus.New()), manager.ManagerRoleAgent, "argocd")
 }
 
 func fakeUnresApp() *unstructured.Unstructured {

--- a/principal/event.go
+++ b/principal/event.go
@@ -555,7 +555,7 @@ func (s *Server) processIncomingResourceResyncEvent(ctx context.Context, agentNa
 		return fmt.Errorf("queue not found for agent: %s", agentName)
 	}
 
-	resyncHandler := resync.NewRequestHandler(dynClient, sendQ, s.events, s.resources.Get(agentName), logCtx, manager.ManagerRolePrincipal)
+	resyncHandler := resync.NewRequestHandler(dynClient, sendQ, s.events, s.resources.Get(agentName), logCtx, manager.ManagerRolePrincipal, s.namespace)
 
 	switch ev.Type() {
 	case event.SyncedResourceList.String():

--- a/principal/server.go
+++ b/principal/server.go
@@ -652,7 +652,7 @@ func (s *Server) handleResyncOnConnect(agent types.Agent) error {
 			return err
 		}
 
-		resyncHandler := resync.NewRequestHandler(dynClient, sendQ, s.events, s.resources.Get(agent.Name()), logCtx, manager.ManagerRolePrincipal)
+		resyncHandler := resync.NewRequestHandler(dynClient, sendQ, s.events, s.resources.Get(agent.Name()), logCtx, manager.ManagerRolePrincipal, s.namespace)
 		go resyncHandler.SendRequestUpdates(s.ctx)
 
 		// Principal should request SyncedResourceList to revert any deletions on the Principal side.


### PR DESCRIPTION
**What does this PR do / why we need it**:

The resync logic removes the default appProject on restart when the agent and the principal are installed in different namespaces. This PR updates the resync logic to consider the Argo CD namespace of the principal/agent, rather than the incoming request.

**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:
1. Install and run agent and the principal in different namespaces
2. Observe that the default appProject was not created on the managed agent cluster.

**Checklist**

* [ ] Documentation update is required by this PR (and has been updated) OR no documentation update is required.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Enhanced namespace context propagation through resource synchronization handlers for improved consistency across clusters.
  * Refined namespace resolution logic to properly handle different resource types based on their role and context.
  * Strengthened cross-cluster resource management with explicit validation and updates.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->