### PR TITLE
fix: use prefixed AppProject name while handling resyncs  (#666)

### DIFF
--- a/agent/inbound.go
+++ b/agent/inbound.go
@@ -15,9 +15,11 @@
 package agent
 
 import (
+	"encoding/json"
 	"fmt"
 	"time"
 
+	"github.com/argoproj-labs/argocd-agent/internal/auth"
 	"github.com/argoproj-labs/argocd-agent/internal/backend"
 	"github.com/argoproj-labs/argocd-agent/internal/checkpoint"
 	"github.com/argoproj-labs/argocd-agent/internal/event"
@@ -380,6 +382,13 @@ func (a *Agent) processIncomingResourceResyncEvent(ev *event.Event) error {
 	}
 
 	resyncHandler := resync.NewRequestHandler(dynClient, sendQ, a.emitter, a.resources, logCtx, manager.ManagerRoleAgent, a.namespace)
+	subject := &auth.AuthSubject{}
+	err = json.Unmarshal([]byte(a.remote.ClientID()), subject)
+	if err != nil {
+		return fmt.Errorf("failed to extract agent name from client ID: %w", err)
+	}
+
+	agentName := subject.ClientID
 
 	switch ev.Type() {
 	case event.SyncedResourceList:
@@ -392,7 +401,7 @@ func (a *Agent) processIncomingResourceResyncEvent(ev *event.Event) error {
 			return err
 		}
 
-		return resyncHandler.ProcessSyncedResourceListRequest(a.remote.ClientID(), req)
+		return resyncHandler.ProcessSyncedResourceListRequest(agentName, req)
 	case event.ResponseSyncedResource:
 		if a.mode != types.AgentModeManaged {
 			return fmt.Errorf("agent can only handle SyncedResource request in the managed mode")
@@ -403,7 +412,7 @@ func (a *Agent) processIncomingResourceResyncEvent(ev *event.Event) error {
 			return err
 		}
 
-		return resyncHandler.ProcessIncomingSyncedResource(a.context, req, a.remote.ClientID())
+		return resyncHandler.ProcessIncomingSyncedResource(a.context, req, agentName)
 	case event.EventRequestUpdate:
 		if a.mode != types.AgentModeAutonomous {
 			return fmt.Errorf("agent can only handle RequestUpdate in the autonomous mode")
@@ -414,13 +423,23 @@ func (a *Agent) processIncomingResourceResyncEvent(ev *event.Event) error {
 			return err
 		}
 
-		return resyncHandler.ProcessRequestUpdateEvent(a.context, a.remote.ClientID(), incoming)
+		// For autonomous agents, the principal stores AppProjects with a prefixed name (agent-name + "-" + project-name).
+		// When the principal sends a RequestUpdate, it uses the prefixed name. We need to strip the prefix
+		// before looking up the resource locally.
+		if incoming.Kind == "AppProject" {
+			prefix := agentName + "-"
+			if len(incoming.Name) > len(prefix) && incoming.Name[:len(prefix)] == prefix {
+				incoming.Name = incoming.Name[len(prefix):]
+			}
+		}
+
+		return resyncHandler.ProcessRequestUpdateEvent(a.context, agentName, incoming)
 	case event.EventRequestResourceResync:
 		if a.mode != types.AgentModeManaged {
 			return fmt.Errorf("agent can only handle ResourceResync request in the managed mode")
 		}
 
-		return resyncHandler.ProcessIncomingResourceResyncRequest(a.context, a.remote.ClientID())
+		return resyncHandler.ProcessIncomingResourceResyncRequest(a.context, agentName)
 	default:
 		return fmt.Errorf("invalid type of resource resync: %s", ev.Type())
 	}

--- a/agent/inbound_test.go
+++ b/agent/inbound_test.go
@@ -16,6 +16,7 @@ package agent
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"testing"
 
@@ -27,6 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/rest"
 
+	"github.com/argoproj-labs/argocd-agent/internal/auth"
 	backend_mocks "github.com/argoproj-labs/argocd-agent/internal/backend/mocks"
 	"github.com/argoproj-labs/argocd-agent/internal/event"
 	"github.com/argoproj-labs/argocd-agent/internal/manager"
@@ -1468,7 +1470,16 @@ func Test_processIncomingResourceResyncEvent(t *testing.T) {
 	a.namespace = "test"
 	a.context = context.Background()
 
-	err := a.queues.Create(a.remote.ClientID())
+	subject := &auth.AuthSubject{
+		ClientID: "test",
+	}
+	subjectJSON, err := json.Marshal(subject)
+	if err != nil {
+		t.Fatalf("Failed to marshal subject: %v", err)
+	}
+	a.remote.SetClientID(string(subjectJSON))
+	fmt.Println("a.remote.ClientID()", a.remote.ClientID())
+	err = a.queues.Create(a.remote.ClientID())
 	assert.Nil(t, err)
 	a.emitter = event.NewEventSource("test")
 

--- a/internal/resync/resync.go
+++ b/internal/resync/resync.go
@@ -156,6 +156,7 @@ func (r *RequestHandler) ProcessIncomingResourceResyncRequest(ctx context.Contex
 			r.log.Errorf("failed to send request update for resource %s: %v", resource.Name, err)
 			continue
 		}
+		r.log.WithField(logfields.Kind, resource.Kind).WithField(logfields.Name, resource.Name).Trace("Sent a request update event")
 	}
 
 	return nil

--- a/principal/callbacks.go
+++ b/principal/callbacks.go
@@ -170,13 +170,19 @@ func (s *Server) newAppProjectCallback(outbound *v1alpha1.AppProject) {
 		"appproject_name": outbound.Name,
 	})
 
-	s.resources.Add(outbound.Namespace, resources.NewResourceKeyFromAppProject(outbound))
-
 	// Check if this AppProject was created by an autonomous agent
 	if isResourceFromAutonomousAgent(outbound) {
+		// For autonomous agents, the agent name may be different from the namespace name.
+		// SourceNamespaces[0] contains the exact agent name.
+		if len(outbound.Spec.SourceNamespaces) > 0 {
+			agentName := outbound.Spec.SourceNamespaces[0]
+			s.resources.Add(agentName, resources.NewResourceKeyFromAppProject(outbound))
+		}
 		logCtx.Debugf("Discarding event, because the appProject is managed by an autonomous agent")
 		return
 	}
+
+	s.resources.Add(outbound.Namespace, resources.NewResourceKeyFromAppProject(outbound))
 
 	// Return early if no interested agent is connected
 	if !s.queues.HasQueuePair(outbound.Namespace) {
@@ -284,15 +290,18 @@ func (s *Server) deleteAppProjectCallback(outbound *v1alpha1.AppProject) {
 			logCtx.Trace("Deleted appProject is recreated")
 			return
 		}
-	}
 
-	s.resources.Remove(outbound.Namespace, resources.NewResourceKeyFromAppProject(outbound))
-
-	// Check if this AppProject was created by an autonomous agent by examining its name prefix
-	if isResourceFromAutonomousAgent(outbound) {
+		// For autonomous agents, the agent name may be different from the namespace name.
+		// SourceNamespaces[0] contains the exact agent name.
+		if len(outbound.Spec.SourceNamespaces) > 0 {
+			agentName := outbound.Spec.SourceNamespaces[0]
+			s.resources.Remove(agentName, resources.NewResourceKeyFromAppProject(outbound))
+		}
 		logCtx.Debugf("Discarding event, because the appProject is managed by an autonomous agent")
 		return
 	}
+
+	s.resources.Remove(outbound.Namespace, resources.NewResourceKeyFromAppProject(outbound))
 
 	if !s.queues.HasQueuePair(outbound.Namespace) {
 		if err := s.queues.Create(outbound.Namespace); err != nil {

--- a/test/e2e/resync_test.go
+++ b/test/e2e/resync_test.go
@@ -17,6 +17,7 @@ package e2e
 import (
 	"fmt"
 	"os"
+	"reflect"
 	"testing"
 	"time"
 
@@ -827,6 +828,422 @@ func (suite *ResyncTestSuite) Test_AppProjectResync_CreateOnAgentDelete() {
 	}, 30*time.Second, 1*time.Second)
 }
 
+// AppProjects on both the agent and the principal must be synchronized when the principal is restarted
+func (suite *ResyncTestSuite) Test_AppProjectResyncOnPrincipalRestart_Autonomous() {
+	requires := suite.Require()
+
+	// Create an autonomous application on the autonomous-agent's cluster
+	appProject := suite.createAutonomousAppProject()
+	principalKey := types.NamespacedName{Name: "agent-autonomous-" + appProject.Name, Namespace: "argocd"}
+	agentKey := types.NamespacedName{Name: appProject.Name, Namespace: "argocd"}
+
+	// Restart the principal
+	err := fixture.StopProcess("principal")
+	requires.NoError(err)
+
+	requires.Eventually(func() bool {
+		return !fixture.IsProcessRunning("principal")
+	}, 30*time.Second, 1*time.Second)
+
+	// Start the principal and ensure that the appProject is still present on the workload cluster
+	err = fixture.StartProcess("principal")
+	requires.NoError(err)
+
+	fixture.CheckReadiness(suite.T(), "principal")
+
+	agentProj := argoapp.AppProject{}
+	requires.Eventually(func() bool {
+		err := suite.AutonomousAgentClient.Get(suite.Ctx, agentKey, &agentProj, metav1.GetOptions{})
+		return err == nil
+	}, 30*time.Second, 1*time.Second)
+
+	requires.Eventually(func() bool {
+		appProject := argoapp.AppProject{}
+		err := suite.PrincipalClient.Get(suite.Ctx, principalKey, &appProject, metav1.GetOptions{})
+		if err != nil {
+			return false
+		}
+
+		// For autonomous agents, the principal transforms the spec:
+		// - SourceNamespaces is set to [agentName]
+		// - All destinations are modified to point to the agent cluster
+		expectedSpec := agentProj.Spec.DeepCopy()
+		expectedSpec.SourceNamespaces = []string{"agent-autonomous"}
+		for i := range expectedSpec.Destinations {
+			expectedSpec.Destinations[i].Name = "agent-autonomous"
+			expectedSpec.Destinations[i].Server = "*"
+		}
+
+		return reflect.DeepEqual(appProject.Spec, *expectedSpec)
+	}, 30*time.Second, 1*time.Second)
+}
+
+// AppProjects on both the agent and the principal must be synchronized when the agent is restarted
+func (suite *ResyncTestSuite) Test_AppProjectResyncOnAgentRestart_Autonomous() {
+	requires := suite.Require()
+
+	// Create an autonomous application on the autonomous-agent's cluster
+	appProject := suite.createAutonomousAppProject()
+	principalKey := types.NamespacedName{Name: "agent-autonomous-" + appProject.Name, Namespace: "argocd"}
+	agentKey := types.NamespacedName{Name: appProject.Name, Namespace: "argocd"}
+
+	// Restart the autonomous-agent
+	err := fixture.StopProcess("agent-autonomous")
+	requires.NoError(err)
+
+	requires.Eventually(func() bool {
+		return !fixture.IsProcessRunning("agent-autonomous")
+	}, 30*time.Second, 1*time.Second)
+
+	// Start the agent and ensure that the appProject is still present on both the clusters
+	err = fixture.StartProcess("agent-autonomous")
+	requires.NoError(err)
+
+	fixture.CheckReadiness(suite.T(), "agent-autonomous")
+
+	agentProj := argoapp.AppProject{}
+	requires.Eventually(func() bool {
+		err := suite.AutonomousAgentClient.Get(suite.Ctx, agentKey, &agentProj, metav1.GetOptions{})
+		return err == nil
+	}, 30*time.Second, 1*time.Second)
+
+	requires.Eventually(func() bool {
+		appProject := argoapp.AppProject{}
+		err := suite.PrincipalClient.Get(suite.Ctx, principalKey, &appProject, metav1.GetOptions{})
+		if err != nil {
+			return false
+		}
+
+		expectedSpec := agentProj.Spec.DeepCopy()
+		expectedSpec.SourceNamespaces = []string{"agent-autonomous"}
+		for i := range expectedSpec.Destinations {
+			expectedSpec.Destinations[i].Name = "agent-autonomous"
+			expectedSpec.Destinations[i].Server = "*"
+		}
+
+		return reflect.DeepEqual(appProject.Spec, *expectedSpec)
+	}, 30*time.Second, 1*time.Second)
+}
+
+// Autonomous: Updates on the principal must be reverted when the principal is restarted
+func (suite *ResyncTestSuite) Test_AppProjectResyncOnPrincipalRestartWithUpdateOnPrincipal() {
+	requires := suite.Require()
+
+	// Create an autonomous application on the autonomous-agent's cluster
+	appProject := suite.createAutonomousAppProject()
+	principalKey := types.NamespacedName{Name: "agent-autonomous-" + appProject.Name, Namespace: "argocd"}
+
+	// Stop the principal
+	err := fixture.StopProcess("principal")
+	requires.NoError(err)
+
+	requires.Eventually(func() bool {
+		return !fixture.IsProcessRunning("principal")
+	}, 30*time.Second, 1*time.Second)
+
+	// Update the AppProject on the control-plane cluster
+	principalAppProject := appProject.DeepCopy()
+	err = fixture.EnsureUpdate(suite.Ctx, suite.PrincipalClient, principalAppProject, func(obj fixture.KubeObject) {
+		a := obj.(*argoapp.AppProject)
+		a.Spec.Description = "updated from e2e test"
+	})
+	requires.NoError(err)
+
+	// Restart the principal
+	err = fixture.StartProcess("principal")
+	requires.NoError(err)
+
+	fixture.CheckReadiness(suite.T(), "principal")
+
+	// The changes made to the AppProject on the control-plane cluster must be reverted when the principal restarts
+	requires.Eventually(func() bool {
+		appProject := argoapp.AppProject{}
+		err := suite.PrincipalClient.Get(suite.Ctx, principalKey, &appProject, metav1.GetOptions{})
+		return err == nil && appProject.Spec.Description == ""
+	}, 30*time.Second, 1*time.Second)
+}
+
+// Autonomous: Updates on the agent must be synced to the principal when the principal is restarted
+func (suite *ResyncTestSuite) Test_AppProjectResyncOnPrincipalRestartWithUpdateOnAgent() {
+	requires := suite.Require()
+
+	// Create an autonomous application on the autonomous-agent's cluster
+	appProject := suite.createAutonomousAppProject()
+	principalKey := types.NamespacedName{Name: "agent-autonomous-" + appProject.Name, Namespace: "argocd"}
+
+	// Stop the principal
+	err := fixture.StopProcess("principal")
+	requires.NoError(err)
+
+	requires.Eventually(func() bool {
+		return !fixture.IsProcessRunning("principal")
+	}, 30*time.Second, 1*time.Second)
+
+	// Update the AppProject on the agent's cluster
+	agentAppProject := appProject.DeepCopy()
+	err = fixture.EnsureUpdate(suite.Ctx, suite.AutonomousAgentClient, agentAppProject, func(obj fixture.KubeObject) {
+		a := obj.(*argoapp.AppProject)
+		a.Spec.Description = "updated from e2e test"
+	})
+	requires.NoError(err)
+
+	// Restart the principal
+	err = fixture.StartProcess("principal")
+	requires.NoError(err)
+
+	fixture.CheckReadiness(suite.T(), "principal")
+
+	// The changes made to the AppProject on the agent's cluster must be synced to the control-plane cluster
+	requires.Eventually(func() bool {
+		appProject := argoapp.AppProject{}
+		err := suite.PrincipalClient.Get(suite.Ctx, principalKey, &appProject, metav1.GetOptions{})
+		return err == nil && appProject.Spec.Description == "updated from e2e test"
+	}, 30*time.Second, 1*time.Second)
+}
+
+// Autonomous: Updates on the agent must be synced to the principal when the agent is restarted
+func (suite *ResyncTestSuite) Test_AppProjectResyncOnAgentRestartWithUpdateOnAgent() {
+	requires := suite.Require()
+
+	// Create an autonomous application on the autonomous-agent's cluster
+	appProject := suite.createAutonomousAppProject()
+	principalKey := types.NamespacedName{Name: "agent-autonomous-" + appProject.Name, Namespace: "argocd"}
+
+	// Stop the autonomous-agent
+	err := fixture.StopProcess("agent-autonomous")
+	requires.NoError(err)
+
+	requires.Eventually(func() bool {
+		return !fixture.IsProcessRunning("agent-autonomous")
+	}, 30*time.Second, 1*time.Second)
+
+	// Update the AppProject on the autonomous-agent's cluster
+	err = fixture.EnsureUpdate(suite.Ctx, suite.AutonomousAgentClient, appProject, func(obj fixture.KubeObject) {
+		a := obj.(*argoapp.AppProject)
+		a.Spec.Description = "updated from e2e test"
+	})
+	requires.NoError(err)
+
+	// Restart the autonomous-agent
+	err = fixture.StartProcess("agent-autonomous")
+	requires.NoError(err)
+
+	fixture.CheckReadiness(suite.T(), "agent-autonomous")
+
+	// The changes made to the AppProject on the autonomous-agent's cluster must be synced to the control-plane cluster
+	requires.Eventually(func() bool {
+		appProject := argoapp.AppProject{}
+		err := suite.PrincipalClient.Get(suite.Ctx, principalKey, &appProject, metav1.GetOptions{})
+		return err == nil && appProject.Spec.Description == "updated from e2e test"
+	}, 30*time.Second, 1*time.Second)
+}
+
+// Autonomous: Updates on the principal must be reverted when the agent is restarted
+func (suite *ResyncTestSuite) Test_AppProjectResyncOnAgentRestartWithUpdateOnPrincipal() {
+	requires := suite.Require()
+
+	// Create an autonomous application on the autonomous-agent's cluster
+	appProject := suite.createAutonomousAppProject()
+	principalKey := types.NamespacedName{Name: "agent-autonomous-" + appProject.Name, Namespace: "argocd"}
+
+	// Stop the autonomous-agent
+	err := fixture.StopProcess("agent-autonomous")
+	requires.NoError(err)
+
+	requires.Eventually(func() bool {
+		return !fixture.IsProcessRunning("agent-autonomous")
+	}, 30*time.Second, 1*time.Second)
+
+	// Update the AppProject on the principal's cluster
+	principalAppProject := appProject.DeepCopy()
+	principalAppProject.Name = principalKey.Name
+	err = fixture.EnsureUpdate(suite.Ctx, suite.PrincipalClient, principalAppProject, func(obj fixture.KubeObject) {
+		a := obj.(*argoapp.AppProject)
+		a.Spec.Description = "updated from e2e test"
+	})
+	requires.NoError(err)
+
+	// Restart the autonomous-agent
+	err = fixture.StartProcess("agent-autonomous")
+	requires.NoError(err)
+
+	fixture.CheckReadiness(suite.T(), "agent-autonomous")
+
+	// The changes made to the AppProject on the principal's cluster must be reverted
+	requires.Eventually(func() bool {
+		appProject := argoapp.AppProject{}
+		err := suite.PrincipalClient.Get(suite.Ctx, principalKey, &appProject, metav1.GetOptions{})
+		return err == nil && appProject.Spec.Description == ""
+	}, 30*time.Second, 1*time.Second)
+}
+
+// Autonomous: Deleted AppProjects on the principal must be recreated when the principal is restarted
+func (suite *ResyncTestSuite) Test_AppProjectResyncOnPrincipalRestartWithDeleteOnPrincipal() {
+	requires := suite.Require()
+
+	// Create an autonomous application on the autonomous-agent's cluster
+	appProject := suite.createAutonomousAppProject()
+	principalKey := types.NamespacedName{Name: "agent-autonomous-" + appProject.Name, Namespace: "argocd"}
+
+	// Stop the principal
+	err := fixture.StopProcess("principal")
+	requires.NoError(err)
+
+	requires.Eventually(func() bool {
+		return !fixture.IsProcessRunning("principal")
+	}, 30*time.Second, 1*time.Second)
+
+	// Delete the AppProject on the control-plane cluster
+	principalAppProject := appProject.DeepCopy()
+	principalAppProject.Name = principalKey.Name
+	err = suite.PrincipalClient.Delete(suite.Ctx, principalAppProject, metav1.DeleteOptions{})
+	requires.NoError(err)
+
+	// Restart the principal
+	err = fixture.StartProcess("principal")
+	requires.NoError(err)
+
+	fixture.CheckReadiness(suite.T(), "principal")
+
+	// The AppProject should be recreated on the control-plane cluster
+	requires.Eventually(func() bool {
+		appProject := argoapp.AppProject{}
+		err := suite.PrincipalClient.Get(suite.Ctx, principalKey, &appProject, metav1.GetOptions{})
+		if err != nil {
+			return false
+		}
+
+		expectedSpec := appProject.Spec.DeepCopy()
+		expectedSpec.SourceNamespaces = []string{"agent-autonomous"}
+		for i := range expectedSpec.Destinations {
+			expectedSpec.Destinations[i].Name = "agent-autonomous"
+			expectedSpec.Destinations[i].Server = "*"
+		}
+
+		return reflect.DeepEqual(appProject.Spec, *expectedSpec)
+	}, 30*time.Second, 1*time.Second)
+}
+
+// Autonomous: Deleted AppProjects on the agent must be removed from the principal when the principal is restarted
+func (suite *ResyncTestSuite) Test_AppProjectResyncOnPrincipalRestartWithDeleteOnAgent() {
+	requires := suite.Require()
+
+	// Create an autonomous application on the autonomous-agent's cluster
+	appProject := suite.createAutonomousAppProject()
+	principalKey := types.NamespacedName{Name: "agent-autonomous-" + appProject.Name, Namespace: "argocd"}
+
+	// Stop the principal
+	err := fixture.StopProcess("principal")
+	requires.NoError(err)
+
+	requires.Eventually(func() bool {
+		return !fixture.IsProcessRunning("principal")
+	}, 30*time.Second, 1*time.Second)
+
+	// Delete the AppProject on the agent's cluster
+	err = suite.AutonomousAgentClient.Delete(suite.Ctx, appProject, metav1.DeleteOptions{})
+	requires.NoError(err)
+
+	// Restart the principal
+	err = fixture.StartProcess("principal")
+	requires.NoError(err)
+
+	fixture.CheckReadiness(suite.T(), "principal")
+
+	// The AppProject should be deleted from the control-plane cluster
+	requires.Eventually(func() bool {
+		appProject := argoapp.AppProject{}
+		err := suite.PrincipalClient.Get(suite.Ctx, principalKey, &appProject, metav1.GetOptions{})
+		return errors.IsNotFound(err)
+	}, 30*time.Second, 1*time.Second)
+}
+
+// Autonomous: Deleted AppProjects on the agent must be removed from the principal when the agent is restarted
+func (suite *ResyncTestSuite) Test_AppProjectResyncOnAgentRestartWithDeleteOnAgent() {
+	requires := suite.Require()
+
+	// Create an autonomous AppProject on the autonomous-agent's cluster
+	appProject := suite.createAutonomousAppProject()
+	principalKey := types.NamespacedName{Name: "agent-autonomous-" + appProject.Name, Namespace: "argocd"}
+
+	// Stop the autonomous-agent
+	err := fixture.StopProcess("agent-autonomous")
+	requires.NoError(err)
+
+	requires.Eventually(func() bool {
+		return !fixture.IsProcessRunning("agent-autonomous")
+	}, 30*time.Second, 1*time.Second)
+
+	// Delete the AppProject on the autonomous-agent's cluster
+	agentAppProject := appProject.DeepCopy()
+	err = suite.AutonomousAgentClient.Delete(suite.Ctx, agentAppProject, metav1.DeleteOptions{})
+	requires.NoError(err)
+
+	// Restart the autonomous-agent
+	err = fixture.StartProcess("agent-autonomous")
+	requires.NoError(err)
+
+	fixture.CheckReadiness(suite.T(), "agent-autonomous")
+
+	// The AppProject should be deleted from the control-plane cluster
+	requires.Eventually(func() bool {
+		appProject := argoapp.AppProject{}
+		err := suite.PrincipalClient.Get(suite.Ctx, principalKey, &appProject, metav1.GetOptions{})
+		return errors.IsNotFound(err)
+	}, 30*time.Second, 1*time.Second)
+}
+
+// Autonomous: Deleted AppProjects on the principal must be recreated when the agent is restarted
+func (suite *ResyncTestSuite) Test_AppProjectResyncOnAgentRestartWithDeleteOnPrincipal() {
+	requires := suite.Require()
+
+	// Create an autonomous AppProject on the autonomous-agent's cluster
+	appProject := suite.createAutonomousAppProject()
+	principalKey := types.NamespacedName{Name: "agent-autonomous-" + appProject.Name, Namespace: "argocd"}
+
+	// Stop the autonomous-agent
+	err := fixture.StopProcess("agent-autonomous")
+	requires.NoError(err)
+
+	requires.Eventually(func() bool {
+		return !fixture.IsProcessRunning("agent-autonomous")
+	}, 30*time.Second, 1*time.Second)
+
+	// Delete the AppProject on the principal's cluster
+	principalAppProject := appProject.DeepCopy()
+	principalAppProject.Name = principalKey.Name
+	err = suite.PrincipalClient.Delete(suite.Ctx, principalAppProject, metav1.DeleteOptions{})
+	requires.NoError(err)
+
+	// Restart the autonomous-agent
+	err = fixture.StartProcess("agent-autonomous")
+	requires.NoError(err)
+
+	fixture.CheckReadiness(suite.T(), "agent-autonomous")
+
+	agentProj := argoapp.AppProject{}
+	err = suite.AutonomousAgentClient.Get(suite.Ctx, types.NamespacedName{Name: appProject.Name, Namespace: "argocd"}, &agentProj, metav1.GetOptions{})
+	requires.NoError(err)
+
+	// The AppProject should be recreated on the control-plane cluster
+	requires.Eventually(func() bool {
+		appProject := argoapp.AppProject{}
+		err := suite.PrincipalClient.Get(suite.Ctx, principalKey, &appProject, metav1.GetOptions{})
+		if err != nil {
+			return false
+		}
+
+		expectedSpec := agentProj.Spec.DeepCopy()
+		expectedSpec.SourceNamespaces = []string{"agent-autonomous"}
+		for i := range expectedSpec.Destinations {
+			expectedSpec.Destinations[i].Name = "agent-autonomous"
+			expectedSpec.Destinations[i].Server = "*"
+		}
+
+		return reflect.DeepEqual(appProject.Spec, *expectedSpec)
+	}, 30*time.Second, 1*time.Second)
+}
+
 func (suite *ResyncTestSuite) createAutonomousApp() *argoapp.Application {
 	requires := suite.Require()
 	// Create an autonomous application on the autonomous-agent's cluster
@@ -962,6 +1379,31 @@ func (suite *ResyncTestSuite) createAppProject() *argoapp.AppProject {
 	}, 30*time.Second, 1*time.Second)
 
 	return appProject
+}
+
+func (suite *ResyncTestSuite) createAutonomousAppProject() *argoapp.AppProject {
+	requires := suite.Require()
+
+	// Create an AppProject on the autonomous-agent's cluster
+	agentAppProject := sampleAppProject()
+
+	err := suite.AutonomousAgentClient.Create(suite.Ctx, agentAppProject, metav1.CreateOptions{})
+	requires.NoError(err)
+
+	projKey := types.NamespacedName{Name: "agent-autonomous-" + agentAppProject.Name, Namespace: "argocd"}
+
+	// Ensure the AppProject has been pushed to the control-plane cluster
+	requires.Eventually(func() bool {
+		appProject := argoapp.AppProject{}
+		err := suite.PrincipalClient.Get(suite.Ctx, projKey, &appProject, metav1.GetOptions{})
+		if err != nil {
+			fmt.Println("error getting appProject", err)
+			return false
+		}
+		return true
+	}, 30*time.Second, 1*time.Second)
+
+	return agentAppProject
 }
 
 func (suite *ResyncTestSuite) createRepository() *corev1.Secret {


### PR DESCRIPTION
cherry-pick https://github.com/argoproj-labs/argocd-agent/commit/c8217aa09c07a0f14eead6c27a8afad43b2863c6 (fix: use prefixed AppProject name while handling resyncs (https://github.com/argoproj-labs/argocd-agent/pull/666))