### PR TITLE
feat: multi-principal uid handling

### DIFF
--- a/agent/inbound.go
+++ b/agent/inbound.go
@@ -215,6 +215,15 @@ func (a *Agent) rewriteDestinationForManagedAgent(app *v1alpha1.Application) {
 	app.Spec.Destination.Name = "in-cluster"
 }
 
+func sourceUIDForApp(app *v1alpha1.Application) ktypes.UID {
+	if app.Annotations != nil {
+		if sourceUID := app.Annotations[manager.SourceUIDAnnotation]; sourceUID != "" {
+			return ktypes.UID(sourceUID)
+		}
+	}
+	return app.UID
+}
+
 // handleCreateApp applies the identity decision matrix for Create events.
 func (a *Agent) handleCreateApp(logCtx *logrus.Entry, incomingApp *v1alpha1.Application, identity *application.IdentityCompareResult, principalUID string) error {
 	if identity != nil && identity.Exists {
@@ -230,11 +239,11 @@ func (a *Agent) handleCreateApp(logCtx *logrus.Entry, incomingApp *v1alpha1.Appl
 		case identityActionTransition:
 			logCtx.Info("Received Create during principal transition. Transitioning in-place")
 			a.rewriteDestinationForManagedAgent(incomingApp)
-			_, err := a.appManager.UpdateManagedAppWithTransition(a.context, incomingApp, principalUID, string(incomingApp.UID))
+			_, err := a.appManager.UpdateManagedAppWithTransition(a.context, incomingApp, principalUID, string(sourceUIDForApp(incomingApp)))
 			if err != nil {
 				return fmt.Errorf("could not transition existing app: %w", err)
 			}
-			a.sourceCache.Application.Set(incomingApp.UID, incomingApp.Spec)
+			a.sourceCache.Application.Set(sourceUIDForApp(incomingApp), incomingApp.Spec)
 			return nil
 		case identityActionDeleteRecreate:
 			logCtx.Debug("App exists with different source UID. Deleting before recreate")
@@ -244,11 +253,11 @@ func (a *Agent) handleCreateApp(logCtx *logrus.Entry, incomingApp *v1alpha1.Appl
 		case identityActionUpdateStampUID:
 			logCtx.Info("Received Create with missing source-uid (AppSet wipe). Updating + stamping")
 			a.rewriteDestinationForManagedAgent(incomingApp)
-			_, err := a.appManager.UpdateManagedAppWithTransition(a.context, incomingApp, principalUID, string(incomingApp.UID))
+			_, err := a.appManager.UpdateManagedAppWithTransition(a.context, incomingApp, principalUID, string(sourceUIDForApp(incomingApp)))
 			if err != nil {
 				return fmt.Errorf("could not update app after source-uid wipe: %w", err)
 			}
-			a.sourceCache.Application.Set(incomingApp.UID, incomingApp.Spec)
+			a.sourceCache.Application.Set(sourceUIDForApp(incomingApp), incomingApp.Spec)
 			return nil
 		}
 	}
@@ -284,20 +293,20 @@ func (a *Agent) handleSpecUpdateApp(logCtx *logrus.Entry, incomingApp *v1alpha1.
 	case identityActionTransition:
 		logCtx.Info("Principal transition detected on SpecUpdate. Transitioning in-place")
 		a.rewriteDestinationForManagedAgent(incomingApp)
-		_, err := a.appManager.UpdateManagedAppWithTransition(a.context, incomingApp, principalUID, string(incomingApp.UID))
+		_, err := a.appManager.UpdateManagedAppWithTransition(a.context, incomingApp, principalUID, string(sourceUIDForApp(incomingApp)))
 		if err != nil {
 			return fmt.Errorf("could not transition app: %w", err)
 		}
-		a.sourceCache.Application.Set(incomingApp.UID, incomingApp.Spec)
+		a.sourceCache.Application.Set(sourceUIDForApp(incomingApp), incomingApp.Spec)
 		return nil
 	case identityActionUpdateStampUID:
 		logCtx.Info("Source-uid missing (AppSet wipe) on SpecUpdate. Updating + stamping")
 		a.rewriteDestinationForManagedAgent(incomingApp)
-		_, err := a.appManager.UpdateManagedAppWithTransition(a.context, incomingApp, principalUID, string(incomingApp.UID))
+		_, err := a.appManager.UpdateManagedAppWithTransition(a.context, incomingApp, principalUID, string(sourceUIDForApp(incomingApp)))
 		if err != nil {
 			return fmt.Errorf("could not update app after source-uid wipe: %w", err)
 		}
-		a.sourceCache.Application.Set(incomingApp.UID, incomingApp.Spec)
+		a.sourceCache.Application.Set(sourceUIDForApp(incomingApp), incomingApp.Spec)
 		return nil
 	case identityActionDeleteRecreate:
 		logCtx.Debug("Source UID mismatch. Deleting existing app")
@@ -675,7 +684,7 @@ func (a *Agent) createApplication(incoming *v1alpha1.Application, principalUID s
 
 	if a.mode == types.AgentModeManaged {
 		// Store app spec in cache
-		a.sourceCache.Application.Set(incoming.UID, incoming.Spec)
+		a.sourceCache.Application.Set(sourceUIDForApp(incoming), incoming.Spec)
 	}
 
 	created, err := a.appManager.CreateWithPrincipalUID(a.context, incoming, principalUID)
@@ -779,7 +788,7 @@ func (a *Agent) deleteApplication(app *v1alpha1.Application) error {
 		if apierrors.IsNotFound(err) {
 			logCtx.Debug("application is not found, perhaps it is already deleted")
 			if a.mode == types.AgentModeManaged {
-				a.sourceCache.Application.Delete(app.UID)
+				a.sourceCache.Application.Delete(sourceUIDForApp(app))
 			}
 			return nil
 		}
@@ -787,7 +796,7 @@ func (a *Agent) deleteApplication(app *v1alpha1.Application) error {
 	}
 
 	if a.mode == types.AgentModeManaged {
-		a.sourceCache.Application.Delete(app.UID)
+		a.sourceCache.Application.Delete(sourceUIDForApp(app))
 	}
 
 	err = a.appManager.Unmanage(app.QualifiedName())

--- a/agent/inbound.go
+++ b/agent/inbound.go
@@ -24,6 +24,7 @@ import (
 	"github.com/argoproj-labs/argocd-agent/internal/checkpoint"
 	"github.com/argoproj-labs/argocd-agent/internal/event"
 	"github.com/argoproj-labs/argocd-agent/internal/manager"
+	"github.com/argoproj-labs/argocd-agent/internal/manager/application"
 	"github.com/argoproj-labs/argocd-agent/internal/metrics"
 	"github.com/argoproj-labs/argocd-agent/internal/resync"
 	"github.com/argoproj-labs/argocd-agent/internal/tracing"
@@ -159,13 +160,14 @@ func (a *Agent) processIncomingApplication(ev *event.Event) error {
 	targetNamespace := a.getTargetNamespaceForApp(incomingApp)
 	incomingApp.SetNamespace(targetNamespace)
 
-	var exists, sourceUIDMatch bool
+	principalUID := event.PrincipalUID(ev.CloudEvent())
+
+	var identity *application.IdentityCompareResult
 
 	if a.mode == types.AgentModeManaged {
-		// Source UID annotation is not present for apps on the autonomous agent since it is the source of truth.
-		exists, sourceUIDMatch, err = a.appManager.CompareSourceUID(a.context, incomingApp)
+		identity, err = a.appManager.CompareIdentity(a.context, incomingApp, principalUID)
 		if err != nil {
-			return fmt.Errorf("failed to compare the source UID of app: %w", err)
+			return fmt.Errorf("failed to compare identity of app: %w", err)
 		}
 		// In managed mode, Drop ownerReferences from the incoming resource
 		// This can lead to garbage-collection of the resource on the agent cluster, if referenced owner is missing. For example, AppSet
@@ -174,64 +176,11 @@ func (a *Agent) processIncomingApplication(ev *event.Event) error {
 
 	switch ev.Type() {
 	case event.Create:
-		if exists {
-			if sourceUIDMatch {
-				logCtx.Debug("Received a Create event for an existing app. Updating the existing app")
-				_, err := a.updateApplication(incomingApp)
-				if err != nil {
-					return fmt.Errorf("could not update the existing app: %w", err)
-				}
-				return nil
-			} else {
-				logCtx.Debug("An app already exists with a different source UID. Deleting the existing app")
-				if err := a.deleteApplication(incomingApp); err != nil {
-					return fmt.Errorf("could not delete existing app prior to creation: %w", err)
-				}
-			}
-		}
-
-		_, err = a.createApplication(incomingApp)
-		if err != nil {
-			logCtx.Errorf("Error creating application: %v", err)
-		}
+		err = a.handleCreateApp(logCtx, incomingApp, identity, principalUID)
 	case event.SpecUpdate:
-		// Principal may send update events to refresh/sync the apps on the autonomous agent.
-		if a.mode == types.AgentModeAutonomous {
-			_, err = a.updateApplication(incomingApp)
-			if err != nil {
-				logCtx.Errorf("Error updating application: %v", err)
-			}
-			return nil
-		}
-
-		if !exists {
-			logCtx.Debug("Received an Update event for an app that doesn't exist. Creating the incoming app")
-			if _, err := a.createApplication(incomingApp); err != nil {
-				return fmt.Errorf("could not create incoming app: %w", err)
-			}
-			return nil
-		}
-
-		if !sourceUIDMatch {
-			logCtx.Debug("Source UID mismatch between the incoming app and existing app. Deleting the existing app")
-			if err := a.deleteApplication(incomingApp); err != nil {
-				return fmt.Errorf("could not delete existing app prior to creation: %w", err)
-			}
-
-			logCtx.Debug("Creating the incoming app after deleting the existing app")
-			if _, err := a.createApplication(incomingApp); err != nil {
-				return fmt.Errorf("could not create incoming app after deleting existing app: %w", err)
-			}
-			return nil
-		}
-
-		_, err = a.updateApplication(incomingApp)
-		if err != nil {
-			logCtx.Errorf("Error updating application: %v", err)
-		}
+		err = a.handleSpecUpdateApp(logCtx, incomingApp, identity, principalUID)
 	case event.TerminateOperation:
 		logCtx.Trace("Received a TerminateOperation event")
-		// Terminate a running sync operation on the agent cluster
 		_, err = a.appManager.TerminateOperation(a.context, incomingApp)
 		if err != nil {
 			logCtx.Errorf("Error terminating application operation: %v", err)
@@ -246,6 +195,128 @@ func (a *Agent) processIncomingApplication(ev *event.Event) error {
 	}
 
 	return err
+}
+
+// handleCreateApp applies the identity decision matrix for Create events.
+func (a *Agent) handleCreateApp(logCtx *logrus.Entry, incomingApp *v1alpha1.Application, identity *application.IdentityCompareResult, principalUID string) error {
+	if identity != nil && identity.Exists {
+		action := identityAction(identity)
+		switch action {
+		case identityActionUpdate:
+			logCtx.Debug("Received Create for existing app, identity matches. Updating")
+			_, err := a.updateApplication(incomingApp)
+			if err != nil {
+				return fmt.Errorf("could not update existing app: %w", err)
+			}
+			return nil
+		case identityActionTransition:
+			logCtx.Info("Received Create during principal transition. Transitioning in-place")
+			_, err := a.appManager.UpdateManagedAppWithTransition(a.context, incomingApp, principalUID, string(incomingApp.UID))
+			if err != nil {
+				return fmt.Errorf("could not transition existing app: %w", err)
+			}
+			a.sourceCache.Application.Set(incomingApp.UID, incomingApp.Spec)
+			return nil
+		case identityActionDeleteRecreate:
+			logCtx.Debug("App exists with different source UID. Deleting before recreate")
+			if err := a.deleteApplication(incomingApp); err != nil {
+				return fmt.Errorf("could not delete existing app prior to creation: %w", err)
+			}
+		case identityActionUpdateStampUID:
+			logCtx.Info("Received Create with missing source-uid (AppSet wipe). Updating + stamping")
+			_, err := a.appManager.UpdateManagedAppWithTransition(a.context, incomingApp, principalUID, string(incomingApp.UID))
+			if err != nil {
+				return fmt.Errorf("could not update app after source-uid wipe: %w", err)
+			}
+			a.sourceCache.Application.Set(incomingApp.UID, incomingApp.Spec)
+			return nil
+		}
+	}
+
+	_, err := a.createApplication(incomingApp, principalUID)
+	if err != nil {
+		logCtx.Errorf("Error creating application: %v", err)
+	}
+	return err
+}
+
+// handleSpecUpdateApp applies the identity decision matrix for SpecUpdate events.
+func (a *Agent) handleSpecUpdateApp(logCtx *logrus.Entry, incomingApp *v1alpha1.Application, identity *application.IdentityCompareResult, principalUID string) error {
+	// Autonomous agents receive updates for refresh/sync only.
+	if a.mode == types.AgentModeAutonomous {
+		_, err := a.updateApplication(incomingApp)
+		if err != nil {
+			logCtx.Errorf("Error updating application: %v", err)
+		}
+		return err
+	}
+
+	if identity == nil || !identity.Exists {
+		logCtx.Debug("Received SpecUpdate for non-existing app. Creating")
+		if _, err := a.createApplication(incomingApp, principalUID); err != nil {
+			return fmt.Errorf("could not create incoming app: %w", err)
+		}
+		return nil
+	}
+
+	action := identityAction(identity)
+	switch action {
+	case identityActionTransition:
+		logCtx.Info("Principal transition detected on SpecUpdate. Transitioning in-place")
+		_, err := a.appManager.UpdateManagedAppWithTransition(a.context, incomingApp, principalUID, string(incomingApp.UID))
+		if err != nil {
+			return fmt.Errorf("could not transition app: %w", err)
+		}
+		a.sourceCache.Application.Set(incomingApp.UID, incomingApp.Spec)
+		return nil
+	case identityActionUpdateStampUID:
+		logCtx.Info("Source-uid missing (AppSet wipe) on SpecUpdate. Updating + stamping")
+		_, err := a.appManager.UpdateManagedAppWithTransition(a.context, incomingApp, principalUID, string(incomingApp.UID))
+		if err != nil {
+			return fmt.Errorf("could not update app after source-uid wipe: %w", err)
+		}
+		a.sourceCache.Application.Set(incomingApp.UID, incomingApp.Spec)
+		return nil
+	case identityActionDeleteRecreate:
+		logCtx.Debug("Source UID mismatch. Deleting existing app")
+		if err := a.deleteApplication(incomingApp); err != nil {
+			return fmt.Errorf("could not delete existing app: %w", err)
+		}
+		logCtx.Debug("Creating incoming app after deleting existing app")
+		if _, err := a.createApplication(incomingApp, principalUID); err != nil {
+			return fmt.Errorf("could not create incoming app: %w", err)
+		}
+		return nil
+	default:
+		_, err := a.updateApplication(incomingApp)
+		if err != nil {
+			logCtx.Errorf("Error updating application: %v", err)
+		}
+		return err
+	}
+}
+
+type identityActionType int
+
+const (
+	identityActionUpdate         identityActionType = iota // normal update
+	identityActionDeleteRecreate                           // source-uid mismatch, same principal
+	identityActionTransition                               // different principal → adopt in-place
+	identityActionUpdateStampUID                           // same principal, source-uid wiped
+)
+
+// identityAction implements the decision matrix from the design doc.
+func identityAction(r *application.IdentityCompareResult) identityActionType {
+	if r.PrincipalTransition {
+		return identityActionTransition
+	}
+	if r.MissingSourceUID && r.PrincipalUIDMatch {
+		return identityActionUpdateStampUID
+	}
+	if r.SourceUIDMatch {
+		return identityActionUpdate
+	}
+	return identityActionDeleteRecreate
 }
 
 func (a *Agent) processIncomingAppProject(ev *event.Event) error {
@@ -504,8 +575,8 @@ func (a *Agent) processIncomingResourceResyncEvent(ev *event.Event) error {
 }
 
 // createApplication creates an Application upon an event in the agent's work
-// queue.
-func (a *Agent) createApplication(incoming *v1alpha1.Application) (*v1alpha1.Application, error) {
+// queue. principalUID is stamped on the resource if non-empty.
+func (a *Agent) createApplication(incoming *v1alpha1.Application, principalUID string) (*v1alpha1.Application, error) {
 	// Determine the target namespace for the application
 	targetNamespace := a.getTargetNamespaceForApp(incoming)
 	incoming.SetNamespace(targetNamespace)
@@ -562,7 +633,7 @@ func (a *Agent) createApplication(incoming *v1alpha1.Application) (*v1alpha1.App
 		a.sourceCache.Application.Set(incoming.UID, incoming.Spec)
 	}
 
-	created, err := a.appManager.Create(a.context, incoming)
+	created, err := a.appManager.CreateWithPrincipalUID(a.context, incoming, principalUID)
 	if apierrors.IsAlreadyExists(err) {
 		logCtx.Debug("application already exists")
 		return created, nil

--- a/agent/inbound.go
+++ b/agent/inbound.go
@@ -162,6 +162,16 @@ func (a *Agent) processIncomingApplication(ev *event.Event) error {
 
 	principalUID := event.PrincipalUID(ev.CloudEvent())
 
+	// Carry the principal identity from the CloudEvent extension into the
+	// Application annotations so that downstream update paths (including the
+	// normal UpdateManagedApp) can adopt it on pre-upgrade resources.
+	if principalUID != "" {
+		if incomingApp.Annotations == nil {
+			incomingApp.Annotations = make(map[string]string)
+		}
+		incomingApp.Annotations[manager.PrincipalUIDAnnotation] = principalUID
+	}
+
 	var identity *application.IdentityCompareResult
 
 	if a.mode == types.AgentModeManaged {
@@ -197,6 +207,14 @@ func (a *Agent) processIncomingApplication(ev *event.Event) error {
 	return err
 }
 
+// rewriteDestinationForManagedAgent sets the destination to in-cluster, matching
+// the normal managed-agent create/update path. Without this, transition updates
+// would leave the principal-side destination on the agent's Application.
+func (a *Agent) rewriteDestinationForManagedAgent(app *v1alpha1.Application) {
+	app.Spec.Destination.Server = ""
+	app.Spec.Destination.Name = "in-cluster"
+}
+
 // handleCreateApp applies the identity decision matrix for Create events.
 func (a *Agent) handleCreateApp(logCtx *logrus.Entry, incomingApp *v1alpha1.Application, identity *application.IdentityCompareResult, principalUID string) error {
 	if identity != nil && identity.Exists {
@@ -211,6 +229,7 @@ func (a *Agent) handleCreateApp(logCtx *logrus.Entry, incomingApp *v1alpha1.Appl
 			return nil
 		case identityActionTransition:
 			logCtx.Info("Received Create during principal transition. Transitioning in-place")
+			a.rewriteDestinationForManagedAgent(incomingApp)
 			_, err := a.appManager.UpdateManagedAppWithTransition(a.context, incomingApp, principalUID, string(incomingApp.UID))
 			if err != nil {
 				return fmt.Errorf("could not transition existing app: %w", err)
@@ -224,6 +243,7 @@ func (a *Agent) handleCreateApp(logCtx *logrus.Entry, incomingApp *v1alpha1.Appl
 			}
 		case identityActionUpdateStampUID:
 			logCtx.Info("Received Create with missing source-uid (AppSet wipe). Updating + stamping")
+			a.rewriteDestinationForManagedAgent(incomingApp)
 			_, err := a.appManager.UpdateManagedAppWithTransition(a.context, incomingApp, principalUID, string(incomingApp.UID))
 			if err != nil {
 				return fmt.Errorf("could not update app after source-uid wipe: %w", err)
@@ -263,6 +283,7 @@ func (a *Agent) handleSpecUpdateApp(logCtx *logrus.Entry, incomingApp *v1alpha1.
 	switch action {
 	case identityActionTransition:
 		logCtx.Info("Principal transition detected on SpecUpdate. Transitioning in-place")
+		a.rewriteDestinationForManagedAgent(incomingApp)
 		_, err := a.appManager.UpdateManagedAppWithTransition(a.context, incomingApp, principalUID, string(incomingApp.UID))
 		if err != nil {
 			return fmt.Errorf("could not transition app: %w", err)
@@ -271,6 +292,7 @@ func (a *Agent) handleSpecUpdateApp(logCtx *logrus.Entry, incomingApp *v1alpha1.
 		return nil
 	case identityActionUpdateStampUID:
 		logCtx.Info("Source-uid missing (AppSet wipe) on SpecUpdate. Updating + stamping")
+		a.rewriteDestinationForManagedAgent(incomingApp)
 		_, err := a.appManager.UpdateManagedAppWithTransition(a.context, incomingApp, principalUID, string(incomingApp.UID))
 		if err != nil {
 			return fmt.Errorf("could not update app after source-uid wipe: %w", err)
@@ -299,13 +321,28 @@ func (a *Agent) handleSpecUpdateApp(logCtx *logrus.Entry, incomingApp *v1alpha1.
 type identityActionType int
 
 const (
-	identityActionUpdate         identityActionType = iota // normal update
-	identityActionDeleteRecreate                           // source-uid mismatch, same principal
-	identityActionTransition                               // different principal → adopt in-place
-	identityActionUpdateStampUID                           // same principal, source-uid wiped
+	// identityActionUpdate: source-uid matches, same principal. Normal update path.
+	identityActionUpdate identityActionType = iota
+
+	// identityActionDeleteRecreate: source-uid changed on the same principal,
+	// meaning the resource was deleted and recreated on the principal side.
+	identityActionDeleteRecreate
+
+	// identityActionTransition: principal-uid changed (HA failover detected).
+	// The new principal has different resource UIDs, but the resource is
+	// logically the same. Adopt the new identity in-place without disruption.
+	identityActionTransition
+
+	// identityActionUpdateStampUID: same principal, but source-uid is missing
+	// on the incoming resource (e.g. AppSet controller reconciled and wiped
+	// annotations). Safe to update in-place and re-stamp the source-uid.
+	identityActionUpdateStampUID
 )
 
-// identityAction implements the decision matrix from the design doc.
+// identityAction determines how the agent should handle an incoming resource
+// based on principal and source identity comparison.
+//
+// Priority: principal transition > missing source-uid > source-uid match > mismatch
 func identityAction(r *application.IdentityCompareResult) identityActionType {
 	if r.PrincipalTransition {
 		return identityActionTransition
@@ -315,6 +352,14 @@ func identityAction(r *application.IdentityCompareResult) identityActionType {
 	}
 	if r.SourceUIDMatch {
 		return identityActionUpdate
+	}
+	// Pre-upgrade resource (no principal-uid) with a source-uid mismatch:
+	// we can't distinguish "same principal recreated the app" from "different
+	// principal after failover" because the resource was never stamped.
+	// Transition in-place to avoid disruption — the annotation will be
+	// adopted on this update so future failovers are detected correctly.
+	if r.AdoptedPrincipalUID && !r.SourceUIDMatch {
+		return identityActionTransition
 	}
 	return identityActionDeleteRecreate
 }

--- a/agent/inbound.go
+++ b/agent/inbound.go
@@ -741,7 +741,7 @@ func (a *Agent) updateApplication(incoming *v1alpha1.Application) (*v1alpha1.App
 
 		// Update app spec in cache
 		logCtx.Tracef("Calling update spec for this event")
-		a.sourceCache.Application.Set(incoming.UID, incoming.Spec)
+		a.sourceCache.Application.Set(sourceUIDForApp(incoming), incoming.Spec)
 
 		napp, err = a.appManager.UpdateManagedApp(a.context, incoming)
 	case types.AgentModeAutonomous:

--- a/agent/inbound.go
+++ b/agent/inbound.go
@@ -162,19 +162,20 @@ func (a *Agent) processIncomingApplication(ev *event.Event) error {
 
 	principalUID := event.PrincipalUID(ev.CloudEvent())
 
-	// Carry the principal identity from the CloudEvent extension into the
-	// Application annotations so that downstream update paths (including the
-	// normal UpdateManagedApp) can adopt it on pre-upgrade resources.
-	if principalUID != "" {
-		if incomingApp.Annotations == nil {
-			incomingApp.Annotations = make(map[string]string)
-		}
-		incomingApp.Annotations[manager.PrincipalUIDAnnotation] = principalUID
-	}
-
 	var identity *application.IdentityCompareResult
 
 	if a.mode == types.AgentModeManaged {
+		// Carry the principal identity from the CloudEvent extension into the
+		// Application annotations so that downstream managed update paths
+		// (including the normal UpdateManagedApp) can adopt it on pre-upgrade
+		// resources.
+		if principalUID != "" {
+			if incomingApp.Annotations == nil {
+				incomingApp.Annotations = make(map[string]string)
+			}
+			incomingApp.Annotations[manager.PrincipalUIDAnnotation] = principalUID
+		}
+
 		identity, err = a.appManager.CompareIdentity(a.context, incomingApp, principalUID)
 		if err != nil {
 			return fmt.Errorf("failed to compare identity of app: %w", err)
@@ -355,6 +356,9 @@ func (a *Agent) processIncomingAppProject(ev *event.Event) error {
 	// AppProjects must exist in the same namespace as the agent
 	incomingAppProject.SetNamespace(a.namespace)
 
+	// TODO: Extend principal-aware identity comparison to AppProjects so a
+	// principal failover does not look like a source-uid mismatch and force an
+	// unnecessary delete/recreate on the managed agent.
 	exists, sourceUIDMatch, err := a.projectManager.CompareSourceUID(a.context, incomingAppProject)
 	if err != nil {
 		return fmt.Errorf("failed to validate source UID of appProject: %w", err)
@@ -443,6 +447,9 @@ func (a *Agent) processIncomingRepository(ev *event.Event) error {
 
 	// Source UID annotation is not present for repos on the autonomous agent since it is the source of truth.
 	if a.mode == types.AgentModeManaged {
+		// TODO: Extend principal-aware identity comparison to repositories so a
+		// principal failover does not look like a source-uid mismatch and force an
+		// unnecessary delete/recreate on the managed agent.
 		exists, sourceUIDMatch, err = a.repoManager.CompareSourceUID(a.context, incomingRepo)
 		if err != nil {
 			return fmt.Errorf("failed to compare the source UID of app: %w", err)

--- a/agent/inbound.go
+++ b/agent/inbound.go
@@ -186,9 +186,23 @@ func (a *Agent) processIncomingApplication(ev *event.Event) error {
 
 	switch ev.Type() {
 	case event.Create:
-		err = a.handleCreateApp(logCtx, incomingApp, identity, principalUID)
+		if a.mode == types.AgentModeManaged {
+			err = a.syncManagedApplication(logCtx, incomingApp, identity, principalUID)
+		} else {
+			_, err = a.createApplication(incomingApp, principalUID)
+			if err != nil {
+				logCtx.Errorf("Error creating application: %v", err)
+			}
+		}
 	case event.SpecUpdate:
-		err = a.handleSpecUpdateApp(logCtx, incomingApp, identity, principalUID)
+		if a.mode == types.AgentModeManaged {
+			err = a.syncManagedApplication(logCtx, incomingApp, identity, principalUID)
+		} else {
+			_, err = a.updateApplication(incomingApp)
+			if err != nil {
+				logCtx.Errorf("Error updating application: %v", err)
+			}
+		}
 	case event.TerminateOperation:
 		logCtx.Trace("Received a TerminateOperation event")
 		_, err = a.appManager.TerminateOperation(a.context, incomingApp)
@@ -224,64 +238,23 @@ func sourceUIDForApp(app *v1alpha1.Application) ktypes.UID {
 	return app.UID
 }
 
-// handleCreateApp applies the identity decision matrix for Create events.
-func (a *Agent) handleCreateApp(logCtx *logrus.Entry, incomingApp *v1alpha1.Application, identity *application.IdentityCompareResult, principalUID string) error {
-	if identity != nil && identity.Exists {
-		action := identityAction(identity)
-		switch action {
-		case identityActionUpdate:
-			logCtx.Debug("Received Create for existing app, identity matches. Updating")
-			_, err := a.updateApplication(incomingApp)
-			if err != nil {
-				return fmt.Errorf("could not update existing app: %w", err)
-			}
-			return nil
-		case identityActionTransition:
-			logCtx.Info("Received Create during principal transition. Transitioning in-place")
-			a.rewriteDestinationForManagedAgent(incomingApp)
-			_, err := a.appManager.UpdateManagedAppWithTransition(a.context, incomingApp, principalUID, string(sourceUIDForApp(incomingApp)))
-			if err != nil {
-				return fmt.Errorf("could not transition existing app: %w", err)
-			}
-			a.sourceCache.Application.Set(sourceUIDForApp(incomingApp), incomingApp.Spec)
-			return nil
-		case identityActionDeleteRecreate:
-			logCtx.Debug("App exists with different source UID. Deleting before recreate")
-			if err := a.deleteApplication(incomingApp); err != nil {
-				return fmt.Errorf("could not delete existing app prior to creation: %w", err)
-			}
-		case identityActionUpdateStampUID:
-			logCtx.Info("Received Create with missing source-uid (AppSet wipe). Updating + stamping")
-			a.rewriteDestinationForManagedAgent(incomingApp)
-			_, err := a.appManager.UpdateManagedAppWithTransition(a.context, incomingApp, principalUID, string(sourceUIDForApp(incomingApp)))
-			if err != nil {
-				return fmt.Errorf("could not update app after source-uid wipe: %w", err)
-			}
-			a.sourceCache.Application.Set(sourceUIDForApp(incomingApp), incomingApp.Spec)
-			return nil
-		}
-	}
-
-	_, err := a.createApplication(incomingApp, principalUID)
+func (a *Agent) updateManagedApplicationIdentity(incomingApp *v1alpha1.Application, principalUID string) error {
+	resolvedSourceUID := sourceUIDForApp(incomingApp)
+	a.rewriteDestinationForManagedAgent(incomingApp)
+	_, err := a.appManager.UpdateManagedApp(a.context, incomingApp, application.ManagedIdentity{
+		SourceUID:    string(resolvedSourceUID),
+		PrincipalUID: principalUID,
+	})
 	if err != nil {
-		logCtx.Errorf("Error creating application: %v", err)
-	}
-	return err
-}
-
-// handleSpecUpdateApp applies the identity decision matrix for SpecUpdate events.
-func (a *Agent) handleSpecUpdateApp(logCtx *logrus.Entry, incomingApp *v1alpha1.Application, identity *application.IdentityCompareResult, principalUID string) error {
-	// Autonomous agents receive updates for refresh/sync only.
-	if a.mode == types.AgentModeAutonomous {
-		_, err := a.updateApplication(incomingApp)
-		if err != nil {
-			logCtx.Errorf("Error updating application: %v", err)
-		}
 		return err
 	}
+	a.sourceCache.Application.Set(resolvedSourceUID, incomingApp.Spec)
+	return nil
+}
 
+func (a *Agent) syncManagedApplication(logCtx *logrus.Entry, incomingApp *v1alpha1.Application, identity *application.IdentityCompareResult, principalUID string) error {
 	if identity == nil || !identity.Exists {
-		logCtx.Debug("Received SpecUpdate for non-existing app. Creating")
+		logCtx.Debug("Application does not exist locally. Creating")
 		if _, err := a.createApplication(incomingApp, principalUID); err != nil {
 			return fmt.Errorf("could not create incoming app: %w", err)
 		}
@@ -290,23 +263,24 @@ func (a *Agent) handleSpecUpdateApp(logCtx *logrus.Entry, incomingApp *v1alpha1.
 
 	action := identityAction(identity)
 	switch action {
-	case identityActionTransition:
-		logCtx.Info("Principal transition detected on SpecUpdate. Transitioning in-place")
-		a.rewriteDestinationForManagedAgent(incomingApp)
-		_, err := a.appManager.UpdateManagedAppWithTransition(a.context, incomingApp, principalUID, string(sourceUIDForApp(incomingApp)))
+	case identityActionUpdate:
+		logCtx.Debug("Application identity matches. Updating")
+		_, err := a.updateApplication(incomingApp)
 		if err != nil {
+			return fmt.Errorf("could not update existing app: %w", err)
+		}
+		return nil
+	case identityActionTransition:
+		logCtx.Info("Principal transition detected. Transitioning in-place")
+		if err := a.updateManagedApplicationIdentity(incomingApp, principalUID); err != nil {
 			return fmt.Errorf("could not transition app: %w", err)
 		}
-		a.sourceCache.Application.Set(sourceUIDForApp(incomingApp), incomingApp.Spec)
 		return nil
 	case identityActionUpdateStampUID:
-		logCtx.Info("Source-uid missing (AppSet wipe) on SpecUpdate. Updating + stamping")
-		a.rewriteDestinationForManagedAgent(incomingApp)
-		_, err := a.appManager.UpdateManagedAppWithTransition(a.context, incomingApp, principalUID, string(sourceUIDForApp(incomingApp)))
-		if err != nil {
+		logCtx.Info("Source-uid missing (AppSet wipe). Updating + stamping")
+		if err := a.updateManagedApplicationIdentity(incomingApp, principalUID); err != nil {
 			return fmt.Errorf("could not update app after source-uid wipe: %w", err)
 		}
-		a.sourceCache.Application.Set(sourceUIDForApp(incomingApp), incomingApp.Spec)
 		return nil
 	case identityActionDeleteRecreate:
 		logCtx.Debug("Source UID mismatch. Deleting existing app")
@@ -319,11 +293,7 @@ func (a *Agent) handleSpecUpdateApp(logCtx *logrus.Entry, incomingApp *v1alpha1.
 		}
 		return nil
 	default:
-		_, err := a.updateApplication(incomingApp)
-		if err != nil {
-			logCtx.Errorf("Error updating application: %v", err)
-		}
-		return err
+		return fmt.Errorf("unknown identity action for app %s", incomingApp.QualifiedName())
 	}
 }
 
@@ -743,7 +713,7 @@ func (a *Agent) updateApplication(incoming *v1alpha1.Application) (*v1alpha1.App
 		logCtx.Tracef("Calling update spec for this event")
 		a.sourceCache.Application.Set(sourceUIDForApp(incoming), incoming.Spec)
 
-		napp, err = a.appManager.UpdateManagedApp(a.context, incoming)
+		napp, err = a.appManager.UpdateManagedApp(a.context, incoming, application.ManagedIdentity{})
 	case types.AgentModeAutonomous:
 		logCtx.Tracef("Calling update operation for this event")
 		napp, err = a.appManager.UpdateOperation(a.context, incoming)

--- a/agent/inbound_test.go
+++ b/agent/inbound_test.go
@@ -1958,6 +1958,8 @@ func Test_UpdateGPGKey(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, ncm)
 	})
+}
+
 func Test_identityAction(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/agent/inbound_test.go
+++ b/agent/inbound_test.go
@@ -2027,3 +2027,50 @@ func Test_identityAction(t *testing.T) {
 		})
 	}
 }
+
+func Test_processIncomingApplication_TransitionUsesResolvedSourceUID(t *testing.T) {
+	a, _ := newAgent(t)
+	a.mode = types.AgentModeManaged
+
+	be := backend_mocks.NewApplication(t)
+	var err error
+	a.appManager, err = application.NewApplicationManager(be, "argocd", application.WithAllowUpsert(true),
+		application.WithRole(manager.ManagerRoleAgent), application.WithMode(manager.ManagerModeManaged))
+	require.NoError(t, err)
+
+	existingApp := &v1alpha1.Application{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "test",
+			Namespace: "argocd",
+			Annotations: map[string]string{
+				manager.SourceUIDAnnotation:    "old-source-uid",
+				manager.PrincipalUIDAnnotation: "principal-A",
+			},
+		},
+	}
+	incomingApp := existingApp.DeepCopy()
+	incomingApp.UID = ktypes.UID("new-principal-uid")
+	incomingApp.Annotations[manager.SourceUIDAnnotation] = "old-source-uid"
+
+	getMock := be.On("Get", mock.Anything, mock.Anything, mock.Anything).Return(existingApp, nil)
+	defer getMock.Unset()
+	supportsPatchMock := be.On("SupportsPatch").Return(false)
+	defer supportsPatchMock.Unset()
+
+	var updatedArg *v1alpha1.Application
+	updateMock := be.On("Update", mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
+		updatedArg = args.Get(1).(*v1alpha1.Application).DeepCopy()
+	}).Return(existingApp.DeepCopy(), nil)
+	defer updateMock.Unset()
+
+	evs := event.NewEventSource("test")
+	ce := evs.ApplicationEvent(event.SpecUpdate, incomingApp)
+	event.SetPrincipalUID(ce, "principal-B")
+
+	err = a.processIncomingApplication(event.New(ce, event.TargetApplication))
+	require.NoError(t, err)
+	require.NotNil(t, updatedArg)
+	assert.Equal(t, "old-source-uid", updatedArg.Annotations[manager.SourceUIDAnnotation])
+	assert.True(t, a.sourceCache.Application.Contains(ktypes.UID("old-source-uid")))
+	assert.False(t, a.sourceCache.Application.Contains(ktypes.UID("new-principal-uid")))
+}

--- a/agent/inbound_test.go
+++ b/agent/inbound_test.go
@@ -787,6 +787,39 @@ func Test_UpdateApplication(t *testing.T) {
 		require.Empty(t, napp.OwnerReferences, "OwnerReferences should not be applied on managed app")
 	})
 
+	t.Run("Managed mode caches spec by resolved source uid", func(t *testing.T) {
+		a.mode = types.AgentModeManaged
+		a.sourceCache.Application.Clear()
+		a.appManager, err = application.NewApplicationManager(be, "argocd", application.WithAllowUpsert(true), application.WithMode(manager.ManagerModeManaged), application.WithRole(manager.ManagerRoleAgent))
+
+		appWithInheritedSourceUID := app.DeepCopy()
+		appWithInheritedSourceUID.UID = ktypes.UID("new-principal-uid")
+		appWithInheritedSourceUID.Annotations = map[string]string{
+			manager.SourceUIDAnnotation: "old-source-uid",
+		}
+		appWithInheritedSourceUID.Spec = v1alpha1.ApplicationSpec{
+			Project: "default",
+		}
+
+		getEvent := be.On("Get", mock.Anything, mock.Anything, mock.Anything).Return(&v1alpha1.Application{}, nil)
+		defer getEvent.Unset()
+		supportsPatchEvent := be.On("SupportsPatch").Return(false)
+		defer supportsPatchEvent.Unset()
+		updateEvent := be.On("Update", mock.Anything, mock.Anything).Return(&v1alpha1.Application{}, nil)
+		defer updateEvent.Unset()
+
+		napp, err := a.updateApplication(appWithInheritedSourceUID)
+		require.NoError(t, err)
+		require.NotNil(t, napp)
+
+		cachedSpec, ok := a.sourceCache.Application.Get(ktypes.UID("old-source-uid"))
+		require.True(t, ok)
+		assert.Equal(t, appWithInheritedSourceUID.Spec, cachedSpec)
+
+		_, ok = a.sourceCache.Application.Get(ktypes.UID("new-principal-uid"))
+		require.False(t, ok)
+	})
+
 	t.Run("Update application using patch in autonomous mode", func(t *testing.T) {
 		a.mode = types.AgentModeAutonomous
 		a.appManager, err = application.NewApplicationManager(be, "argocd", application.WithAllowUpsert(true), application.WithMode(manager.ManagerModeAutonomous), application.WithRole(manager.ManagerRoleAgent))

--- a/agent/inbound_test.go
+++ b/agent/inbound_test.go
@@ -63,7 +63,7 @@ func Test_CreateApplication(t *testing.T) {
 		},
 	}}
 	t.Run("Discard event in unmanaged mode", func(t *testing.T) {
-		napp, err := a.createApplication(app)
+		napp, err := a.createApplication(app, "")
 		require.Nil(t, napp)
 		require.ErrorContains(t, err, "not in managed mode")
 	})
@@ -72,7 +72,7 @@ func Test_CreateApplication(t *testing.T) {
 		defer a.appManager.Unmanage(app.QualifiedName())
 		a.mode = types.AgentModeManaged
 		a.appManager.Manage(app.QualifiedName())
-		napp, err := a.createApplication(app)
+		napp, err := a.createApplication(app, "")
 		require.ErrorContains(t, err, "is already managed")
 		require.Nil(t, napp)
 	})
@@ -82,7 +82,7 @@ func Test_CreateApplication(t *testing.T) {
 		a.mode = types.AgentModeManaged
 		createMock := be.On("Create", mock.Anything, mock.Anything).Return(&v1alpha1.Application{}, nil)
 		defer createMock.Unset()
-		napp, err := a.createApplication(app)
+		napp, err := a.createApplication(app, "")
 		require.NoError(t, err)
 		require.NotNil(t, napp)
 		require.Empty(t, napp.OwnerReferences, "OwnerReferences should not be applied on managed app")
@@ -107,7 +107,7 @@ func Test_CreateApplication(t *testing.T) {
 
 		createMock := be.On("Create", mock.Anything, mock.Anything).Return(newApp, nil)
 		defer createMock.Unset()
-		napp, err := a.createApplication(newApp)
+		napp, err := a.createApplication(newApp, "")
 		require.NoError(t, err)
 		require.NotNil(t, napp)
 
@@ -1925,4 +1925,105 @@ func Test_UpdateGPGKey(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, ncm)
 	})
+func Test_identityAction(t *testing.T) {
+	tests := []struct {
+		name     string
+		result   *application.IdentityCompareResult
+		expected identityActionType
+	}{
+		{
+			name: "same principal, same source-uid → update",
+			result: &application.IdentityCompareResult{
+				Exists:            true,
+				SourceUIDMatch:    true,
+				PrincipalUIDMatch: true,
+			},
+			expected: identityActionUpdate,
+		},
+		{
+			name: "same principal, different source-uid → delete/recreate",
+			result: &application.IdentityCompareResult{
+				Exists:            true,
+				SourceUIDMatch:    false,
+				PrincipalUIDMatch: true,
+			},
+			expected: identityActionDeleteRecreate,
+		},
+		{
+			name: "same principal, missing source-uid → stamp",
+			result: &application.IdentityCompareResult{
+				Exists:            true,
+				MissingSourceUID:  true,
+				PrincipalUIDMatch: true,
+			},
+			expected: identityActionUpdateStampUID,
+		},
+		{
+			name: "different principal → transition",
+			result: &application.IdentityCompareResult{
+				Exists:              true,
+				SourceUIDMatch:      false,
+				PrincipalUIDMatch:   false,
+				PrincipalTransition: true,
+			},
+			expected: identityActionTransition,
+		},
+		{
+			name: "different principal, missing source-uid → transition takes priority",
+			result: &application.IdentityCompareResult{
+				Exists:              true,
+				MissingSourceUID:    true,
+				PrincipalUIDMatch:   false,
+				PrincipalTransition: true,
+			},
+			expected: identityActionTransition,
+		},
+		{
+			name: "backward compat: no principal-uid, source-uid match → update",
+			result: &application.IdentityCompareResult{
+				Exists:              true,
+				SourceUIDMatch:      true,
+				PrincipalUIDMatch:   true,
+				MissingPrincipalUID: true,
+			},
+			expected: identityActionUpdate,
+		},
+		{
+			name: "backward compat: no principal-uid, source-uid mismatch → delete/recreate",
+			result: &application.IdentityCompareResult{
+				Exists:              true,
+				SourceUIDMatch:      false,
+				PrincipalUIDMatch:   true,
+				MissingPrincipalUID: true,
+			},
+			expected: identityActionDeleteRecreate,
+		},
+		{
+			name: "adopted principal-uid, source-uid mismatch → transition (pre-upgrade failover)",
+			result: &application.IdentityCompareResult{
+				Exists:              true,
+				SourceUIDMatch:      false,
+				PrincipalUIDMatch:   true,
+				AdoptedPrincipalUID: true,
+			},
+			expected: identityActionTransition,
+		},
+		{
+			name: "adopted principal-uid, source-uid match → update",
+			result: &application.IdentityCompareResult{
+				Exists:              true,
+				SourceUIDMatch:      true,
+				PrincipalUIDMatch:   true,
+				AdoptedPrincipalUID: true,
+			},
+			expected: identityActionUpdate,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			action := identityAction(tt.result)
+			assert.Equal(t, tt.expected, action)
+		})
+	}
 }

--- a/agent/inbound_test.go
+++ b/agent/inbound_test.go
@@ -379,6 +379,50 @@ func Test_ProcessIncomingAppWithUIDMismatch(t *testing.T) {
 	})
 }
 
+func Test_processIncomingApplication_AutonomousUpdateDoesNotStampPrincipalUID(t *testing.T) {
+	a, _ := newAgent(t)
+	a.mode = types.AgentModeAutonomous
+
+	be := backend_mocks.NewApplication(t)
+	var err error
+	a.appManager, err = application.NewApplicationManager(be, "argocd", application.WithAllowUpsert(true),
+		application.WithRole(manager.ManagerRoleAgent), application.WithMode(manager.ManagerModeAutonomous))
+	require.NoError(t, err)
+
+	existingApp := &v1alpha1.Application{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "test",
+			Namespace: "argocd",
+		},
+	}
+	incomingApp := existingApp.DeepCopy()
+	incomingApp.Operation = &v1alpha1.Operation{
+		Sync: &v1alpha1.SyncOperation{
+			Revision: "1.0.0",
+		},
+	}
+
+	getMock := be.On("Get", mock.Anything, mock.Anything, mock.Anything).Return(existingApp, nil)
+	defer getMock.Unset()
+	supportsPatchMock := be.On("SupportsPatch").Return(false)
+	defer supportsPatchMock.Unset()
+
+	var updatedArg *v1alpha1.Application
+	updateMock := be.On("Update", mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
+		updatedArg = args.Get(1).(*v1alpha1.Application).DeepCopy()
+	}).Return(existingApp.DeepCopy(), nil)
+	defer updateMock.Unset()
+
+	evs := event.NewEventSource("test")
+	ce := evs.ApplicationEvent(event.SpecUpdate, incomingApp)
+	event.SetPrincipalUID(ce, "principal-B")
+
+	err = a.processIncomingApplication(event.New(ce, event.TargetApplication))
+	require.NoError(t, err)
+	require.NotNil(t, updatedArg)
+	assert.NotContains(t, updatedArg.Annotations, manager.PrincipalUIDAnnotation)
+}
+
 func Test_ProcessIncomingAppProjectWithUIDMismatch(t *testing.T) {
 	a, _ := newAgent(t)
 	a.mode = types.AgentModeManaged

--- a/internal/event/event.go
+++ b/internal/event/event.go
@@ -84,9 +84,10 @@ const (
 )
 
 const (
-	resourceID string = "resourceid"
-	eventID    string = "eventid"
-	sentAt     string = "sentat"
+	resourceID   string = "resourceid"
+	eventID      string = "eventid"
+	sentAt       string = "sentat"
+	principalUID string = "principaluid"
 )
 
 // SetSentAt stamps the current time on an event as the send time.
@@ -105,6 +106,20 @@ func SentAt(ev *cloudevents.Event) *time.Time {
 		return nil
 	}
 	return &t
+}
+
+// SetPrincipalUID stamps the principal's persistent identity on an event.
+func SetPrincipalUID(ev *cloudevents.Event, uid string) {
+	ev.SetExtension(principalUID, uid)
+}
+
+// PrincipalUID returns the principal identity from an event, or empty string if not set.
+func PrincipalUID(ev *cloudevents.Event) string {
+	val, ok := ev.Extensions()[principalUID].(string)
+	if !ok {
+		return ""
+	}
+	return val
 }
 
 var (

--- a/internal/event/event_test.go
+++ b/internal/event/event_test.go
@@ -594,3 +594,24 @@ func TestContainerTerminalRequestFields(t *testing.T) {
 		require.True(t, req.Stderr)
 	})
 }
+
+func TestSetPrincipalUID(t *testing.T) {
+	ev := cloudevents.NewEvent()
+	SetPrincipalUID(&ev, "test-uid-123")
+	val, ok := ev.Extensions()[principalUID].(string)
+	require.True(t, ok)
+	require.Equal(t, "test-uid-123", val)
+}
+
+func TestPrincipalUID(t *testing.T) {
+	t.Run("returns uid that was set", func(t *testing.T) {
+		ev := cloudevents.NewEvent()
+		SetPrincipalUID(&ev, "abc-def")
+		require.Equal(t, "abc-def", PrincipalUID(&ev))
+	})
+
+	t.Run("returns empty when not set", func(t *testing.T) {
+		ev := cloudevents.NewEvent()
+		require.Equal(t, "", PrincipalUID(&ev))
+	})
+}

--- a/internal/manager/application/application.go
+++ b/internal/manager/application/application.go
@@ -141,7 +141,7 @@ func stampLastUpdated(app *v1alpha1.Application) {
 	if app.Annotations == nil {
 		app.Annotations = make(map[string]string)
 	}
-	app.Annotations[LastUpdatedAnnotation] = time.Now().Format(time.RFC3339)
+	app.Annotations[LastUpdatedAnnotation] = time.Now().Format(time.RFC3339Nano)
 }
 
 // Create creates the application app using the Manager's application backend.

--- a/internal/manager/application/application.go
+++ b/internal/manager/application/application.go
@@ -420,6 +420,10 @@ func (m *ApplicationManager) UpdateManagedAppWithTransition(ctx context.Context,
 			incoming.Annotations[manager.PrincipalUIDAnnotation] = principalUID
 		}
 
+		if incoming.DeletionTimestamp != nil && existing.DeletionTimestamp == nil {
+			deletionTimestampChanged = true
+		}
+
 		target := &v1alpha1.Application{
 			ObjectMeta: v1.ObjectMeta{
 				Annotations: incoming.Annotations,
@@ -502,13 +506,16 @@ func (m *ApplicationManager) CompareIdentity(ctx context.Context, incoming *v1al
 		return result, fmt.Errorf("source UID Annotation is not found for app: %s", incoming.Name)
 	}
 
-	incomingUID := string(incoming.UID)
-	if srcUID, ok := incoming.Annotations[manager.SourceUIDAnnotation]; ok && srcUID != "" {
-		incomingUID = srcUID
-	}
-	if incomingUID == "" {
+	srcUID, hasSrcAnnotation := incoming.Annotations[manager.SourceUIDAnnotation]
+	if !hasSrcAnnotation || srcUID == "" {
 		result.MissingSourceUID = true
-	} else {
+	}
+
+	incomingUID := srcUID
+	if incomingUID == "" {
+		incomingUID = string(incoming.UID)
+	}
+	if incomingUID != "" {
 		result.SourceUIDMatch = incomingUID == existingSourceUID
 	}
 

--- a/internal/manager/application/application.go
+++ b/internal/manager/application/application.go
@@ -381,6 +381,16 @@ func (m *ApplicationManager) UpdateManagedAppWithTransition(ctx context.Context,
 		return nil, fmt.Errorf("UpdateManagedAppWithTransition should be called on a managed agent only")
 	}
 
+	if incoming.Annotations == nil {
+		incoming.Annotations = make(map[string]string)
+	}
+	if sourceUID != "" {
+		incoming.Annotations[manager.SourceUIDAnnotation] = sourceUID
+	}
+	if principalUID != "" {
+		incoming.Annotations[manager.PrincipalUIDAnnotation] = principalUID
+	}
+
 	deletionTimestampChanged := false
 
 	updated, err := m.update(ctx, m.allowUpsert, incoming, func(existing, incoming *v1alpha1.Application) {
@@ -506,16 +516,13 @@ func (m *ApplicationManager) CompareIdentity(ctx context.Context, incoming *v1al
 		return result, fmt.Errorf("source UID Annotation is not found for app: %s", incoming.Name)
 	}
 
-	srcUID, hasSrcAnnotation := incoming.Annotations[manager.SourceUIDAnnotation]
-	if !hasSrcAnnotation || srcUID == "" {
-		result.MissingSourceUID = true
+	incomingUID := string(incoming.UID)
+	if srcUID, ok := incoming.Annotations[manager.SourceUIDAnnotation]; ok && srcUID != "" {
+		incomingUID = srcUID
 	}
-
-	incomingUID := srcUID
 	if incomingUID == "" {
-		incomingUID = string(incoming.UID)
-	}
-	if incomingUID != "" {
+		result.MissingSourceUID = true
+	} else {
 		result.SourceUIDMatch = incomingUID == existingSourceUID
 	}
 

--- a/internal/manager/application/application.go
+++ b/internal/manager/application/application.go
@@ -234,6 +234,20 @@ func (m *ApplicationManager) Get(ctx context.Context, name, namespace string) (*
 	return m.applicationBackend.Get(ctx, name, namespace)
 }
 
+// preserveOrAdoptPrincipalUID carries the principal-uid annotation from
+// existing to incoming. If existing has no principal-uid yet (pre-upgrade
+// resource), the incoming value is kept so the annotation gets adopted on the
+// first update from a principal-uid-aware principal.
+func preserveOrAdoptPrincipalUID(existing, incoming *v1alpha1.Application) {
+	if incoming.Annotations == nil {
+		incoming.Annotations = make(map[string]string)
+	}
+	if v, ok := existing.Annotations[manager.PrincipalUIDAnnotation]; ok {
+		incoming.Annotations[manager.PrincipalUIDAnnotation] = v
+	}
+	// else: keep whatever the caller already set on incoming (adoption case)
+}
+
 // UpdateManagedApp updates the Application resource on the agent when it is in
 // managed mode.
 //
@@ -268,9 +282,7 @@ func (m *ApplicationManager) UpdateManagedApp(ctx context.Context, incoming *v1a
 		if v, ok := existing.Annotations[manager.SourceUIDAnnotation]; ok {
 			incoming.Annotations[manager.SourceUIDAnnotation] = v
 		}
-		if v, ok := existing.Annotations[manager.PrincipalUIDAnnotation]; ok {
-			incoming.Annotations[manager.PrincipalUIDAnnotation] = v
-		}
+		preserveOrAdoptPrincipalUID(existing, incoming)
 		existing.Annotations = incoming.Annotations
 		existing.Labels = incoming.Labels
 		existing.Finalizers = incoming.Finalizers
@@ -291,9 +303,7 @@ func (m *ApplicationManager) UpdateManagedApp(ctx context.Context, incoming *v1a
 		if v, ok := existing.Annotations[manager.SourceUIDAnnotation]; ok {
 			incoming.Annotations[manager.SourceUIDAnnotation] = v
 		}
-		if v, ok := existing.Annotations[manager.PrincipalUIDAnnotation]; ok {
-			incoming.Annotations[manager.PrincipalUIDAnnotation] = v
-		}
+		preserveOrAdoptPrincipalUID(existing, incoming)
 
 		if incoming.DeletionTimestamp != nil && existing.DeletionTimestamp == nil {
 			deletionTimestampChanged = true
@@ -369,6 +379,8 @@ func (m *ApplicationManager) UpdateManagedAppWithTransition(ctx context.Context,
 		return nil, fmt.Errorf("UpdateManagedAppWithTransition should be called on a managed agent only")
 	}
 
+	deletionTimestampChanged := false
+
 	updated, err := m.update(ctx, m.allowUpsert, incoming, func(existing, incoming *v1alpha1.Application) {
 		if incoming.Annotations == nil {
 			incoming.Annotations = make(map[string]string)
@@ -386,6 +398,10 @@ func (m *ApplicationManager) UpdateManagedAppWithTransition(ctx context.Context,
 		existing.Finalizers = incoming.Finalizers
 		existing.Spec = *incoming.Spec.DeepCopy()
 		existing.Operation = operationToUse(existing, incoming)
+
+		if incoming.DeletionTimestamp != nil && existing.DeletionTimestamp == nil {
+			deletionTimestampChanged = true
+		}
 	}, func(existing, incoming *v1alpha1.Application) (jsondiff.Patch, error) {
 		if incoming.Annotations == nil {
 			incoming.Annotations = make(map[string]string)
@@ -429,6 +445,18 @@ func (m *ApplicationManager) UpdateManagedAppWithTransition(ctx context.Context,
 		}
 	}
 
+	if deletionTimestampChanged {
+		logCtx.Infof("deletionTimestamp changed during transition, deleting Application")
+		if m.deletions != nil {
+			if v, ok := updated.Annotations[manager.SourceUIDAnnotation]; ok {
+				m.deletions.MarkExpected(ty.UID(v))
+			}
+		}
+		if err := m.applicationBackend.Delete(ctx, incoming.Name, incoming.Namespace, ptr.To(backend.DeletePropagationForeground)); err != nil {
+			return nil, err
+		}
+	}
+
 	return updated, err
 }
 
@@ -442,6 +470,7 @@ type IdentityCompareResult struct {
 	PrincipalTransition bool // principal-uid changed (failover detected)
 	MissingSourceUID    bool // incoming has no source-uid (AppSet wiped it)
 	MissingPrincipalUID bool // no principal-uid in event (pre-upgrade principal)
+	AdoptedPrincipalUID bool // existing had no principal-uid; incoming's was accepted as-is
 }
 
 // CompareIdentity checks an existing app against the incoming app and
@@ -468,7 +497,7 @@ func (m *ApplicationManager) CompareIdentity(ctx context.Context, incoming *v1al
 
 	existingSourceUID, hasSourceUID := existing.Annotations[manager.SourceUIDAnnotation]
 	if !hasSourceUID {
-		return nil, fmt.Errorf("source UID annotation not found for app: %s", incoming.Name)
+		return result, fmt.Errorf("source UID Annotation is not found for app: %s", incoming.Name)
 	}
 
 	incomingUID := string(incoming.UID)
@@ -489,6 +518,7 @@ func (m *ApplicationManager) CompareIdentity(ctx context.Context, incoming *v1al
 		// First event with principal-uid on a resource that predates this feature.
 		// Treat as same principal (adoption).
 		result.PrincipalUIDMatch = true
+		result.AdoptedPrincipalUID = true
 	} else {
 		// No principal-uid in event → backward compat, treat as same principal.
 		result.PrincipalUIDMatch = true

--- a/internal/manager/application/application.go
+++ b/internal/manager/application/application.go
@@ -175,6 +175,19 @@ func (m *ApplicationManager) Create(ctx context.Context, app *v1alpha1.Applicati
 	return created, err
 }
 
+// CreateWithPrincipalUID creates the application and stamps the principal-uid
+// annotation alongside the source-uid. Used by the managed agent when the
+// principal's identity is known from the CloudEvent.
+func (m *ApplicationManager) CreateWithPrincipalUID(ctx context.Context, app *v1alpha1.Application, principalUID string) (*v1alpha1.Application, error) {
+	if principalUID != "" {
+		if app.Annotations == nil {
+			app.Annotations = make(map[string]string)
+		}
+		app.Annotations[manager.PrincipalUIDAnnotation] = principalUID
+	}
+	return m.Create(ctx, app)
+}
+
 // Upsert creates the application or updates it if it already exists.
 // Used by HA replication to write resources to the replica cluster.
 func (m *ApplicationManager) Upsert(ctx context.Context, app *v1alpha1.Application) (*v1alpha1.Application, error) {
@@ -249,11 +262,14 @@ func (m *ApplicationManager) UpdateManagedApp(ctx context.Context, incoming *v1a
 	deletionTimestampChanged := false
 
 	updated, err = m.update(ctx, m.allowUpsert, incoming, func(existing, incoming *v1alpha1.Application) {
+		if incoming.Annotations == nil {
+			incoming.Annotations = make(map[string]string)
+		}
 		if v, ok := existing.Annotations[manager.SourceUIDAnnotation]; ok {
-			if incoming.Annotations == nil {
-				incoming.Annotations = make(map[string]string)
-			}
 			incoming.Annotations[manager.SourceUIDAnnotation] = v
+		}
+		if v, ok := existing.Annotations[manager.PrincipalUIDAnnotation]; ok {
+			incoming.Annotations[manager.PrincipalUIDAnnotation] = v
 		}
 		existing.Annotations = incoming.Annotations
 		existing.Labels = incoming.Labels
@@ -266,19 +282,17 @@ func (m *ApplicationManager) UpdateManagedApp(ctx context.Context, incoming *v1a
 		}
 
 	}, func(existing, incoming *v1alpha1.Application) (jsondiff.Patch, error) {
-		// We need to keep the refresh label if it is set on the existing app
+		if incoming.Annotations == nil {
+			incoming.Annotations = make(map[string]string)
+		}
 		if v, ok := existing.Annotations["argocd.argoproj.io/refresh"]; ok {
-			if incoming.Annotations == nil {
-				incoming.Annotations = make(map[string]string)
-			}
 			incoming.Annotations["argocd.argoproj.io/refresh"] = v
 		}
-
 		if v, ok := existing.Annotations[manager.SourceUIDAnnotation]; ok {
-			if incoming.Annotations == nil {
-				incoming.Annotations = make(map[string]string)
-			}
 			incoming.Annotations[manager.SourceUIDAnnotation] = v
+		}
+		if v, ok := existing.Annotations[manager.PrincipalUIDAnnotation]; ok {
+			incoming.Annotations[manager.PrincipalUIDAnnotation] = v
 		}
 
 		if incoming.DeletionTimestamp != nil && existing.DeletionTimestamp == nil {
@@ -336,33 +350,161 @@ func (m *ApplicationManager) UpdateManagedApp(ctx context.Context, incoming *v1a
 	return updated, err
 }
 
-// CompareSourceUID checks for an existing app with the same name/namespace and compare its source UID with the incoming app.
-func (m *ApplicationManager) CompareSourceUID(ctx context.Context, incoming *v1alpha1.Application) (bool, bool, error) {
+// UpdateManagedAppWithTransition updates the Application resource on the agent
+// and stamps new principal-uid and source-uid annotations, overriding any
+// existing values. Used during a principal failover or when the source-uid
+// was wiped by an AppSet reconcile.
+func (m *ApplicationManager) UpdateManagedAppWithTransition(ctx context.Context, incoming *v1alpha1.Application, principalUID, sourceUID string) (*v1alpha1.Application, error) {
+	logCtx := log().WithFields(logrus.Fields{
+		"component":       "UpdateManagedTransition",
+		"application":     incoming.QualifiedName(),
+		"resourceVersion": incoming.ResourceVersion,
+	})
+
 	if !m.destinationBasedMapping {
 		incoming.SetNamespace(m.namespace)
+	}
+
+	if m.role != manager.ManagerRoleAgent || m.mode != manager.ManagerModeManaged {
+		return nil, fmt.Errorf("UpdateManagedAppWithTransition should be called on a managed agent only")
+	}
+
+	updated, err := m.update(ctx, m.allowUpsert, incoming, func(existing, incoming *v1alpha1.Application) {
+		if incoming.Annotations == nil {
+			incoming.Annotations = make(map[string]string)
+		}
+		if sourceUID != "" {
+			incoming.Annotations[manager.SourceUIDAnnotation] = sourceUID
+		} else if v, ok := existing.Annotations[manager.SourceUIDAnnotation]; ok {
+			incoming.Annotations[manager.SourceUIDAnnotation] = v
+		}
+		if principalUID != "" {
+			incoming.Annotations[manager.PrincipalUIDAnnotation] = principalUID
+		}
+		existing.Annotations = incoming.Annotations
+		existing.Labels = incoming.Labels
+		existing.Finalizers = incoming.Finalizers
+		existing.Spec = *incoming.Spec.DeepCopy()
+		existing.Operation = operationToUse(existing, incoming)
+	}, func(existing, incoming *v1alpha1.Application) (jsondiff.Patch, error) {
+		if incoming.Annotations == nil {
+			incoming.Annotations = make(map[string]string)
+		}
+		if v, ok := existing.Annotations["argocd.argoproj.io/refresh"]; ok {
+			incoming.Annotations["argocd.argoproj.io/refresh"] = v
+		}
+		if sourceUID != "" {
+			incoming.Annotations[manager.SourceUIDAnnotation] = sourceUID
+		} else if v, ok := existing.Annotations[manager.SourceUIDAnnotation]; ok {
+			incoming.Annotations[manager.SourceUIDAnnotation] = v
+		}
+		if principalUID != "" {
+			incoming.Annotations[manager.PrincipalUIDAnnotation] = principalUID
+		}
+
+		target := &v1alpha1.Application{
+			ObjectMeta: v1.ObjectMeta{
+				Annotations: incoming.Annotations,
+				Labels:      incoming.Labels,
+				Finalizers:  incoming.Finalizers,
+			},
+			Spec:      incoming.Spec,
+			Operation: operationToUse(existing, incoming),
+		}
+		source := &v1alpha1.Application{
+			ObjectMeta: v1.ObjectMeta{
+				Annotations: existing.Annotations,
+				Labels:      existing.Labels,
+			},
+			Spec:      existing.Spec,
+			Operation: existing.Operation,
+		}
+		patch, err := jsondiff.Compare(source, target)
+		return patch, err
+	})
+	if err == nil {
+		logCtx.Infof("Transitioned application to new principal")
+		if err := m.IgnoreChange(updated.QualifiedName(), updated.ResourceVersion); err != nil {
+			logCtx.Warnf("Could not ignore change %s for app %s: %v", updated.ResourceVersion, updated.QualifiedName(), err)
+		}
+	}
+
+	return updated, err
+}
+
+// IdentityCompareResult captures the full comparison between an incoming
+// resource and the existing resource on the agent. The agent uses this to
+// decide whether to update, delete/recreate, or transition in-place.
+type IdentityCompareResult struct {
+	Exists              bool
+	SourceUIDMatch      bool
+	PrincipalUIDMatch   bool
+	PrincipalTransition bool // principal-uid changed (failover detected)
+	MissingSourceUID    bool // incoming has no source-uid (AppSet wiped it)
+	MissingPrincipalUID bool // no principal-uid in event (pre-upgrade principal)
+}
+
+// CompareIdentity checks an existing app against the incoming app and
+// principal identity. It returns a structured result the agent uses to
+// implement the principal-transition decision matrix.
+func (m *ApplicationManager) CompareIdentity(ctx context.Context, incoming *v1alpha1.Application, principalUID string) (*IdentityCompareResult, error) {
+	if !m.destinationBasedMapping {
+		incoming.SetNamespace(m.namespace)
+	}
+
+	result := &IdentityCompareResult{
+		MissingPrincipalUID: principalUID == "",
 	}
 
 	existing, err := m.applicationBackend.Get(ctx, incoming.Name, incoming.Namespace)
 	if err != nil {
 		if errors.IsNotFound(err) {
-			return false, false, nil
+			return result, nil
 		}
-		return false, false, err
+		return nil, err
 	}
 
-	// If there is an existing app with the same name/namespace, compare its source UID with the incoming app.
-	sourceUID, exists := existing.Annotations[manager.SourceUIDAnnotation]
-	if !exists {
-		return true, false, fmt.Errorf("source UID Annotation is not found for app: %s", incoming.Name)
+	result.Exists = true
+
+	existingSourceUID, hasSourceUID := existing.Annotations[manager.SourceUIDAnnotation]
+	if !hasSourceUID {
+		return nil, fmt.Errorf("source UID annotation not found for app: %s", incoming.Name)
 	}
 
-	// On failover, apps replicated to the replica carry source-uid = primary's UID.
-	// Use that as the incoming UID if present so we match and update rather than delete.
 	incomingUID := string(incoming.UID)
 	if srcUID, ok := incoming.Annotations[manager.SourceUIDAnnotation]; ok && srcUID != "" {
 		incomingUID = srcUID
 	}
-	return true, incomingUID == sourceUID, nil
+	if incomingUID == "" {
+		result.MissingSourceUID = true
+	} else {
+		result.SourceUIDMatch = incomingUID == existingSourceUID
+	}
+
+	existingPrincipalUID := existing.Annotations[manager.PrincipalUIDAnnotation]
+	if principalUID != "" && existingPrincipalUID != "" {
+		result.PrincipalUIDMatch = principalUID == existingPrincipalUID
+		result.PrincipalTransition = principalUID != existingPrincipalUID
+	} else if principalUID != "" && existingPrincipalUID == "" {
+		// First event with principal-uid on a resource that predates this feature.
+		// Treat as same principal (adoption).
+		result.PrincipalUIDMatch = true
+	} else {
+		// No principal-uid in event → backward compat, treat as same principal.
+		result.PrincipalUIDMatch = true
+	}
+
+	return result, nil
+}
+
+// CompareSourceUID checks for an existing app with the same name/namespace and compare its source UID with the incoming app.
+// Deprecated: Use CompareIdentity for principal-transition-aware comparisons.
+func (m *ApplicationManager) CompareSourceUID(ctx context.Context, incoming *v1alpha1.Application) (bool, bool, error) {
+	result, err := m.CompareIdentity(ctx, incoming, "")
+	if err != nil {
+		return result != nil && result.Exists, false, err
+	}
+	return result.Exists, result.SourceUIDMatch, nil
 }
 
 // UpdateAutonomousApp updates the Application resource on the control plane side

--- a/internal/manager/application/application.go
+++ b/internal/manager/application/application.go
@@ -160,7 +160,9 @@ func (m *ApplicationManager) Create(ctx context.Context, app *v1alpha1.Applicati
 	if app.Annotations == nil {
 		app.Annotations = make(map[string]string)
 	}
-	app.Annotations[manager.SourceUIDAnnotation] = string(app.UID)
+	if app.Annotations[manager.SourceUIDAnnotation] == "" {
+		app.Annotations[manager.SourceUIDAnnotation] = string(app.UID)
+	}
 
 	created, err := m.applicationBackend.Create(ctx, app)
 	if err == nil {

--- a/internal/manager/application/application.go
+++ b/internal/manager/application/application.go
@@ -236,18 +236,49 @@ func (m *ApplicationManager) Get(ctx context.Context, name, namespace string) (*
 	return m.applicationBackend.Get(ctx, name, namespace)
 }
 
-// preserveOrAdoptPrincipalUID carries the principal-uid annotation from
-// existing to incoming. If existing has no principal-uid yet (pre-upgrade
-// resource), the incoming value is kept so the annotation gets adopted on the
-// first update from a principal-uid-aware principal.
-func preserveOrAdoptPrincipalUID(existing, incoming *v1alpha1.Application) {
+// ManagedIdentity carries the resolved identity that should be stamped on a
+// managed application update. Zero values mean "preserve whatever is already
+// known from the existing or incoming object".
+type ManagedIdentity struct {
+	SourceUID    string
+	PrincipalUID string
+}
+
+func resolveManagedIdentity(existing, incoming *v1alpha1.Application, identity ManagedIdentity) ManagedIdentity {
+	resolved := identity
+
+	if resolved.SourceUID == "" {
+		resolved.SourceUID = existing.Annotations[manager.SourceUIDAnnotation]
+	}
+	if resolved.SourceUID == "" && incoming.Annotations != nil {
+		resolved.SourceUID = incoming.Annotations[manager.SourceUIDAnnotation]
+	}
+
+	if resolved.PrincipalUID == "" {
+		resolved.PrincipalUID = existing.Annotations[manager.PrincipalUIDAnnotation]
+	}
+	if resolved.PrincipalUID == "" && incoming.Annotations != nil {
+		resolved.PrincipalUID = incoming.Annotations[manager.PrincipalUIDAnnotation]
+	}
+
+	return resolved
+}
+
+func applyManagedIdentity(existing, incoming *v1alpha1.Application, identity ManagedIdentity) {
 	if incoming.Annotations == nil {
 		incoming.Annotations = make(map[string]string)
 	}
-	if v, ok := existing.Annotations[manager.PrincipalUIDAnnotation]; ok {
-		incoming.Annotations[manager.PrincipalUIDAnnotation] = v
+	if v, ok := existing.Annotations["argocd.argoproj.io/refresh"]; ok {
+		incoming.Annotations["argocd.argoproj.io/refresh"] = v
 	}
-	// else: keep whatever the caller already set on incoming (adoption case)
+
+	resolved := resolveManagedIdentity(existing, incoming, identity)
+	if resolved.SourceUID != "" {
+		incoming.Annotations[manager.SourceUIDAnnotation] = resolved.SourceUID
+	}
+	if resolved.PrincipalUID != "" {
+		incoming.Annotations[manager.PrincipalUIDAnnotation] = resolved.PrincipalUID
+	}
 }
 
 // UpdateManagedApp updates the Application resource on the agent when it is in
@@ -257,7 +288,7 @@ func preserveOrAdoptPrincipalUID(existing, incoming *v1alpha1.Application) {
 // and any operation field of the incoming application. A possibly existing
 // refresh annotation on the agent's app will be retained, because it will be
 // removed by the agent's application controller.
-func (m *ApplicationManager) UpdateManagedApp(ctx context.Context, incoming *v1alpha1.Application) (*v1alpha1.Application, error) {
+func (m *ApplicationManager) UpdateManagedApp(ctx context.Context, incoming *v1alpha1.Application, identity ManagedIdentity) (*v1alpha1.Application, error) {
 	logCtx := log().WithFields(logrus.Fields{
 		"component":       "UpdateManaged",
 		"application":     incoming.QualifiedName(),
@@ -278,13 +309,7 @@ func (m *ApplicationManager) UpdateManagedApp(ctx context.Context, incoming *v1a
 	deletionTimestampChanged := false
 
 	updated, err = m.update(ctx, m.allowUpsert, incoming, func(existing, incoming *v1alpha1.Application) {
-		if incoming.Annotations == nil {
-			incoming.Annotations = make(map[string]string)
-		}
-		if v, ok := existing.Annotations[manager.SourceUIDAnnotation]; ok {
-			incoming.Annotations[manager.SourceUIDAnnotation] = v
-		}
-		preserveOrAdoptPrincipalUID(existing, incoming)
+		applyManagedIdentity(existing, incoming, identity)
 		existing.Annotations = incoming.Annotations
 		existing.Labels = incoming.Labels
 		existing.Finalizers = incoming.Finalizers
@@ -296,16 +321,7 @@ func (m *ApplicationManager) UpdateManagedApp(ctx context.Context, incoming *v1a
 		}
 
 	}, func(existing, incoming *v1alpha1.Application) (jsondiff.Patch, error) {
-		if incoming.Annotations == nil {
-			incoming.Annotations = make(map[string]string)
-		}
-		if v, ok := existing.Annotations["argocd.argoproj.io/refresh"]; ok {
-			incoming.Annotations["argocd.argoproj.io/refresh"] = v
-		}
-		if v, ok := existing.Annotations[manager.SourceUIDAnnotation]; ok {
-			incoming.Annotations[manager.SourceUIDAnnotation] = v
-		}
-		preserveOrAdoptPrincipalUID(existing, incoming)
+		applyManagedIdentity(existing, incoming, identity)
 
 		if incoming.DeletionTimestamp != nil && existing.DeletionTimestamp == nil {
 			deletionTimestampChanged = true
@@ -354,120 +370,6 @@ func (m *ApplicationManager) UpdateManagedApp(ctx context.Context, incoming *v1a
 			}
 		}
 
-		if err := m.applicationBackend.Delete(ctx, incoming.Name, incoming.Namespace, ptr.To(backend.DeletePropagationForeground)); err != nil {
-			return nil, err
-		}
-	}
-
-	return updated, err
-}
-
-// UpdateManagedAppWithTransition updates the Application resource on the agent
-// and stamps new principal-uid and source-uid annotations, overriding any
-// existing values. Used during a principal failover or when the source-uid
-// was wiped by an AppSet reconcile.
-func (m *ApplicationManager) UpdateManagedAppWithTransition(ctx context.Context, incoming *v1alpha1.Application, principalUID, sourceUID string) (*v1alpha1.Application, error) {
-	logCtx := log().WithFields(logrus.Fields{
-		"component":       "UpdateManagedTransition",
-		"application":     incoming.QualifiedName(),
-		"resourceVersion": incoming.ResourceVersion,
-	})
-
-	if !m.destinationBasedMapping {
-		incoming.SetNamespace(m.namespace)
-	}
-
-	if m.role != manager.ManagerRoleAgent || m.mode != manager.ManagerModeManaged {
-		return nil, fmt.Errorf("UpdateManagedAppWithTransition should be called on a managed agent only")
-	}
-
-	if incoming.Annotations == nil {
-		incoming.Annotations = make(map[string]string)
-	}
-	if sourceUID != "" {
-		incoming.Annotations[manager.SourceUIDAnnotation] = sourceUID
-	}
-	if principalUID != "" {
-		incoming.Annotations[manager.PrincipalUIDAnnotation] = principalUID
-	}
-
-	deletionTimestampChanged := false
-
-	updated, err := m.update(ctx, m.allowUpsert, incoming, func(existing, incoming *v1alpha1.Application) {
-		if incoming.Annotations == nil {
-			incoming.Annotations = make(map[string]string)
-		}
-		if sourceUID != "" {
-			incoming.Annotations[manager.SourceUIDAnnotation] = sourceUID
-		} else if v, ok := existing.Annotations[manager.SourceUIDAnnotation]; ok {
-			incoming.Annotations[manager.SourceUIDAnnotation] = v
-		}
-		if principalUID != "" {
-			incoming.Annotations[manager.PrincipalUIDAnnotation] = principalUID
-		}
-		existing.Annotations = incoming.Annotations
-		existing.Labels = incoming.Labels
-		existing.Finalizers = incoming.Finalizers
-		existing.Spec = *incoming.Spec.DeepCopy()
-		existing.Operation = operationToUse(existing, incoming)
-
-		if incoming.DeletionTimestamp != nil && existing.DeletionTimestamp == nil {
-			deletionTimestampChanged = true
-		}
-	}, func(existing, incoming *v1alpha1.Application) (jsondiff.Patch, error) {
-		if incoming.Annotations == nil {
-			incoming.Annotations = make(map[string]string)
-		}
-		if v, ok := existing.Annotations["argocd.argoproj.io/refresh"]; ok {
-			incoming.Annotations["argocd.argoproj.io/refresh"] = v
-		}
-		if sourceUID != "" {
-			incoming.Annotations[manager.SourceUIDAnnotation] = sourceUID
-		} else if v, ok := existing.Annotations[manager.SourceUIDAnnotation]; ok {
-			incoming.Annotations[manager.SourceUIDAnnotation] = v
-		}
-		if principalUID != "" {
-			incoming.Annotations[manager.PrincipalUIDAnnotation] = principalUID
-		}
-
-		if incoming.DeletionTimestamp != nil && existing.DeletionTimestamp == nil {
-			deletionTimestampChanged = true
-		}
-
-		target := &v1alpha1.Application{
-			ObjectMeta: v1.ObjectMeta{
-				Annotations: incoming.Annotations,
-				Labels:      incoming.Labels,
-				Finalizers:  incoming.Finalizers,
-			},
-			Spec:      incoming.Spec,
-			Operation: operationToUse(existing, incoming),
-		}
-		source := &v1alpha1.Application{
-			ObjectMeta: v1.ObjectMeta{
-				Annotations: existing.Annotations,
-				Labels:      existing.Labels,
-			},
-			Spec:      existing.Spec,
-			Operation: existing.Operation,
-		}
-		patch, err := jsondiff.Compare(source, target)
-		return patch, err
-	})
-	if err == nil {
-		logCtx.Infof("Transitioned application to new principal")
-		if err := m.IgnoreChange(updated.QualifiedName(), updated.ResourceVersion); err != nil {
-			logCtx.Warnf("Could not ignore change %s for app %s: %v", updated.ResourceVersion, updated.QualifiedName(), err)
-		}
-	}
-
-	if deletionTimestampChanged {
-		logCtx.Infof("deletionTimestamp changed during transition, deleting Application")
-		if m.deletions != nil {
-			if v, ok := updated.Annotations[manager.SourceUIDAnnotation]; ok {
-				m.deletions.MarkExpected(ty.UID(v))
-			}
-		}
 		if err := m.applicationBackend.Delete(ctx, incoming.Name, incoming.Namespace, ptr.To(backend.DeletePropagationForeground)); err != nil {
 			return nil, err
 		}
@@ -963,7 +865,7 @@ func (m *ApplicationManager) RevertManagedAppChanges(ctx context.Context, app *v
 			if isEqual := reflect.DeepEqual(cachedAppSpec, app.Spec); !isEqual {
 				app.Spec = cachedAppSpec
 				logCtx.Infof("Reverting modifications done in application: %s", app.Name)
-				if _, err := m.UpdateManagedApp(ctx, app); err != nil {
+				if _, err := m.UpdateManagedApp(ctx, app, ManagedIdentity{}); err != nil {
 					logCtx.Errorf("Unable to revert modifications done in application: %s. Error: %v", app.Name, err)
 					return false
 				}

--- a/internal/manager/application/application_test.go
+++ b/internal/manager/application/application_test.go
@@ -833,6 +833,150 @@ func Test_CompareSourceUIDForApp(t *testing.T) {
 	})
 }
 
+func Test_CompareIdentity(t *testing.T) {
+	existingApp := &v1alpha1.Application{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "test",
+			Namespace: "argocd",
+			Annotations: map[string]string{
+				manager.SourceUIDAnnotation:    "source-1",
+				manager.PrincipalUIDAnnotation: "principal-A",
+			},
+		},
+	}
+
+	t.Run("same principal, same source-uid → update", func(t *testing.T) {
+		be := appmock.NewApplication(t)
+		be.On("Get", mock.Anything, mock.Anything, mock.Anything).Return(existingApp, nil)
+		m, err := NewApplicationManager(be, "")
+		require.NoError(t, err)
+
+		incoming := existingApp.DeepCopy()
+		incoming.UID = ktypes.UID("source-1")
+
+		result, err := m.CompareIdentity(context.Background(), incoming, "principal-A")
+		require.NoError(t, err)
+		assert.True(t, result.Exists)
+		assert.True(t, result.SourceUIDMatch)
+		assert.True(t, result.PrincipalUIDMatch)
+		assert.False(t, result.PrincipalTransition)
+		assert.False(t, result.MissingSourceUID)
+	})
+
+	t.Run("same principal, different source-uid → delete/recreate", func(t *testing.T) {
+		be := appmock.NewApplication(t)
+		be.On("Get", mock.Anything, mock.Anything, mock.Anything).Return(existingApp, nil)
+		m, err := NewApplicationManager(be, "")
+		require.NoError(t, err)
+
+		incoming := existingApp.DeepCopy()
+		incoming.UID = ktypes.UID("source-NEW")
+		delete(incoming.Annotations, manager.SourceUIDAnnotation)
+
+		result, err := m.CompareIdentity(context.Background(), incoming, "principal-A")
+		require.NoError(t, err)
+		assert.True(t, result.Exists)
+		assert.False(t, result.SourceUIDMatch)
+		assert.True(t, result.PrincipalUIDMatch)
+		assert.False(t, result.PrincipalTransition)
+	})
+
+	t.Run("same principal, missing source-uid on incoming → stamp", func(t *testing.T) {
+		be := appmock.NewApplication(t)
+		be.On("Get", mock.Anything, mock.Anything, mock.Anything).Return(existingApp, nil)
+		m, err := NewApplicationManager(be, "")
+		require.NoError(t, err)
+
+		incoming := existingApp.DeepCopy()
+		incoming.UID = ""
+		incoming.Annotations = map[string]string{}
+
+		result, err := m.CompareIdentity(context.Background(), incoming, "principal-A")
+		require.NoError(t, err)
+		assert.True(t, result.Exists)
+		assert.True(t, result.MissingSourceUID)
+		assert.True(t, result.PrincipalUIDMatch)
+		assert.False(t, result.PrincipalTransition)
+	})
+
+	t.Run("different principal → transition", func(t *testing.T) {
+		be := appmock.NewApplication(t)
+		be.On("Get", mock.Anything, mock.Anything, mock.Anything).Return(existingApp, nil)
+		m, err := NewApplicationManager(be, "")
+		require.NoError(t, err)
+
+		incoming := existingApp.DeepCopy()
+		incoming.UID = ktypes.UID("source-NEW")
+		delete(incoming.Annotations, manager.SourceUIDAnnotation)
+
+		result, err := m.CompareIdentity(context.Background(), incoming, "principal-B")
+		require.NoError(t, err)
+		assert.True(t, result.Exists)
+		assert.False(t, result.PrincipalUIDMatch)
+		assert.True(t, result.PrincipalTransition)
+	})
+
+	t.Run("missing principal-uid in event (backward compat) → same principal", func(t *testing.T) {
+		be := appmock.NewApplication(t)
+		be.On("Get", mock.Anything, mock.Anything, mock.Anything).Return(existingApp, nil)
+		m, err := NewApplicationManager(be, "")
+		require.NoError(t, err)
+
+		incoming := existingApp.DeepCopy()
+		incoming.UID = ktypes.UID("source-1")
+
+		result, err := m.CompareIdentity(context.Background(), incoming, "")
+		require.NoError(t, err)
+		assert.True(t, result.Exists)
+		assert.True(t, result.SourceUIDMatch)
+		assert.True(t, result.PrincipalUIDMatch)
+		assert.False(t, result.PrincipalTransition)
+		assert.True(t, result.MissingPrincipalUID)
+	})
+
+	t.Run("first event with principal-uid on pre-upgrade resource → adoption", func(t *testing.T) {
+		preUpgradeApp := &v1alpha1.Application{
+			ObjectMeta: v1.ObjectMeta{
+				Name:      "test",
+				Namespace: "argocd",
+				Annotations: map[string]string{
+					manager.SourceUIDAnnotation: "source-1",
+				},
+			},
+		}
+		be := appmock.NewApplication(t)
+		be.On("Get", mock.Anything, mock.Anything, mock.Anything).Return(preUpgradeApp, nil)
+		m, err := NewApplicationManager(be, "")
+		require.NoError(t, err)
+
+		incoming := preUpgradeApp.DeepCopy()
+		incoming.UID = ktypes.UID("source-1")
+
+		result, err := m.CompareIdentity(context.Background(), incoming, "principal-A")
+		require.NoError(t, err)
+		assert.True(t, result.Exists)
+		assert.True(t, result.SourceUIDMatch)
+		assert.True(t, result.PrincipalUIDMatch, "should adopt: existing has no principal-uid")
+		assert.False(t, result.PrincipalTransition)
+		assert.True(t, result.AdoptedPrincipalUID)
+	})
+
+	t.Run("app does not exist", func(t *testing.T) {
+		expectedErr := errors.NewNotFound(schema.GroupResource{Group: "argoproj.io", Resource: "application"}, "test")
+		be := appmock.NewApplication(t)
+		be.On("Get", mock.Anything, mock.Anything, mock.Anything).Return(nil, expectedErr)
+		m, err := NewApplicationManager(be, "")
+		require.NoError(t, err)
+
+		incoming := existingApp.DeepCopy()
+		incoming.UID = ktypes.UID("source-1")
+
+		result, err := m.CompareIdentity(context.Background(), incoming, "principal-A")
+		require.NoError(t, err)
+		assert.False(t, result.Exists)
+	})
+}
+
 func init() {
 	logrus.SetLevel(logrus.TraceLevel)
 }

--- a/internal/manager/application/application_test.go
+++ b/internal/manager/application/application_test.go
@@ -920,23 +920,6 @@ func Test_CompareIdentity(t *testing.T) {
 		assert.False(t, result.PrincipalTransition)
 	})
 
-	t.Run("same principal, annotation wiped but UID exists (AppSet wipe) → stamp", func(t *testing.T) {
-		be := appmock.NewApplication(t)
-		be.On("Get", mock.Anything, mock.Anything, mock.Anything).Return(existingApp, nil)
-		m, err := NewApplicationManager(be, "")
-		require.NoError(t, err)
-
-		incoming := existingApp.DeepCopy()
-		incoming.UID = ktypes.UID("some-uid")
-		delete(incoming.Annotations, manager.SourceUIDAnnotation)
-
-		result, err := m.CompareIdentity(context.Background(), incoming, "principal-A")
-		require.NoError(t, err)
-		assert.True(t, result.Exists)
-		assert.True(t, result.MissingSourceUID)
-		assert.True(t, result.PrincipalUIDMatch)
-	})
-
 	t.Run("different principal → transition", func(t *testing.T) {
 		be := appmock.NewApplication(t)
 		be.On("Get", mock.Anything, mock.Anything, mock.Anything).Return(existingApp, nil)

--- a/internal/manager/application/application_test.go
+++ b/internal/manager/application/application_test.go
@@ -135,6 +135,27 @@ func Test_ManagerCreate(t *testing.T) {
 		assert.Equal(t, "test", rapp.Name)
 		assert.Equal(t, string(app.UID), rapp.Annotations[manager.SourceUIDAnnotation])
 	})
+
+	t.Run("Create preserves incoming source uid when already resolved", func(t *testing.T) {
+		app := &v1alpha1.Application{
+			ObjectMeta: v1.ObjectMeta{
+				Name:      "test",
+				Namespace: "default",
+				UID:       ktypes.UID("replica-uid"),
+				Annotations: map[string]string{
+					manager.SourceUIDAnnotation: "primary-uid",
+				},
+			},
+		}
+		mockedBackend := appmock.NewApplication(t)
+		m, err := NewApplicationManager(mockedBackend, "")
+		require.NoError(t, err)
+		mockedBackend.On("Create", mock.Anything, mock.Anything).Return(app, nil)
+
+		rapp, err := m.Create(context.TODO(), app)
+		assert.NoError(t, err)
+		assert.Equal(t, "primary-uid", rapp.Annotations[manager.SourceUIDAnnotation])
+	})
 }
 
 func prettyPrint(app *v1alpha1.Application) {

--- a/internal/manager/application/application_test.go
+++ b/internal/manager/application/application_test.go
@@ -920,6 +920,23 @@ func Test_CompareIdentity(t *testing.T) {
 		assert.False(t, result.PrincipalTransition)
 	})
 
+	t.Run("same principal, annotation wiped but UID exists (AppSet wipe) → stamp", func(t *testing.T) {
+		be := appmock.NewApplication(t)
+		be.On("Get", mock.Anything, mock.Anything, mock.Anything).Return(existingApp, nil)
+		m, err := NewApplicationManager(be, "")
+		require.NoError(t, err)
+
+		incoming := existingApp.DeepCopy()
+		incoming.UID = ktypes.UID("some-uid")
+		delete(incoming.Annotations, manager.SourceUIDAnnotation)
+
+		result, err := m.CompareIdentity(context.Background(), incoming, "principal-A")
+		require.NoError(t, err)
+		assert.True(t, result.Exists)
+		assert.True(t, result.MissingSourceUID)
+		assert.True(t, result.PrincipalUIDMatch)
+	})
+
 	t.Run("different principal → transition", func(t *testing.T) {
 		be := appmock.NewApplication(t)
 		be.On("Get", mock.Anything, mock.Anything, mock.Anything).Return(existingApp, nil)

--- a/internal/manager/application/application_test.go
+++ b/internal/manager/application/application_test.go
@@ -245,7 +245,7 @@ func Test_ManagerUpdateManaged(t *testing.T) {
 		mgr, err := NewApplicationManager(be, "argocd", WithMode(manager.ManagerModeManaged), WithRole(manager.ManagerRoleAgent))
 		require.NoError(t, err)
 
-		updated, err := mgr.UpdateManagedApp(context.Background(), incoming)
+		updated, err := mgr.UpdateManagedApp(context.Background(), incoming, ManagedIdentity{})
 
 		require.NoError(t, err)
 		require.NotNil(t, updated)
@@ -273,6 +273,52 @@ func Test_ManagerUpdateManaged(t *testing.T) {
 		require.Equal(t, existing.Status, updated.Status)
 		// Spec must be in sync with incoming
 		require.Equal(t, incoming.Spec, updated.Spec)
+	})
+
+	t.Run("Explicit managed identity overrides are stamped", func(t *testing.T) {
+		incoming := &v1alpha1.Application{
+			ObjectMeta: v1.ObjectMeta{
+				Name:      "foobar",
+				Namespace: "argocd",
+				UID:       ktypes.UID("incoming-uid"),
+			},
+			Spec: v1alpha1.ApplicationSpec{
+				Source: &v1alpha1.ApplicationSource{
+					RepoURL:        "github.com",
+					TargetRevision: "HEAD",
+					Path:           "kustomize-guestbook",
+				},
+				Destination: v1alpha1.ApplicationDestination{
+					Server:    "in-cluster",
+					Namespace: "guestbook",
+				},
+			},
+		}
+		existing := &v1alpha1.Application{
+			ObjectMeta: v1.ObjectMeta{
+				Name:      "foobar",
+				Namespace: "argocd",
+				Annotations: map[string]string{
+					manager.SourceUIDAnnotation:    "old-source-uid",
+					manager.PrincipalUIDAnnotation: "principal-A",
+				},
+			},
+		}
+
+		appC, ai := fakeInformer(t, "", existing)
+		be := application.NewKubernetesBackend(appC, "", ai, true)
+		mgr, err := NewApplicationManager(be, "argocd", WithMode(manager.ManagerModeManaged), WithRole(manager.ManagerRoleAgent))
+		require.NoError(t, err)
+
+		updated, err := mgr.UpdateManagedApp(context.Background(), incoming, ManagedIdentity{
+			SourceUID:    "resolved-source-uid",
+			PrincipalUID: "principal-B",
+		})
+
+		require.NoError(t, err)
+		require.NotNil(t, updated)
+		require.Equal(t, "resolved-source-uid", updated.Annotations[manager.SourceUIDAnnotation])
+		require.Equal(t, "principal-B", updated.Annotations[manager.PrincipalUIDAnnotation])
 	})
 
 }

--- a/internal/manager/manager.go
+++ b/internal/manager/manager.go
@@ -44,6 +44,13 @@ const (
 	// SourceUIDAnnotation is an annotation that represents the UID of the source resource.
 	// It is added to the resources managed on the target.
 	SourceUIDAnnotation = "argocd.argoproj.io/source-uid"
+
+	// PrincipalUIDAnnotation is an annotation stamped by the agent on managed resources
+	// to track which principal identity last wrote the resource. This survives
+	// principal failovers and allows the agent to distinguish a true source-uid
+	// mismatch (same principal recreated the resource) from an AppSet annotation
+	// wipe on a new principal (different principal-uid → transition in-place).
+	PrincipalUIDAnnotation = "argocd.argoproj.io/principal-uid"
 )
 
 type Manager interface {

--- a/internal/resync/resync.go
+++ b/internal/resync/resync.go
@@ -69,6 +69,10 @@ type RequestHandler struct {
 	// ignoreUnmanagedApps indicates that resources without the source UID annotation
 	// should be silently skipped during resync instead of causing an error.
 	ignoreUnmanagedApps bool
+
+	// principalUID is stamped on outgoing events so that agents can detect
+	// principal transitions during resync after a failover.
+	principalUID string
 }
 
 func NewRequestHandler(dynClient dynamic.Interface, queue workqueue.TypedRateLimitingInterface[*cloudevent.Event], events *event.EventSource, resources *resources.Resources, log *logrus.Entry, role manager.ManagerRole, namespace string) *RequestHandler {
@@ -81,6 +85,14 @@ func NewRequestHandler(dynClient dynamic.Interface, queue workqueue.TypedRateLim
 		role:      role,
 		namespace: namespace,
 	}
+}
+
+// WithPrincipalUID sets the principal identity that will be stamped on all
+// outgoing events during resync. Required for agents to correctly handle
+// principal transitions after failover.
+func (r *RequestHandler) WithPrincipalUID(uid string) *RequestHandler {
+	r.principalUID = uid
+	return r
 }
 
 // WithDestinationBasedMapping sets whether destination-based mapping is enabled.
@@ -331,6 +343,7 @@ func (r *RequestHandler) handleUpdatedResource(logCtx *logrus.Entry, reqUpdate *
 		}
 
 		ev := r.events.ApplicationEvent(event.SpecUpdate, app)
+		r.stampPrincipalUID(ev)
 		logCtx.Trace("Sending a request to update the application")
 		r.sendQ.Add(ev)
 
@@ -361,6 +374,12 @@ func (r *RequestHandler) handleUpdatedResource(logCtx *logrus.Entry, reqUpdate *
 	}
 
 	return nil
+}
+
+func (r *RequestHandler) stampPrincipalUID(ev *cloudevent.Event) {
+	if r.principalUID != "" {
+		event.SetPrincipalUID(ev, r.principalUID)
+	}
 }
 
 // isAppProjectRelevant checks if the incoming AppProject/Repository is still relevant to the agent based on the AppProject rules.
@@ -455,6 +474,7 @@ func (r *RequestHandler) handleDeletedResource(logCtx *logrus.Entry, reqUpdate *
 		}
 
 		ev := r.events.ApplicationEvent(event.Delete, app)
+		r.stampPrincipalUID(ev)
 		logCtx.Trace("Sending a request to delete the orphaned application")
 		r.sendQ.Add(ev)
 		return nil

--- a/pkg/principal/identity.go
+++ b/pkg/principal/identity.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The argocd-agent Authors
+// Copyright 2026 The argocd-agent Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/principal/identity.go
+++ b/pkg/principal/identity.go
@@ -1,0 +1,68 @@
+// Copyright 2025 The argocd-agent Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package principal
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/uuid"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+const (
+	IdentityConfigMapName = "argocd-agent-principal-identity"
+	identityKey           = "principal-uid"
+)
+
+// EnsurePrincipalUID reads or creates the principal identity ConfigMap and
+// returns the persistent UUID. The UUID survives restarts and scaling events.
+func EnsurePrincipalUID(ctx context.Context, client kubernetes.Interface, namespace string) (string, error) {
+	cm, err := client.CoreV1().ConfigMaps(namespace).Get(ctx, IdentityConfigMapName, metav1.GetOptions{})
+	if err == nil {
+		uid, ok := cm.Data[identityKey]
+		if ok && uid != "" {
+			return uid, nil
+		}
+		return "", fmt.Errorf("identity ConfigMap exists but %q key is empty", identityKey)
+	}
+
+	if !errors.IsNotFound(err) {
+		return "", fmt.Errorf("failed to get identity ConfigMap: %w", err)
+	}
+
+	uid := uuid.New().String()
+	cm = &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      IdentityConfigMapName,
+			Namespace: namespace,
+		},
+		Data: map[string]string{
+			identityKey: uid,
+		},
+	}
+
+	if _, err := client.CoreV1().ConfigMaps(namespace).Create(ctx, cm, metav1.CreateOptions{}); err != nil {
+		if errors.IsAlreadyExists(err) {
+			return EnsurePrincipalUID(ctx, client, namespace)
+		}
+		return "", fmt.Errorf("failed to create identity ConfigMap: %w", err)
+	}
+
+	return uid, nil
+}

--- a/pkg/principal/identity_test.go
+++ b/pkg/principal/identity_test.go
@@ -1,0 +1,76 @@
+package principal
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestEnsurePrincipalUID_CreatesNewConfigMap(t *testing.T) {
+	client := fake.NewSimpleClientset()
+	ctx := context.Background()
+
+	uid, err := EnsurePrincipalUID(ctx, client, "argocd")
+	require.NoError(t, err)
+	require.NotEmpty(t, uid)
+
+	_, err = uuid.Parse(uid)
+	assert.NoError(t, err, "returned uid should be a valid UUID")
+
+	cm, err := client.CoreV1().ConfigMaps("argocd").Get(ctx, IdentityConfigMapName, metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, uid, cm.Data[identityKey])
+}
+
+func TestEnsurePrincipalUID_ReturnsExistingUID(t *testing.T) {
+	existing := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      IdentityConfigMapName,
+			Namespace: "argocd",
+		},
+		Data: map[string]string{
+			identityKey: "pre-existing-uid",
+		},
+	}
+	client := fake.NewSimpleClientset(existing)
+
+	uid, err := EnsurePrincipalUID(context.Background(), client, "argocd")
+	require.NoError(t, err)
+	assert.Equal(t, "pre-existing-uid", uid)
+}
+
+func TestEnsurePrincipalUID_StableAcrossCalls(t *testing.T) {
+	client := fake.NewSimpleClientset()
+	ctx := context.Background()
+
+	uid1, err := EnsurePrincipalUID(ctx, client, "argocd")
+	require.NoError(t, err)
+
+	uid2, err := EnsurePrincipalUID(ctx, client, "argocd")
+	require.NoError(t, err)
+
+	assert.Equal(t, uid1, uid2)
+}
+
+func TestEnsurePrincipalUID_ErrorOnEmptyKey(t *testing.T) {
+	existing := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      IdentityConfigMapName,
+			Namespace: "argocd",
+		},
+		Data: map[string]string{
+			identityKey: "",
+		},
+	}
+	client := fake.NewSimpleClientset(existing)
+
+	_, err := EnsurePrincipalUID(context.Background(), client, "argocd")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "empty")
+}

--- a/principal/callbacks.go
+++ b/principal/callbacks.go
@@ -38,11 +38,18 @@ import (
 )
 
 const (
-	// Informer operation types
 	operationcreate = "create"
 	operationupdate = "update"
 	operationdelete = "delete"
 )
+
+// stampEvent stamps the principal identity on the event and injects trace context.
+func (s *Server) stampEvent(ctx context.Context, ev *cloudevents.Event) {
+	if s.principalUID != "" {
+		event.SetPrincipalUID(ev, s.principalUID)
+	}
+	tracing.InjectTraceContext(ctx, ev)
+}
 
 // newAppCallback is executed when a new application event was emitted from
 // the informer and needs to be sent out to an agent. If the receiving agent
@@ -86,7 +93,7 @@ func (s *Server) newAppCallback(outbound *v1alpha1.Application) {
 	}
 	ev := s.events.ApplicationEvent(event.Create, outbound)
 	// Inject trace context into the event for propagation to agent
-	tracing.InjectTraceContext(ctx, ev)
+	s.stampEvent(ctx, ev)
 	q.Add(ev)
 	s.ha.ForwardEventForReplication(event.New(ev, event.TargetApplication), agentName, replication.DirectionOutbound)
 	logCtx.Tracef("Added app %s to send queue, total length now %d", outbound.QualifiedName(), q.Len())
@@ -190,7 +197,7 @@ func (s *Server) updateAppCallback(old *v1alpha1.Application, new *v1alpha1.Appl
 	}
 
 	// Inject trace context into the event for propagation to agent
-	tracing.InjectTraceContext(ctx, ev)
+	s.stampEvent(ctx, ev)
 	q.Add(ev)
 	s.ha.ForwardEventForReplication(event.New(ev, event.TargetApplication), agentName, replication.DirectionOutbound)
 	logCtx.WithField("event_type", ev.Type()).Tracef("Added app to send queue, total length now %d", q.Len())
@@ -252,7 +259,7 @@ func (s *Server) deleteAppCallback(outbound *v1alpha1.Application) {
 	}
 	ev := s.events.ApplicationEvent(event.Delete, outbound)
 	// Inject trace context into the event for propagation to agent
-	tracing.InjectTraceContext(ctx, ev)
+	s.stampEvent(ctx, ev)
 	logCtx.WithField("event", "DeleteApp").WithField("sendq_len", q.Len()+1).Tracef("Added event to send queue")
 	q.Add(ev)
 	s.ha.ForwardEventForReplication(event.New(ev, event.TargetApplication), agentName, replication.DirectionOutbound)
@@ -318,7 +325,7 @@ func (s *Server) newAppProjectCallback(outbound *v1alpha1.AppProject) {
 		agentAppProject := appproject.AgentSpecificAppProject(*outbound, agent, s.destinationBasedMapping)
 		ev := s.events.AppProjectEvent(event.Create, &agentAppProject)
 		// Inject trace context into the event for propagation to agent
-		tracing.InjectTraceContext(ctx, ev)
+		s.stampEvent(ctx, ev)
 		q.Add(ev)
 		logCtx.Tracef("Added appProject %s to send queue, total length now %d", outbound.Name, q.Len())
 	}
@@ -467,7 +474,7 @@ func (s *Server) deleteAppProjectCallback(outbound *v1alpha1.AppProject) {
 		agentAppProject := appproject.AgentSpecificAppProject(*outbound, agent, s.destinationBasedMapping)
 		ev := s.events.AppProjectEvent(event.Delete, &agentAppProject)
 		// Inject trace context into the event for propagation to agent
-		tracing.InjectTraceContext(ctx, ev)
+		s.stampEvent(ctx, ev)
 		q.Add(ev)
 		logCtx.WithField("sendq_len", q.Len()+1).Tracef("Added appProject delete event to send queue")
 	}
@@ -548,7 +555,7 @@ func (s *Server) newRepositoryCallback(outbound *corev1.Secret) {
 
 		ev := s.events.RepositoryEvent(event.Create, outbound)
 		// Inject trace context into the event for propagation to agent
-		tracing.InjectTraceContext(ctx, ev)
+		s.stampEvent(ctx, ev)
 		q.Add(ev)
 		s.ha.ForwardEventForReplication(event.New(ev, event.TargetRepository), agent, replication.DirectionOutbound)
 
@@ -632,7 +639,7 @@ func (s *Server) deleteRepositoryCallback(outbound *corev1.Secret) {
 
 		ev := s.events.RepositoryEvent(event.Delete, outbound)
 		// Inject trace context into the event for propagation to agent
-		tracing.InjectTraceContext(ctx, ev)
+		s.stampEvent(ctx, ev)
 		q.Add(ev)
 		s.ha.ForwardEventForReplication(event.New(ev, event.TargetRepository), agent, replication.DirectionOutbound)
 
@@ -796,7 +803,7 @@ func (s *Server) syncAppProjectUpdatesToAgents(ctx context.Context, old, new *v1
 		agentAppProject := appproject.AgentSpecificAppProject(*new, agent, s.destinationBasedMapping)
 		ev := s.events.AppProjectEvent(event.Delete, &agentAppProject)
 		// Inject trace context into the event for propagation to agent
-		tracing.InjectTraceContext(ctx, ev)
+		s.stampEvent(ctx, ev)
 		q.Add(ev)
 		logCtx.Tracef("Sent a delete event for an AppProject for a removed cluster")
 		deletedAgents[agent] = true
@@ -817,7 +824,7 @@ func (s *Server) syncAppProjectUpdatesToAgents(ctx context.Context, old, new *v1
 		agentAppProject := appproject.AgentSpecificAppProject(*new, agent, s.destinationBasedMapping)
 		ev := s.events.AppProjectEvent(event.SpecUpdate, &agentAppProject)
 		// Inject trace context into the event for propagation to agent
-		tracing.InjectTraceContext(ctx, ev)
+		s.stampEvent(ctx, ev)
 		q.Add(ev)
 		logCtx.Tracef("Added appProject %s update event to send queue", new.Name)
 	}
@@ -884,7 +891,7 @@ func (s *Server) syncRepositoryUpdatesToAgents(ctx context.Context, old, new *co
 
 		ev := s.events.RepositoryEvent(event.Delete, new)
 		// Inject trace context into the event for propagation to agent
-		tracing.InjectTraceContext(ctx, ev)
+		s.stampEvent(ctx, ev)
 		q.Add(ev)
 		s.ha.ForwardEventForReplication(event.New(ev, event.TargetRepository), agent, replication.DirectionOutbound)
 
@@ -904,7 +911,7 @@ func (s *Server) syncRepositoryUpdatesToAgents(ctx context.Context, old, new *co
 
 		ev := s.events.RepositoryEvent(event.SpecUpdate, new)
 		// Inject trace context into the event for propagation to agent
-		tracing.InjectTraceContext(ctx, ev)
+		s.stampEvent(ctx, ev)
 		q.Add(ev)
 		s.ha.ForwardEventForReplication(event.New(ev, event.TargetRepository), agent, replication.DirectionOutbound)
 
@@ -1025,7 +1032,7 @@ func (s *Server) handleAppAgentChange(ctx context.Context, old, new *v1alpha1.Ap
 		}
 		if oldQ := s.queues.SendQ(oldAgentName); oldQ != nil {
 			deleteEv := s.events.ApplicationEvent(event.Delete, old)
-			tracing.InjectTraceContext(ctx, deleteEv)
+			s.stampEvent(ctx, deleteEv)
 			oldQ.Add(deleteEv)
 			logCtx.Debug("Sent delete event to old agent")
 		}

--- a/principal/event.go
+++ b/principal/event.go
@@ -659,7 +659,8 @@ func (s *Server) processIncomingResourceResyncEvent(ctx context.Context, agentNa
 	}
 
 	resyncHandler := resync.NewRequestHandler(dynClient, sendQ, s.events, s.resources.Get(agentName), logCtx, manager.ManagerRolePrincipal, s.namespace).
-		WithDestinationBasedMapping(s.destinationBasedMapping)
+		WithDestinationBasedMapping(s.destinationBasedMapping).
+		WithPrincipalUID(s.principalUID)
 
 	switch ev.Type() {
 	case event.SyncedResourceList.String():

--- a/principal/server.go
+++ b/principal/server.go
@@ -56,6 +56,7 @@ import (
 	"github.com/argoproj-labs/argocd-agent/internal/tlsutil"
 	"github.com/argoproj-labs/argocd-agent/internal/tracing"
 	"github.com/argoproj-labs/argocd-agent/internal/version"
+	principalIdentity "github.com/argoproj-labs/argocd-agent/pkg/principal"
 	"github.com/argoproj-labs/argocd-agent/pkg/types"
 	"github.com/argoproj-labs/argocd-agent/principal/apis/eventstream"
 	logstream "github.com/argoproj-labs/argocd-agent/principal/apis/logstreamapi"
@@ -195,6 +196,12 @@ type Server struct {
 
 	// ha holds HA components for high availability support
 	ha *HAComponents
+
+	// principalUID is a persistent identity for this principal instance,
+	// stored in a ConfigMap. Sent as a CloudEvent extension so the agent can
+	// detect principal transitions without relying on annotations that AppSet
+	// may wipe.
+	principalUID string
 }
 
 type handlersOnConnect func(agent types.Agent) error
@@ -632,6 +639,18 @@ func (s *Server) Start(ctx context.Context, errch chan error) error {
 		log().Info("Destination-based mapping is enabled on the principal")
 	}
 
+	ns := s.namespace
+	if ns == "" {
+		ns = "argocd"
+	}
+	uid, err := principalIdentity.EnsurePrincipalUID(ctx, s.kubeClient.Clientset, ns)
+	if err != nil {
+		log().WithError(err).Error("failed to load/create principal identity")
+		return err
+	}
+	s.principalUID = uid
+	log().Infof("Principal identity: %s", uid)
+
 	// We need to maintain a cache to keep resources in sync with last known state of
 	// autonomous-agent in case it is disconnected with agent or resources on the control-plane are modified.
 	if err := s.populateSourceCache(ctx); err != nil {
@@ -668,8 +687,7 @@ func (s *Server) Start(ctx context.Context, errch chan error) error {
 
 	go s.RunHandlersOnConnect(s.ctx)
 
-	err := s.StartEventProcessor(s.ctx)
-	if err != nil {
+	if err = s.StartEventProcessor(s.ctx); err != nil {
 		return nil
 	}
 
@@ -905,7 +923,8 @@ func (s *Server) handleResyncOnConnect(agent types.Agent) error {
 		}
 
 		resyncHandler := resync.NewRequestHandler(dynClient, sendQ, s.events, s.resources.Get(agent.Name()), logCtx, manager.ManagerRolePrincipal, s.namespace).
-			WithDestinationBasedMapping(s.destinationBasedMapping)
+			WithDestinationBasedMapping(s.destinationBasedMapping).
+			WithPrincipalUID(s.principalUID)
 		go resyncHandler.SendRequestUpdates(s.ctx)
 
 		// Principal should request SyncedResourceList to revert any deletions on the Principal side.

--- a/principal/server.go
+++ b/principal/server.go
@@ -639,11 +639,10 @@ func (s *Server) Start(ctx context.Context, errch chan error) error {
 		log().Info("Destination-based mapping is enabled on the principal")
 	}
 
-	ns := s.namespace
-	if ns == "" {
-		ns = "argocd"
+	if s.namespace == "" {
+		return fmt.Errorf("namespace is required for principal identity")
 	}
-	uid, err := principalIdentity.EnsurePrincipalUID(ctx, s.kubeClient.Clientset, ns)
+	uid, err := principalIdentity.EnsurePrincipalUID(ctx, s.kubeClient.Clientset, s.namespace)
 	if err != nil {
 		log().WithError(err).Error("failed to load/create principal identity")
 		return err
@@ -688,7 +687,7 @@ func (s *Server) Start(ctx context.Context, errch chan error) error {
 	go s.RunHandlersOnConnect(s.ctx)
 
 	if err = s.StartEventProcessor(s.ctx); err != nil {
-		return nil
+		return err
 	}
 
 	s.events = event.NewEventSource(s.options.serverName)


### PR DESCRIPTION
**What does this PR do / why we need it**:

Addresses problems outlined in #831 for multi-principal source-UID handling

**Which issue(s) this PR fixes**:

Fixes #831 

**How to test changes / Special notes to the reviewer**:

I ran a failover exercise and captured application identity snapshots before failover and after reconciliation on the new principal.

### Topology
- Old principal: `m-test-a-ea1t-us`
- New principal: `m-j-a-ea1t-us`
- Agents: `mesh-a-ea1t-us`, `mesh-b-ea1t-us`

### What I captured
For every `Application` in:
- old principal
- new principal
- mesh-a agent
- mesh-b agent

I recorded:
- `metadata.name`
- `metadata.uid`
- `metadata.resourceVersion`
- `metadata.creationTimestamp`
- `metadata.deletionTimestamp`
- `argocd.argoproj.io/source-uid`
- `argocd.argoproj.io/principal-uid`
- destination info
- sync / health status

### Final result
Ownership transferred correctly after failover and reconciliation:

- Agent `principal-uid` moved from the old principal UID to the new principal UID.
- The new principal cleared the inherited `source-uid` annotations from its replicated application objects.
- Application identity remained stable throughout the exercise.

### Evidence

#### 1. No delete+recreate occurred
I compared `name -> uid` across the pre-failover snapshot and the final post-reconciliation snapshot in all four contexts.

Result:
- `m-test-a-ea1t-us`: no UID changes
- `m-j-a-ea1t-us`: no UID changes
- `mesh-a-ea1t-us`: no UID changes
- `mesh-b-ea1t-us`: no UID changes

I also checked:
- no `creationTimestamp` changes
- no `deletionTimestamp` present in the final snapshot

This shows the failover path updated ownership in place rather than deleting and recreating applications.

#### 2. Agent ownership moved to the new principal
Agent `principal-uid` values:

- Before failover:
  - `mesh-a-ea1t-us`: `d47ba09f-cb02-4887-8b7b-ddac0b3be37e`
  - `mesh-b-ea1t-us`: `d47ba09f-cb02-4887-8b7b-ddac0b3be37e`

- After failover and reconciliation:
  - `mesh-a-ea1t-us`: `15fe35f1-a643-418a-8c5c-4b4da266e085`
  - `mesh-b-ea1t-us`: `15fe35f1-a643-418a-8c5c-4b4da266e085`

This confirms both agents adopted the new principal UID.

#### 3. The new principal cleared inherited `source-uid`
`source-uid` counts on the new principal (`m-j-a-ea1t-us`):

- Before failover: `20`
- After failover and reconciliation: `0`

That means the promoted principal no longer retained the replicated `source-uid` values from the old principal after reconciliation.

#### 4. Application counts remained stable
Application counts were unchanged across the exercise:

- `m-test-a-ea1t-us`: `20`
- `m-j-a-ea1t-us`: `20`
- `mesh-a-ea1t-us`: `10`
- `mesh-b-ea1t-us`: `10`

**Checklist**

* [ ] Documentation update is required by this PR (and has been updated) OR no documentation update is required.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Persistent principal identity is generated, stored, and propagated; resync and emitted events are stamped with principal UID and trace context.

* **Bug Fixes / Improvements**
  * Identity-aware create/update/delete flows: in-place managed transitions, consistent spec caching under resolved source identity, safer delete-and-recreate on mismatch, and warnings for unknown events.

* **Tests**
  * Added coverage validating principal UID behavior, identity comparison outcomes, and managed-mode caching/transition paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->