### PR TITLE
feat: measure agent event propagation latency

### DIFF
--- a/agent/inbound.go
+++ b/agent/inbound.go
@@ -69,6 +69,12 @@ func (a *Agent) processIncomingEvent(ev *event.Event) error {
 	// Start measuring time for event processing
 	cp := checkpoint.NewCheckpoint("process_recv_queue")
 
+	if a.metrics != nil {
+		if sentAt := event.SentAt(ev.CloudEvent()); sentAt != nil {
+			a.metrics.PropagationLatency.WithLabelValues(ev.Target().String()).Observe(time.Since(*sentAt).Seconds())
+		}
+	}
+
 	status := metrics.EventProcessingSuccess
 
 	// Start checkpoint step

--- a/internal/event/event.go
+++ b/internal/event/event.go
@@ -20,6 +20,7 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/argoproj-labs/argocd-agent/internal/resources"
 	"github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
@@ -85,7 +86,26 @@ const (
 const (
 	resourceID string = "resourceid"
 	eventID    string = "eventid"
+	sentAt     string = "sentat"
 )
+
+// SetSentAt stamps the current time on an event as the send time.
+func SetSentAt(ev *cloudevents.Event) {
+	ev.SetExtension(sentAt, time.Now().UTC().Format(time.RFC3339Nano))
+}
+
+// SentAt returns the send timestamp from an event, or nil if not set.
+func SentAt(ev *cloudevents.Event) *time.Time {
+	val, ok := ev.Extensions()[sentAt].(string)
+	if !ok {
+		return nil
+	}
+	t, err := time.Parse(time.RFC3339Nano, val)
+	if err != nil {
+		return nil
+	}
+	return &t
+}
 
 var (
 	ErrEventDiscarded    error = errors.New("event discarded")

--- a/internal/event/event_test.go
+++ b/internal/event/event_test.go
@@ -16,8 +16,10 @@ package event
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
+	cloudevents "github.com/cloudevents/sdk-go/v2"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -496,6 +498,31 @@ func TestTargetTerminal(t *testing.T) {
 
 	t.Run("TerminalRequest event type string representation", func(t *testing.T) {
 		require.Equal(t, "io.argoproj.argocd-agent.event.terminal-request", TerminalRequest.String())
+	})
+}
+
+func TestSentAt(t *testing.T) {
+	t.Run("SentAt returns nil when extension not set", func(t *testing.T) {
+		ev := cloudevents.NewEvent()
+		require.Nil(t, SentAt(&ev))
+	})
+
+	t.Run("SetSentAt and SentAt round-trip", func(t *testing.T) {
+		before := time.Now().UTC().Truncate(time.Nanosecond)
+		ev := cloudevents.NewEvent()
+		SetSentAt(&ev)
+		after := time.Now().UTC()
+
+		ts := SentAt(&ev)
+		require.NotNil(t, ts)
+		require.False(t, ts.Before(before), "sentat should not be before SetSentAt was called")
+		require.False(t, ts.After(after), "sentat should not be after SetSentAt returned")
+	})
+
+	t.Run("SentAt returns nil for malformed extension", func(t *testing.T) {
+		ev := cloudevents.NewEvent()
+		ev.SetExtension(sentAt, "not-a-timestamp")
+		require.Nil(t, SentAt(&ev))
 	})
 }
 

--- a/internal/event/event_writer.go
+++ b/internal/event/event_writer.go
@@ -386,6 +386,10 @@ func (ew *EventWriter) sendUnsentEvent(resID string) {
 		"event_type":   eventMsg.event.Type(),
 	})
 
+	if !isFireAndForget {
+		SetSentAt(eventMsg.event)
+	}
+
 	pev, err := format.ToProto(eventMsg.event)
 	eventMsg.mu.Unlock()
 

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -69,6 +69,7 @@ type AgentMetrics struct {
 	EventReceived       prometheus.Counter
 	EventSent           prometheus.Counter
 	EventProcessingTime *prometheus.HistogramVec
+	PropagationLatency  *prometheus.HistogramVec
 	AgentErrors         *prometheus.CounterVec
 }
 
@@ -172,6 +173,12 @@ func NewAgentMetrics() *AgentMetrics {
 			Name: "agent_event_processing_time",
 			Help: "Histogram of time taken to process events (in seconds)",
 		}, []string{"status", "agent_mode", "resource_type"}),
+
+		PropagationLatency: promauto.NewHistogramVec(prometheus.HistogramOpts{
+			Name:    "agent_event_propagation_latency_seconds",
+			Help:    "Histogram of time from principal send to agent processing (in seconds)",
+			Buckets: prometheus.DefBuckets,
+		}, []string{"resource_type"}),
 
 		AgentErrors: promauto.NewCounterVec(prometheus.CounterOpts{
 			Name: "agent_errors",


### PR DESCRIPTION
**What does this PR do / why we need it**:

Adds sentat timestamps so receivers can compute wire + queue latency

**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:


**Checklist**

* [ ] Documentation update is required by this PR (and has been updated) OR no documentation update is required.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Events now automatically record send timestamps for tracking purposes.
  * Propagation latency monitoring added to measure time from event send to agent processing.
  * New metrics track propagation latency by resource type.

* **Tests**
  * Added test coverage for timestamp and propagation latency functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->