### PR TITLE
feat(cli): additional checks to check config cmd

### DIFF
--- a/cmd/ctl/check_config_test.go
+++ b/cmd/ctl/check_config_test.go
@@ -1659,7 +1659,7 @@ func TestCheckConfigCombined(t *testing.T) {
 		for _, r := range agentRes {
 			if r.err != nil && strings.Contains(r.name, "deployed Argo CD components") {
 				caughtInvalid = strings.Contains(r.err.Error(), "server") &&
-					strings.Contains(r.err.Error(), "de")
+					strings.Contains(r.err.Error(), "dex-server")
 				caughtMissing = strings.Contains(r.err.Error(), "application-controller") &&
 					strings.Contains(r.err.Error(), "redis")
 			}


### PR DESCRIPTION
**What does this PR do / why we need it**:

This PR adds five additional checks to the `check-config` CLI command. The five checks are as follows:
- On the principal cluster, no Application CRs are defined on the principal's Argo CD namespace
- On the principal cluster, the agent cluster secrets server field starts with `https://` and has the query parameter `agentName`
- On the principal cluster, the agent cluster secrets have the skip-reconcile annotation and it is set to true
- On both principal and agent clusters, a check is made to see if the correct Argo CD components are deployed on to them
  - On principal cluster, the repo server, dex server, server, and redis are deployed and the application and application set controllers are not
   - On agent clusters, the application controller, repo server, and redis are deployed and the server and dex server are not
- On both principal and agent clusters, the Argo CD redis network policy allows ingress traffic from the principal or agent components

The agent cluster secrets are found by looking at the secrets and checking for the `managed-by` label and that it is managed by `argocd-agent` and that the argo cd `secret-type` annotation is there and that is set to be a cluster. 

The Argo CD components are found in the checks by searching through the deployments (everything but application controller) and statefulsets in the namespace then looking at the `part-of` and `component` labels to tell what component it is. 

The Argo CD redis network policy is found by looking at the pod selector in the network policy.

**Which issue(s) this PR fixes**:

Works on #713 (Issue should stay open for more checks)

**How to test changes / Special notes to the reviewer**:

1. Build CLI with this patch with `make cli`
2. Edit around your config for your principal or agent to force the error conditions
3. Run the `check-config` command to see the errors be printed if you broke the config

**Checklist**

* [X] Documentation update is required by this PR (and has been updated) OR no documentation update is required.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced configuration validation with expanded checks covering resource configurations, cluster secret server URL and annotation requirements, network policy ingress verification, and Argo CD component deployment validation across principal and agent namespaces.

* **Tests**
  * Added extensive test coverage for configuration validation scenarios with realistic Kubernetes resource simulations and error condition testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->