### PR TITLE
fix: Set a more sane kube-client QPS limit

### DIFF
--- a/internal/config/constants.go
+++ b/internal/config/constants.go
@@ -30,3 +30,9 @@ const SecretNameJWT = "argocd-agent-jwt"
 
 // SkipSyncLabel is the label used to skip sync for an application.
 const SkipSyncLabel = "argocd-agent.argoproj-labs.io/ignore-sync"
+
+// EnvKubeQPS is the name of the environment variable for setting the Kubernetes API QPS.
+const EnvKubeQPS = "ARGOCD_AGENT_KUBE_QPS"
+
+// EnvKubeBurst is the name of the environment variable for setting the Kubernetes API Burst.
+const EnvKubeBurst = "ARGOCD_AGENT_KUBE_BURST"

--- a/internal/kube/client.go
+++ b/internal/kube/client.go
@@ -25,6 +25,7 @@ import (
 	"strings"
 	"syscall"
 
+	conf "github.com/argoproj-labs/argocd-agent/internal/config"
 	"github.com/argoproj-labs/argocd-agent/internal/env"
 	"github.com/argoproj/argo-cd/v3/pkg/client/clientset/versioned"
 	"k8s.io/client-go/dynamic"
@@ -71,8 +72,8 @@ func NewKubernetesClientFromConfig(ctx context.Context, namespace string, kubeco
 		return nil, err
 	}
 
-	config.QPS = float32(env.NumWithDefault("ARGOCD_AGENT_KUBE_QPS", nil, 100))
-	config.Burst = int(env.NumWithDefault("ARGOCD_AGENT_KUBE_BURST", nil, 300))
+	config.QPS = float32(env.NumWithDefault(conf.EnvKubeQPS, nil, 100))
+	config.Burst = int(env.NumWithDefault(conf.EnvKubeBurst, nil, 300))
 
 	if namespace == "" {
 		namespace, _, err = clientConfig.Namespace()

--- a/internal/kube/client.go
+++ b/internal/kube/client.go
@@ -25,6 +25,7 @@ import (
 	"strings"
 	"syscall"
 
+	"github.com/argoproj-labs/argocd-agent/internal/env"
 	"github.com/argoproj/argo-cd/v3/pkg/client/clientset/versioned"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
@@ -69,6 +70,9 @@ func NewKubernetesClientFromConfig(ctx context.Context, namespace string, kubeco
 	if err != nil {
 		return nil, err
 	}
+
+	config.QPS = float32(env.NumWithDefault("ARGOCD_AGENT_KUBE_QPS", nil, 100))
+	config.Burst = int(env.NumWithDefault("ARGOCD_AGENT_KUBE_BURST", nil, 300))
 
 	if namespace == "" {
 		namespace, _, err = clientConfig.Namespace()


### PR DESCRIPTION
**What does this PR do / why we need it**:

The default QPS for the Kubernetes client in Go is 5, with a burst of 10. This is too little, and may lead to throttled Kubernetes API operations.

This fix sets the default to QPS=100, burst=300 and lets users override that using environment variables.

**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:


**Checklist**

* [ ] Documentation update is required by this PR (and has been updated) OR no documentation update is required.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Kubernetes API rate-limiting is now configurable via environment variables ARGOCD_AGENT_KUBE_QPS and ARGOCD_AGENT_KUBE_BURST (defaults: 100 QPS, 300 burst), allowing better control of client request throttling to reduce API overload and improve stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->