### PR TITLE
fix: preserve pending sync operations during managed status updates

### DIFF
--- a/internal/manager/application/application.go
+++ b/internal/manager/application/application.go
@@ -484,16 +484,13 @@ func (m *ApplicationManager) UpdateStatus(ctx context.Context, namespace string,
 		existing.Annotations = incoming.Annotations
 		existing.Labels = incoming.Labels
 		existing.Status = *incoming.Status.DeepCopy()
-		// Managed-agent status updates frequently arrive without .operation.
-		// Preserve any principal-initiated sync operation until the agent
-		// explicitly reports an updated operation payload.
-		existing.Operation = operationToUse(existing, incoming)
+		existing.Operation = statusOperationToUse(existing, incoming)
 	}, func(existing, incoming *v1alpha1.Application) (jsondiff.Patch, error) {
 		refresh, incomingRefresh := incoming.Annotations["argocd.argoproj.io/refresh"]
 		_, existingRefresh := existing.Annotations["argocd.argoproj.io/refresh"]
 		target := &v1alpha1.Application{
 			Status:    incoming.Status,
-			Operation: operationToUse(existing, incoming),
+			Operation: statusOperationToUse(existing, incoming),
 		}
 		source := &v1alpha1.Application{
 			Status:    existing.Status,
@@ -611,6 +608,22 @@ func operationToUse(existing, incoming *v1alpha1.Application) *v1alpha1.Operatio
 	}
 
 	return incoming.Operation.DeepCopy()
+}
+
+func statusOperationToUse(existing, incoming *v1alpha1.Application) *v1alpha1.Operation {
+	if incoming.Operation != nil {
+		return operationToUse(existing, incoming)
+	}
+
+	if incoming.Status.OperationState == nil {
+		return existing.Operation
+	}
+
+	if incoming.Status.OperationState.Phase.Completed() {
+		return nil
+	}
+
+	return existing.Operation
 }
 
 // TerminateOperation aborts a running sync operation by setting .status.operationState.phase to Terminating.

--- a/internal/manager/application/application_test.go
+++ b/internal/manager/application/application_test.go
@@ -386,6 +386,49 @@ func Test_ManagerUpdateStatus(t *testing.T) {
 		require.Contains(t, updated.Annotations, LastUpdatedAnnotation)
 		require.NotEmpty(t, updated.Annotations[LastUpdatedAnnotation])
 	})
+
+	t.Run("Clear existing operation when incoming status update is terminal", func(t *testing.T) {
+		incoming := &v1alpha1.Application{
+			ObjectMeta: v1.ObjectMeta{
+				Name:      "foobar",
+				Namespace: "argocd",
+				Annotations: map[string]string{
+					"bar": "foo",
+				},
+			},
+			Status: v1alpha1.ApplicationStatus{
+				OperationState: &v1alpha1.OperationState{
+					Phase: synccommon.OperationSucceeded,
+				},
+			},
+		}
+		existing := &v1alpha1.Application{
+			ObjectMeta: v1.ObjectMeta{
+				Name:      "foobar",
+				Namespace: "cluster-1",
+				Annotations: map[string]string{
+					"bar": "foo",
+				},
+			},
+			Operation: &v1alpha1.Operation{
+				InitiatedBy: v1alpha1.OperationInitiator{Username: "principal-sync"},
+			},
+		}
+
+		appC, ai := fakeInformer(t, "", existing)
+		be := application.NewKubernetesBackend(appC, "", ai, true)
+		mgr, err := NewApplicationManager(be, "argocd")
+		require.NoError(t, err)
+		mgr.mode = manager.ManagerModeManaged
+		mgr.role = manager.ManagerRolePrincipal
+
+		updated, err := mgr.UpdateStatus(context.Background(), "cluster-1", incoming)
+		require.NoError(t, err)
+		require.NotNil(t, updated)
+		require.Nil(t, updated.Operation)
+		require.Contains(t, updated.Annotations, LastUpdatedAnnotation)
+		require.NotEmpty(t, updated.Annotations[LastUpdatedAnnotation])
+	})
 }
 
 func Test_ManagerUpdateAutonomous(t *testing.T) {


### PR DESCRIPTION
Managed-agent status updates can arrive on the principal with a nil .operation even while a principal-initiated sync request is still pending. The principal UpdateStatus path was previously copying incoming.Operation verbatim, which meant an early status update could clear the sync operation before the Argo CD application controller ever observed it.

That race leaves newly created applications stuck OutOfSync/Missing with no .operation or .status.operationState on either side, even though the deploy flow requested a sync.

Fix this by reusing operationToUse() in the principal UpdateStatus path so an existing operation is preserved when the incoming status payload does not carry one. The operation is still updated when the agent explicitly reports one, and terminating operations keep their existing behavior.

Also add a regression test covering the nil-operation status update case so this remains safe to cherry-pick independently.

Fixes #841 

**How to test changes / Special notes to the reviewer**:


**Checklist**

* [ ] Documentation update is required by this PR (and has been updated) OR no documentation update is required.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserve existing application operations when incoming status updates omit an operation, preventing unintended clearing of principal-initiated operations. When an incoming status indicates a completed operation, the operation is cleared. Status updates also record a last-updated annotation to make operation state stable and traceable.

* **Tests**
  * Added coverage verifying preservation/clearing of operations and presence of the last-updated annotation after status updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->