### PR TITLE
fix(e2e): use server-side apply for installing Argo CD components

### DIFF
--- a/hack/dev-env/setup-vcluster-env.sh
+++ b/hack/dev-env/setup-vcluster-env.sh
@@ -167,8 +167,9 @@ apply() {
 
     # Run 'kubectl apply' twice, to avoid the following error that occurs during the first invocation:
     # - 'error: resource mapping not found for name: "default" namespace: "" from "(...)": no matches for kind "AppProject" in version "argoproj.io/v1alpha1"'
-    kubectl --context vcluster-$cluster apply -n $namespace -k ${TMP_DIR}/${cluster} || true
-    kubectl --context vcluster-$cluster apply -n $namespace -k ${TMP_DIR}/${cluster}
+    # Use --server-side to avoid "metadata.annotations: Too long" error with large CRDs like applicationsets.argoproj.io
+    kubectl --context vcluster-$cluster apply --server-side -n $namespace -k ${TMP_DIR}/${cluster} || true
+    kubectl --context vcluster-$cluster apply --server-side -n $namespace -k ${TMP_DIR}/${cluster}
 
     if [[ "$OPENSHIFT" != "" ]]; then
 
@@ -221,8 +222,9 @@ apply() {
         kubectl --context vcluster-$cluster create ns $namespace || true
 
         # Run 'kubectl apply' twice, to avoid error that occurs during the first invocation (see above for error)
-        kubectl --context vcluster-$cluster apply -n $namespace -k ${TMP_DIR}/${cluster} || true
-        kubectl --context vcluster-$cluster apply -n $namespace -k ${TMP_DIR}/${cluster}
+        # Use --server-side to avoid "metadata.annotations: Too long" error with large CRDs like applicationsets.argoproj.io
+        kubectl --context vcluster-$cluster apply --server-side -n $namespace -k ${TMP_DIR}/${cluster} || true
+        kubectl --context vcluster-$cluster apply --server-side -n $namespace -k ${TMP_DIR}/${cluster}
     done
 
     kubectl --context vcluster-control-plane create ns agent-autonomous || true


### PR DESCRIPTION
**What does this PR do / why we need it**:
The e2e test Job for the PRs is failing with the following error:

```
The CustomResourceDefinition "applicationsets.argoproj.io" is invalid: metadata.annotations: Too long: may not be more than 262144 bytes
```

**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:


**Checklist**

* [ ] Documentation update is required by this PR (and has been updated) OR no documentation update is required.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the development environment setup script to use server-side apply for cluster configuration management, improving the configuration deployment process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->