### PR TITLE
docs: Wire up HA docs into the navigation

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -35,6 +35,7 @@ nav:
       - Autonomous mode: concepts/agent-modes/autonomous.md
     - Agent mapping: concepts/agent-mapping.md
     - Sync protocol: concepts/sync-protocol.md
+    - High availability: concepts/ha.md
   - Getting started:
     - Overview: getting-started/index.md
     - Kubernetes: getting-started/kubernetes/index.md
@@ -56,6 +57,7 @@ nav:
     - Namespaces: configuration/namespaces.md
     - Networking: configuration/networking.md
     - Observability: configuration/observability.md
+    - High availability: configuration/ha.md
     - CTL: configuration/ctl.md
     - Reference:
         - Overview: configuration/reference/index.md
@@ -64,6 +66,7 @@ nav:
   - Operations:
     - Metrics: operations/metrics.md
     - Profiling: operations/profiling.md
+    - High availability: operations/ha-failover.md
   - Contributing:
     - Overview: contributing/index.md
     - Local development: contributing/local.md


### PR DESCRIPTION
**What does this PR do / why we need it**:

Wires up the docs from #768 into the navigation tree for the docs site.

**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:


**Checklist**

* [ ] Documentation update is required by this PR (and has been updated) OR no documentation update is required.

