### PR TITLE
feat: add HA controller and state machine

### DIFF
--- a/pkg/ha/controller.go
+++ b/pkg/ha/controller.go
@@ -1,0 +1,300 @@
+// Copyright 2024 The argocd-agent Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ha
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"github.com/argoproj-labs/argocd-agent/internal/logging"
+	"github.com/sirupsen/logrus"
+)
+
+func log() *logrus.Entry {
+	return logging.GetDefaultLogger().ModuleLogger("ha_controller")
+}
+
+// Controller manages the HA state machine for a principal.
+// All promotions are operator-triggered (Option B) — no automatic failover.
+type Controller struct {
+	mu sync.RWMutex
+
+	// Current state
+	state State
+
+	// Configuration
+	options *Options
+
+	// Lifecycle management
+	ctx      context.Context
+	cancelFn context.CancelFunc
+
+	// Metrics
+	metrics *Metrics
+
+	// Callbacks for integration with principal server
+	onStateChange   func(from, to State)
+	onBecomeActive  func(ctx context.Context)
+	onBecomeReplica func(ctx context.Context)
+}
+
+// NewController creates a new HA controller
+func NewController(ctx context.Context, opts ...Option) (*Controller, error) {
+	options := DefaultOptions()
+	for _, opt := range opts {
+		if err := opt(options); err != nil {
+			return nil, fmt.Errorf("failed to apply option: %w", err)
+		}
+	}
+
+	if err := options.Validate(); err != nil {
+		return nil, fmt.Errorf("invalid options: %w", err)
+	}
+
+	c := &Controller{
+		state:   StateRecovering,
+		options: options,
+		metrics: NewMetrics(),
+	}
+
+	c.ctx, c.cancelFn = context.WithCancel(ctx)
+
+	return c, nil
+}
+
+// Start initializes the HA controller and determines the initial role.
+// Primary always starts active. Replica starts in syncing — the replication
+// client will connect and trigger OnReplicationConnected/OnReplicationDisconnected.
+func (c *Controller) Start() error {
+	if !c.options.Enabled {
+		log().Info("HA is disabled, running as standalone primary")
+		c.transitionTo(StateActive)
+		return nil
+	}
+
+	log().WithField("preferred_role", c.options.PreferredRole).Info("Starting HA controller")
+
+	c.metrics.RecordStateTransition(c.state, c.state)
+
+	if c.options.PreferredRole == RolePrimary {
+		log().Info("Starting as primary (active)")
+		c.transitionTo(StateActive)
+		if c.onBecomeActive != nil {
+			c.onBecomeActive(c.ctx)
+		}
+		return nil
+	}
+
+	// Replica: start in syncing state — replication client handles connectivity
+	log().Info("Starting as replica (syncing)")
+	c.transitionTo(StateSyncing)
+	return nil
+}
+
+// Shutdown gracefully stops the HA controller
+func (c *Controller) Shutdown() error {
+	log().Debug("HA controller shutdown requested")
+	c.cancelFn()
+	return nil
+}
+
+// State returns the current HA state
+func (c *Controller) State() State {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.state
+}
+
+// IsHealthy returns true if GSLB should route traffic to this principal
+func (c *Controller) IsHealthy() bool {
+	return c.State().IsHealthy()
+}
+
+// ShouldAcceptAgents returns true if this principal should accept agent connections
+func (c *Controller) ShouldAcceptAgents() bool {
+	return c.State().ShouldAcceptAgents()
+}
+
+// OnAgentConnect is called when an agent attempts to connect.
+// Returns an error if the connection should be rejected.
+func (c *Controller) OnAgentConnect(agentName string) error {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	if c.state == StateActive {
+		return nil
+	}
+
+	reason := "not accepting connections"
+	c.metrics.RecordRejectedConnection(c.state, reason)
+	return fmt.Errorf("not accepting connections in state %s", c.state)
+}
+
+// OnReplicationConnected is called when the replication stream is established
+func (c *Controller) OnReplicationConnected() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.state == StateSyncing || c.state == StateDisconnected {
+		c.transitionToLocked(StateReplicating)
+	}
+}
+
+// OnReplicationDisconnected is called when the replication stream breaks
+func (c *Controller) OnReplicationDisconnected() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.state == StateReplicating {
+		c.transitionToLocked(StateDisconnected)
+	}
+}
+
+// OnSyncComplete is called when initial sync from peer is complete
+func (c *Controller) OnSyncComplete() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.state == StateSyncing {
+		c.transitionToLocked(StateReplicating)
+	}
+}
+
+// Promote transitions this principal to ACTIVE.
+// Refuses if still replicating (peer is alive) unless force=true.
+func (c *Controller) Promote(ctx context.Context, force bool) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.state == StateActive {
+		return fmt.Errorf("already active")
+	}
+
+	if c.state != StateReplicating && c.state != StateDisconnected {
+		return fmt.Errorf("can only promote from replicating or disconnected state, current: %s", c.state)
+	}
+
+	if !force && c.state == StateReplicating {
+		return fmt.Errorf("still replicating from peer — demote peer first, or use --force")
+	}
+
+	log().Info("Operator triggered: promoting to active")
+	c.transitionToLocked(StateActive)
+	c.metrics.FailoverTotal.Inc()
+	if c.onBecomeActive != nil {
+		go c.onBecomeActive(c.ctx)
+	}
+
+	return nil
+}
+
+// Demote transitions this principal from ACTIVE to REPLICATING.
+func (c *Controller) Demote(ctx context.Context) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.state != StateActive {
+		return fmt.Errorf("can only demote from active state, current: %s", c.state)
+	}
+
+	log().Info("Operator triggered: demoting to replica")
+	c.transitionToLocked(StateReplicating)
+	c.metrics.FailbackTotal.Inc()
+	if c.onBecomeReplica != nil {
+		go c.onBecomeReplica(c.ctx)
+	}
+
+	return nil
+}
+
+// SetOnStateChange sets the callback for state changes
+func (c *Controller) SetOnStateChange(fn func(from, to State)) {
+	c.onStateChange = fn
+}
+
+// SetOnBecomeActive sets the callback for when this principal becomes active
+func (c *Controller) SetOnBecomeActive(fn func(ctx context.Context)) {
+	c.onBecomeActive = fn
+}
+
+// SetOnBecomeReplica sets the callback for when this principal becomes a replica
+func (c *Controller) SetOnBecomeReplica(fn func(ctx context.Context)) {
+	c.onBecomeReplica = fn
+}
+
+// GetStatus returns the current HA status for the CLI/API
+func (c *Controller) GetStatus() *Status {
+	c.mu.RLock()
+	state := c.state
+	c.mu.RUnlock()
+
+	return &Status{
+		State:         state,
+		PreferredRole: c.options.PreferredRole,
+		PeerAddress:   c.options.PeerAddress,
+		PeerReachable: state == StateReplicating,
+		PeerState:     State(""),
+	}
+}
+
+// Status represents the current HA status
+type Status struct {
+	State         State
+	PreferredRole Role
+	PeerAddress   string
+	PeerReachable bool
+	PeerState     State
+}
+
+// transitionTo transitions to a new state (acquires lock)
+func (c *Controller) transitionTo(newState State) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.transitionToLocked(newState)
+}
+
+// transitionToLocked transitions to a new state (caller must hold lock)
+func (c *Controller) transitionToLocked(newState State) {
+	oldState := c.state
+
+	if oldState == newState {
+		return
+	}
+
+	if !ValidTransition(oldState, newState) {
+		log().WithField("from", oldState).WithField("to", newState).Warn("Invalid state transition attempted")
+		return
+	}
+
+	c.state = newState
+	c.metrics.RecordStateTransition(oldState, newState)
+
+	log().WithField("from", oldState).WithField("to", newState).Info("HA state transition")
+
+	if c.onStateChange != nil {
+		go c.onStateChange(oldState, newState)
+	}
+}
+
+// Options returns the controller options (for testing)
+func (c *Controller) Options() *Options {
+	return c.options
+}
+
+// Metrics returns the controller metrics (for testing)
+func (c *Controller) Metrics() *Metrics {
+	return c.metrics
+}

