### PR TITLE
fix: agent should not lose events after reconnection

### DIFF
--- a/agent/connection.go
+++ b/agent/connection.go
@@ -169,8 +169,14 @@ func (a *Agent) handleStreamEvents() error {
 		return err
 	}
 
-	a.eventWriter = event.NewEventWriter(stream)
-	go a.eventWriter.SendWaitingEvents(a.context)
+	if a.eventWriter != nil {
+		// Reuse the existing event writer if it exists.
+		a.eventWriter.UpdateTarget(stream)
+	} else {
+		// Create a new event writer if it doesn't exist.
+		a.eventWriter = event.NewEventWriter(stream)
+		go a.eventWriter.SendWaitingEvents(a.context)
+	}
 
 	logCtx := log().WithFields(logrus.Fields{
 		logfields.Module:     "StreamEvent",

--- a/internal/event/event_writer_test.go
+++ b/internal/event/event_writer_test.go
@@ -300,8 +300,7 @@ func TestEventWriter(t *testing.T) {
 		require.NotNil(t, sentMsg)
 
 		// Exhaust retries
-		maxRetries := sentMsg.backoff.Steps
-		for i := 0; i < maxRetries; i++ {
+		for i := 0; i <= maxEventRetries; i++ {
 			pastTime := time.Now().Add(-1 * time.Second)
 			sentMsg.retryAfter = &pastTime
 			evSender.retrySentEvent(resID, sentMsg)


### PR DESCRIPTION
**What does this PR do / why we need it**:

The event writer keeps track of sent/unsent events. On reconnection, the agent creates a new event writer, and all the events in the old event writer are dropped. In this PR:

* Use the existing event writer if it already exists
* Reset the retry after so that the unsent events don't have to wait after reconnecting with the new stream
* Don't use backoff Steps to compare with the retry count since it is decremented internally.

**Which issue(s) this PR fixes**:

Fixes #715 

**How to test changes / Special notes to the reviewer**:

* Follow the steps mentioned in the #715 issue description

**Checklist**

* [ ] Documentation update is required by this PR (and has been updated) OR no documentation update is required.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved event handling efficiency by reusing existing connections instead of repeatedly creating new ones, reducing unnecessary reinitialization.

* **Refactor**
  * Consolidated retry logic with a consistent maximum retry limit for improved reliability and maintainability.
  * Updated test coverage to reflect enhanced retry behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->