### PR TITLE
fix: allow principal to read CA from opaque secret with ca.crt

### DIFF
--- a/cmd/argocd-agent/principal.go
+++ b/cmd/argocd-agent/principal.go
@@ -202,7 +202,7 @@ func NewPrincipalRunCommand() *cobra.Command {
 					opts = append(opts, principal.WithTLSRootCaFromFile(rootCaPath))
 				} else {
 					logrus.Infof("Loading root CA certificate from secret %s/%s", namespace, rootCaSecretName)
-					opts = append(opts, principal.WithTLSRootCaFromSecret(kubeConfig.Clientset, namespace, rootCaSecretName, "tls.crt"))
+					opts = append(opts, principal.WithTLSRootCaFromSecret(kubeConfig.Clientset, namespace, rootCaSecretName, "tls.crt", "ca.crt"))
 				}
 			}
 
@@ -515,7 +515,7 @@ func getResourceProxyTLSConfigFromKube(kubeClient *kube.KubernetesClient, namesp
 		return nil, fmt.Errorf("error getting proxy certificate: %w", err)
 	}
 
-	clientCA, err := tlsutil.X509CertPoolFromSecret(ctx, kubeClient.Clientset, namespace, caName, "tls.crt")
+	clientCA, err := tlsutil.X509CertPoolFromSecret(ctx, kubeClient.Clientset, namespace, caName, "tls.crt", "ca.crt")
 	if err != nil {
 		return nil, fmt.Errorf("error getting client CA certificate: %w", err)
 	}

--- a/pkg/client/remote.go
+++ b/pkg/client/remote.go
@@ -208,9 +208,9 @@ func WithRootAuthoritiesFromFile(caPath string) RemoteOption {
 // field. Otherwise, the ConfigMap is expected to contain one or more
 // certificates in each field of the ConfigMap, and all certificates will be
 // loaded into the certificate pool.
-func WithRootAuthoritiesFromSecret(kube kubernetes.Interface, namespace, name, field string) RemoteOption {
+func WithRootAuthoritiesFromSecret(kube kubernetes.Interface, namespace, name string, fields ...string) RemoteOption {
 	return func(r *Remote) error {
-		pool, err := tlsutil.X509CertPoolFromSecret(context.Background(), kube, namespace, name, field)
+		pool, err := tlsutil.X509CertPoolFromSecret(context.Background(), kube, namespace, name, fields...)
 		if err != nil {
 			return err
 		}

--- a/principal/options.go
+++ b/principal/options.go
@@ -225,9 +225,9 @@ func WithTLSRootCaFromFile(caPath string) ServerOption {
 // If field is non-empty, only loads certificates stored in the named field.
 // Otherwise, if field is empty, loads certificates from all fields in the
 // Secret.
-func WithTLSRootCaFromSecret(kube kubernetes.Interface, namespace, name, field string) ServerOption {
+func WithTLSRootCaFromSecret(kube kubernetes.Interface, namespace, name string, fields ...string) ServerOption {
 	return func(o *Server) error {
-		pool, err := tlsutil.X509CertPoolFromSecret(context.Background(), kube, namespace, name, field)
+		pool, err := tlsutil.X509CertPoolFromSecret(context.Background(), kube, namespace, name, fields...)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
**What does this PR do / why we need it**:

This PR fixes an issue with reading the ca from a secret in the principal. If the secret is an opaque secret, it will only read the tls.crt field so if you need ca.crt. This extends the function to read different specified fields. Implemented the fix the way it was described in the issue. Also adjusted the function to return an error if no certs are loaded into the pool.

**Which issue(s) this PR fixes**:

Fixes #740 

**How to test changes / Special notes to the reviewer**:

**Checklist**

* [X] Documentation update is required by this PR (and has been updated) OR no documentation update is required.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * TLS root CA loading now accepts multiple secret fields, allowing certificates to be loaded from one or several secret entries for more flexible CA configuration and clearer validation when specific fields are requested.

* **Tests**
  * Expanded test coverage for multi-field certificate loading, including single-field, multi-field, all-fields, and missing-field scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->