--- a/pkg/ha/controller_test.go
+++ b/pkg/ha/controller_test.go
@@ -1,0 +1,522 @@
+// Copyright 2024 The argocd-agent Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ha
+
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewController(t *testing.T) {
+	t.Run("creates controller with defaults", func(t *testing.T) {
+		ctx := context.Background()
+		c, err := NewController(ctx)
+		require.NoError(t, err)
+		require.NotNil(t, c)
+		assert.Equal(t, StateRecovering, c.State())
+		assert.False(t, c.options.Enabled)
+	})
+
+	t.Run("creates controller with HA enabled", func(t *testing.T) {
+		ctx := context.Background()
+		c, err := NewController(ctx,
+			WithEnabled(true),
+			WithPeerAddress("peer.example.com:8404"),
+			WithPreferredRole("primary"),
+		)
+		require.NoError(t, err)
+		require.NotNil(t, c)
+		assert.True(t, c.options.Enabled)
+		assert.Equal(t, RolePrimary, c.options.PreferredRole)
+		assert.Equal(t, "peer.example.com:8404", c.options.PeerAddress)
+	})
+
+	t.Run("fails with invalid options - replica without peer", func(t *testing.T) {
+		ctx := context.Background()
+		_, err := NewController(ctx,
+			WithEnabled(true),
+			WithPreferredRole("replica"),
+			// Missing peer address
+		)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "peer address is required for replica")
+	})
+
+	t.Run("primary without peer address succeeds", func(t *testing.T) {
+		ctx := context.Background()
+		c, err := NewController(ctx,
+			WithEnabled(true),
+			WithPreferredRole("primary"),
+		)
+		require.NoError(t, err)
+		require.NotNil(t, c)
+		assert.True(t, c.options.Enabled)
+		assert.Equal(t, RolePrimary, c.options.PreferredRole)
+		assert.Empty(t, c.options.PeerAddress)
+	})
+
+	t.Run("fails with invalid role", func(t *testing.T) {
+		ctx := context.Background()
+		_, err := NewController(ctx,
+			WithPreferredRole("invalid"),
+		)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "unknown role")
+	})
+}
+
+func TestControllerStart_Disabled(t *testing.T) {
+	ctx := context.Background()
+	c, err := NewController(ctx)
+	require.NoError(t, err)
+
+	err = c.Start()
+	require.NoError(t, err)
+
+	assert.Equal(t, StateActive, c.State())
+}
+
+func TestControllerStart_PrimaryNoPeerAddress(t *testing.T) {
+	ctx := context.Background()
+	c, err := NewController(ctx,
+		WithEnabled(true),
+		WithPreferredRole("primary"),
+	)
+	require.NoError(t, err)
+
+	var activeCalled atomic.Bool
+	c.SetOnBecomeActive(func(ctx context.Context) {
+		activeCalled.Store(true)
+	})
+
+	err = c.Start()
+	require.NoError(t, err)
+	assert.Equal(t, StateActive, c.State())
+	assert.True(t, activeCalled.Load())
+}
+
+func TestControllerStart_PrimaryWithPeer(t *testing.T) {
+	ctx := context.Background()
+	c, err := NewController(ctx,
+		WithEnabled(true),
+		WithPeerAddress("peer.example.com:8404"),
+		WithPreferredRole("primary"),
+	)
+	require.NoError(t, err)
+
+	var activeCalled atomic.Bool
+	c.SetOnBecomeActive(func(ctx context.Context) {
+		activeCalled.Store(true)
+	})
+
+	err = c.Start()
+	require.NoError(t, err)
+	assert.Equal(t, StateActive, c.State())
+	assert.True(t, activeCalled.Load())
+}
+
+func TestControllerStart_Replica(t *testing.T) {
+	ctx := context.Background()
+	c, err := NewController(ctx,
+		WithEnabled(true),
+		WithPeerAddress("peer.example.com:8404"),
+		WithPreferredRole("replica"),
+	)
+	require.NoError(t, err)
+
+	err = c.Start()
+	require.NoError(t, err)
+
+	// Replica starts in syncing — replication client handles connectivity
+	assert.Equal(t, StateSyncing, c.State())
+}
+
+func TestControllerOnAgentConnect(t *testing.T) {
+	t.Run("accepts connection in active state", func(t *testing.T) {
+		ctx := context.Background()
+		c, err := NewController(ctx)
+		require.NoError(t, err)
+
+		c.Start()
+		assert.Equal(t, StateActive, c.State())
+
+		err = c.OnAgentConnect("test-agent")
+		require.NoError(t, err)
+	})
+
+	t.Run("rejects connection in replicating state", func(t *testing.T) {
+		ctx := context.Background()
+		c, err := NewController(ctx,
+			WithEnabled(true),
+			WithPeerAddress("peer.example.com:8404"),
+		)
+		require.NoError(t, err)
+
+		c.mu.Lock()
+		c.state = StateReplicating
+		c.mu.Unlock()
+
+		err = c.OnAgentConnect("test-agent")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not accepting connections")
+	})
+
+	t.Run("rejects connection in disconnected state", func(t *testing.T) {
+		ctx := context.Background()
+		c, err := NewController(ctx,
+			WithEnabled(true),
+			WithPeerAddress("peer.example.com:8404"),
+		)
+		require.NoError(t, err)
+
+		c.mu.Lock()
+		c.state = StateDisconnected
+		c.mu.Unlock()
+
+		err = c.OnAgentConnect("test-agent")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not accepting connections")
+	})
+}
+
+func TestControllerReplicationCallbacks(t *testing.T) {
+	t.Run("OnReplicationConnected transitions from disconnected to replicating", func(t *testing.T) {
+		ctx := context.Background()
+		c, err := NewController(ctx,
+			WithEnabled(true),
+			WithPeerAddress("peer.example.com:8404"),
+		)
+		require.NoError(t, err)
+
+		c.mu.Lock()
+		c.state = StateDisconnected
+		c.mu.Unlock()
+
+		c.OnReplicationConnected()
+		assert.Equal(t, StateReplicating, c.State())
+	})
+
+	t.Run("OnReplicationConnected transitions from syncing to replicating", func(t *testing.T) {
+		ctx := context.Background()
+		c, err := NewController(ctx,
+			WithEnabled(true),
+			WithPeerAddress("peer.example.com:8404"),
+		)
+		require.NoError(t, err)
+
+		c.mu.Lock()
+		c.state = StateSyncing
+		c.mu.Unlock()
+
+		c.OnReplicationConnected()
+		assert.Equal(t, StateReplicating, c.State())
+	})
+
+	t.Run("OnReplicationDisconnected transitions to disconnected", func(t *testing.T) {
+		ctx := context.Background()
+		c, err := NewController(ctx,
+			WithEnabled(true),
+			WithPeerAddress("peer.example.com:8404"),
+		)
+		require.NoError(t, err)
+
+		c.mu.Lock()
+		c.state = StateReplicating
+		c.mu.Unlock()
+
+		c.OnReplicationDisconnected()
+		assert.Equal(t, StateDisconnected, c.State())
+	})
+
+	t.Run("OnSyncComplete transitions from syncing to replicating", func(t *testing.T) {
+		ctx := context.Background()
+		c, err := NewController(ctx,
+			WithEnabled(true),
+			WithPeerAddress("peer.example.com:8404"),
+		)
+		require.NoError(t, err)
+
+		c.mu.Lock()
+		c.state = StateSyncing
+		c.mu.Unlock()
+
+		c.OnSyncComplete()
+		assert.Equal(t, StateReplicating, c.State())
+	})
+}
+
+func TestControllerPromote(t *testing.T) {
+	t.Run("promotes from disconnected without force", func(t *testing.T) {
+		ctx := context.Background()
+		c, err := NewController(ctx,
+			WithEnabled(true),
+			WithPeerAddress("peer.example.com:8404"),
+		)
+		require.NoError(t, err)
+
+		c.mu.Lock()
+		c.state = StateDisconnected
+		c.mu.Unlock()
+
+		var activeCalled atomic.Bool
+		c.SetOnBecomeActive(func(ctx context.Context) {
+			activeCalled.Store(true)
+		})
+
+		err = c.Promote(ctx, false)
+		require.NoError(t, err)
+		assert.Equal(t, StateActive, c.State())
+
+		time.Sleep(50 * time.Millisecond)
+		assert.True(t, activeCalled.Load())
+	})
+
+	t.Run("promotes from replicating with force", func(t *testing.T) {
+		ctx := context.Background()
+		c, err := NewController(ctx,
+			WithEnabled(true),
+			WithPeerAddress("peer.example.com:8404"),
+		)
+		require.NoError(t, err)
+
+		c.mu.Lock()
+		c.state = StateReplicating
+		c.mu.Unlock()
+
+		err = c.Promote(ctx, true)
+		require.NoError(t, err)
+		assert.Equal(t, StateActive, c.State())
+	})
+
+	t.Run("refuses promote from replicating without force", func(t *testing.T) {
+		ctx := context.Background()
+		c, err := NewController(ctx,
+			WithEnabled(true),
+			WithPeerAddress("peer.example.com:8404"),
+		)
+		require.NoError(t, err)
+
+		c.mu.Lock()
+		c.state = StateReplicating
+		c.mu.Unlock()
+
+		err = c.Promote(ctx, false)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "still replicating from peer")
+	})
+
+	t.Run("refuses if already active", func(t *testing.T) {
+		ctx := context.Background()
+		c, err := NewController(ctx,
+			WithEnabled(true),
+			WithPeerAddress("peer.example.com:8404"),
+		)
+		require.NoError(t, err)
+
+		c.mu.Lock()
+		c.state = StateActive
+		c.mu.Unlock()
+
+		err = c.Promote(ctx, true)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "already active")
+	})
+
+	t.Run("refuses from recovering state", func(t *testing.T) {
+		ctx := context.Background()
+		c, err := NewController(ctx,
+			WithEnabled(true),
+			WithPeerAddress("peer.example.com:8404"),
+		)
+		require.NoError(t, err)
+
+		err = c.Promote(ctx, true)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "can only promote from replicating or disconnected")
+	})
+}
+
+func TestControllerDemote(t *testing.T) {
+	t.Run("demotes from active to replicating", func(t *testing.T) {
+		ctx := context.Background()
+		c, err := NewController(ctx,
+			WithEnabled(true),
+			WithPeerAddress("peer.example.com:8404"),
+		)
+		require.NoError(t, err)
+
+		c.mu.Lock()
+		c.state = StateActive
+		c.mu.Unlock()
+
+		var replicaCalled atomic.Bool
+		c.SetOnBecomeReplica(func(ctx context.Context) {
+			replicaCalled.Store(true)
+		})
+
+		err = c.Demote(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, StateReplicating, c.State())
+
+		time.Sleep(50 * time.Millisecond)
+		assert.True(t, replicaCalled.Load())
+	})
+
+	t.Run("fails to demote from non-active state", func(t *testing.T) {
+		ctx := context.Background()
+		c, err := NewController(ctx,
+			WithEnabled(true),
+			WithPeerAddress("peer.example.com:8404"),
+		)
+		require.NoError(t, err)
+
+		c.mu.Lock()
+		c.state = StateReplicating
+		c.mu.Unlock()
+
+		err = c.Demote(ctx)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "can only demote from active")
+	})
+}
+
+func TestControllerHealthStatus(t *testing.T) {
+	t.Run("healthy in active state", func(t *testing.T) {
+		ctx := context.Background()
+		c, err := NewController(ctx)
+		require.NoError(t, err)
+		c.Start()
+
+		assert.True(t, c.IsHealthy())
+		assert.True(t, c.ShouldAcceptAgents())
+	})
+
+	t.Run("unhealthy in replicating state", func(t *testing.T) {
+		ctx := context.Background()
+		c, err := NewController(ctx,
+			WithEnabled(true),
+			WithPeerAddress("peer.example.com:8404"),
+		)
+		require.NoError(t, err)
+
+		c.mu.Lock()
+		c.state = StateReplicating
+		c.mu.Unlock()
+
+		assert.False(t, c.IsHealthy())
+		assert.False(t, c.ShouldAcceptAgents())
+	})
+
+	t.Run("unhealthy in disconnected state", func(t *testing.T) {
+		ctx := context.Background()
+		c, err := NewController(ctx,
+			WithEnabled(true),
+			WithPeerAddress("peer.example.com:8404"),
+		)
+		require.NoError(t, err)
+
+		c.mu.Lock()
+		c.state = StateDisconnected
+		c.mu.Unlock()
+
+		assert.False(t, c.IsHealthy())
+		assert.False(t, c.ShouldAcceptAgents())
+	})
+}
+
+func TestControllerGetStatus(t *testing.T) {
+	t.Run("active state shows peer reachable false", func(t *testing.T) {
+		ctx := context.Background()
+		c, err := NewController(ctx,
+			WithEnabled(true),
+			WithPeerAddress("peer.example.com:8404"),
+			WithPreferredRole("primary"),
+		)
+		require.NoError(t, err)
+
+		c.mu.Lock()
+		c.state = StateActive
+		c.mu.Unlock()
+
+		status := c.GetStatus()
+		assert.Equal(t, StateActive, status.State)
+		assert.Equal(t, RolePrimary, status.PreferredRole)
+		assert.Equal(t, "peer.example.com:8404", status.PeerAddress)
+		assert.False(t, status.PeerReachable)
+	})
+
+	t.Run("replicating state shows peer reachable true", func(t *testing.T) {
+		ctx := context.Background()
+		c, err := NewController(ctx,
+			WithEnabled(true),
+			WithPeerAddress("peer.example.com:8404"),
+		)
+		require.NoError(t, err)
+
+		c.mu.Lock()
+		c.state = StateReplicating
+		c.mu.Unlock()
+
+		status := c.GetStatus()
+		assert.Equal(t, StateReplicating, status.State)
+		assert.True(t, status.PeerReachable)
+	})
+}
+
+func TestControllerShutdown(t *testing.T) {
+	ctx := context.Background()
+	c, err := NewController(ctx)
+	require.NoError(t, err)
+
+	err = c.Start()
+	require.NoError(t, err)
+
+	err = c.Shutdown()
+	require.NoError(t, err)
+
+	select {
+	case <-c.ctx.Done():
+		// Expected
+	default:
+		t.Error("context should be cancelled after shutdown")
+	}
+}
+
+func TestStateCallbacks(t *testing.T) {
+	ctx := context.Background()
+	c, err := NewController(ctx,
+		WithEnabled(true),
+		WithPeerAddress("peer.example.com:8404"),
+	)
+	require.NoError(t, err)
+
+	var transitions []string
+	c.SetOnStateChange(func(from, to State) {
+		transitions = append(transitions, fmt.Sprintf("%s->%s", from, to))
+	})
+
+	c.transitionTo(StateActive)
+
+	time.Sleep(50 * time.Millisecond)
+
+	assert.Len(t, transitions, 1)
+	assert.Equal(t, "recovering->active", transitions[0])
+}

