### PR TITLE
docs(kind): add optional ApplicationSet controller support for autonomous agents install

### DIFF
--- a/docs/getting-started/kubernetes/kind/index.md
+++ b/docs/getting-started/kubernetes/kind/index.md
@@ -347,10 +347,27 @@ This configuration includes:
 - ✅ **argocd-redis** (local state for the application controller)
 - ❌ **argocd-server** (runs on control plane only)
 - ❌ **argocd-dex-server** (runs on control plane only)
-- ❌ **argocd-applicationset-controller** (managed agents don't create their own ApplicationSets)
+- ❌ **argocd-applicationset-controller** (not included by default)
 
 !!! info "Why Application Controller Runs Here"
     The **argocd-application-controller** runs on workload clusters because it needs direct access to the Kubernetes API to create, update, and delete resources. The argocd-agent facilitates communication between the control plane and these controllers, enabling centralized management while maintaining local execution.
+
+### (Optional) Install Argo CD for Workload Cluster with ApplicationSet (Autonomous mode only)
+
+**Instead of the standard install above**, use the following command with `--server-side=true` (required due to the large ApplicationSet CRD):
+
+```bash
+kubectl apply -n $NAMESPACE_NAME --server-side=true \
+  -k "https://github.com/argoproj-labs/argocd-agent/install/kubernetes/argo-cd/agent-autonomous-appset?ref=$RELEASE_BRANCH" \
+  --context kind-$AGENT_CLUSTER_NAME
+```
+
+This configuration includes everything from the standard install, plus:
+
+- ✅ **argocd-applicationset-controller** (generates Applications from ApplicationSet templates)
+
+!!! info "Why ApplicationSet Controller Runs Here"
+    The **argocd-applicationset-controller** runs on workload clusters because it allows the cluster to generate Applications dynamically using ApplicationSet generators such as list, git, and cluster, enables autonomous mode with template-based application creation, and provides a way to manage multiple similar applications from a single ApplicationSet definition.
 
 ### Create Agent configuration
 Create Agent configuration on Principal. <br />

--- a/install/kubernetes/argo-cd/agent-autonomous-appset/kustomization.yaml
+++ b/install/kubernetes/argo-cd/agent-autonomous-appset/kustomization.yaml
@@ -1,0 +1,16 @@
+resources:
+- https://github.com/argoproj/argo-cd/manifests/core-install?ref=stable
+
+patches:
+- target:
+    group: networking.k8s.io
+    version: v1
+    kind: NetworkPolicy
+    name: argocd-redis-network-policy
+  patch: |-
+    - op: add
+      path: /spec/ingress/0/from/-
+      value:
+        podSelector:
+          matchLabels:
+            app.kubernetes.io/name: argocd-agent-agent


### PR DESCRIPTION
**What does this PR do / why we need it**:
docs(kind): add optional ApplicationSet controller instructions for autonomous agents install.

In some cases, users want to enable ApplicationSet on the spoke cluster for templating purposes. Update the KinD Getting Started guide with instructions on how to do this.

**Which issue(s) this PR fixes**:

Fixes NA

**How to test changes / Special notes to the reviewer**:
I am only updating the KinD instructions for now, since KinD clusters are generally used for experimental or development purposes and this support is optional.

**Checklist**

* [x] Documentation update is required by this PR (and has been updated) OR no documentation update is required.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that the ApplicationSet controller is not included by default and expanded installation guidance with an optional autonomous-mode path enabling ApplicationSet-driven dynamic application generation.
* **Chores**
  * Updated installation manifests to include an optional patch allowing agent pods to communicate with core components during workload-cluster installs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->