### PR TITLE
fix: detect RST_STREAM errors and trigger reconnection

### DIFF
--- a/agent/connection.go
+++ b/agent/connection.go
@@ -195,7 +195,7 @@ func (a *Agent) handleStreamEvents() error {
 				if grpcutil.NeedReconnectOnError(err) {
 					a.SetConnected(false)
 				} else {
-					logCtx.Errorf("Error while sending to stream: %v", err)
+					logCtx.Errorf("Error while receiving from stream: %v", err)
 				}
 			}
 

--- a/internal/grpcutil/errors_test.go
+++ b/internal/grpcutil/errors_test.go
@@ -41,4 +41,13 @@ func Test_NeedReconnectOnError(t *testing.T) {
 		err := status.Error(codes.Internal, "")
 		assert.False(t, NeedReconnectOnError(err))
 	})
+	t.Run("Need reconnect on stream termination (RST_STREAM)", func(t *testing.T) {
+		// This matches the exact error message seen when HTTP/2 RST_STREAM is received
+		err := status.Error(codes.Internal, "stream terminated by RST_STREAM with error code: NO_ERROR")
+		assert.True(t, NeedReconnectOnError(err))
+	})
+	t.Run("No reconnect on other Internal errors", func(t *testing.T) {
+		err := status.Error(codes.Internal, "some other internal error")
+		assert.False(t, NeedReconnectOnError(err))
+	})
 }


### PR DESCRIPTION
The agent was logging "stream terminated by RST_STREAM" errors but not triggering reconnection because these errors come as gRPC codes.Internal rather than one of the expected reconnectable error codes.

- Add detection for "stream terminated" in codes.Internal messages
- Trigger reconnection when RST_STREAM errors occur
- Fix log message in receiver goroutine (was "sending")




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Improved connection handling for stream termination scenarios. The system now enhances its ability to detect stream termination errors and automatically triggers reconnection procedures to maintain service stability during network disruptions.
* Refined error logging to accurately report whether errors occur during stream receiving operations or stream sending operations, providing improved diagnostic clarity.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->