--- a/pkg/ha/metrics.go
+++ b/pkg/ha/metrics.go
@@ -1,0 +1,141 @@
+// Copyright 2024 The argocd-agent Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ha
+
+import (
+	"sync"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+var (
+	metricsOnce     sync.Once
+	metricsInstance *Metrics
+)
+
+// Metrics contains Prometheus metrics for the HA controller
+type Metrics struct {
+	// StateGauge reports the current HA state (1 for active state, 0 for others)
+	StateGauge *prometheus.GaugeVec
+
+	// TransitionCounter counts state transitions by target state
+	TransitionCounter *prometheus.CounterVec
+
+	// ReplicationLagGauge reports the replication lag in seconds
+	ReplicationLagGauge prometheus.Gauge
+
+	// ReplicationEventsTotal counts total replication events received
+	ReplicationEventsTotal prometheus.Counter
+
+	// ReplicationErrorsTotal counts replication errors
+	ReplicationErrorsTotal prometheus.Counter
+
+	// FailoverTotal counts total failover events
+	FailoverTotal prometheus.Counter
+
+	// FailbackTotal counts total failback events
+	FailbackTotal prometheus.Counter
+
+	// AgentConnectionsRejected counts agent connections rejected due to HA state
+	AgentConnectionsRejected *prometheus.CounterVec
+}
+
+// NewMetrics creates new HA metrics. It returns a singleton instance to avoid
+// duplicate metric registration when multiple controllers are created (e.g., in tests).
+func NewMetrics() *Metrics {
+	metricsOnce.Do(func() {
+		metricsInstance = &Metrics{
+			StateGauge: promauto.NewGaugeVec(prometheus.GaugeOpts{
+				Name: "argocd_agent_ha_state",
+				Help: "Current HA state: 1 for the active state, 0 for all others",
+			}, []string{"state"}),
+			TransitionCounter: promauto.NewCounterVec(prometheus.CounterOpts{
+				Name: "argocd_agent_ha_transitions_total",
+				Help: "Total number of HA state transitions",
+			}, []string{"from_state", "to_state"}),
+			ReplicationLagGauge: promauto.NewGauge(prometheus.GaugeOpts{
+				Name: "argocd_agent_ha_replication_lag_seconds",
+				Help: "Replication lag in seconds",
+			}),
+			ReplicationEventsTotal: promauto.NewCounter(prometheus.CounterOpts{
+				Name: "argocd_agent_ha_replication_events_total",
+				Help: "Total number of replication events received",
+			}),
+			ReplicationErrorsTotal: promauto.NewCounter(prometheus.CounterOpts{
+				Name: "argocd_agent_ha_replication_errors_total",
+				Help: "Total number of replication errors",
+			}),
+			FailoverTotal: promauto.NewCounter(prometheus.CounterOpts{
+				Name: "argocd_agent_ha_failovers_total",
+				Help: "Total number of failover events",
+			}),
+			FailbackTotal: promauto.NewCounter(prometheus.CounterOpts{
+				Name: "argocd_agent_ha_failbacks_total",
+				Help: "Total number of failback events",
+			}),
+			AgentConnectionsRejected: promauto.NewCounterVec(prometheus.CounterOpts{
+				Name: "argocd_agent_ha_connections_rejected_total",
+				Help: "Total number of agent connections rejected due to HA state",
+			}, []string{"state", "reason"}),
+		}
+	})
+	return metricsInstance
+}
+
+// allStates enumerates every HA state for metric initialization.
+var allStates = []State{StateReplicating, StateDisconnected, StateActive, StateRecovering, StateSyncing}
+
+// RecordStateTransition records a state transition in metrics
+func (m *Metrics) RecordStateTransition(from, to State) {
+	for _, s := range allStates {
+		if s == to {
+			m.StateGauge.WithLabelValues(s.String()).Set(1)
+		} else {
+			m.StateGauge.WithLabelValues(s.String()).Set(0)
+		}
+	}
+	m.TransitionCounter.WithLabelValues(from.String(), to.String()).Inc()
+}
+
+// RecordReplicationLag records the current replication lag
+func (m *Metrics) RecordReplicationLag(lagSeconds float64) {
+	m.ReplicationLagGauge.Set(lagSeconds)
+}
+
+// RecordReplicationEvent records a replication event
+func (m *Metrics) RecordReplicationEvent() {
+	m.ReplicationEventsTotal.Inc()
+}
+
+// RecordReplicationError records a replication error
+func (m *Metrics) RecordReplicationError() {
+	m.ReplicationErrorsTotal.Inc()
+}
+
+// RecordFailover records a failover event
+func (m *Metrics) RecordFailover() {
+	m.FailoverTotal.Inc()
+}
+
+// RecordFailback records a failback event
+func (m *Metrics) RecordFailback() {
+	m.FailbackTotal.Inc()
+}
+
+// RecordRejectedConnection records a rejected agent connection
+func (m *Metrics) RecordRejectedConnection(state State, reason string) {
+	m.AgentConnectionsRejected.WithLabelValues(state.String(), reason).Inc()
+}

--- a/pkg/ha/options.go
+++ b/pkg/ha/options.go
@@ -1,0 +1,160 @@
+// Copyright 2024 The argocd-agent Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ha
+
+import (
+	"crypto/tls"
+	"fmt"
+	"time"
+)
+
+// Options contains configuration for the HA controller
+type Options struct {
+	// Enabled indicates whether HA is enabled
+	Enabled bool
+
+	// PreferredRole is the preferred role for this principal ("primary" or "replica")
+	PreferredRole Role
+
+	// PeerAddress is the address of the peer principal (host:port)
+	PeerAddress string
+
+	// FailoverTimeout is how long to wait before promoting to standby after losing primary
+	FailoverTimeout time.Duration
+
+	// ReplicationPort is the port to use for replication traffic
+	ReplicationPort int
+
+	// TLSConfig is the TLS configuration for replication connections
+	TLSConfig *tls.Config
+
+	// ReconnectBackoffInitial is the initial backoff duration for reconnection attempts
+	ReconnectBackoffInitial time.Duration
+
+	// ReconnectBackoffMax is the maximum backoff duration for reconnection attempts
+	ReconnectBackoffMax time.Duration
+
+	// ReconnectBackoffFactor is the factor to multiply backoff by after each attempt
+	ReconnectBackoffFactor float64
+}
+
+// DefaultOptions returns the default HA options
+func DefaultOptions() *Options {
+	return &Options{
+		Enabled:                 false,
+		PreferredRole:           RoleReplica,
+		FailoverTimeout:         30 * time.Second,
+		ReplicationPort:         8404,
+		ReconnectBackoffInitial: 1 * time.Second,
+		ReconnectBackoffMax:     30 * time.Second,
+		ReconnectBackoffFactor:  1.5,
+	}
+}
+
+// Option is a function that modifies Options
+type Option func(*Options) error
+
+// WithEnabled sets whether HA is enabled
+func WithEnabled(enabled bool) Option {
+	return func(o *Options) error {
+		o.Enabled = enabled
+		return nil
+	}
+}
+
+// WithPreferredRole sets the preferred role for this principal
+func WithPreferredRole(role string) Option {
+	return func(o *Options) error {
+		r, err := ParseRole(role)
+		if err != nil {
+			return err
+		}
+		o.PreferredRole = r
+		return nil
+	}
+}
+
+// WithPeerAddress sets the address of the peer principal
+func WithPeerAddress(address string) Option {
+	return func(o *Options) error {
+		if address == "" {
+			return fmt.Errorf("peer address cannot be empty")
+		}
+		o.PeerAddress = address
+		return nil
+	}
+}
+
+// WithFailoverTimeout sets the failover timeout duration
+func WithFailoverTimeout(timeout time.Duration) Option {
+	return func(o *Options) error {
+		if timeout < 0 {
+			return fmt.Errorf("failover timeout cannot be negative")
+		}
+		o.FailoverTimeout = timeout
+		return nil
+	}
+}
+
+// WithReplicationPort sets the port for replication traffic
+func WithReplicationPort(port int) Option {
+	return func(o *Options) error {
+		if port < 1 || port > 65535 {
+			return fmt.Errorf("replication port must be between 1 and 65535")
+		}
+		o.ReplicationPort = port
+		return nil
+	}
+}
+
+// WithTLSConfig sets the TLS configuration for replication
+func WithTLSConfig(config *tls.Config) Option {
+	return func(o *Options) error {
+		o.TLSConfig = config
+		return nil
+	}
+}
+
+// WithReconnectBackoff sets the reconnection backoff parameters
+func WithReconnectBackoff(initial, max time.Duration, factor float64) Option {
+	return func(o *Options) error {
+		if initial < 0 {
+			return fmt.Errorf("initial backoff cannot be negative")
+		}
+		if max < initial {
+			return fmt.Errorf("max backoff cannot be less than initial")
+		}
+		if factor < 1.0 {
+			return fmt.Errorf("backoff factor must be at least 1.0")
+		}
+		o.ReconnectBackoffInitial = initial
+		o.ReconnectBackoffMax = max
+		o.ReconnectBackoffFactor = factor
+		return nil
+	}
+}
+
+// Validate validates the options
+func (o *Options) Validate() error {
+	if !o.Enabled {
+		return nil
+	}
+
+	if o.PeerAddress == "" && o.PreferredRole == RoleReplica {
+		return fmt.Errorf("peer address is required for replica role")
+	}
+
+	return nil
+}

--- a/pkg/ha/options_test.go
+++ b/pkg/ha/options_test.go
@@ -1,0 +1,197 @@
+// Copyright 2024 The argocd-agent Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ha
+
+import (
+	"crypto/tls"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDefaultOptions(t *testing.T) {
+	opts := DefaultOptions()
+
+	assert.False(t, opts.Enabled)
+	assert.Equal(t, RoleReplica, opts.PreferredRole)
+	assert.Equal(t, 30*time.Second, opts.FailoverTimeout)
+	assert.Equal(t, 8404, opts.ReplicationPort)
+	assert.Equal(t, 1*time.Second, opts.ReconnectBackoffInitial)
+	assert.Equal(t, 30*time.Second, opts.ReconnectBackoffMax)
+	assert.Equal(t, 1.5, opts.ReconnectBackoffFactor)
+}
+
+func TestWithEnabled(t *testing.T) {
+	opts := DefaultOptions()
+	err := WithEnabled(true)(opts)
+	require.NoError(t, err)
+	assert.True(t, opts.Enabled)
+}
+
+func TestWithPreferredRole(t *testing.T) {
+	t.Run("primary", func(t *testing.T) {
+		opts := DefaultOptions()
+		err := WithPreferredRole("primary")(opts)
+		require.NoError(t, err)
+		assert.Equal(t, RolePrimary, opts.PreferredRole)
+	})
+
+	t.Run("replica", func(t *testing.T) {
+		opts := DefaultOptions()
+		err := WithPreferredRole("replica")(opts)
+		require.NoError(t, err)
+		assert.Equal(t, RoleReplica, opts.PreferredRole)
+	})
+
+	t.Run("invalid", func(t *testing.T) {
+		opts := DefaultOptions()
+		err := WithPreferredRole("invalid")(opts)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "unknown role")
+	})
+}
+
+func TestWithPeerAddress(t *testing.T) {
+	t.Run("valid address", func(t *testing.T) {
+		opts := DefaultOptions()
+		err := WithPeerAddress("peer.example.com:8404")(opts)
+		require.NoError(t, err)
+		assert.Equal(t, "peer.example.com:8404", opts.PeerAddress)
+	})
+
+	t.Run("empty address", func(t *testing.T) {
+		opts := DefaultOptions()
+		err := WithPeerAddress("")(opts)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "cannot be empty")
+	})
+}
+
+func TestWithFailoverTimeout(t *testing.T) {
+	t.Run("valid timeout", func(t *testing.T) {
+		opts := DefaultOptions()
+		err := WithFailoverTimeout(60 * time.Second)(opts)
+		require.NoError(t, err)
+		assert.Equal(t, 60*time.Second, opts.FailoverTimeout)
+	})
+
+	t.Run("negative timeout", func(t *testing.T) {
+		opts := DefaultOptions()
+		err := WithFailoverTimeout(-1 * time.Second)(opts)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "cannot be negative")
+	})
+}
+
+func TestWithReplicationPort(t *testing.T) {
+	t.Run("valid port", func(t *testing.T) {
+		opts := DefaultOptions()
+		err := WithReplicationPort(8405)(opts)
+		require.NoError(t, err)
+		assert.Equal(t, 8405, opts.ReplicationPort)
+	})
+
+	t.Run("port too low", func(t *testing.T) {
+		opts := DefaultOptions()
+		err := WithReplicationPort(0)(opts)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "must be between 1 and 65535")
+	})
+
+	t.Run("port too high", func(t *testing.T) {
+		opts := DefaultOptions()
+		err := WithReplicationPort(65536)(opts)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "must be between 1 and 65535")
+	})
+}
+
+func TestWithTLSConfig(t *testing.T) {
+	opts := DefaultOptions()
+	tlsConfig := &tls.Config{MinVersion: tls.VersionTLS12}
+	err := WithTLSConfig(tlsConfig)(opts)
+	require.NoError(t, err)
+	assert.Equal(t, tlsConfig, opts.TLSConfig)
+}
+
+func TestWithReconnectBackoff(t *testing.T) {
+	t.Run("valid backoff", func(t *testing.T) {
+		opts := DefaultOptions()
+		err := WithReconnectBackoff(2*time.Second, 60*time.Second, 2.0)(opts)
+		require.NoError(t, err)
+		assert.Equal(t, 2*time.Second, opts.ReconnectBackoffInitial)
+		assert.Equal(t, 60*time.Second, opts.ReconnectBackoffMax)
+		assert.Equal(t, 2.0, opts.ReconnectBackoffFactor)
+	})
+
+	t.Run("negative initial", func(t *testing.T) {
+		opts := DefaultOptions()
+		err := WithReconnectBackoff(-1*time.Second, 60*time.Second, 2.0)(opts)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "initial backoff cannot be negative")
+	})
+
+	t.Run("max less than initial", func(t *testing.T) {
+		opts := DefaultOptions()
+		err := WithReconnectBackoff(60*time.Second, 30*time.Second, 2.0)(opts)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "max backoff cannot be less than initial")
+	})
+
+	t.Run("factor less than 1", func(t *testing.T) {
+		opts := DefaultOptions()
+		err := WithReconnectBackoff(1*time.Second, 60*time.Second, 0.5)(opts)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "backoff factor must be at least 1.0")
+	})
+}
+
+func TestOptionsValidate(t *testing.T) {
+	t.Run("disabled is always valid", func(t *testing.T) {
+		opts := DefaultOptions()
+		opts.Enabled = false
+		err := opts.Validate()
+		require.NoError(t, err)
+	})
+
+	t.Run("enabled replica requires peer address", func(t *testing.T) {
+		opts := DefaultOptions()
+		opts.Enabled = true
+		opts.PreferredRole = RoleReplica
+		opts.PeerAddress = ""
+		err := opts.Validate()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "peer address is required for replica")
+	})
+
+	t.Run("enabled primary without peer address is valid", func(t *testing.T) {
+		opts := DefaultOptions()
+		opts.Enabled = true
+		opts.PreferredRole = RolePrimary
+		opts.PeerAddress = ""
+		err := opts.Validate()
+		require.NoError(t, err)
+	})
+
+	t.Run("valid enabled options with peer", func(t *testing.T) {
+		opts := DefaultOptions()
+		opts.Enabled = true
+		opts.PeerAddress = "peer:8404"
+		err := opts.Validate()
+		require.NoError(t, err)
+	})
+}

