### PR TITLE
fix: set server host name in TLS config

### DIFF
--- a/hack/dev-env/start-agent-autonomous.sh
+++ b/hack/dev-env/start-agent-autonomous.sh
@@ -38,7 +38,6 @@ go run github.com/argoproj-labs/argocd-agent/cmd/argocd-agent agent \
     --agent-mode autonomous \
     --creds mtls:any \
     --server-address 127.0.0.1 \
-    --insecure-tls \
     --kubecontext vcluster-agent-autonomous \
     --namespace argocd \
     --log-level ${ARGOCD_AGENT_LOG_LEVEL:-trace} $ARGS \

--- a/hack/dev-env/start-agent-managed.sh
+++ b/hack/dev-env/start-agent-managed.sh
@@ -38,7 +38,6 @@ go run github.com/argoproj-labs/argocd-agent/cmd/argocd-agent agent \
     --agent-mode managed \
     --creds "mtls:any" \
     --server-address 127.0.0.1 \
-    --insecure-tls \
     --kubecontext vcluster-agent-managed \
     --namespace argocd \
     --log-level ${ARGOCD_AGENT_LOG_LEVEL:-trace} $ARGS \

--- a/pkg/client/remote.go
+++ b/pkg/client/remote.go
@@ -263,9 +263,11 @@ func WithCompression(flag bool) RemoteOption {
 
 func NewRemote(hostname string, port int, opts ...RemoteOption) (*Remote, error) {
 	r := &Remote{
-		hostname:  hostname,
-		port:      port,
-		tlsConfig: &tls.Config{},
+		hostname: hostname,
+		port:     port,
+		tlsConfig: &tls.Config{
+			ServerName: hostname,
+		},
 		backoff: wait.Backoff{
 			Duration: 1 * time.Second,
 			Factor:   2,


### PR DESCRIPTION
**What does this PR do / why we need it**:
When running the agent in secure mode and websocket enabled, the agent fails to authenticate with the following error:

```
time="2025-12-03T04:54:50Z" level=warning msg="Auth failure: rpc error: code = Unavailable desc = connection error: desc = \"transport: authentication handshake failed: tls: failed to verify certificate: x509: certificate is valid for *.apps.fips-h.ocp-gitops-qe.com, not pipe\" (retrying in 4.29981696s)"
```

We pass the TLS config to the go-grpc-http1 library and it fails to verify the certificate because the hostname doesn't match. We didn't observe this error when running the e2e test because we ran the agent in insecure mode. This PR fixes:
1. Set the server hostname so that the hostname matches the cert
2. Run the e2e tests in secure mode.

Co-authored-by: Varsha B

**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:


**Checklist**

* [ ] Documentation update is required by this PR (and has been updated) OR no documentation update is required.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * TLS certificate verification is now enabled by default for agent startup in development environments
  * Remote connections now include explicit server name indication (SNI) support for improved security during TLS handshakes

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->