### PR TITLE
fix: SkipSync label not respected on AppProjects if connection is lost

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -298,6 +298,7 @@ func NewAgent(ctx context.Context, client *kube.KubernetesClient, namespace stri
 		informer.WithAddHandler[*v1alpha1.AppProject](a.addAppProjectCreationToQueue),
 		informer.WithUpdateHandler[*v1alpha1.AppProject](a.addAppProjectUpdateToQueue),
 		informer.WithDeleteHandler[*v1alpha1.AppProject](a.addAppProjectDeletionToQueue),
+		informer.WithFilters[*v1alpha1.AppProject](a.DefaultAppProjectFilterChain()),
 		informer.WithGroupResource[*v1alpha1.AppProject]("argoproj.io", "appprojects"),
 	}
 

--- a/agent/filters.go
+++ b/agent/filters.go
@@ -53,3 +53,20 @@ func (a *Agent) DefaultAppFilterChain() *filter.Chain[*v1alpha1.Application] {
 
 func (a *Agent) WithLabelFilter() {
 }
+
+// DefaultAppProjectFilterChain returns a FilterChain for AppProject resources.
+// This chain contains a set of default filters that the agent will
+// evaluate for every change.
+func (a *Agent) DefaultAppProjectFilterChain() *filter.Chain[*v1alpha1.AppProject] {
+	fc := &filter.Chain[*v1alpha1.AppProject]{}
+
+	// Ignore appprojects that have the skip sync label
+	fc.AppendAdmitFilter(func(appProject *v1alpha1.AppProject) bool {
+		if v, ok := appProject.Labels[config.SkipSyncLabel]; ok && v == "true" {
+			return false
+		}
+		return true
+	})
+
+	return fc
+}

--- a/principal/server.go
+++ b/principal/server.go
@@ -300,6 +300,7 @@ func NewServer(ctx context.Context, kubeClient *kube.KubernetesClient, namespace
 		informer.WithUpdateHandler[*v1alpha1.AppProject](s.updateAppProjectCallback),
 		informer.WithDeleteHandler[*v1alpha1.AppProject](s.deleteAppProjectCallback),
 		informer.WithGroupResource[*v1alpha1.AppProject]("argoproj.io", "appprojects"),
+		informer.WithFilters[*v1alpha1.AppProject](s.defaultAppProjectFilterChain()),
 	}
 
 	projManagerOpts := []appproject.AppProjectManagerOption{
@@ -792,6 +793,13 @@ func (s *Server) sendCurrentStateToAgent(agent string) error {
 			continue
 		}
 
+		// Don't send AppProjects that have SkipSyncLabel=true
+		if appProject.Labels != nil {
+			if val, ok := appProject.Labels[config.SkipSyncLabel]; ok && val == "true" {
+				continue
+			}
+		}
+
 		agentAppProject := appproject.AgentSpecificAppProject(appProject, agent, s.destinationBasedMapping)
 		ev := s.events.AppProjectEvent(event.SpecUpdate, &agentAppProject)
 		tracing.PopulateSpanFromObject(span, &appProject)
@@ -939,6 +947,19 @@ func (s *Server) defaultAppFilterChain() *filter.Chain[*v1alpha1.Application] {
 	// Ignore applications that have the skip sync label
 	c.AppendAdmitFilter(func(res *v1alpha1.Application) bool {
 		if v, ok := res.Labels[config.SkipSyncLabel]; ok && v == "true" {
+			return false
+		}
+		return true
+	})
+	return c
+}
+
+// defaultAppFilterChain returns the default filter chain for server s to use
+func (s *Server) defaultAppProjectFilterChain() *filter.Chain[*v1alpha1.AppProject] {
+	c := filter.NewFilterChain[*v1alpha1.AppProject]()
+	// Ignore AppProjects that have the skip sync label
+	c.AppendAdmitFilter(func(appProj *v1alpha1.AppProject) bool {
+		if v, ok := appProj.Labels[config.SkipSyncLabel]; ok && v == "true" {
 			return false
 		}
 		return true

--- a/principal/server_test.go
+++ b/principal/server_test.go
@@ -23,13 +23,24 @@ import (
 	"testing"
 	"time"
 
+	"github.com/argoproj-labs/argocd-agent/internal/backend/mocks"
+	"github.com/argoproj-labs/argocd-agent/internal/config"
 	"github.com/argoproj-labs/argocd-agent/internal/event"
+	"github.com/argoproj-labs/argocd-agent/internal/manager"
+	"github.com/argoproj-labs/argocd-agent/internal/manager/appproject"
+	"github.com/argoproj-labs/argocd-agent/internal/manager/repository"
+	"github.com/argoproj-labs/argocd-agent/internal/queue"
 	"github.com/argoproj-labs/argocd-agent/pkg/types"
 	"github.com/argoproj-labs/argocd-agent/test/fake/kube"
 	fakecerts "github.com/argoproj-labs/argocd-agent/test/fake/testcerts"
+	"github.com/argoproj/argo-cd/v3/common"
+	"github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/rest"
 )
 
@@ -268,6 +279,221 @@ func Test_ServerStartWithDefaultSyncTimeout(t *testing.T) {
 	require.NoError(t, err)
 
 	defer s.Shutdown()
+}
+
+func Test_SendCurrentStateToAgent(t *testing.T) {
+	const agentName = "test-agent"
+	const ns = "argocd"
+
+	// newServer returns a Server obj with appropriate mock harness
+	newServer := func(t *testing.T, mockProjBackend *mocks.AppProject, mockRepoBackend *mocks.Repository) *Server {
+		t.Helper()
+		projMgr, err := appproject.NewAppProjectManager(mockProjBackend, ns)
+		require.NoError(t, err)
+		repoMgr := repository.NewManager(mockRepoBackend, ns, false)
+		s := &Server{
+			ctx:            context.Background(),
+			namespace:      ns,
+			queues:         queue.NewSendRecvQueues(),
+			events:         event.NewEventSource("test"),
+			projectManager: projMgr,
+			repoManager:    repoMgr,
+			repoToAgents:   NewMapToSet(),
+			projectToRepos: NewMapToSet(),
+		}
+		require.NoError(t, s.queues.Create(agentName))
+		return s
+	}
+
+	// generateAppProject returns a simple AppProject with the given name, which allows Applications (et al) from agent namespace
+	generateAppProject := func(name string) v1alpha1.AppProject {
+		return v1alpha1.AppProject{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},
+			Spec: v1alpha1.AppProjectSpec{
+				Destinations: []v1alpha1.ApplicationDestination{
+					{Name: agentName, Namespace: "*", Server: "*"},
+				},
+				SourceNamespaces: []string{agentName},
+			},
+		}
+	}
+
+	// generateRepoSecret returns an simple Argo CD repository Secret for a given project
+	generateRepoSecret := func(name, projectName string) corev1.Secret {
+		return corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: ns,
+				Labels: map[string]string{
+					common.LabelKeySecretType: common.LabelValueSecretTypeRepository,
+				},
+			},
+			Data: map[string][]byte{
+				"project": []byte(projectName),
+			},
+		}
+	}
+
+	t.Run("sends matching project to agent", func(t *testing.T) {
+		proj := generateAppProject("proj1")
+
+		mockProjBackend := &mocks.AppProject{}
+		mockRepoBackend := &mocks.Repository{}
+		mockProjBackend.On("List", mock.Anything, mock.Anything).Return([]v1alpha1.AppProject{proj}, nil)
+		mockRepoBackend.On("List", mock.Anything, mock.Anything).Return([]corev1.Secret{}, nil)
+
+		s := newServer(t, mockProjBackend, mockRepoBackend)
+		err := s.sendCurrentStateToAgent(agentName)
+		require.NoError(t, err)
+
+		sendQ := s.queues.SendQ(agentName)
+		assert.Equal(t, 1, sendQ.Len())
+
+		ev, shutdown := sendQ.Get()
+		assert.False(t, shutdown)
+		assert.Equal(t, event.SpecUpdate.String(), ev.Type())
+		assert.Equal(t, event.TargetAppProject.String(), ev.DataSchema())
+	})
+
+	t.Run("skips project that does not match the agent", func(t *testing.T) {
+		proj := v1alpha1.AppProject{
+			ObjectMeta: metav1.ObjectMeta{Name: "proj1", Namespace: ns},
+			Spec: v1alpha1.AppProjectSpec{
+				Destinations: []v1alpha1.ApplicationDestination{
+					{Name: "other-agent", Namespace: "*", Server: "*"},
+				},
+				SourceNamespaces: []string{"other-agent"},
+			},
+		}
+
+		mockProjBackend := &mocks.AppProject{}
+		mockRepoBackend := &mocks.Repository{}
+		mockProjBackend.On("List", mock.Anything, mock.Anything).Return([]v1alpha1.AppProject{proj}, nil)
+		mockRepoBackend.On("List", mock.Anything, mock.Anything).Return([]corev1.Secret{}, nil)
+
+		s := newServer(t, mockProjBackend, mockRepoBackend)
+		err := s.sendCurrentStateToAgent(agentName)
+		require.NoError(t, err)
+
+		sendQ := s.queues.SendQ(agentName)
+		assert.Equal(t, 0, sendQ.Len())
+	})
+
+	t.Run("skips project with SourceUIDAnnotation", func(t *testing.T) {
+		proj := generateAppProject("proj1")
+		proj.Annotations = map[string]string{manager.SourceUIDAnnotation: "some-uid"}
+
+		mockProjBackend := &mocks.AppProject{}
+		mockRepoBackend := &mocks.Repository{}
+		mockProjBackend.On("List", mock.Anything, mock.Anything).Return([]v1alpha1.AppProject{proj}, nil)
+		mockRepoBackend.On("List", mock.Anything, mock.Anything).Return([]corev1.Secret{}, nil)
+
+		s := newServer(t, mockProjBackend, mockRepoBackend)
+		err := s.sendCurrentStateToAgent(agentName)
+		require.NoError(t, err)
+
+		sendQ := s.queues.SendQ(agentName)
+		assert.Equal(t, 0, sendQ.Len())
+	})
+
+	t.Run("skips project with SkipSyncLabel=true", func(t *testing.T) {
+		proj := generateAppProject("proj1")
+		proj.Labels = map[string]string{config.SkipSyncLabel: "true"}
+
+		mockProjBackend := &mocks.AppProject{}
+		mockRepoBackend := &mocks.Repository{}
+		mockProjBackend.On("List", mock.Anything, mock.Anything).Return([]v1alpha1.AppProject{proj}, nil)
+		mockRepoBackend.On("List", mock.Anything, mock.Anything).Return([]corev1.Secret{}, nil)
+
+		s := newServer(t, mockProjBackend, mockRepoBackend)
+		err := s.sendCurrentStateToAgent(agentName)
+		require.NoError(t, err)
+
+		sendQ := s.queues.SendQ(agentName)
+		assert.Equal(t, 0, sendQ.Len())
+	})
+
+	t.Run("does not skip project with SkipSyncLabel=false", func(t *testing.T) {
+		proj := generateAppProject("proj1")
+		proj.Labels = map[string]string{config.SkipSyncLabel: "false"}
+
+		mockProjBackend := &mocks.AppProject{}
+		mockRepoBackend := &mocks.Repository{}
+		mockProjBackend.On("List", mock.Anything, mock.Anything).Return([]v1alpha1.AppProject{proj}, nil)
+		mockRepoBackend.On("List", mock.Anything, mock.Anything).Return([]corev1.Secret{}, nil)
+
+		s := newServer(t, mockProjBackend, mockRepoBackend)
+		err := s.sendCurrentStateToAgent(agentName)
+		require.NoError(t, err)
+
+		sendQ := s.queues.SendQ(agentName)
+		assert.Equal(t, 1, sendQ.Len())
+	})
+
+	t.Run("sends repository for matching project and updates mappings", func(t *testing.T) {
+		proj := generateAppProject("proj1")
+		repo := generateRepoSecret("repo1", "proj1")
+
+		mockProjBackend := &mocks.AppProject{}
+		mockRepoBackend := &mocks.Repository{}
+		mockProjBackend.On("List", mock.Anything, mock.Anything).Return([]v1alpha1.AppProject{proj}, nil)
+		mockRepoBackend.On("List", mock.Anything, mock.Anything).Return([]corev1.Secret{repo}, nil)
+
+		s := newServer(t, mockProjBackend, mockRepoBackend)
+		err := s.sendCurrentStateToAgent(agentName)
+		require.NoError(t, err)
+
+		// 1 project event + 1 repository event
+		sendQ := s.queues.SendQ(agentName)
+		assert.Equal(t, 2, sendQ.Len())
+
+		assert.True(t, s.projectToRepos.Get("proj1")["repo1"])
+		assert.True(t, s.repoToAgents.Get("repo1")[agentName])
+	})
+
+	t.Run("skips repository whose project was not sent to agent", func(t *testing.T) {
+		proj := generateAppProject("proj1")
+		repo := generateRepoSecret("repo1", "unknown-project")
+
+		mockProjBackend := &mocks.AppProject{}
+		mockRepoBackend := &mocks.Repository{}
+		mockProjBackend.On("List", mock.Anything, mock.Anything).Return([]v1alpha1.AppProject{proj}, nil)
+		mockRepoBackend.On("List", mock.Anything, mock.Anything).Return([]corev1.Secret{repo}, nil)
+
+		s := newServer(t, mockProjBackend, mockRepoBackend)
+		err := s.sendCurrentStateToAgent(agentName)
+		require.NoError(t, err)
+
+		// Only 1 project event, no repository event
+		sendQ := s.queues.SendQ(agentName)
+		assert.Equal(t, 1, sendQ.Len())
+	})
+
+	t.Run("sends projects and repos for wildcard destination match", func(t *testing.T) {
+		proj := v1alpha1.AppProject{
+			ObjectMeta: metav1.ObjectMeta{Name: "proj1", Namespace: ns},
+			Spec: v1alpha1.AppProjectSpec{
+				Destinations: []v1alpha1.ApplicationDestination{
+					{Name: "test-*", Namespace: "*", Server: "*"},
+				},
+				SourceNamespaces: []string{"test-*"},
+			},
+		}
+		repo := generateRepoSecret("repo1", "proj1")
+
+		mockProjBackend := &mocks.AppProject{}
+		mockRepoBackend := &mocks.Repository{}
+		mockProjBackend.On("List", mock.Anything, mock.Anything).Return([]v1alpha1.AppProject{proj}, nil)
+		mockRepoBackend.On("List", mock.Anything, mock.Anything).Return([]corev1.Secret{repo}, nil)
+
+		s := newServer(t, mockProjBackend, mockRepoBackend)
+		err := s.sendCurrentStateToAgent(agentName)
+		require.NoError(t, err)
+
+		sendQ := s.queues.SendQ(agentName)
+		assert.Equal(t, 2, sendQ.Len())
+	})
+
 }
 
 func init() {


### PR DESCRIPTION
**What does this PR do / why we need it**:
- Updated 'sendCurrentStateToAgent' to ensure it now checks for the SkipSync label for AppProjects
- Additional logic to ensure that the SkipSync label is respected when AppProject events come from informers. 
- I've also added unit tests for the  'sendCurrentStateToAgent'  function to verify the fix, and also ensure that we don't regress the fix in the future.

**Which issue(s) this PR fixes**:

Fixes #783, see that issue for detailed description of problem


**Checklist**

* [ ] Documentation update is required by this PR (and has been updated) OR no documentation update is required.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * AppProject resources now support synchronization filtering, allowing users to exclude specific projects from being synced through label configuration.
  * Filtering behavior is now consistent with other resource types for unified management.

* **Tests**
  * Comprehensive test coverage added for AppProject filtering, state synchronization, repository secret associations, and event handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->