--- a/pkg/ha/state.go
+++ b/pkg/ha/state.go
@@ -1,0 +1,108 @@
+// Copyright 2024 The argocd-agent Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ha
+
+import "fmt"
+
+// State represents the current HA state of a principal
+type State string
+
+const (
+	// StateReplicating indicates the principal is connected to the primary and receiving replication events
+	StateReplicating State = "replicating"
+
+	// StateDisconnected indicates the principal lost connection to the primary
+	StateDisconnected State = "disconnected"
+
+	// StateActive indicates the principal is actively serving agent connections
+	StateActive State = "active"
+
+	// StateRecovering indicates the principal just started and is determining its role
+	StateRecovering State = "recovering"
+
+	// StateSyncing indicates the principal is catching up to the current primary after recovering
+	StateSyncing State = "syncing"
+)
+
+// Role represents the preferred role of a principal
+type Role string
+
+const (
+	// RolePrimary indicates this principal prefers to be the primary
+	RolePrimary Role = "primary"
+
+	// RoleReplica indicates this principal prefers to be a replica
+	RoleReplica Role = "replica"
+)
+
+// String returns the string representation of the state
+func (s State) String() string {
+	return string(s)
+}
+
+// String returns the string representation of the role
+func (r Role) String() string {
+	return string(r)
+}
+
+// IsHealthy returns true if the state should report healthy to GSLB
+func (s State) IsHealthy() bool {
+	return s == StateActive
+}
+
+// ShouldAcceptAgents returns true if the state allows accepting agent connections
+func (s State) ShouldAcceptAgents() bool {
+	return s == StateActive
+}
+
+// IsReplicating returns true if the state indicates active replication
+func (s State) IsReplicating() bool {
+	return s == StateReplicating || s == StateSyncing
+}
+
+// ParseRole parses a string into a Role
+func ParseRole(s string) (Role, error) {
+	switch s {
+	case "primary":
+		return RolePrimary, nil
+	case "replica":
+		return RoleReplica, nil
+	default:
+		return "", fmt.Errorf("unknown role: %s", s)
+	}
+}
+
+// ValidTransition checks if transitioning from one state to another is valid
+func ValidTransition(from, to State) bool {
+	validTransitions := map[State][]State{
+		StateRecovering:   {StateActive, StateSyncing, StateReplicating, StateDisconnected},
+		StateReplicating:  {StateDisconnected, StateActive},
+		StateDisconnected: {StateReplicating, StateActive},
+		StateActive:       {StateReplicating},
+		StateSyncing:      {StateReplicating},
+	}
+
+	allowed, ok := validTransitions[from]
+	if !ok {
+		return false
+	}
+
+	for _, s := range allowed {
+		if s == to {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/ha/state_test.go
+++ b/pkg/ha/state_test.go
@@ -1,0 +1,174 @@
+// Copyright 2024 The argocd-agent Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ha
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStateString(t *testing.T) {
+	tests := []struct {
+		state    State
+		expected string
+	}{
+		{StateReplicating, "replicating"},
+		{StateDisconnected, "disconnected"},
+		{StateActive, "active"},
+		{StateRecovering, "recovering"},
+		{StateSyncing, "syncing"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.expected, func(t *testing.T) {
+			assert.Equal(t, tt.expected, tt.state.String())
+		})
+	}
+}
+
+func TestRoleString(t *testing.T) {
+	assert.Equal(t, "primary", RolePrimary.String())
+	assert.Equal(t, "replica", RoleReplica.String())
+}
+
+func TestStateIsHealthy(t *testing.T) {
+	healthyStates := []State{StateActive}
+	unhealthyStates := []State{StateReplicating, StateDisconnected, StateRecovering, StateSyncing}
+
+	for _, s := range healthyStates {
+		t.Run(s.String()+"_healthy", func(t *testing.T) {
+			assert.True(t, s.IsHealthy())
+		})
+	}
+
+	for _, s := range unhealthyStates {
+		t.Run(s.String()+"_unhealthy", func(t *testing.T) {
+			assert.False(t, s.IsHealthy())
+		})
+	}
+}
+
+func TestStateShouldAcceptAgents(t *testing.T) {
+	acceptingStates := []State{StateActive}
+	rejectingStates := []State{StateReplicating, StateDisconnected, StateRecovering, StateSyncing}
+
+	for _, s := range acceptingStates {
+		t.Run(s.String()+"_accepts", func(t *testing.T) {
+			assert.True(t, s.ShouldAcceptAgents())
+		})
+	}
+
+	for _, s := range rejectingStates {
+		t.Run(s.String()+"_rejects", func(t *testing.T) {
+			assert.False(t, s.ShouldAcceptAgents())
+		})
+	}
+}
+
+func TestStateIsReplicating(t *testing.T) {
+	replicatingStates := []State{StateReplicating, StateSyncing}
+	nonReplicatingStates := []State{StateDisconnected, StateActive, StateRecovering}
+
+	for _, s := range replicatingStates {
+		t.Run(s.String()+"_is_replicating", func(t *testing.T) {
+			assert.True(t, s.IsReplicating())
+		})
+	}
+
+	for _, s := range nonReplicatingStates {
+		t.Run(s.String()+"_not_replicating", func(t *testing.T) {
+			assert.False(t, s.IsReplicating())
+		})
+	}
+}
+
+func TestParseRole(t *testing.T) {
+	t.Run("primary", func(t *testing.T) {
+		role, err := ParseRole("primary")
+		require.NoError(t, err)
+		assert.Equal(t, RolePrimary, role)
+	})
+
+	t.Run("replica", func(t *testing.T) {
+		role, err := ParseRole("replica")
+		require.NoError(t, err)
+		assert.Equal(t, RoleReplica, role)
+	})
+
+	t.Run("unknown", func(t *testing.T) {
+		_, err := ParseRole("unknown")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "unknown role")
+	})
+}
+
+func TestValidTransition(t *testing.T) {
+	validTransitions := []struct {
+		from State
+		to   State
+	}{
+		// From recovering
+		{StateRecovering, StateActive},
+		{StateRecovering, StateSyncing},
+		{StateRecovering, StateReplicating},
+		{StateRecovering, StateDisconnected},
+
+		// From replicating (operator promote or stream break)
+		{StateReplicating, StateDisconnected},
+		{StateReplicating, StateActive},
+
+		// From disconnected (replication reconnects or operator promote)
+		{StateDisconnected, StateReplicating},
+		{StateDisconnected, StateActive},
+
+		// From active (operator demote)
+		{StateActive, StateReplicating},
+
+		// From syncing
+		{StateSyncing, StateReplicating},
+	}
+
+	for _, tt := range validTransitions {
+		t.Run(tt.from.String()+"->"+tt.to.String(), func(t *testing.T) {
+			assert.True(t, ValidTransition(tt.from, tt.to), "expected transition from %s to %s to be valid", tt.from, tt.to)
+		})
+	}
+
+	invalidTransitions := []struct {
+		from State
+		to   State
+	}{
+		// Cannot go from active to anything except replicating
+		{StateActive, StateDisconnected},
+		{StateActive, StateRecovering},
+
+		// Cannot go from replicating directly to recovering
+		{StateReplicating, StateRecovering},
+
+		// Cannot transition to recovering from anywhere
+		{StateActive, StateRecovering},
+
+		// Same state is not a valid transition
+		{StateActive, StateActive},
+	}
+
+	for _, tt := range invalidTransitions {
+		t.Run(tt.from.String()+"->"+tt.to.String()+"_invalid", func(t *testing.T) {
+			assert.False(t, ValidTransition(tt.from, tt.to), "expected transition from %s to %s to be invalid", tt.from, tt.to)
+		})
+	}
+}


### PR DESCRIPTION
Introduce the HA (high availability) state machine for principal failover. The controller manages transitions between states: recovering, replicating, syncing, disconnected, and active.

Includes:
- State machine with validated transitions and preferred-role config
- Prometheus metrics with label-based state gauge
- Configurable failover timeout, health checking, reconnect backoff
- Callbacks for state changes (onBecomeActive, onBecomeReplica)

**What does this PR do / why we need it**:

**Which issue(s) this PR fixes**:

part-of #723 

This is part 1 of 5 of a set of stacked commits / prs

**How to test changes / Special notes to the reviewer**:


**Checklist**

* [ ] Documentation update is required by this PR (and has been updated) OR no documentation update is required.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added High Availability support with configurable primary and replica modes
  * Enabled operator-driven server promotion and demotion
  * Introduced replication lifecycle management and state tracking
  * Added health monitoring, status reporting, and comprehensive HA metrics
  * Implemented connection policies based on HA state

<!-- end of auto-generated comment: release notes by coderabbit.ai -->