### PR TITLE
chore: remove unused 'Update' event in 'internal/event'

### DIFF
--- a/docs/concepts/sync-protocol.md
+++ b/docs/concepts/sync-protocol.md
@@ -38,7 +38,7 @@ The protocol uses a **hub-and-spoke** architecture where:
 
 ```
 ┌─────────────────────────────────────┐
-│         Application Events          │  ← Create, Update, Delete, Status
+│         Application Events          │  ← Create, Delete, SpecUpdate, Status, etc
 ├─────────────────────────────────────┤
 │        CloudEvents Format           │  ← Event envelope with metadata
 ├─────────────────────────────────────┤
@@ -100,7 +100,6 @@ The protocol defines several event types for different synchronization scenarios
 #### Resource Management Events
 
 - **`create`**: Create new resource (managed mode only)
-- **`update`**: Update resource configuration
 - **`delete`**: Remove resource (managed mode only)
 - **`spec-update`**: Update resource specification
 - **`status-update`**: Update resource status

--- a/docs/operations/tracing.md
+++ b/docs/operations/tracing.md
@@ -112,7 +112,7 @@ The following custom attributes are added to spans to provide context:
 
 ### Event Attributes
 
-- `argocd.event.type`: Type of event (Create, Update, Delete, etc.)
+- `argocd.event.type`: Type of event (Create, SpecUpdate, Delete, etc.)
 - `argocd.event.id`: Unique event identifier
 - `argocd.operation.type`: Operation type (create, update, delete, get, list, etc.)
 

--- a/internal/event/event.go
+++ b/internal/event/event.go
@@ -50,7 +50,6 @@ const (
 	Pong                       EventType = TypePrefix + ".pong"
 	Create                     EventType = TypePrefix + ".create"
 	Delete                     EventType = TypePrefix + ".delete"
-	Update                     EventType = TypePrefix + ".update"
 	SpecUpdate                 EventType = TypePrefix + ".spec-update"
 	StatusUpdate               EventType = TypePrefix + ".status-update"
 	OperationUpdate            EventType = TypePrefix + ".operation-update"

--- a/internal/event/event_test.go
+++ b/internal/event/event_test.go
@@ -18,8 +18,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/require"
 	cloudevents "github.com/cloudevents/sdk-go/v2"
+	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 

--- a/internal/event/event_writer_test.go
+++ b/internal/event/event_writer_test.go
@@ -63,9 +63,9 @@ func TestEventWriter(t *testing.T) {
 		require.Equal(t, latestEvent.event, ev)
 		require.Nil(t, latestEvent.retryAfter)
 
-		// Add an Update event for the same resource
+		// Add a SpecUpdate event for the same resource
 		app1.ResourceVersion = "2"
-		newEv := es.ApplicationEvent(Update, app1)
+		newEv := es.ApplicationEvent(SpecUpdate, app1)
 		evSender.Add(newEv)
 
 		latestEvent = evSender.Get(ResourceID(ev))
@@ -75,7 +75,7 @@ func TestEventWriter(t *testing.T) {
 
 		// Try removing an event with the same resourceID but different eventID.
 		app1.ResourceVersion = "3"
-		newEv = es.ApplicationEvent(Update, app1)
+		newEv = es.ApplicationEvent(SpecUpdate, app1)
 		evSender.Remove(newEv)
 
 		// The old event should not removed from the queue.
@@ -96,8 +96,8 @@ func TestEventWriter(t *testing.T) {
 		fs := &fakeStream{}
 		evSender := NewEventWriter(fs)
 
-		app1Events := []EventType{Create, Update, Delete}
-		app2Events := []EventType{Create, Update, Update, Delete}
+		app1Events := []EventType{Create, SpecUpdate, Delete}
+		app2Events := []EventType{Create, SpecUpdate, SpecUpdate, Delete}
 
 		for v, e := range app2Events {
 			app2.ResourceVersion = fmt.Sprintf("%d", v)
@@ -152,12 +152,12 @@ func TestEventWriter(t *testing.T) {
 		fs := &fakeStream{}
 		evSender := NewEventWriter(fs)
 
-		// Add Create and Update events
+		// Add Create and SpecUpdate events
 		ev1 := es.ApplicationEvent(Create, app1)
 		evSender.Add(ev1)
 
 		app1.ResourceVersion = "2"
-		ev2 := es.ApplicationEvent(Update, app1)
+		ev2 := es.ApplicationEvent(SpecUpdate, app1)
 		evSender.Add(ev2)
 
 		resID := createResourceID(app1.ObjectMeta)
@@ -201,7 +201,7 @@ func TestEventWriter(t *testing.T) {
 							UID:             types.UID(fmt.Sprintf("%d", id)),
 						},
 					}
-					ev := es.ApplicationEvent(Update, app)
+					ev := es.ApplicationEvent(SpecUpdate, app)
 					evSender.Add(ev)
 				}
 			}(i)
@@ -222,7 +222,7 @@ func TestEventWriter(t *testing.T) {
 							UID:             types.UID(fmt.Sprintf("%d", id)),
 						},
 					}
-					ev := es.ApplicationEvent(Update, app)
+					ev := es.ApplicationEvent(SpecUpdate, app)
 					evSender.Remove(ev)
 				}
 			}(i)
@@ -414,7 +414,7 @@ func TestEventWriter(t *testing.T) {
 
 		// Add another event for the same resource with version 2
 		app1.ResourceVersion = "2"
-		ev2 := es.ApplicationEvent(Update, app1)
+		ev2 := es.ApplicationEvent(SpecUpdate, app1)
 		evSender.Add(ev2)
 
 		// Get should return the sent event (version 1), not the unsent one (version 2)
@@ -465,7 +465,7 @@ func TestEventWriter(t *testing.T) {
 		// Add multiple updates
 		for i := 1; i <= 5; i++ {
 			app1.ResourceVersion = fmt.Sprintf("%d", i)
-			ev := es.ApplicationEvent(Update, app1)
+			ev := es.ApplicationEvent(SpecUpdate, app1)
 			evSender.Add(ev)
 		}
 

--- a/principal/apis/eventstream/eventstream_test.go
+++ b/principal/apis/eventstream/eventstream_test.go
@@ -145,7 +145,7 @@ func Test_Subscribe(t *testing.T) {
 			&v1alpha1.Application{ObjectMeta: v1.ObjectMeta{Name: "foo", Namespace: "test"}},
 		))
 		qs.SendQ("default").Add(emitter.ApplicationEvent(
-			event.Update,
+			event.SpecUpdate,
 			&v1alpha1.Application{ObjectMeta: v1.ObjectMeta{Name: "foo", Namespace: "test"}},
 		))
 		qs.SendQ("default").Add(emitter.ApplicationEvent(


### PR DESCRIPTION
**What does this PR do / why we need it**:
- `internal/event/event.go` contains an event constant which is not used. It can be removed.
- This PR removes the constant, and updates tests/docs that reference it.

**How to test changes / Special notes to the reviewer**:
N/A

**Checklist**

* [x] Documentation update is required by this PR (and has been updated) OR no documentation update is required.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated event type references across documentation to reflect current event naming conventions, replacing legacy terminology with SpecUpdate event type nomenclature.

* **Refactor**
  * Aligned internal event type definitions and test cases with updated event taxonomy to ensure consistency across the codebase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->