### PR TITLE
chore(dev-env): Allow custom images in dev env

### DIFF
--- a/hack/dev-env/deploy.sh
+++ b/hack/dev-env/deploy.sh
@@ -131,7 +131,7 @@ case "$1" in
 	;;
 *)
 	echo "USAGE: $0 <deploy|undeploy> [image]" >&2
-	echo "[image] is optional and defaults to ${DEFAULT_IMAGE_NAME}"
+	echo "[image] is optional and defaults to ${DEFAULT_IMAGE_NAME}" >&2
 	exit 1
 esac
 


### PR DESCRIPTION
**What does this PR do / why we need it**:

Allow deploying custom images (instead of `latest` from GitHub) to the dev-env. This is useful if you have a custom registry (e.g. the one provided by `microk8s.enable registry`) and you build/push/test images before they were built by the CI. This allows for more thorough in-depth testing.

**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:


**Checklist**

* [ ] Documentation update is required by this PR (and has been updated) OR no documentation update is required.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Made the agent container image configurable with a default and optional override.
  * Ensures all deployment paths consistently apply the specified agent image during deploys.
  * Updated the deployment script usage message to document the new optional image argument and its default.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->