### PR TITLE
fix: add known good redis prefixes to forward-to-principal list

### DIFF
--- a/agent/inbound_redis.go
+++ b/agent/inbound_redis.go
@@ -307,6 +307,12 @@ func (a *Agent) handleRedisGetMessage(logCtx *logrus.Entry, rreq *event.RedisReq
 // needs to be converted to, e.g.
 // "app|resources-tree|my-app|1.8.3.gz
 func stripNamespaceFromRedisKey(key string, logCtx *logrus.Entry) (string, error) {
+
+	// git-refs and gitdirs keys don't contain namespace information; return as-is
+	if strings.HasPrefix(key, "git-refs|") || strings.HasPrefix(key, "gitdirs|") {
+		return key, nil
+	}
+
 	var matchedPrefix string
 	expectedPrefixes := []string{
 		"app|resources-tree|",

--- a/agent/inbound_redis_test.go
+++ b/agent/inbound_redis_test.go
@@ -69,6 +69,18 @@ func Test_stripNamespaceFromKeyForAutonomousAgent(t *testing.T) {
 			expectedValue: "",
 			errorExpected: true,
 		},
+		{
+			name:          "git-refs key is returned unchanged",
+			key:           "git-refs|https://github.com/gnunn-gitops/cluster-config-v2%7C1.8.3.gz",
+			expectedValue: "git-refs|https://github.com/gnunn-gitops/cluster-config-v2%7C1.8.3.gz",
+			errorExpected: false,
+		},
+		{
+			name:          "gitdirs key is returned unchanged",
+			key:           "gitdirs|https://github.com/gnunn-gitops/cluster-config-v2%7C232c92db490001cb7f239ba70a2a14ff42b7e2d0%7C1.8.3.gz",
+			expectedValue: "gitdirs|https://github.com/gnunn-gitops/cluster-config-v2%7C232c92db490001cb7f239ba70a2a14ff42b7e2d0%7C1.8.3.gz",
+			errorExpected: false,
+		},
 	}
 
 	for _, testEntry := range testEntries {

--- a/principal/redisproxy/redisproxy.go
+++ b/principal/redisproxy/redisproxy.go
@@ -963,6 +963,13 @@ func (rp *RedisProxy) extractAgentNameFromRedisCommandKey(redisKey string, logCt
 			return "", nil
 		}
 
+		if strings.HasPrefix(redisKey, "git-refs|") || strings.HasPrefix(redisKey, "gitdirs|") {
+			// 'git-refs' redis prefix: a cache of git references (branches, tags, etc) (used in a number of places, including exposed via '/api/v1/repositories/{repo}/refs' api)
+			// 'gitdirs' redis prefix: a cache of all directories contained within a git repo (e.g. a dir list, but excluding files. Seemingly only used by appset, presumably by git directory generator)
+			logCtx.Debug("redirecting git redis key to principal redis")
+			return "", nil
+		}
+
 		logCtx.Warningf("Unexpected redis key seen: '%s'. Redirecting to principal by default.", redisKey)
 
 		return "", nil


### PR DESCRIPTION
**What does this PR do / why we need it**:
- See #751 and comments on that for details.
- This PR adds the `git-refs|` and `gitdirs|` prefixes as A) recognized, and B) known to good to forward to principal.

**Which issue(s) this PR fixes**:

Fixes #751

**How to test changes / Special notes to the reviewer**:


**Checklist**

* [ ] Documentation update is required by this PR (and has been updated) OR no documentation update is required.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of git-related Redis keys (with `git-refs` and `gitdirs` prefixes) by preventing namespace stripping and routing them directly to the principal Redis service.

* **Tests**
  * Added test cases to validate that git-related Redis keys are preserved and routed correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->