### PR TITLE
fix: AppProject is deleted on principal restart for autonomous agents

### DIFF
--- a/internal/resync/resync.go
+++ b/internal/resync/resync.go
@@ -288,8 +288,8 @@ func (r *RequestHandler) ProcessRequestUpdateEvent(ctx context.Context, agentNam
 		return r.handleDeletedResource(logCtx, reqUpdate)
 	}
 
-	// If the resource is AppProject/Repository, we need to ensure that it is still relevant with the current AppProject rules
-	if reqUpdate.Kind == "AppProject" || reqUpdate.Kind == "Repository" {
+	// If the resource is AppProject/Repository, we need to ensure that it is still relevant with the current AppProject rules.
+	if r.role == manager.ManagerRolePrincipal && (reqUpdate.Kind == "AppProject" || reqUpdate.Kind == "Repository") {
 		err, isRelevant := r.isAppProjectRelevant(ctx, logCtx, agentName, reqUpdate, res)
 		if err != nil {
 			return err

--- a/test/e2e/resync_test.go
+++ b/test/e2e/resync_test.go
@@ -1460,6 +1460,74 @@ func sampleRepository() *corev1.Secret {
 	}
 }
 
+// AppProject on the principal must persist after principal restart when the destination name is "in-cluster"
+func (suite *ResyncTestSuite) Test_AppProjectResyncOnPrincipalRestart_Autonomous_InClusterDestination() {
+	suite.assertAppProjectSurvivesPrincipalRestart("incluster-sample", "in-cluster")
+}
+
+// AppProject on the principal must persist after principal restart when the destination name is "production"
+func (suite *ResyncTestSuite) Test_AppProjectResyncOnPrincipalRestart_Autonomous_ArbitraryDestination() {
+	suite.assertAppProjectSurvivesPrincipalRestart("production-sample", "production")
+}
+
+func (suite *ResyncTestSuite) assertAppProjectSurvivesPrincipalRestart(projectName, destinationName string) {
+	requires := suite.Require()
+
+	agentAppProject := &argoapp.AppProject{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      projectName,
+			Namespace: "argocd",
+		},
+		Spec: argoapp.AppProjectSpec{
+			Destinations: []argoapp.ApplicationDestination{
+				{
+					Namespace: "*",
+					Name:      destinationName,
+					Server:    "https://kubernetes.default.svc",
+				},
+			},
+			SourceRepos: []string{"*"},
+		},
+	}
+
+	err := suite.AutonomousAgentClient.Create(suite.Ctx, agentAppProject, metav1.CreateOptions{})
+	requires.NoError(err)
+
+	principalKey := types.NamespacedName{Name: "agent-autonomous-" + agentAppProject.Name, Namespace: "argocd"}
+	agentKey := types.NamespacedName{Name: agentAppProject.Name, Namespace: "argocd"}
+
+	// Wait for the AppProject to sync to the principal
+	requires.Eventually(func() bool {
+		proj := argoapp.AppProject{}
+		return suite.PrincipalClient.Get(suite.Ctx, principalKey, &proj, metav1.GetOptions{}) == nil
+	}, 30*time.Second, 1*time.Second, "AppProject should sync to principal")
+
+	// Restart the principal
+	err = fixture.StopProcess("principal")
+	requires.NoError(err)
+
+	requires.Eventually(func() bool {
+		return !fixture.IsProcessRunning("principal")
+	}, 30*time.Second, 1*time.Second)
+
+	err = fixture.StartProcess("principal")
+	requires.NoError(err)
+
+	fixture.CheckReadiness(suite.T(), "principal")
+
+	// The AppProject must still exist on the agent cluster
+	requires.Eventually(func() bool {
+		agentProj := argoapp.AppProject{}
+		return suite.AutonomousAgentClient.Get(suite.Ctx, agentKey, &agentProj, metav1.GetOptions{}) == nil
+	}, 30*time.Second, 1*time.Second, "AppProject should still exist on agent after principal restart")
+
+	// The AppProject must still exist on the principal
+	requires.Eventually(func() bool {
+		proj := argoapp.AppProject{}
+		return suite.PrincipalClient.Get(suite.Ctx, principalKey, &proj, metav1.GetOptions{}) == nil
+	}, 30*time.Second, 1*time.Second, "AppProject should still exist on principal after principal restart")
+}
+
 func TestResyncTestSuite(t *testing.T) {
 	suite.Run(t, new(ResyncTestSuite))
 }


### PR DESCRIPTION
This PR fixes the issue where AppProject is deleted from control-plane after restarting principal, if agent is running in autonomous agent.

Fixes https://github.com/argoproj-labs/argocd-agent/issues/813

**How to test changes / Special notes to the reviewer**:
- Start principal and autonomous agent.
- Deploy app project in autonomous agent having "in-cluster" in destination field
- Check AppProject is created on control-plane.
- Restart principal and AppProject should not be deleted.

Assisted by: Cursor


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resource management by adding role-based conditional logic for relevance checks, ensuring proper cleanup behavior.

* **Tests**
  * Added comprehensive end-to-end tests validating AppProject persistence across principal restarts for different destination configurations, including in-cluster and production deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->