### PR TITLE
fix: add argocd-agent-principal to Redis network policy ingress rules

### DIFF
--- a/install/kubernetes/argo-cd/principal/kustomization.yaml
+++ b/install/kubernetes/argo-cd/principal/kustomization.yaml
@@ -106,3 +106,15 @@ patches:
         apiGroups: ["argoproj.io"]
         resources: ["applications"]
         verbs: ["update"]
+- target:
+    group: networking.k8s.io
+    version: v1
+    kind: NetworkPolicy
+    name: argocd-redis-network-policy
+  patch: |-
+    - op: add
+      path: /spec/ingress/0/from/-
+      value:
+        podSelector:
+          matchLabels:
+            app.kubernetes.io/name: argocd-agent-principal


### PR DESCRIPTION
**What does this PR do / why we need it**:

This PR updates the Redis `NetworkPolicy` to explicitly allow ingress traffic from the `argocd-agent-principal` component.
Previously, the NetworkPolicy only allowed Redis access from
- `argocd-server`
- `argocd-repo-server`
- `argocd-application-controller`

However, the principal component runs with a **different pod label**, and therefore did not match any of the existing ingress rules.

```bash
# cmd
kubectl describe -n argocd deployment argocd-agent-principal --context kind-argocd-hub  

# result         
Name:                   argocd-agent-principal
Namespace:              argocd
CreationTimestamp:      Sat, 07 Feb 2026 00:02:55 +0900
Labels:                 app.kubernetes.io/name=argocd-agent-principal
Annotations:            deployment.kubernetes.io/revision: 6
Selector:               app.kubernetes.io/component=principal,app.kubernetes.io/name=argocd-agent-principal,app.kubernetes.io/part-of=argocd-agent
Replicas:               1 desired | 1 updated | 1 total | 1 available | 0 unavailable
StrategyType:           RollingUpdate
MinReadySeconds:        0
```

As a result, the principal component was blocked from connecting to Redis, which caused
```bash
# cmd
kubectl logs -n argocd deployment/argocd-agent-principal --context <principal-cluster>

# result
redis: 2026/02/06 15:31:18 pool.go:426: redis: connection pool: failed to dial after 1 attempts: dial tcp 10.109.185.189:6379: i/o timeout
time="2026-02-06T15:31:18Z" level=error msg="failed to refresh connection info in cluster: 'argocd-agent1' mapped with agent: 'argocd-agent1'. Error: failed to refresh connection info in cluster: 'argocd-agent1' mapped with agent: 'argocd-agent1': dial tcp 10.109.185.189:6379: i/o timeout" component=ClusterManager
time="2026-02-06T15:31:18Z" level=info msg="Starting event writer" clientAddr="10.245.0.1:61639" module=EventWriter
```

This change adds the missing ingress rule so the principal can access Redis as intended, restoring normal cluster state updates and event delivery.

**Which issue(s) this PR fixes**:
Fixes #?

**How to test changes / Special notes to the reviewer**:

1. **Deploy Argo CD with the updated NetworkPolicy**
```bash
kubectl describe networkpolicy argocd-redis-network-policy -n argocd --context kind-argocd-hub
```
Expected result (ingress rules include principal):

```bash
Allowing ingress traffic:
  To Port: 6379/TCP
  From:
    PodSelector: app.kubernetes.io/name=argocd-server
  From:
    PodSelector: app.kubernetes.io/name=argocd-repo-server
  From:
    PodSelector: app.kubernetes.io/name=argocd-application-controller
  From:
    PodSelector: app.kubernetes.io/name=argocd-agent-principal
```

**2. Check principal logs**
```bash
kubectl logs -n argocd deployment/argocd-agent-principal --context <principal-cluster>
```

**3. Check agent list**
If Thers is an agent named agent1, it should appear in the output list.

```bash
argocd-agentctl agent list --principal-context kind-argocd-hub --principal-namespace argocd
```

**Checklist**
* [x] Documentation update is required by this PR (and has been updated) OR no documentation update is required.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Kubernetes network policies for Argo CD to permit communication between Argo CD agent pods and Redis services, enhancing component integration and operational stability in managed Kubernetes deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->