### PR TITLE
docs: note `ApplicationSet` conditional availability

### DIFF
--- a/docs/getting-started/kubernetes/index.md
+++ b/docs/getting-started/kubernetes/index.md
@@ -255,9 +255,10 @@ This configuration includes:
 - ✅ **argocd-application-controller** (reconciles applications - **required on workload clusters**)
 - ✅ **argocd-repo-server** (Git access for the application controller)
 - ✅ **argocd-redis** (local state for the application controller)
+- ⚠️ **argocd-applicationset-controller** (runs on control plane in managed mode)
 - ❌ **argocd-server** (runs on control plane only)
 - ❌ **argocd-dex-server** (runs on control plane only)
-- ❌ **argocd-applicationset-controller** (managed agents don't create their own ApplicationSets)
+
 
 !!! info "Why Application Controller Runs Here"
     The **argocd-application-controller** runs on workload clusters because it needs direct access to the Kubernetes API to create, update, and delete resources. The argocd-agent facilitates communication between the control plane and these controllers, enabling centralized management while maintaining local execution.


### PR DESCRIPTION

**What does this PR do / why we need it**:

updates a line which says `ApplicationSet` is unavailable, because there are other docs which claim that it is:

- https://argocd-agent.readthedocs.io/latest/concepts/agent-modes/managed/#:~:text=Allows%20use%20of%20ApplicationSet%20generators%20that%20span%20over%20multiple%20clusters%2C%20such%20as%20cluster%20or%20cluster%2Ddecision%20generators

there may be other instances elsewhere in the docs, but it seems pretty clear this feature is available and intended for use

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Kubernetes setup documentation to clarify that the ApplicationSet controller runs on the control plane in managed mode.
  * Removed outdated information about ApplicationSet controller support limitations in managed environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->