### PR TITLE
fix: logger fix ACK routing mapping to agent queue

### DIFF
--- a/principal/event.go
+++ b/principal/event.go
@@ -733,20 +733,20 @@ func (s *Server) processIncomingResourceResyncEvent(ctx context.Context, agentNa
 func (s *Server) eventProcessor(ctx context.Context) error {
 	sem := semaphore.NewWeighted(s.options.eventProcessors)
 	queueLock := namedlock.NewNamedLock()
-	logCtx := s.logGrpcEvent().WithField("module", "EventProcessor")
+	baseLogCtx := s.logGrpcEvent().WithField("module", "EventProcessor")
 	for {
 		queuesProcessed := 0
 		for _, queueName := range s.queues.Names() {
 			select {
 			case <-ctx.Done():
-				logCtx.Infof("Shutting down event processor")
+				baseLogCtx.Infof("Shutting down event processor")
 				return nil
 			default:
 				// Though unlikely, the agent might have disconnected, and
 				// the queue will be gone. In this case, we'll just skip.
 				q := s.queues.RecvQ(queueName)
 				if q == nil {
-					logCtx.Debugf("Queue disappeared -- client probably has disconnected")
+					baseLogCtx.WithField("queueName", queueName).Debugf("Queue disappeared -- client probably has disconnected")
 					break
 				}
 
@@ -767,22 +767,22 @@ func (s *Server) eventProcessor(ctx context.Context) error {
 					break
 				}
 
-				logCtx = logCtx.WithField("queueName", queueName)
+				queueLogCtx := baseLogCtx.WithField("queueName", queueName)
 
 				queuesProcessed += 1
 
-				logCtx.Trace("Acquired queue lock")
+				queueLogCtx.Trace("Acquired queue lock")
 
 				err := sem.Acquire(ctx, 1)
 				if err != nil {
-					logCtx.Tracef("Error acquiring semaphore: %v", err)
+					queueLogCtx.Tracef("Error acquiring semaphore: %v", err)
 					queueLock.Unlock(queueName)
 					break
 				}
 
-				logCtx.Trace("Acquired semaphore")
+				queueLogCtx.Trace("Acquired semaphore")
 
-				go func(agentName string, q workqueue.TypedRateLimitingInterface[*cloudevents.Event]) {
+				go func(agentName string, q workqueue.TypedRateLimitingInterface[*cloudevents.Event], logCtx *logrus.Entry) {
 					defer func() {
 						sem.Release(1)
 						queueLock.Unlock(agentName)
@@ -799,7 +799,7 @@ func (s *Server) eventProcessor(ctx context.Context) error {
 					}
 
 					// Send an ACK if the event is processed successfully.
-					sendQ := s.queues.SendQ(queueName)
+					sendQ := s.queues.SendQ(agentName)
 					if sendQ == nil {
 						logCtx.Debugf("Queue disappeared -- client probably has disconnected")
 						return
@@ -812,7 +812,7 @@ func (s *Server) eventProcessor(ctx context.Context) error {
 
 					logCtx.Trace("sending an ACK for an event")
 					sendQ.Add(s.events.ProcessedEvent(event.EventProcessed, event.New(ev, event.TargetEventAck)))
-				}(queueName, q)
+				}(queueName, q, queueLogCtx)
 			}
 		}
 		// Give the CPU a little rest when no agents are connected

--- a/principal/event_test.go
+++ b/principal/event_test.go
@@ -36,6 +36,62 @@ import (
 	"k8s.io/utils/ptr"
 )
 
+func Test_EventProcessorRoutesACKToMatchingQueue(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	s, err := NewServer(ctx, kube.NewKubernetesFakeClientWithApps("argocd"), "argocd", WithGeneratedTokenSigningKey(), WithRedisProxyDisabled())
+	require.NoError(t, err)
+	s.events = event.NewEventSource("test")
+
+	require.NoError(t, s.queues.Create("mesh-a-ea1t-us"))
+	require.NoError(t, s.queues.Create("mesh-b-ea1t-us"))
+
+	evs := event.NewEventSource("test")
+
+	heartbeatA := evs.HeartbeatEvent("mesh-a-ea1t-us")
+	heartbeatA.SetExtension("eventid", "mesh-a-heartbeat")
+	heartbeatA.SetExtension("resourceid", "mesh-a-heartbeat")
+
+	heartbeatB := evs.HeartbeatEvent("mesh-b-ea1t-us")
+	heartbeatB.SetExtension("eventid", "mesh-b-heartbeat")
+	heartbeatB.SetExtension("resourceid", "mesh-b-heartbeat")
+
+	s.queues.RecvQ("mesh-a-ea1t-us").Add(heartbeatA)
+	s.queues.RecvQ("mesh-b-ea1t-us").Add(heartbeatB)
+
+	done := make(chan struct{})
+	go func() {
+		_ = s.eventProcessor(ctx)
+		close(done)
+	}()
+
+	require.Eventually(t, func() bool {
+		return s.queues.SendQ("mesh-a-ea1t-us").Len() == 1 && s.queues.SendQ("mesh-b-ea1t-us").Len() == 1
+	}, 2*time.Second, 10*time.Millisecond)
+
+	ackA, shutdown := s.queues.SendQ("mesh-a-ea1t-us").Get()
+	require.False(t, shutdown)
+	require.NotNil(t, ackA)
+	require.Equal(t, event.EventProcessed.String(), ackA.Type())
+	require.Equal(t, "mesh-a-heartbeat", event.EventID(ackA))
+	s.queues.SendQ("mesh-a-ea1t-us").Done(ackA)
+
+	ackB, shutdown := s.queues.SendQ("mesh-b-ea1t-us").Get()
+	require.False(t, shutdown)
+	require.NotNil(t, ackB)
+	require.Equal(t, event.EventProcessed.String(), ackB.Type())
+	require.Equal(t, "mesh-b-heartbeat", event.EventID(ackB))
+	s.queues.SendQ("mesh-b-ea1t-us").Done(ackB)
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(1 * time.Second):
+		t.Fatal("eventProcessor did not stop after context cancellation")
+	}
+}
+
 func Test_InvalidEvents(t *testing.T) {
 	t.Run("Unknown event schema", func(t *testing.T) {
 		ev := cloudevents.NewEvent()


### PR DESCRIPTION
The principal event processor was reusing mutable outer loop state inside its per-queue goroutines.

In practice that meant log fields such as queueName and client could be mixed across concurrent goroutines, making the processor look like it was handling mesh-a events under mesh-b context

Make the queue identity explicit by creating a per-queue logger before launching the goroutine and by routing processed ACKs with SendQ(agentName) inside the goroutine.

**What does this PR do / why we need it**:

**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:


**Checklist**

* [ ] Documentation update is required by this PR (and has been updated) OR no documentation update is required.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed logging context handling to prevent shared state mutations across queue processing iterations
  * Corrected ACK message routing to use agent names for proper queue matching

* **Tests**
  * Added test coverage for ACK message routing across multiple receive queues with distinct events

<!-- end of auto-generated comment: release notes by coderabbit.ai -->