### PR TITLE
fix: fix intermittent update retry conflict E2E test failures

### DIFF
--- a/test/e2e/rp_test.go
+++ b/test/e2e/rp_test.go
@@ -92,8 +92,11 @@ func (suite *ResourceProxyTestSuite) Test_ResourceProxy_HTTP() {
 	requires.NoError(err)
 	requires.Equal("argocd", depl.Namespace)
 	requires.Equal("argocd-repo-server", depl.Name)
-	depl.Labels["app.kubernetes.io/instance"] = "argocd-repo-server"
-	err = suite.ManagedAgentClient.Update(context.TODO(), depl, v1.UpdateOptions{})
+
+	err = suite.ManagedAgentClient.EnsureDeploymentUpdate(context.TODO(), fixture.ToNamespacedName(depl), func(d *appsv1.Deployment) error {
+		d.Labels["app.kubernetes.io/instance"] = "argocd-repo-server"
+		return nil
+	}, v1.UpdateOptions{})
 	requires.NoError(err)
 
 	// Managed agents should respond swiftly
@@ -465,8 +468,11 @@ func (suite *ResourceProxyTestSuite) Test_ResourceProxy_Subresources() {
 	requires.NoError(err)
 	requires.Equal("argocd", depl.Namespace)
 	requires.Equal("argocd-repo-server", depl.Name)
-	depl.Labels["app.kubernetes.io/instance"] = "argocd-repo-server"
-	err = suite.ManagedAgentClient.Update(context.TODO(), depl, v1.UpdateOptions{})
+
+	err = suite.ManagedAgentClient.EnsureDeploymentUpdate(context.TODO(), fixture.ToNamespacedName(depl), func(d *appsv1.Deployment) error {
+		d.Labels["app.kubernetes.io/instance"] = "argocd-repo-server"
+		return nil
+	}, v1.UpdateOptions{})
 	requires.NoError(err)
 
 	// Test GET request for status subresource


### PR DESCRIPTION
**What does this PR do / why we need it**:

In a few places, our E2E tests are making unprotected K8s Update API calls, which will fail if the K8s resource is updated between Get and Update. 

This PR add Update retry-on-conflicts as needed.

**Checklist**

* [ ] Documentation update is required by this PR (and has been updated) OR no documentation update is required.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Improved test reliability by adding retry-aware, atomic update helpers to avoid conflicts during resource updates.
  * Refactored end-to-end tests to use standardized, safer update patterns for deployments and application resources.

* **Chores**
  * Consolidated test utilities to centralize update-and-retry logic and simplify cleanup paths.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->