### PR TITLE
fix: increase GRPC message size, allow configuration via env/param, log large messages

### DIFF
--- a/cmd/argocd-agent/principal.go
+++ b/cmd/argocd-agent/principal.go
@@ -32,6 +32,7 @@ import (
 	"github.com/argoproj-labs/argocd-agent/internal/auth/userpass"
 	"github.com/argoproj-labs/argocd-agent/internal/config"
 	"github.com/argoproj-labs/argocd-agent/internal/env"
+	"github.com/argoproj-labs/argocd-agent/internal/grpcutil"
 	"github.com/argoproj-labs/argocd-agent/internal/kube"
 	"github.com/argoproj-labs/argocd-agent/internal/labels"
 	"github.com/argoproj-labs/argocd-agent/internal/tlsutil"
@@ -93,6 +94,8 @@ func NewPrincipalRunCommand() *cobra.Command {
 		redisPassword        string
 		redisCompressionType string
 		healthzPort          int
+
+		maxGRPCMessageSize int
 
 		// OpenTelemetry configuration
 		otlpAddress  string
@@ -326,6 +329,7 @@ func NewPrincipalRunCommand() *cobra.Command {
 			opts = append(opts, principal.WithRedis(redisAddress, redisPassword, redisCompressionType))
 			opts = append(opts, principal.WithHealthzPort(healthzPort))
 			opts = append(opts, principal.WithDestinationBasedMapping(destinationBasedMapping))
+			opts = append(opts, principal.WithMaxGRPCMessageSize(maxGRPCMessageSize))
 
 			s, err := principal.NewServer(ctx, kubeConfig, namespace, opts...)
 			if err != nil {
@@ -468,6 +472,10 @@ func NewPrincipalRunCommand() *cobra.Command {
 	command.Flags().IntVar(&healthzPort, "healthz-port",
 		env.NumWithDefault("ARGOCD_PRINCIPAL_HEALTH_CHECK_PORT", cmdutil.ValidPort, 8003),
 		"Port the health check server will listen on")
+
+	command.Flags().IntVar(&maxGRPCMessageSize, "grpc-max-message-size",
+		env.NumWithDefault("ARGOCD_PRINCIPAL_GRPC_MAX_MESSAGE_SIZE", nil, grpcutil.DefaultGRPCMaxMessageSize),
+		"Maximum gRPC message size in bytes for send and receive (default: 200MB)")
 
 	command.Flags().StringVar(&otlpAddress, "otlp-address",
 		env.StringWithDefault("ARGOCD_PRINCIPAL_OTLP_ADDRESS", nil, ""),

--- a/internal/grpcutil/constants.go
+++ b/internal/grpcutil/constants.go
@@ -1,0 +1,6 @@
+package grpcutil
+
+const (
+	// DefaultGRPCMaxMessageSize is the default maximum size that we will allow an incoming GRPC message to be. The value chosen here is 200MB default, which is equivalent to that used by upstream Argo CD. My expectation is that we will never get messages that are anywhere near this value. We may wish to reduce this constant once we have sufficient data from the field.
+	DefaultGRPCMaxMessageSize = 200 * 1024 * 1024
+)

--- a/internal/grpcutil/msgsize.go
+++ b/internal/grpcutil/msgsize.go
@@ -1,0 +1,168 @@
+// Copyright 2026 The argocd-agent Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package grpcutil
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/argoproj-labs/argocd-agent/pkg/api/grpc/eventstreamapi"
+	"github.com/sirupsen/logrus"
+	"google.golang.org/grpc"
+	"google.golang.org/protobuf/proto"
+)
+
+// messageSizeLoggerStream wraps a grpc.ServerStream or grpc.ClientStream to
+// log warnings when sent or received messages exceed a threshold percentage
+// of the configured maximum gRPC message size.
+type messageSizeLoggerStream struct {
+	grpc.ServerStream
+	maxSize int
+	method  string
+}
+
+// messageSizeLoggerClientStream wraps a grpc.ClientStream with the same
+// message size logging behavior.
+type messageSizeLoggerClientStream struct {
+	grpc.ClientStream
+	maxSize int
+	method  string
+}
+
+// protoSize returns the serialized size of a message if it implements
+// proto.Message, or -1 if the size cannot be determined.
+func protoSize(msg interface{}) int {
+	if pm, ok := msg.(proto.Message); ok {
+		return proto.Size(pm)
+	}
+	return -1
+}
+
+// warnIfExceedsThreshold logs a warning when the serialized size of msg meets
+// or exceeds x% of maxSize.
+func warnIfExceedsThreshold(method string, msg interface{}, maxSize int, direction string) {
+	if maxSize <= 0 {
+		return
+	}
+	size := protoSize(msg)
+	if size < maxSize*4/5 { // Log warning at 80%
+		return
+	}
+	fields := logrus.Fields{
+		"method":       method,
+		"message_size": size,
+		"max_size":     maxSize,
+		"direction":    direction,
+	}
+	if ev, ok := msg.(*eventstreamapi.Event); ok {
+		if ce := ev.GetEvent(); ce != nil {
+			fields["event_source"] = ce.GetSource()
+			fields["event_type"] = ce.GetType()
+		}
+	} else {
+		fields["message_type"] = fmt.Sprintf("%T", msg)
+	}
+	pct := 100 * size / maxSize
+	logrus.WithFields(fields).Warnf("gRPC message size (%d bytes) is %d%% of max (%d bytes)", size, pct, maxSize)
+}
+
+func (s *messageSizeLoggerStream) SendMsg(m interface{}) error {
+	warnIfExceedsThreshold(s.method, m, s.maxSize, "send")
+	return s.ServerStream.SendMsg(m)
+}
+
+func (s *messageSizeLoggerStream) RecvMsg(m interface{}) error {
+	err := s.ServerStream.RecvMsg(m)
+	if err != nil {
+		return err
+	}
+	warnIfExceedsThreshold(s.method, m, s.maxSize, "recv")
+	return nil
+}
+
+func (s *messageSizeLoggerClientStream) SendMsg(m interface{}) error {
+	warnIfExceedsThreshold(s.method, m, s.maxSize, "send")
+	return s.ClientStream.SendMsg(m)
+}
+
+func (s *messageSizeLoggerClientStream) RecvMsg(m interface{}) error {
+	err := s.ClientStream.RecvMsg(m)
+	if err != nil {
+		return err
+	}
+	warnIfExceedsThreshold(s.method, m, s.maxSize, "recv")
+	return nil
+}
+
+// StreamServerMsgSizeInterceptor returns a gRPC stream server interceptor that
+// logs a warning when any message sent or received on a stream exceeds x% of
+// maxGRPCMessageSize.
+func StreamServerMsgSizeInterceptor(maxGRPCMessageSize int) grpc.StreamServerInterceptor {
+	return func(srv interface{}, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+		wrapped := &messageSizeLoggerStream{
+			ServerStream: ss,
+			maxSize:      maxGRPCMessageSize,
+			method:       info.FullMethod,
+		}
+		return handler(srv, wrapped)
+	}
+}
+
+// StreamClientMsgSizeInterceptor returns a gRPC stream client interceptor that
+// logs a warning when any message sent or received on a stream exceeds x% of
+// maxGRPCMessageSize.
+func StreamClientMsgSizeInterceptor(maxGRPCMessageSize int) grpc.StreamClientInterceptor {
+	return func(ctx context.Context, desc *grpc.StreamDesc, cc *grpc.ClientConn, method string, streamer grpc.Streamer, opts ...grpc.CallOption) (grpc.ClientStream, error) {
+		cs, err := streamer(ctx, desc, cc, method, opts...)
+		if err != nil {
+			return cs, err
+		}
+		return &messageSizeLoggerClientStream{
+			ClientStream: cs,
+			maxSize:      maxGRPCMessageSize,
+			method:       method,
+		}, nil
+	}
+}
+
+// UnaryServerMsgSizeInterceptor returns a gRPC unary server interceptor that
+// logs a warning when the request or response message exceeds x% of
+// maxGRPCMessageSize.
+func UnaryServerMsgSizeInterceptor(maxGRPCMessageSize int) grpc.UnaryServerInterceptor {
+	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
+		warnIfExceedsThreshold(info.FullMethod, req, maxGRPCMessageSize, "recv")
+		resp, err := handler(ctx, req)
+		if err != nil {
+			return resp, err
+		}
+		warnIfExceedsThreshold(info.FullMethod, resp, maxGRPCMessageSize, "send")
+		return resp, err
+	}
+}
+
+// UnaryClientMsgSizeInterceptor returns a gRPC unary client interceptor that
+// logs a warning when the request or response message exceeds x% of
+// maxGRPCMessageSize.
+func UnaryClientMsgSizeInterceptor(maxGRPCMessageSize int) grpc.UnaryClientInterceptor {
+	return func(ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
+		warnIfExceedsThreshold(method, req, maxGRPCMessageSize, "send")
+		err := invoker(ctx, method, req, reply, cc, opts...)
+		if err != nil {
+			return err
+		}
+		warnIfExceedsThreshold(method, reply, maxGRPCMessageSize, "recv")
+		return nil
+	}
+}

--- a/principal/resource_regex_test.go
+++ b/principal/resource_regex_test.go
@@ -10,14 +10,14 @@ import (
 
 func TestResourceRequestRegexp(t *testing.T) {
 	tests := []struct {
-		name               string
-		path               string
-		shouldMatch        bool
-		expectedGroup      string
-		expectedVer        string
-		expectedNs         string
-		expectedRes        string
-		expectedName       string
+		name                string
+		path                string
+		shouldMatch         bool
+		expectedGroup       string
+		expectedVer         string
+		expectedNs          string
+		expectedRes         string
+		expectedName        string
 		expectedSubresource string
 	}{
 		// Current patterns that should work
@@ -28,21 +28,21 @@ func TestResourceRequestRegexp(t *testing.T) {
 			expectedVer: "v1",
 		},
 		{
-			name:          "Namespaced resource list",
-			path:          "/api/v1/namespaces/default/pods",
-			shouldMatch:   true,
-			expectedVer:   "v1",
-			expectedNs:    "default",
-			expectedRes:   "pods",
+			name:        "Namespaced resource list",
+			path:        "/api/v1/namespaces/default/pods",
+			shouldMatch: true,
+			expectedVer: "v1",
+			expectedNs:  "default",
+			expectedRes: "pods",
 		},
 		{
-			name:          "Specific namespaced resource",
-			path:          "/api/v1/namespaces/default/pods/my-pod",
-			shouldMatch:   true,
-			expectedVer:   "v1",
-			expectedNs:    "default",
-			expectedRes:   "pods",
-			expectedName:  "my-pod",
+			name:         "Specific namespaced resource",
+			path:         "/api/v1/namespaces/default/pods/my-pod",
+			shouldMatch:  true,
+			expectedVer:  "v1",
+			expectedNs:   "default",
+			expectedRes:  "pods",
+			expectedName: "my-pod",
 		},
 		{
 			name:          "Group API resource",
@@ -55,82 +55,82 @@ func TestResourceRequestRegexp(t *testing.T) {
 			expectedName:  "my-deployment",
 		},
 		{
-			name:          "Cluster-scoped resource",
-			path:          "/api/v1/nodes/my-node",
-			shouldMatch:   true,
-			expectedVer:   "v1",
-			expectedRes:   "nodes",
-			expectedName:  "my-node",
+			name:         "Cluster-scoped resource",
+			path:         "/api/v1/nodes/my-node",
+			shouldMatch:  true,
+			expectedVer:  "v1",
+			expectedRes:  "nodes",
+			expectedName: "my-node",
 		},
 		// Subresource patterns now work with the updated regex
 		{
-			name:               "Pod status subresource",
-			path:               "/api/v1/namespaces/default/pods/my-pod/status",
-			shouldMatch:        true, // Now matches with updated regex
-			expectedVer:        "v1",
-			expectedNs:         "default",
-			expectedRes:        "pods",
-			expectedName:       "my-pod",
+			name:                "Pod status subresource",
+			path:                "/api/v1/namespaces/default/pods/my-pod/status",
+			shouldMatch:         true, // Now matches with updated regex
+			expectedVer:         "v1",
+			expectedNs:          "default",
+			expectedRes:         "pods",
+			expectedName:        "my-pod",
 			expectedSubresource: "status",
 		},
 		{
-			name:               "Pod log subresource",
-			path:               "/api/v1/namespaces/default/pods/my-pod/log",
-			shouldMatch:        true, // Now matches with updated regex
-			expectedVer:        "v1",
-			expectedNs:         "default",
-			expectedRes:        "pods",
-			expectedName:       "my-pod",
+			name:                "Pod log subresource",
+			path:                "/api/v1/namespaces/default/pods/my-pod/log",
+			shouldMatch:         true, // Now matches with updated regex
+			expectedVer:         "v1",
+			expectedNs:          "default",
+			expectedRes:         "pods",
+			expectedName:        "my-pod",
 			expectedSubresource: "log",
 		},
 		{
-			name:               "Deployment scale subresource",
-			path:               "/apis/apps/v1/namespaces/default/deployments/my-deployment/scale",
-			shouldMatch:        true, // Now matches with updated regex
-			expectedGroup:      "apps",
-			expectedVer:        "v1",
-			expectedNs:         "default",
-			expectedRes:        "deployments",
-			expectedName:       "my-deployment",
+			name:                "Deployment scale subresource",
+			path:                "/apis/apps/v1/namespaces/default/deployments/my-deployment/scale",
+			shouldMatch:         true, // Now matches with updated regex
+			expectedGroup:       "apps",
+			expectedVer:         "v1",
+			expectedNs:          "default",
+			expectedRes:         "deployments",
+			expectedName:        "my-deployment",
 			expectedSubresource: "scale",
 		},
 		{
-			name:               "Service proxy subresource with port",
-			path:               "/api/v1/namespaces/default/services/my-service:80/proxy",
-			shouldMatch:        true, // Now matches with updated regex
-			expectedVer:        "v1",
-			expectedNs:         "default",
-			expectedRes:        "services",
-			expectedName:       "my-service:80",
+			name:                "Service proxy subresource with port",
+			path:                "/api/v1/namespaces/default/services/my-service:80/proxy",
+			shouldMatch:         true, // Now matches with updated regex
+			expectedVer:         "v1",
+			expectedNs:          "default",
+			expectedRes:         "services",
+			expectedName:        "my-service:80",
 			expectedSubresource: "proxy",
 		},
 		{
-			name:               "Node proxy subresource",
-			path:               "/api/v1/nodes/my-node/proxy",
-			shouldMatch:        true, // Now matches with updated regex
-			expectedVer:        "v1",
-			expectedRes:        "nodes",
-			expectedName:       "my-node",
+			name:                "Node proxy subresource",
+			path:                "/api/v1/nodes/my-node/proxy",
+			shouldMatch:         true, // Now matches with updated regex
+			expectedVer:         "v1",
+			expectedRes:         "nodes",
+			expectedName:        "my-node",
 			expectedSubresource: "proxy",
 		},
 		{
-			name:               "Pod exec subresource",
-			path:               "/api/v1/namespaces/default/pods/my-pod/exec",
-			shouldMatch:        true,
-			expectedVer:        "v1",
-			expectedNs:         "default",
-			expectedRes:        "pods",
-			expectedName:       "my-pod",
+			name:                "Pod exec subresource",
+			path:                "/api/v1/namespaces/default/pods/my-pod/exec",
+			shouldMatch:         true,
+			expectedVer:         "v1",
+			expectedNs:          "default",
+			expectedRes:         "pods",
+			expectedName:        "my-pod",
 			expectedSubresource: "exec",
 		},
 		{
-			name:               "Pod portforward subresource",
-			path:               "/api/v1/namespaces/default/pods/my-pod/portforward",
-			shouldMatch:        true,
-			expectedVer:        "v1",
-			expectedNs:         "default",
-			expectedRes:        "pods",
-			expectedName:       "my-pod",
+			name:                "Pod portforward subresource",
+			path:                "/api/v1/namespaces/default/pods/my-pod/portforward",
+			shouldMatch:         true,
+			expectedVer:         "v1",
+			expectedNs:          "default",
+			expectedRes:         "pods",
+			expectedName:        "my-pod",
 			expectedSubresource: "portforward",
 		},
 		// Negative test cases - patterns that should NOT match
@@ -198,4 +198,3 @@ func TestResourceRequestRegexp(t *testing.T) {
 		})
 	}
 }
-


### PR DESCRIPTION
**What does this PR do / why we need it**:

**Which issue(s) this PR fixes**:
- This PR increases GRPC message size to same default as Argo CD, allows further configuration of size via env/CLI param
- This PR also adds an interceptor that outputs a warning log statement if the message size exceeds a certain threshold (50%), along with the agent event type and source.

Related to #748


Here are some example log statements (simulating) the warning when grpc message is too large:
```
22:39:52        principal | time="2026-02-11T22:39:52-05:00" level=warning msg="gRPC message size (2063 bytes) exceeds 50% of max (209715200 bytes)" direction=send max_size=209715200 message_size=2063 message_type="*authapi.AuthResponse" method=/authapi.Authentication/Authenticate percent_used=0.0009837150573730469
22:39:52 agent-autonomous | time="2026-02-11T22:39:52-05:00" level=warning msg="gRPC message size (2063 bytes) exceeds 50% of max (209715200 bytes)" direction=recv max_size=209715200 message_size=2063 message_type="*authapi.AuthResponse" method=/authapi.Authentication/Authenticate percent_used=0.0009837150573730469
22:39:52        principal | time="2026-02-11T22:39:52-05:00" level=warning msg="gRPC message size (2047 bytes) exceeds 50% of max (209715200 bytes)" direction=send max_size=209715200 message_size=2047 message_type="*authapi.AuthResponse" method=/authapi.Authentication/Authenticate percent_used=0.0009760856628417969
22:39:52    agent-managed | time="2026-02-11T22:39:52-05:00" level=warning msg="gRPC message size (2047 bytes) exceeds 50% of max (209715200 bytes)" direction=recv max_size=209715200 message_size=2047 message_type="*authapi.AuthResponse" method=/authapi.Authentication/Authenticate percent_used=0.0009760856628417969
22:39:52 agent-autonomous | time="2026-02-11T22:39:52-05:00" level=warning msg="gRPC message size (1209 bytes) exceeds 50% of max (209715200 bytes)" direction=send event_source="agent://agent-managed" event_type=io.argoproj.argocd-agent.event.create max_size=209715200 message_size=1209 method=/eventstreamapi.EventStream/Subscribe percent_used=0.0005764961242675781
22:39:52        principal | time="2026-02-11T22:39:52-05:00" level=warning msg="gRPC message size (1209 bytes) exceeds 50% of max (209715200 bytes)" direction=recv event_source="agent://agent-managed" event_type=io.argoproj.argocd-agent.event.create max_size=209715200 message_size=1209 method=/eventstreamapi.EventStream/Subscribe percent_used=0.0005764961242675781
22:39:52 agent-autonomous | time="2026-02-11T22:39:52-05:00" level=warning msg="gRPC message size (267 bytes) exceeds 50% of max (209715200 bytes)" direction=send event_source="agent://agent-managed" event_type=io.argoproj.argocd-agent.event.request-resource-resync max_size=209715200 message_size=267 method=/eventstreamapi.EventStream/Subscribe percent_used=0.00012731552124023438
22:39:52        principal | time="2026-02-11T22:39:52-05:00" level=warning msg="gRPC message size (267 bytes) exceeds 50% of max (209715200 bytes)" direction=recv event_source="agent://agent-managed" event_type=io.argoproj.argocd-agent.event.request-resource-resync max_size=209715200 message_size=267 method=/eventstreamapi.EventStream/Subscribe percent_used=0.00012731552124023438
22:39:52    agent-managed | time="2026-02-11T22:39:52-05:00" level=warning msg="gRPC message size (2246 bytes) exceeds 50% of max (209715200 bytes)" direction=send event_source="agent://agent-managed" event_type=io.argoproj.argocd-agent.event.status-update max_size=209715200 message_size=2246 method=/eventstreamapi.EventStream/Subscribe percent_used=0.0010709762573242188
22:39:52    agent-managed | time="2026-02-11T22:39:52-05:00" level=warning msg="gRPC message size (329 bytes) exceeds 50% of max (209715200 bytes)" direction=send event_source="agent://agent-managed" event_type=io.argoproj.argocd-agent.event.request-synced-resource-list max_size=209715200 message_size=329 method=/eventstreamapi.EventStream/Subscribe percent_used=0.00015687942504882812
22:39:52    agent-managed | time="2026-02-11T22:39:52-05:00" level=warning msg="gRPC message size (422 bytes) exceeds 50% of max (209715200 bytes)" direction=send event_source="agent://agent-managed" event_type=io.argoproj.argocd-agent.event.request-update max_size=209715200 message_size=422 method=/eventstreamapi.EventStream/Subscribe percent_used=0.00020122528076171875
22:39:52        principal | time="2026-02-11T22:39:52-05:00" level=warning msg="gRPC message size (306 bytes) exceeds 50% of max (209715200 bytes)" direction=send event_source= event_type=io.argoproj.argocd-agent.event.request-synced-resource-list max_size=209715200 message_size=306 method=/eventstreamapi.EventStream/Subscribe percent_used=0.00014591217041015625
22:39:52        principal | time="2026-02-11T22:39:52-05:00" level=warning msg="gRPC message size (2246 bytes) exceeds 50% of max (209715200 bytes)" direction=recv event_source="agent://agent-managed" event_type=io.argoproj.argocd-agent.event.status-update max_size=209715200 message_size=2246 method=/eventstreamapi.EventStream/Subscribe percent_used=0.0010709762573242188
22:39:52 agent-autonomous | time="2026-02-11T22:39:52-05:00" level=warning msg="gRPC message size (306 bytes) exceeds 50% of max (209715200 bytes)" direction=recv event_source= event_type=io.argoproj.argocd-agent.event.request-synced-resource-list max_size=209715200 message_size=306 method=/eventstreamapi.EventStream/Subscribe percent_used=0.00014591217041015625
22:39:52        principal | time="2026-02-11T22:39:52-05:00" level=warning msg="gRPC message size (413 bytes) exceeds 50% of max (209715200 bytes)" direction=send event_source= event_type=io.argoproj.argocd-agent.event.request-update max_size=209715200 message_size=413 method=/eventstreamapi.EventStream/Subscribe percent_used=0.00019693374633789062
22:39:52        principal | time="2026-02-11T22:39:52-05:00" level=warning msg="gRPC message size (329 bytes) exceeds 50% of max (209715200 bytes)" direction=recv event_source="agent://agent-managed" event_type=io.argoproj.argocd-agent.event.request-synced-resource-list max_size=209715200 message_size=329 method=/eventstreamapi.EventStream/Subscribe percent_used=0.0001568794250
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a --grpc-max-message-size flag (default 200MB) to configure max gRPC message sizes for agent and server components.
  * Enforced configured limits across client/server connections and added runtime monitoring that emits warnings when messages approach or exceed the configured size.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->