### PR TITLE
chore: update VERSION file to '99.9.9-unreleased'

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,1 +1,1 @@
-0.0.1-alpha
+99.9.9-unreleased


### PR DESCRIPTION
**What does this PR do / why we need it**:
- Update `VERSION` file to the same value from https://github.com/argoproj-labs/argocd-agent/blob/e47703c3f359ab6bf3b7dd6905fed2bf43b1f447/internal/version/version.go#L26
- This new VERSION string makes it more obvious that the version being tested is a dev build.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated version identifier to 99.9.9-unreleased.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->