### PR TITLE
feat: derive resource names from helm release name

### DIFF
--- a/install/helm-repo/argocd-agent-agent/README.md
+++ b/install/helm-repo/argocd-agent-agent/README.md
@@ -75,8 +75,8 @@ Kubernetes: `>=1.24.0-0`
 | serviceAccount.annotations | object | `{}` | Annotations to add to the ServiceAccount. |
 | serviceAccount.create | bool | `true` | Whether to create the ServiceAccount. |
 | serviceAccount.name | string | `""` | Name of the ServiceAccount to use. If empty, a name is generated. |
-| tests | object | `{"enabled":"true","image":"bitnamilegacy/kubectl","tag":"1.33.4"}` | Configuration for helm-chart tests. |
-| tests.enabled | string | `"true"` | Enable chart tests. |
+| tests | object | `{"enabled":false,"image":"bitnamilegacy/kubectl","tag":"1.33.4"}` | Configuration for helm-chart tests. |
+| tests.enabled | bool | `false` | By default, chart tests are disabled. |
 | tests.image | string | `"bitnamilegacy/kubectl"` | Test image. |
 | tests.tag | string | `"1.33.4"` | Test image tag. |
 | tlsClientCertPath | string | `""` | Path to the TLS client certificate. |

--- a/install/helm-repo/argocd-agent-agent/templates/NOTES.txt
+++ b/install/helm-repo/argocd-agent-agent/templates/NOTES.txt
@@ -7,30 +7,30 @@ Namespace: {{ include  "argocd-agent-agent.namespace" . }}
 
 Deployment
 ----------
-- Name: argocd-agent-agent
+- Name: {{ include "argocd-agent-agent.agentDeploymentName" . }}
 - Replicas: {{ .Values.replicaCount }}
 - Image: {{ .Values.image.repository }}:{{ .Values.image.tag }} (pullPolicy: {{ .Values.image.pullPolicy }})
 
 Services
 --------
-- Metrics Service:  argocd-agent-agent-metrics
+- Metrics Service:  {{ include "argocd-agent-agent.metricsServiceName" . }}
   - Port/TargetPort: {{ .Values.service.metrics.port }} / {{ .Values.service.metrics.targetPort }}
-- Healthz Service:  argocd-agent-agent-healthz
+- Healthz Service:  {{ include "argocd-agent-agent.healthzServiceName" . }}
   - Port/TargetPort: {{ .Values.service.healthz.port }} / {{ .Values.service.healthz.targetPort }}
 
 Quick checks
 ------------
 1) Check Deployment rollout
-   kubectl -n {{ include  "argocd-agent-agent.namespace" . }} rollout status deploy/argocd-agent-agent
+   kubectl -n {{ include  "argocd-agent-agent.namespace" . }} rollout status deploy/{{ include "argocd-agent-agent.agentDeploymentName" . }}
 
 2) List Services
-   kubectl -n {{ include  "argocd-agent-agent.namespace" . }} get svc argocd-agent-agent-metrics argocd-agent-agent-healthz
+   kubectl -n {{ include  "argocd-agent-agent.namespace" . }} get svc {{ include "argocd-agent-agent.metricsServiceName" . }} {{ include "argocd-agent-agent.healthzServiceName" . }}
 
 3) Port-forward to Metrics and Healthz
    # Metrics
-   kubectl -n {{ include  "argocd-agent-agent.namespace" . }} port-forward deploy/argocd-agent-agent 127.0.0.1:{{ .Values.service.metrics.port }}:{{ .Values.service.metrics.targetPort }}
+   kubectl -n {{ include  "argocd-agent-agent.namespace" . }} port-forward deploy/{{ include "argocd-agent-agent.agentDeploymentName" . }} 127.0.0.1:{{ .Values.service.metrics.port }}:{{ .Values.service.metrics.targetPort }}
    # Healthz
-   kubectl -n {{ include  "argocd-agent-agent.namespace" . }} port-forward deploy/argocd-agent-agent 127.0.0.1:{{ .Values.service.healthz.port }}:{{ .Values.service.healthz.targetPort }}
+   kubectl -n {{ include  "argocd-agent-agent.namespace" . }} port-forward deploy/{{ include "argocd-agent-agent.agentDeploymentName" . }} 127.0.0.1:{{ .Values.service.healthz.port }}:{{ .Values.service.healthz.targetPort }}
 
 4) Probe endpoints
    curl -sf http://127.0.0.1:{{ .Values.service.healthz.port }}/healthz || true

--- a/install/helm-repo/argocd-agent-agent/templates/_helpers.tpl
+++ b/install/helm-repo/argocd-agent-agent/templates/_helpers.tpl
@@ -24,6 +24,77 @@ If release name contains chart name it will be used as a full name.
 {{- end }}
 
 {{/*
+Base name for Helm-created resources, derived from the release.
+*/}}
+{{- define "argocd-agent-agent.agentBaseName" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-agent-helm" .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+
+{{/*
+Helper to append a suffix to the resource base name.
+Usage: {{ include "argocd-agent-agent.resourceName" (dict "root" . "suffix" "metrics") }}
+*/}}
+{{- define "argocd-agent-agent.resourceName" -}}
+{{- $root := .root -}}
+{{- $suffix := .suffix | default "" -}}
+{{- $base := include "argocd-agent-agent.agentBaseName" $root -}}
+{{- if $suffix }}
+{{- printf "%s-%s" $base $suffix | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $base }}
+{{- end }}
+{{- end }}
+
+{{/*
+Name for the agent deployment.
+*/}}
+{{- define "argocd-agent-agent.agentDeploymentName" -}}
+{{- include "argocd-agent-agent.resourceName" (dict "root" . "suffix" "") }}
+{{- end }}
+
+{{/*
+Common resource-specific helpers.
+*/}}
+{{- define "argocd-agent-agent.paramsConfigMapName" -}}
+{{- include "argocd-agent-agent.resourceName" (dict "root" . "suffix" "params") }}
+{{- end }}
+
+{{- define "argocd-agent-agent.metricsServiceName" -}}
+{{- include "argocd-agent-agent.resourceName" (dict "root" . "suffix" "metrics") }}
+{{- end }}
+
+{{- define "argocd-agent-agent.healthzServiceName" -}}
+{{- include "argocd-agent-agent.resourceName" (dict "root" . "suffix" "healthz") }}
+{{- end }}
+
+{{- define "argocd-agent-agent.roleName" -}}
+{{- include "argocd-agent-agent.resourceName" (dict "root" . "suffix" "role") }}
+{{- end }}
+
+{{- define "argocd-agent-agent.roleBindingName" -}}
+{{- include "argocd-agent-agent.resourceName" (dict "root" . "suffix" "rolebinding") }}
+{{- end }}
+
+{{- define "argocd-agent-agent.clusterRoleName" -}}
+{{- include "argocd-agent-agent.resourceName" (dict "root" . "suffix" "clusterrole") }}
+{{- end }}
+
+{{- define "argocd-agent-agent.clusterRoleBindingName" -}}
+{{- include "argocd-agent-agent.resourceName" (dict "root" . "suffix" "clusterrolebinding") }}
+{{- end }}
+
+{{/*
+Name for resources used exclusively by Helm tests.
+*/}}
+{{- define "argocd-agent-agent.testResourceName" -}}
+{{- printf "%s-test" (include "argocd-agent-agent.agentBaseName" .) | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
 Create chart name and version as used by the chart label.
 */}}
 {{- define "argocd-agent-agent.chart" -}}
@@ -55,7 +126,11 @@ Create the name of the service account to use
 */}}
 {{- define "argocd-agent-agent.serviceAccountName" -}}
 {{- if .Values.serviceAccount.create }}
