### PR TITLE
chore: Enable data race detection in argocd-agent 'dev-env' and E2E tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,7 @@ BIN_NAME_CLI?=argocd-agentctl
 BIN_ARCH?=$(shell go env GOARCH)
 BIN_OS?=$(shell go env GOOS)
 CGO_ENABLED?=0
+ENABLE_DATA_RACE_DETECTOR?=true
 GOEXPERIMENT?=
 GO_TAGS?=
 GO_MOD?=
@@ -94,7 +95,7 @@ teardown-e2e:
 
 .PHONY: start-e2e
 start-e2e: cli install-goreman
-	./hack/dev-env/start-e2e.sh
+	ENABLE_DATA_RACE_DETECTOR=$(ENABLE_DATA_RACE_DETECTOR) ./hack/dev-env/start-e2e.sh
 
 .PHONY: test-e2e
 test-e2e:

--- a/hack/dev-env/start-agent-autonomous.sh
+++ b/hack/dev-env/start-agent-autonomous.sh
@@ -35,7 +35,12 @@ if [ -f "$E2E_ENV_FILE" ]; then
     source "$E2E_ENV_FILE"
 fi
 
-go run github.com/argoproj-labs/argocd-agent/cmd/argocd-agent agent \
+RACE_FLAG=""
+if [ "${ENABLE_DATA_RACE_DETECTOR}" = "true" ]; then
+    RACE_FLAG="-race"
+fi
+
+go run ${RACE_FLAG} github.com/argoproj-labs/argocd-agent/cmd/argocd-agent agent \
     --agent-mode autonomous \
     --creds mtls:any \
     --server-address 127.0.0.1 \

--- a/hack/dev-env/start-agent-managed.sh
+++ b/hack/dev-env/start-agent-managed.sh
@@ -38,7 +38,12 @@ if [ -f "$E2E_ENV_FILE" ]; then
     export ARGOCD_AGENT_ON_APPLICATION_RECREATE=${ARGOCD_AGENT_ON_APPLICATION_RECREATE:-ignore}
 fi
 
-go run github.com/argoproj-labs/argocd-agent/cmd/argocd-agent agent \
+RACE_FLAG=""
+if [ "${ENABLE_DATA_RACE_DETECTOR}" = "true" ]; then
+    RACE_FLAG="-race"
+fi
+
+go run ${RACE_FLAG} github.com/argoproj-labs/argocd-agent/cmd/argocd-agent agent \
     --agent-mode managed \
     --allowed-namespaces '*' \
     --creds "mtls:any" \

--- a/hack/dev-env/start-e2e.sh
+++ b/hack/dev-env/start-e2e.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -o pipefail
 
 # Copyright 2025 The argocd-agent Authors
 #

--- a/hack/dev-env/start-e2e.sh
+++ b/hack/dev-env/start-e2e.sh
@@ -71,5 +71,8 @@ export AUTONOMOUS_AGENT_REDIS_ADDR="$EXTERNAL_IP:6379"
 
 export REDIS_PASSWORD=$(kubectl get secret argocd-redis --context=vcluster-agent-managed -n ${ARGOCD_MANAGED_NAMESPACE} -o jsonpath='{.data.auth}' | base64 --decode)
 
-goreman -exit-on-stop=false -f hack/dev-env/Procfile.e2e start
+# Route output to a temporary file, to allow us to process the text in 'run-e2e.sh'
+rm -f /tmp/argocd-agent-e2e-process-output.log
+
+goreman -exit-on-stop=false -f hack/dev-env/Procfile.e2e start 2>&1 | tee /tmp/argocd-agent-e2e-process-output.log
 

--- a/hack/dev-env/start-principal.sh
+++ b/hack/dev-env/start-principal.sh
@@ -56,7 +56,12 @@ fi
 ARGOCD_AGENT_RESOURCE_PROXY=$(ip r show default | sed -e 's,.*\ src\ ,,' | sed -e 's,\ metric.*$,,')
 export ARGOCD_AGENT_RESOURCE_PROXY
 
-go run github.com/argoproj-labs/argocd-agent/cmd/argocd-agent principal \
+RACE_FLAG=""
+if [ "${ENABLE_DATA_RACE_DETECTOR}" = "true" ]; then
+    RACE_FLAG="-race"
+fi
+
+go run ${RACE_FLAG} github.com/argoproj-labs/argocd-agent/cmd/argocd-agent principal \
 	--allowed-namespaces '*' \
 	--kubecontext vcluster-control-plane \
 	--log-level ${ARGOCD_AGENT_LOG_LEVEL:-trace} \

--- a/test/run-e2e.sh
+++ b/test/run-e2e.sh
@@ -22,3 +22,10 @@ if ! kubectl config get-contexts | tail -n +2 | awk '{ print $2 }' | grep -qE '^
 fi
 
 go test -count=1 -v -race -timeout 45m github.com/argoproj-labs/argocd-agent/test/e2e
+
+# If we detect a data race in the 'make start-e2e' output, then fail here to cause the overall test job to fail.
+E2E_LOG="/tmp/argocd-agent-e2e-process-output.log"
+if [ -f "$E2E_LOG" ] && grep -q "WARNING: DATA RACE" "$E2E_LOG"; then
+    echo "ERROR: Data race detected in e2e process output. See logs for details." >&2
+    exit 1
+fi


### PR DESCRIPTION
**What does this PR do / why we need it**:
We currently enable go data race detection for unit tests, and the E2E test portion of E2E tests, but NOT for the actual argocd agent binaries themselves when running E2E test. (The actual binaries are where we would expect most data races to occur)

This PR adds a new script which will wrap the 'go run' calls we use for executing agents (locally). 

This script will:
- Switch the default to 'data race detection enabled' for argocd-agent when running via `make start-e2e`
- When `make test-e2e` completed, it will check the above log for DATA RACE log, and fail if found.
    - Data race detection can be disable via env var

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable Go race-detector support for local agent start scripts (enabled by default).
* **Bug Fixes**
  * Improved e2e startup reliability by enabling stricter shell error handling and tee’ing process output to a persistent log.
* **Tests**
  * Increased the e2e test timeout to **45 minutes**.
  * E2e now automatically fails if the captured log contains `WARNING: DATA RACE`.
* **Chores**
  * Updated dev tooling to pass the race-detector setting through the e2e start workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->