### PR TITLE
feat: filter in-cluster apps in destination-based mapping mode

### DIFF
--- a/principal/server.go
+++ b/principal/server.go
@@ -951,6 +951,15 @@ func (s *Server) defaultAppFilterChain() *filter.Chain[*v1alpha1.Application] {
 		}
 		return true
 	})
+	// In destination-based mapping mode, apps without a destination name
+	// (e.g. in-cluster apps using destination.server) cannot be routed to
+	// any agent, so filter them out.
+	if s.options.destinationBasedMapping {
+		c.AppendAdmitFilter(func(res *v1alpha1.Application) bool {
+			name := res.Spec.Destination.Name
+			return name != "" && name != "in-cluster"
+		})
+	}
 	return c
 }
 

--- a/principal/server_filter_test.go
+++ b/principal/server_filter_test.go
@@ -258,6 +258,45 @@ func TestServer_DefaultAppFilterChain_EdgeCases(t *testing.T) {
 	}
 }
 
+func TestServer_DefaultAppFilterChain_DestinationBasedMapping(t *testing.T) {
+	withDestName := &v1alpha1.Application{
+		ObjectMeta: metav1.ObjectMeta{Name: "app-with-dest", Namespace: "argocd"},
+		Spec:       v1alpha1.ApplicationSpec{Destination: v1alpha1.ApplicationDestination{Name: "some-agent"}},
+	}
+	withoutDestName := &v1alpha1.Application{
+		ObjectMeta: metav1.ObjectMeta{Name: "in-cluster-app", Namespace: "argocd"},
+		Spec:       v1alpha1.ApplicationSpec{Destination: v1alpha1.ApplicationDestination{Server: "https://kubernetes.default.svc"}},
+	}
+
+	t.Run("destination-based mapping disabled: in-cluster app is admitted", func(t *testing.T) {
+		server := &Server{options: &ServerOptions{namespaces: []string{"argocd"}}}
+		fc := server.defaultAppFilterChain()
+		assert.True(t, fc.Admit(withoutDestName))
+	})
+
+	t.Run("destination-based mapping enabled: app with destination name is admitted", func(t *testing.T) {
+		server := &Server{options: &ServerOptions{namespaces: []string{"argocd"}, destinationBasedMapping: true}}
+		fc := server.defaultAppFilterChain()
+		assert.True(t, fc.Admit(withDestName))
+	})
+
+	t.Run("destination-based mapping enabled: in-cluster app without destination name is rejected", func(t *testing.T) {
+		server := &Server{options: &ServerOptions{namespaces: []string{"argocd"}, destinationBasedMapping: true}}
+		fc := server.defaultAppFilterChain()
+		assert.False(t, fc.Admit(withoutDestName))
+	})
+
+	t.Run("destination-based mapping enabled: app with destination name 'in-cluster' is rejected", func(t *testing.T) {
+		server := &Server{options: &ServerOptions{namespaces: []string{"argocd"}, destinationBasedMapping: true}}
+		fc := server.defaultAppFilterChain()
+		inClusterApp := &v1alpha1.Application{
+			ObjectMeta: metav1.ObjectMeta{Name: "in-cluster-named-app", Namespace: "argocd"},
+			Spec:       v1alpha1.ApplicationSpec{Destination: v1alpha1.ApplicationDestination{Name: "in-cluster"}},
+		}
+		assert.False(t, fc.Admit(inClusterApp))
+	})
+}
+
 func init() {
 	logrus.SetLevel(logrus.TraceLevel)
 }


### PR DESCRIPTION
When destination-based mapping is enabled, apps with no destination.name or with destination.name 'in-cluster' cannot be routed to any agent. Filter them at the informer level to prevent callback errors.

**What does this PR do / why we need it**:

**Which issue(s) this PR fixes**:

Fixes #798 

**How to test changes / Special notes to the reviewer**:


**Checklist**

* [ ] Documentation update is required by this PR (and has been updated) OR no documentation update is required.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Applications with missing destination names or destination names matching "in-cluster" are now filtered from view when destination-based mapping is enabled, improving app visibility and routing accuracy.

* **Tests**
  * Added comprehensive tests validating destination-based mapping filter behavior across multiple configuration scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->