-{{- default (include "argocd-agent-agent.fullname" .) .Values.serviceAccount.name }}
+{{- if .Values.serviceAccount.name }}
+{{- .Values.serviceAccount.name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- include "argocd-agent-agent.resourceName" (dict "root" . "suffix" "sa") }}
+{{- end }}
 {{- else }}
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}

--- a/install/helm-repo/argocd-agent-agent/templates/agent-clusterrole.yaml
+++ b/install/helm-repo/argocd-agent-agent/templates/agent-clusterrole.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/name: argocd-agent-agent
     app.kubernetes.io/part-of: argocd-agent
     app.kubernetes.io/component: agent
-  name: argocd-agent-agent
+  name: {{ include "argocd-agent-agent.clusterRoleName" . }}
 rules:
 - apiGroups:
   - ""

--- a/install/helm-repo/argocd-agent-agent/templates/agent-clusterrolebinding.yaml
+++ b/install/helm-repo/argocd-agent-agent/templates/agent-clusterrolebinding.yaml
@@ -5,12 +5,12 @@ metadata:
     app.kubernetes.io/name: argocd-agent-agent
     app.kubernetes.io/part-of: argocd-agent
     app.kubernetes.io/component: agent
-  name: argocd-agent-agent
+  name: {{ include "argocd-agent-agent.clusterRoleBindingName" . }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: argocd-agent-agent
+  name: {{ include "argocd-agent-agent.clusterRoleName" . }}
 subjects:
 - kind: ServiceAccount
-  name: argocd-agent-agent
+  name: {{ include "argocd-agent-agent.serviceAccountName" . }}
   namespace: {{ include  "argocd-agent-agent.namespace" . }}

--- a/install/helm-repo/argocd-agent-agent/templates/agent-deployment.yaml
+++ b/install/helm-repo/argocd-agent-agent/templates/agent-deployment.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/name: argocd-agent-agent
     app.kubernetes.io/part-of: argocd-agent
     app.kubernetes.io/component: agent
-  name: argocd-agent-agent
+  name: {{ include "argocd-agent-agent.agentDeploymentName" . }}
   namespace: {{ include  "argocd-agent-agent.namespace" . }}
 spec:
   replicas: {{ .Values.replicaCount }}
@@ -28,97 +28,97 @@ spec:
           - name: ARGOCD_AGENT_REMOTE_SERVER
             valueFrom:
               configMapKeyRef:
-                name: argocd-agent-params
+                name: {{ include "argocd-agent-agent.paramsConfigMapName" . }}
                 key: agent.server.address
                 optional: true
           - name: ARGOCD_AGENT_REMOTE_PORT
             valueFrom:
               configMapKeyRef:
-                name: argocd-agent-params
+                name: {{ include "argocd-agent-agent.paramsConfigMapName" . }}
                 key: agent.server.port
                 optional: true
           - name: ARGOCD_AGENT_LOG_LEVEL
             valueFrom:
               configMapKeyRef:
-                name: argocd-agent-params
+                name: {{ include "argocd-agent-agent.paramsConfigMapName" . }}
                 key: agent.log.level
                 optional: true
           - name: ARGOCD_AGENT_NAMESPACE
             valueFrom:
               configMapKeyRef:
-                name: argocd-agent-params
+                name: {{ include "argocd-agent-agent.paramsConfigMapName" . }}
                 key: agent.namespace
                 optional: true
           - name: ARGOCD_AGENT_TLS_SECRET_NAME
             valueFrom:
               configMapKeyRef:
-                name: argocd-agent-params
+                name: {{ include "argocd-agent-agent.paramsConfigMapName" . }}
                 key: agent.tls.secret-name
                 optional: true
           - name: ARGOCD_AGENT_TLS_CLIENT_CERT_PATH
             valueFrom:
               configMapKeyRef:
-                name: argocd-agent-params
+                name: {{ include "argocd-agent-agent.paramsConfigMapName" . }}
                 key: agent.tls.client.cert-path
                 optional: true
           - name: ARGOCD_AGENT_TLS_CLIENT_KEY_PATH
             valueFrom:
               configMapKeyRef:
-                name: argocd-agent-params
+                name: {{ include "argocd-agent-agent.paramsConfigMapName" . }}
                 key: agent.tls.client.key-path
                 optional: true
           - name: ARGOCD_AGENT_TLS_INSECURE
             valueFrom:
               configMapKeyRef:
-                name: argocd-agent-params
+                name: {{ include "argocd-agent-agent.paramsConfigMapName" . }}
                 key: agent.tls.client.insecure
                 optional: true
           - name: ARGOCD_AGENT_TLS_ROOT_CA_SECRET_NAME
             valueFrom:
               configMapKeyRef:
-                name: argocd-agent-params
+                name: {{ include "argocd-agent-agent.paramsConfigMapName" . }}
                 key: agent.tls.root-ca-secret-name
                 optional: true
           - name: ARGOCD_AGENT_TLS_ROOT_CA_PATH
             valueFrom:
               configMapKeyRef:
-                name: argocd-agent-params
+                name: {{ include "argocd-agent-agent.paramsConfigMapName" . }}
                 key: agent.tls.root-ca-path
                 optional: true
           - name: ARGOCD_AGENT_MODE
             valueFrom:
               configMapKeyRef:
-                name: argocd-agent-params
+                name: {{ include "argocd-agent-agent.paramsConfigMapName" . }}
                 key: agent.mode
                 optional: true
           - name: ARGOCD_AGENT_CREDS
             valueFrom:
               configMapKeyRef:
-                name: argocd-agent-params
+                name: {{ include "argocd-agent-agent.paramsConfigMapName" . }}
                 key: agent.creds
                 optional: true
           - name: ARGOCD_AGENT_METRICS_PORT
             valueFrom:
               configMapKeyRef:
-                name: argocd-agent-params
+                name: {{ include "argocd-agent-agent.paramsConfigMapName" . }}
                 key: agent.metrics.port
                 optional: true
           - name: ARGOCD_AGENT_HEALTH_CHECK_PORT
             valueFrom:
               configMapKeyRef:
-                name: argocd-agent-params
+                name: {{ include "argocd-agent-agent.paramsConfigMapName" . }}
                 key: agent.healthz.port
                 optional: true
           - name: REDIS_ADDR
             valueFrom:
               configMapKeyRef:
-                name: argocd-agent-params
+                name: {{ include "argocd-agent-agent.paramsConfigMapName" . }}
                 key: agent.redis.address
                 optional: true
           - name: ARGOCD_AGENT_KEEP_ALIVE_PING_INTERVAL
             valueFrom:
               configMapKeyRef:
-                name: argocd-agent-params
+                name: {{ include "argocd-agent-agent.paramsConfigMapName" . }}
                 key: agent.keep-alive.interval
                 optional: true
           - name: REDIS_PASSWORD
@@ -130,43 +130,43 @@ spec:
           - name: REDIS_USERNAME
             valueFrom:
               configMapKeyRef:
-                name: argocd-agent-params
+                name: {{ include "argocd-agent-agent.paramsConfigMapName" . }}
                 key: agent.redis.username
                 optional: true
           - name: ARGOCD_PRINCIPAL_LOG_FORMAT
             valueFrom:
               configMapKeyRef:
-                name: argocd-agent-params
+                name: {{ include "argocd-agent-agent.paramsConfigMapName" . }}
                 key: agent.log.format
                 optional: true
           - name: ARGOCD_AGENT_ENABLE_WEBSOCKET
             valueFrom:
               configMapKeyRef:
-                name: argocd-agent-params
+                name: {{ include "argocd-agent-agent.paramsConfigMapName" . }}
                 key: agent.websocket.enabled
                 optional: true
           - name: ARGOCD_AGENT_ENABLE_COMPRESSION
             valueFrom:
               configMapKeyRef:
-                name: argocd-agent-params
+                name: {{ include "argocd-agent-agent.paramsConfigMapName" . }}
                 key: agent.compression.enabled
                 optional: true
           - name: ARGOCD_AGENT_PPROF_PORT
             valueFrom:
               configMapKeyRef:
-                name: argocd-agent-params
+                name: {{ include "argocd-agent-agent.paramsConfigMapName" . }}
                 key: agent.pprof.port
                 optional: true
           - name: ARGOCD_AGENT_ENABLE_RESOURCE_PROXY
             valueFrom:
               configMapKeyRef:
-                name: argocd-agent-params
+                name: {{ include "argocd-agent-agent.paramsConfigMapName" . }}
                 key: agent.resource-proxy.enabled
                 optional: true
           - name: ARGOCD_AGENT_CACHE_REFRESH_INTERVAL
             valueFrom:
               configMapKeyRef:
-                name: argocd-agent-params
+                name: {{ include "argocd-agent-agent.paramsConfigMapName" . }}
                 key: agent.cache.refresh-interval
                 optional: true
           name: argocd-agent-agent
@@ -211,7 +211,7 @@ spec:
           volumeMounts:
             - name: userpass-passwd
               mountPath: /app/config/creds
-      serviceAccountName: argocd-agent-agent
+      serviceAccountName: {{ include "argocd-agent-agent.serviceAccountName" . }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
 {{ toYaml . | indent 8 }}

--- a/install/helm-repo/argocd-agent-agent/templates/agent-healthz-service.yaml
+++ b/install/helm-repo/argocd-agent-agent/templates/agent-healthz-service.yaml
@@ -5,7 +5,7 @@ metadata:
       app.kubernetes.io/name: argocd-agent-agent
       app.kubernetes.io/part-of: argocd-agent
       app.kubernetes.io/component: agent
-  name: argocd-agent-agent-healthz
+  name: {{ include "argocd-agent-agent.healthzServiceName" . }}
   namespace: {{ include  "argocd-agent-agent.namespace" . }}
   {{- with .Values.service.healthz.annotations }}
   annotations:

--- a/install/helm-repo/argocd-agent-agent/templates/agent-metrics-service.yaml
+++ b/install/helm-repo/argocd-agent-agent/templates/agent-metrics-service.yaml
@@ -5,7 +5,7 @@ metadata:
       app.kubernetes.io/name: argocd-agent-agent
       app.kubernetes.io/part-of: argocd-agent
       app.kubernetes.io/component: agent
-  name: argocd-agent-agent-metrics
+  name: {{ include "argocd-agent-agent.metricsServiceName" . }}
   namespace: {{ include  "argocd-agent-agent.namespace" . }}
   {{- with .Values.service.metrics.annotations }}
   annotations:

--- a/install/helm-repo/argocd-agent-agent/templates/agent-params-cm.yaml
+++ b/install/helm-repo/argocd-agent-agent/templates/agent-params-cm.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: argocd-agent-params
+  name: {{ include "argocd-agent-agent.paramsConfigMapName" . }}
   namespace: {{ include  "argocd-agent-agent.namespace" . }}
   labels:
     app.kubernetes.io/name: argocd-agent-agent

--- a/install/helm-repo/argocd-agent-agent/templates/agent-role.yaml
+++ b/install/helm-repo/argocd-agent-agent/templates/agent-role.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/name: argocd-agent-agent
     app.kubernetes.io/part-of: argocd-agent
     app.kubernetes.io/component: agent
-  name: argocd-agent-agent
+  name: {{ include "argocd-agent-agent.roleName" . }}
   namespace: {{ include  "argocd-agent-agent.namespace" . }}
 rules:
 - apiGroups:

--- a/install/helm-repo/argocd-agent-agent/templates/agent-rolebinding.yaml
+++ b/install/helm-repo/argocd-agent-agent/templates/agent-rolebinding.yaml
@@ -5,13 +5,13 @@ metadata:
     app.kubernetes.io/name: argocd-agent-agent
     app.kubernetes.io/part-of: argocd-agent
     app.kubernetes.io/component: agent
-  name: argocd-agent-agent
+  name: {{ include "argocd-agent-agent.roleBindingName" . }}
   namespace: {{ include  "argocd-agent-agent.namespace" . }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: argocd-agent-agent
+  name: {{ include "argocd-agent-agent.roleName" . }}
 subjects:
 - kind: ServiceAccount
-  name: argocd-agent-agent
+  name: {{ include "argocd-agent-agent.serviceAccountName" . }}
   namespace: {{ include "argocd-agent-agent.namespace" . }}

--- a/install/helm-repo/argocd-agent-agent/templates/agent-sa.yaml
+++ b/install/helm-repo/argocd-agent-agent/templates/agent-sa.yaml
@@ -5,5 +5,5 @@ metadata:
     app.kubernetes.io/name: argocd-agent-agent
     app.kubernetes.io/part-of: argocd-agent
     app.kubernetes.io/component: agent
-  name: argocd-agent-agent
+  name: {{ include "argocd-agent-agent.serviceAccountName" . }}
   namespace: {{ include  "argocd-agent-agent.namespace" . }}

--- a/install/helm-repo/argocd-agent-agent/templates/tests/test-configMap.yaml
+++ b/install/helm-repo/argocd-agent-agent/templates/tests/test-configMap.yaml
@@ -137,6 +137,6 @@ spec:
   volumes:
     - name: argocd-agent-params
       configMap:
-        name: argocd-agent-params
+        name: {{ include "argocd-agent-agent.paramsConfigMapName" . }}
   restartPolicy: Never
 {{- end }}

--- a/install/helm-repo/argocd-agent-agent/templates/tests/test-deployment.yaml
+++ b/install/helm-repo/argocd-agent-agent/templates/tests/test-deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     "helm.sh/hook": test
 spec:
-  serviceAccountName: argocd-agent-test
+  serviceAccountName: {{ include "argocd-agent-agent.testResourceName" . }}
   containers:
     - name: kubectl
       image: "{{ .Values.tests.image }}:{{ .Values.tests.tag }}"
@@ -16,8 +16,11 @@ spec:
         - |
           echo "Testing Deployment configuration..."
           
+          DEPLOYMENT_NAME={{ include "argocd-agent-agent.agentDeploymentName" . | quote }}
+          SERVICE_ACCOUNT_NAME={{ include "argocd-agent-agent.serviceAccountName" . | quote }}
+
           # Check if deployment exists
-          if kubectl get deployment argocd-agent-agent -n {{ include "argocd-agent-agent.namespace" . }}; then
+          if kubectl get deployment "$DEPLOYMENT_NAME" -n {{ include "argocd-agent-agent.namespace" . }}; then
             echo "✓ Deployment exists"
           else
             echo "✗ Deployment not found"
@@ -25,7 +28,7 @@ spec:
           fi
           
           # Check deployment labels
-          DEPLOYMENT_LABELS=$(kubectl get deployment argocd-agent-agent -n {{ include "argocd-agent-agent.namespace" . }} -o jsonpath="{.metadata.labels}")
+          DEPLOYMENT_LABELS=$(kubectl get deployment "$DEPLOYMENT_NAME" -n {{ include "argocd-agent-agent.namespace" . }} -o jsonpath="{.metadata.labels}")
           echo "DEPLOYMENT_LABELS: $DEPLOYMENT_LABELS"
           
           if echo "$DEPLOYMENT_LABELS" | grep -q "app.kubernetes.io/name.*argocd-agent-agent"; then
@@ -50,7 +53,7 @@ spec:
           fi
           
           # Check deployment replicas
-          REPLICAS=$(kubectl get deployment argocd-agent-agent -n {{ include "argocd-agent-agent.namespace" . }} -o jsonpath="{.spec.replicas}")
+          REPLICAS=$(kubectl get deployment "$DEPLOYMENT_NAME" -n {{ include "argocd-agent-agent.namespace" . }} -o jsonpath="{.spec.replicas}")
           if [ "$REPLICAS" = "1" ]; then
             echo "✓ Deployment has correct replica count: $REPLICAS"
           else
@@ -59,7 +62,7 @@ spec:
           fi
           
           # Check container image
-          IMAGE=$(kubectl get deployment argocd-agent-agent -n {{ include "argocd-agent-agent.namespace" . }} -o jsonpath="{.spec.template.spec.containers[0].image}")
+          IMAGE=$(kubectl get deployment "$DEPLOYMENT_NAME" -n {{ include "argocd-agent-agent.namespace" . }} -o jsonpath="{.spec.template.spec.containers[0].image}")
           if [ -n "$IMAGE" ]; then
             echo "✓ Deployment has container image: $IMAGE"
           else
@@ -68,11 +71,11 @@ spec:
           fi
           
           # Check service account
-          SA=$(kubectl get deployment argocd-agent-agent -n {{ include "argocd-agent-agent.namespace" . }} -o jsonpath="{.spec.template.spec.serviceAccountName}")
-          if [ "$SA" = "argocd-agent-agent" ]; then
+          SA=$(kubectl get deployment "$DEPLOYMENT_NAME" -n {{ include "argocd-agent-agent.namespace" . }} -o jsonpath="{.spec.template.spec.serviceAccountName}")
+          if [ "$SA" = "$SERVICE_ACCOUNT_NAME" ]; then
             echo "✓ Deployment uses correct service account: $SA"
           else
-            echo "✗ Deployment uses incorrect service account: $SA (expected argocd-agent-agent)"
+            echo "✗ Deployment uses incorrect service account: $SA (expected $SERVICE_ACCOUNT_NAME)"
             exit 1
           fi
           

--- a/install/helm-repo/argocd-agent-agent/templates/tests/test-labels.yaml
+++ b/install/helm-repo/argocd-agent-agent/templates/tests/test-labels.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     "helm.sh/hook": test
 spec:
-  serviceAccountName: argocd-agent-test
+  serviceAccountName: {{ include "argocd-agent-agent.testResourceName" . }}
   containers:
     - name: kubectl
       image: "{{ .Values.tests.image }}:{{ .Values.tests.tag }}"
@@ -16,9 +16,17 @@ spec:
         - |
           echo "Testing Labels and Annotations..."
           
+          DEPLOYMENT_NAME={{ include "argocd-agent-agent.agentDeploymentName" . | quote }}
+          METRICS_SERVICE={{ include "argocd-agent-agent.metricsServiceName" . | quote }}
+          HEALTHZ_SERVICE={{ include "argocd-agent-agent.healthzServiceName" . | quote }}
+          ROLE_NAME={{ include "argocd-agent-agent.roleName" . | quote }}
+          CLUSTER_ROLE_NAME={{ include "argocd-agent-agent.clusterRoleName" . | quote }}
+          SERVICE_ACCOUNT_NAME={{ include "argocd-agent-agent.serviceAccountName" . | quote }}
+          CONFIGMAP_NAME={{ include "argocd-agent-agent.paramsConfigMapName" . | quote }}
+
           # Test Deployment labels
           echo "Testing Deployment labels..."
-          DEPLOYMENT_LABELS=$(kubectl get deployment argocd-agent-agent -n {{ include "argocd-agent-agent.namespace" . }} -o jsonpath="{.metadata.labels}")
+          DEPLOYMENT_LABELS=$(kubectl get deployment "$DEPLOYMENT_NAME" -n {{ include "argocd-agent-agent.namespace" . }} -o jsonpath="{.metadata.labels}")
           
           echo "DEPLOYMENT_LABELS: $DEPLOYMENT_LABELS"
           
@@ -45,7 +53,7 @@ spec:
           
           # Test Service labels
           echo "Testing Service labels..."
-          METRICS_SERVICE_LABELS=$(kubectl get service argocd-agent-agent-metrics -n {{ include "argocd-agent-agent.namespace" . }} -o jsonpath="{.metadata.labels}")
+          METRICS_SERVICE_LABELS=$(kubectl get service "$METRICS_SERVICE" -n {{ include "argocd-agent-agent.namespace" . }} -o jsonpath="{.metadata.labels}")
           
           if echo "$METRICS_SERVICE_LABELS" | grep -q "app.kubernetes.io/name.*argocd-agent-agent"; then
             echo "✓ Metrics service has app.kubernetes.io/name label"
@@ -68,7 +76,7 @@ spec:
             exit 1
           fi
           
-          HEALTHZ_SERVICE_LABELS=$(kubectl get service argocd-agent-agent-healthz -n {{ include "argocd-agent-agent.namespace" . }} -o jsonpath="{.metadata.labels}")
+          HEALTHZ_SERVICE_LABELS=$(kubectl get service "$HEALTHZ_SERVICE" -n {{ include "argocd-agent-agent.namespace" . }} -o jsonpath="{.metadata.labels}")
           
           if echo "$HEALTHZ_SERVICE_LABELS" | grep -q "app.kubernetes.io/name.*argocd-agent-agent"; then
             echo "✓ Healthz service has app.kubernetes.io/name label"
@@ -93,7 +101,7 @@ spec:
           
           # Test RBAC labels
           echo "Testing RBAC labels..."
-          ROLE_LABELS=$(kubectl get role argocd-agent-agent -n {{ include "argocd-agent-agent.namespace" . }} -o jsonpath="{.metadata.labels}")
+          ROLE_LABELS=$(kubectl get role "$ROLE_NAME" -n {{ include "argocd-agent-agent.namespace" . }} -o jsonpath="{.metadata.labels}")
           
           if echo "$ROLE_LABELS" | grep -q "app.kubernetes.io/name.*argocd-agent-agent"; then
             echo "✓ Role has app.kubernetes.io/name label"
@@ -116,7 +124,7 @@ spec:
             exit 1
           fi
           
-          CLUSTER_ROLE_LABELS=$(kubectl get clusterrole argocd-agent-agent -o jsonpath="{.metadata.labels}")
+          CLUSTER_ROLE_LABELS=$(kubectl get clusterrole "$CLUSTER_ROLE_NAME" -o jsonpath="{.metadata.labels}")
           
           if echo "$CLUSTER_ROLE_LABELS" | grep -q "app.kubernetes.io/name.*argocd-agent-agent"; then
             echo "✓ ClusterRole has app.kubernetes.io/name label"
@@ -140,7 +148,7 @@ spec:
           fi
           
           # Test ServiceAccount labels
-          SA_LABELS=$(kubectl get serviceaccount argocd-agent-agent -n {{ include "argocd-agent-agent.namespace" . }} -o jsonpath="{.metadata.labels}")
+          SA_LABELS=$(kubectl get serviceaccount "$SERVICE_ACCOUNT_NAME" -n {{ include "argocd-agent-agent.namespace" . }} -o jsonpath="{.metadata.labels}")
           
           if echo "$SA_LABELS" | grep -q "app.kubernetes.io/name.*argocd-agent-agent"; then
             echo "✓ ServiceAccount has app.kubernetes.io/name label"
@@ -164,7 +172,7 @@ spec:
           fi
           
           # Test ConfigMap labels
-          CM_LABELS=$(kubectl get configmap argocd-agent-params -n {{ include "argocd-agent-agent.namespace" . }} -o jsonpath="{.metadata.labels}")
+          CM_LABELS=$(kubectl get configmap "$CONFIGMAP_NAME" -n {{ include "argocd-agent-agent.namespace" . }} -o jsonpath="{.metadata.labels}")
           
           if echo "$CM_LABELS" | grep -q "app.kubernetes.io/name.*argocd-agent-agent"; then
             echo "✓ ConfigMap has app.kubernetes.io/name label"

--- a/install/helm-repo/argocd-agent-agent/templates/tests/test-overall.yaml
+++ b/install/helm-repo/argocd-agent-agent/templates/tests/test-overall.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     "helm.sh/hook": test
 spec:
-  serviceAccountName: argocd-agent-test
+  serviceAccountName: {{ include "argocd-agent-agent.testResourceName" . }}
   containers:
     - name: kubectl
       image: "{{ .Values.tests.image }}:{{ .Values.tests.tag }}"
@@ -15,6 +15,10 @@ spec:
         - -c
         - |
           echo "Testing Overall Chart Installation..."
+
+          DEPLOYMENT_NAME={{ include "argocd-agent-agent.agentDeploymentName" . | quote }}
+          METRICS_SERVICE={{ include "argocd-agent-agent.metricsServiceName" . | quote }}
+          HEALTHZ_SERVICE={{ include "argocd-agent-agent.healthzServiceName" . | quote }}
           
           # Count and verify all resources
           echo "Verifying resource counts..."
@@ -104,7 +108,7 @@ spec:
           
           # Check if deployment is ready
           echo "Checking deployment readiness..."
-          READY_REPLICAS=$(kubectl get deployment argocd-agent-agent -n {{ include "argocd-agent-agent.namespace" . }} -o jsonpath="{.status.readyReplicas}")
+          READY_REPLICAS=$(kubectl get deployment "$DEPLOYMENT_NAME" -n {{ include "argocd-agent-agent.namespace" . }} -o jsonpath="{.status.readyReplicas}")
           if [ "$READY_REPLICAS" = "1" ]; then
             echo "✓ Deployment is ready with $READY_REPLICAS replica(s)"
           else
@@ -129,7 +133,7 @@ spec:
           
           # Verify service endpoints
           echo "Checking service endpoints..."
-          METRICS_ENDPOINTS=$(kubectl get endpoints argocd-agent-agent-metrics -n {{ include "argocd-agent-agent.namespace" . }} -o jsonpath="{.subsets[0].addresses}" | wc -l)
+          METRICS_ENDPOINTS=$(kubectl get endpoints "$METRICS_SERVICE" -n {{ include "argocd-agent-agent.namespace" . }} -o jsonpath="{.subsets[0].addresses}" | wc -l)
           if [ "$METRICS_ENDPOINTS" -gt 0 ]; then
             echo "✓ Metrics service has endpoints"
           else
@@ -137,7 +141,7 @@ spec:
             exit 1
           fi
           
-          HEALTHZ_ENDPOINTS=$(kubectl get endpoints argocd-agent-agent-healthz -n {{ include "argocd-agent-agent.namespace" . }} -o jsonpath="{.subsets[0].addresses}" | wc -l)
+          HEALTHZ_ENDPOINTS=$(kubectl get endpoints "$HEALTHZ_SERVICE" -n {{ include "argocd-agent-agent.namespace" . }} -o jsonpath="{.subsets[0].addresses}" | wc -l)
           if [ "$HEALTHZ_ENDPOINTS" -gt 0 ]; then
             echo "✓ Healthz service has endpoints"
           else

--- a/install/helm-repo/argocd-agent-agent/templates/tests/test-rbac.yaml
+++ b/install/helm-repo/argocd-agent-agent/templates/tests/test-rbac.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     "helm.sh/hook": test
 spec:
-  serviceAccountName: argocd-agent-test
+  serviceAccountName: {{ include "argocd-agent-agent.testResourceName" . }}
   containers:
     - name: kubectl
       image: "{{ .Values.tests.image }}:{{ .Values.tests.tag }}"
@@ -15,10 +15,16 @@ spec:
         - -c
         - |
           echo "Testing RBAC configuration..."
+
+          SERVICE_ACCOUNT_NAME={{ include "argocd-agent-agent.serviceAccountName" . | quote }}
+          ROLE_NAME={{ include "argocd-agent-agent.roleName" . | quote }}
+          ROLEBINDING_NAME={{ include "argocd-agent-agent.roleBindingName" . | quote }}
+          CLUSTER_ROLE_NAME={{ include "argocd-agent-agent.clusterRoleName" . | quote }}
+          CLUSTER_ROLEBINDING_NAME={{ include "argocd-agent-agent.clusterRoleBindingName" . | quote }}
           
           # Test ServiceAccount
           echo "Testing ServiceAccount..."
-          if kubectl get serviceaccount argocd-agent-agent -n {{ include "argocd-agent-agent.namespace" . }}; then
+          if kubectl get serviceaccount "$SERVICE_ACCOUNT_NAME" -n {{ include "argocd-agent-agent.namespace" . }}; then
             echo "✓ ServiceAccount exists"
           else
             echo "✗ ServiceAccount not found"
@@ -27,7 +33,7 @@ spec:
           
           # Test Role
           echo "Testing Role..."
-          if kubectl get role argocd-agent-agent -n {{ include "argocd-agent-agent.namespace" . }}; then
+          if kubectl get role "$ROLE_NAME" -n {{ include "argocd-agent-agent.namespace" . }}; then
             echo "✓ Role exists"
           else
             echo "✗ Role not found"
@@ -35,7 +41,7 @@ spec:
           fi
           
           # Check Role rules for argoproj.io resources
-          ARGOPROJ_RULES=$(kubectl get role argocd-agent-agent -n {{ include "argocd-agent-agent.namespace" . }} -o jsonpath="{.rules[?(@.apiGroups[0]==\"argoproj.io\")]}")
+          ARGOPROJ_RULES=$(kubectl get role "$ROLE_NAME" -n {{ include "argocd-agent-agent.namespace" . }} -o jsonpath="{.rules[?(@.apiGroups[0]==\"argoproj.io\")]}")
           if [ -n "$ARGOPROJ_RULES" ]; then
             echo "✓ Role has argoproj.io rules"
           else
@@ -44,7 +50,7 @@ spec:
           fi
           
           # Check Role rules for core resources
-          CORE_RULES=$(kubectl get role argocd-agent-agent -n {{ include "argocd-agent-agent.namespace" . }} -o jsonpath="{.rules[?(@.apiGroups[0]==\"\")]}")
+          CORE_RULES=$(kubectl get role "$ROLE_NAME" -n {{ include "argocd-agent-agent.namespace" . }} -o jsonpath="{.rules[?(@.apiGroups[0]==\"\")]}")
           if [ -n "$CORE_RULES" ]; then
             echo "✓ Role has core resource rules"
           else
@@ -54,7 +60,7 @@ spec:
           
           # Test RoleBinding
           echo "Testing RoleBinding..."
-          if kubectl get rolebinding argocd-agent-agent -n {{ include "argocd-agent-agent.namespace" . }}; then
+          if kubectl get rolebinding "$ROLEBINDING_NAME" -n {{ include "argocd-agent-agent.namespace" . }}; then
             echo "✓ RoleBinding exists"
           else
             echo "✗ RoleBinding not found"
@@ -62,26 +68,26 @@ spec:
           fi
           
           # Check RoleBinding references correct role
-          ROLE_REF=$(kubectl get rolebinding argocd-agent-agent -n {{ include "argocd-agent-agent.namespace" . }} -o jsonpath="{.roleRef.name}")
-          if [ "$ROLE_REF" = "argocd-agent-agent" ]; then
+          ROLE_REF=$(kubectl get rolebinding "$ROLEBINDING_NAME" -n {{ include "argocd-agent-agent.namespace" . }} -o jsonpath="{.roleRef.name}")
+          if [ "$ROLE_REF" = "$ROLE_NAME" ]; then
             echo "✓ RoleBinding references correct role: $ROLE_REF"
           else
-            echo "✗ RoleBinding references incorrect role: $ROLE_REF (expected argocd-agent-agent)"
+            echo "✗ RoleBinding references incorrect role: $ROLE_REF (expected $ROLE_NAME)"
             exit 1
           fi
           
           # Check RoleBinding references correct service account
-          SA_REF=$(kubectl get rolebinding argocd-agent-agent -n {{ include "argocd-agent-agent.namespace" . }} -o jsonpath="{.subjects[0].name}")
-          if [ "$SA_REF" = "argocd-agent-agent" ]; then
+          SA_REF=$(kubectl get rolebinding "$ROLEBINDING_NAME" -n {{ include "argocd-agent-agent.namespace" . }} -o jsonpath="{.subjects[0].name}")
+          if [ "$SA_REF" = "$SERVICE_ACCOUNT_NAME" ]; then
             echo "✓ RoleBinding references correct service account: $SA_REF"
           else
-            echo "✗ RoleBinding references incorrect service account: $SA_REF (expected argocd-agent-agent)"
+            echo "✗ RoleBinding references incorrect service account: $SA_REF (expected $SERVICE_ACCOUNT_NAME)"
             exit 1
           fi
           
           # Test ClusterRole
           echo "Testing ClusterRole..."
-          if kubectl get clusterrole argocd-agent-agent; then
+          if kubectl get clusterrole "$CLUSTER_ROLE_NAME"; then
             echo "✓ ClusterRole exists"
           else
             echo "✗ ClusterRole not found"
@@ -90,7 +96,7 @@ spec:
           
           # Test ClusterRoleBinding
           echo "Testing ClusterRoleBinding..."
-          if kubectl get clusterrolebinding argocd-agent-agent; then
+          if kubectl get clusterrolebinding "$CLUSTER_ROLEBINDING_NAME"; then
             echo "✓ ClusterRoleBinding exists"
           else
             echo "✗ ClusterRoleBinding not found"
@@ -98,25 +104,25 @@ spec:
           fi
           
           # Check ClusterRoleBinding references correct cluster role
-          CLUSTER_ROLE_REF=$(kubectl get clusterrolebinding argocd-agent-agent -o jsonpath="{.roleRef.name}")
-          if [ "$CLUSTER_ROLE_REF" = "argocd-agent-agent" ]; then
+          CLUSTER_ROLE_REF=$(kubectl get clusterrolebinding "$CLUSTER_ROLEBINDING_NAME" -o jsonpath="{.roleRef.name}")
+          if [ "$CLUSTER_ROLE_REF" = "$CLUSTER_ROLE_NAME" ]; then
             echo "✓ ClusterRoleBinding references correct cluster role: $CLUSTER_ROLE_REF"
           else
-            echo "✗ ClusterRoleBinding references incorrect cluster role: $CLUSTER_ROLE_REF (expected argocd-agent-agent)"
+            echo "✗ ClusterRoleBinding references incorrect cluster role: $CLUSTER_ROLE_REF (expected $CLUSTER_ROLE_NAME)"
             exit 1
           fi
           
           # Check ClusterRoleBinding references correct service account
-          CLUSTER_SA_REF=$(kubectl get clusterrolebinding argocd-agent-agent -o jsonpath="{.subjects[0].name}")
-          if [ "$CLUSTER_SA_REF" = "argocd-agent-agent" ]; then
+          CLUSTER_SA_REF=$(kubectl get clusterrolebinding "$CLUSTER_ROLEBINDING_NAME" -o jsonpath="{.subjects[0].name}")
+          if [ "$CLUSTER_SA_REF" = "$SERVICE_ACCOUNT_NAME" ]; then
             echo "✓ ClusterRoleBinding references correct service account: $CLUSTER_SA_REF"
           else
-            echo "✗ ClusterRoleBinding references incorrect service account: $CLUSTER_SA_REF (expected argocd-agent-agent)"
+            echo "✗ ClusterRoleBinding references incorrect service account: $CLUSTER_SA_REF (expected $SERVICE_ACCOUNT_NAME)"
             exit 1
           fi
           
           # Check ClusterRoleBinding references correct namespace
-          CLUSTER_NS_REF=$(kubectl get clusterrolebinding argocd-agent-agent -o jsonpath="{.subjects[0].namespace}")
+          CLUSTER_NS_REF=$(kubectl get clusterrolebinding "$CLUSTER_ROLEBINDING_NAME" -o jsonpath="{.subjects[0].namespace}")
           if [ "$CLUSTER_NS_REF" = "{{ include "argocd-agent-agent.namespace" . }}" ]; then
             echo "✓ ClusterRoleBinding references correct namespace: $CLUSTER_NS_REF"
           else

--- a/install/helm-repo/argocd-agent-agent/templates/tests/test-sa.yaml
+++ b/install/helm-repo/argocd-agent-agent/templates/tests/test-sa.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: argocd-agent-test
+  name: {{ include "argocd-agent-agent.testResourceName" . }}
   namespace: {{ include "argocd-agent-agent.namespace" . }}
   labels:
     app.kubernetes.io/name: argocd-agent-agent
@@ -11,7 +11,7 @@ metadata:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: argocd-agent-test
+  name: {{ include "argocd-agent-agent.testResourceName" . }}
   namespace: {{ include "argocd-agent-agent.namespace" . }}
   labels:
     app.kubernetes.io/name: argocd-agent-agent
@@ -30,7 +30,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: argocd-agent-test
+  name: {{ include "argocd-agent-agent.testResourceName" . }}
   namespace: {{ include "argocd-agent-agent.namespace" . }}
   labels:
     app.kubernetes.io/name: argocd-agent-agent
@@ -38,16 +38,16 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: argocd-agent-test
+  name: {{ include "argocd-agent-agent.testResourceName" . }}
 subjects:
 - kind: ServiceAccount
-  name: argocd-agent-test
+  name: {{ include "argocd-agent-agent.testResourceName" . }}
   namespace: {{ include "argocd-agent-agent.namespace" . }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: argocd-agent-test
+  name: {{ include "argocd-agent-agent.testResourceName" . }}
   labels:
     app.kubernetes.io/name: argocd-agent-agent
     app.kubernetes.io/component: test
@@ -65,16 +65,16 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: argocd-agent-test
+  name: {{ include "argocd-agent-agent.testResourceName" . }}
   labels:
     app.kubernetes.io/name: argocd-agent-agent
     app.kubernetes.io/component: test
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: argocd-agent-test
+  name: {{ include "argocd-agent-agent.testResourceName" . }}
 subjects:
 - kind: ServiceAccount
-  name: argocd-agent-test
+  name: {{ include "argocd-agent-agent.testResourceName" . }}
   namespace: {{ include "argocd-agent-agent.namespace" . }}
 {{- end }}

--- a/install/helm-repo/argocd-agent-agent/templates/tests/test-services.yaml
+++ b/install/helm-repo/argocd-agent-agent/templates/tests/test-services.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     "helm.sh/hook": test
 spec:
-  serviceAccountName: argocd-agent-test
+  serviceAccountName: {{ include "argocd-agent-agent.testResourceName" . }}
   containers:
     - name: kubectl
       image: "{{ .Values.tests.image }}:{{ .Values.tests.tag }}"
@@ -15,10 +15,13 @@ spec:
         - -c
         - |
           echo "Testing Services configuration..."
+
+          METRICS_SERVICE={{ include "argocd-agent-agent.metricsServiceName" . | quote }}
+          HEALTHZ_SERVICE={{ include "argocd-agent-agent.healthzServiceName" . | quote }}
           
           # Test metrics service
           echo "Testing metrics service..."
-          if kubectl get service argocd-agent-agent-metrics -n {{ include "argocd-agent-agent.namespace" . }}; then
+          if kubectl get service "$METRICS_SERVICE" -n {{ include "argocd-agent-agent.namespace" . }}; then
             echo "✓ Metrics service exists"
           else
             echo "✗ Metrics service not found"
@@ -26,7 +29,7 @@ spec:
           fi
           
           # Check metrics service port
-          METRICS_PORT=$(kubectl get service argocd-agent-agent-metrics -n {{ include "argocd-agent-agent.namespace" . }} -o jsonpath="{.spec.ports[0].port}")
+          METRICS_PORT=$(kubectl get service "$METRICS_SERVICE" -n {{ include "argocd-agent-agent.namespace" . }} -o jsonpath="{.spec.ports[0].port}")
           if [ "$METRICS_PORT" = "8181" ]; then
             echo "✓ Metrics service has correct port: $METRICS_PORT"
           else
@@ -35,7 +38,7 @@ spec:
           fi
           
           # Check metrics service target port
-          METRICS_TARGET_PORT=$(kubectl get service argocd-agent-agent-metrics -n {{ include "argocd-agent-agent.namespace" . }} -o jsonpath="{.spec.ports[0].targetPort}")
+          METRICS_TARGET_PORT=$(kubectl get service "$METRICS_SERVICE" -n {{ include "argocd-agent-agent.namespace" . }} -o jsonpath="{.spec.ports[0].targetPort}")
           if [ "$METRICS_TARGET_PORT" = "8181" ]; then
             echo "✓ Metrics service has correct target port: $METRICS_TARGET_PORT"
           else
@@ -45,7 +48,7 @@ spec:
           
           # Test healthz service
           echo "Testing healthz service..."
-          if kubectl get service argocd-agent-agent-healthz -n {{ include "argocd-agent-agent.namespace" . }}; then
+          if kubectl get service "$HEALTHZ_SERVICE" -n {{ include "argocd-agent-agent.namespace" . }}; then
             echo "✓ Healthz service exists"
           else
             echo "✗ Healthz service not found"
@@ -53,7 +56,7 @@ spec:
           fi
           
           # Check healthz service port
-          HEALTHZ_PORT=$(kubectl get service argocd-agent-agent-healthz -n {{ include "argocd-agent-agent.namespace" . }} -o jsonpath="{.spec.ports[0].port}")
+          HEALTHZ_PORT=$(kubectl get service "$HEALTHZ_SERVICE" -n {{ include "argocd-agent-agent.namespace" . }} -o jsonpath="{.spec.ports[0].port}")
           if [ "$HEALTHZ_PORT" = "8002" ]; then
             echo "✓ Healthz service has correct port: $HEALTHZ_PORT"
           else
@@ -62,7 +65,7 @@ spec:
           fi
           
           # Check healthz service target port
-          HEALTHZ_TARGET_PORT=$(kubectl get service argocd-agent-agent-healthz -n {{ include "argocd-agent-agent.namespace" . }} -o jsonpath="{.spec.ports[0].targetPort}")
+          HEALTHZ_TARGET_PORT=$(kubectl get service "$HEALTHZ_SERVICE" -n {{ include "argocd-agent-agent.namespace" . }} -o jsonpath="{.spec.ports[0].targetPort}")
           if [ "$HEALTHZ_TARGET_PORT" = "8002" ]; then
             echo "✓ Healthz service has correct target port: $HEALTHZ_TARGET_PORT"
           else
@@ -71,7 +74,7 @@ spec:
           fi
           
           # Check service selectors
-          METRICS_SELECTOR=$(kubectl get service argocd-agent-agent-metrics -n {{ include "argocd-agent-agent.namespace" . }} -o jsonpath="{.spec.selector.app\\.kubernetes\\.io/name}")
+          METRICS_SELECTOR=$(kubectl get service "$METRICS_SERVICE" -n {{ include "argocd-agent-agent.namespace" . }} -o jsonpath="{.spec.selector.app\\.kubernetes\\.io/name}")
           if [ "$METRICS_SELECTOR" = "argocd-agent-agent" ]; then
             echo "✓ Metrics service has correct selector: $METRICS_SELECTOR"
           else
@@ -79,7 +82,7 @@ spec:
             exit 1
           fi
           
-          HEALTHZ_SELECTOR=$(kubectl get service argocd-agent-agent-healthz -n {{ include "argocd-agent-agent.namespace" . }} -o jsonpath="{.spec.selector.app\\.kubernetes\\.io/name}")
+          HEALTHZ_SELECTOR=$(kubectl get service "$HEALTHZ_SERVICE" -n {{ include "argocd-agent-agent.namespace" . }} -o jsonpath="{.spec.selector.app\\.kubernetes\\.io/name}")
           if [ "$HEALTHZ_SELECTOR" = "argocd-agent-agent" ]; then
             echo "✓ Healthz service has correct selector: $HEALTHZ_SELECTOR"
           else

--- a/install/helm-repo/argocd-agent-agent/values.schema.json
+++ b/install/helm-repo/argocd-agent-agent/values.schema.json
@@ -285,7 +285,7 @@
       "additionalProperties": false,
       "properties": {
         "enabled": {
-          "type": "string",
+          "type": "boolean",
           "description": "Enable chart tests"
         },
         "image": {

--- a/install/helm-repo/argocd-agent-agent/values.yaml
+++ b/install/helm-repo/argocd-agent-agent/values.yaml
@@ -156,8 +156,8 @@ service:
 ## @section Tests
 # -- Configuration for helm-chart tests.
 tests:
-  # -- Enable chart tests.
-  enabled: "true"
+  # -- By default, chart tests are disabled.
+  enabled: false
   # -- Test image.
   image: bitnamilegacy/kubectl
   # -- Test image tag.

--- a/install/helm-repo/docs/install-agent.md
+++ b/install/helm-repo/docs/install-agent.md
@@ -12,6 +12,8 @@ Use the following command to install the argocd-agent-agent-helm chart.
 
 `helm install argocd-agent ghcr.io/argoproj-labs/argocd-agent/argocd-agent-agent-helm --version 0.1.0`
 
+> **Resource naming:** every Kubernetes object that this chart creates is derived from your Helm release name. For example, installing with `helm install agent-prod ...` generates resource name `agent-prod-agent-helm`. Pick a release name that matches how you want the objects to appear in the cluster.
+
 ### Namespace Handling
 
 If you run the helm install command without specifying a namespace flag, Helm will attempt to deploy resources into the `default` namespace.


### PR DESCRIPTION
This PR updates logic to generate resource names of agent based on release names when agent is installed via helm charts. In existing logic resource names were hard coded to `argocd-agent-agent`, but now it would be `<HELM RELEASE NAME>-agent-helm`. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Resource names are now dynamically derived from the Helm release name for more predictable, customizable deployments.

* **Documentation**
  * Added guidance showing how generated resource names incorporate the release name.

* **Chores**
  * Chart tests disabled by default (tests.enabled changed to boolean false).
  * All chart test scripts and validations updated to use templated/dynamic resource names.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->