### PR TITLE
feat: expose k8s client metrics 

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -292,6 +292,7 @@ func NewAgent(ctx context.Context, client *kube.KubernetesClient, namespace stri
 
 	if a.options.metricsPort > 0 {
 		a.metrics = metrics.NewAgentMetrics()
+		metrics.RegisterK8sClientMetrics()
 	}
 
 	appInformer, err := informer.NewInformer(ctx, appInformerOptions...)

--- a/internal/metrics/k8sclient.go
+++ b/internal/metrics/k8sclient.go
@@ -1,0 +1,84 @@
+// Copyright 2026 The argocd-agent Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metrics
+
+import (
+	"context"
+	neturl "net/url"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+	k8smetrics "k8s.io/client-go/tools/metrics"
+)
+
+// RegisterK8sClientMetrics wires the standard client-go REST client metrics
+// (request latency, rate-limiter latency, request totals, retries) into the
+// default Prometheus registry using the conventional rest_client_* names.
+// It is safe to call multiple times; client-go only registers once.
+func RegisterK8sClientMetrics() {
+	requestLatency := promauto.NewHistogramVec(prometheus.HistogramOpts{
+		Name:    "rest_client_request_duration_seconds",
+		Help:    "Request latency in seconds. Broken down by verb and host.",
+		Buckets: prometheus.DefBuckets,
+	}, []string{"verb", "host"})
+
+	rateLimiterLatency := promauto.NewHistogramVec(prometheus.HistogramOpts{
+		Name:    "rest_client_rate_limiter_duration_seconds",
+		Help:    "Client-side rate limiter latency in seconds. Broken down by verb and host.",
+		Buckets: prometheus.DefBuckets,
+	}, []string{"verb", "host"})
+
+	requestResult := promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "rest_client_requests_total",
+		Help: "Number of HTTP requests, partitioned by status code, method, and host.",
+	}, []string{"code", "method", "host"})
+
+	requestRetries := promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "rest_client_request_retries_total",
+		Help: "Number of request retries, partitioned by status code, method, and host.",
+	}, []string{"code", "method", "host"})
+
+	k8smetrics.Register(k8smetrics.RegisterOpts{
+		RequestLatency:     &latencyAdapter{requestLatency},
+		RateLimiterLatency: &latencyAdapter{rateLimiterLatency},
+		RequestResult:      &resultAdapter{requestResult},
+		RequestRetry:       &retryAdapter{requestRetries},
+	})
+}
+
+type latencyAdapter struct {
+	m *prometheus.HistogramVec
+}
+
+func (a *latencyAdapter) Observe(_ context.Context, verb string, u neturl.URL, latency time.Duration) {
+	a.m.WithLabelValues(verb, u.Host).Observe(latency.Seconds())
+}
+
+type resultAdapter struct {
+	m *prometheus.CounterVec
+}
+
+func (a *resultAdapter) Increment(_ context.Context, code, method, host string) {
+	a.m.WithLabelValues(code, method, host).Inc()
+}
+
+type retryAdapter struct {
+	m *prometheus.CounterVec
+}
+
+func (a *retryAdapter) IncrementRetry(_ context.Context, code, method, host string) {
+	a.m.WithLabelValues(code, method, host).Inc()
+}

--- a/principal/server.go
+++ b/principal/server.go
@@ -324,6 +324,7 @@ func NewServer(ctx context.Context, kubeClient *kube.KubernetesClient, namespace
 
 	if s.options.metricsPort > 0 {
 		s.metrics = metrics.NewPrincipalMetrics()
+		metrics.RegisterK8sClientMetrics()
 
 		appInformerOpts = append(appInformerOpts, informer.WithMetrics[*v1alpha1.Application](prometheus.NewRegistry(), metrics.NewInformerMetrics("applications")))
 		projInformerOpts = append(projInformerOpts, informer.WithMetrics[*v1alpha1.AppProject](prometheus.NewRegistry(), metrics.NewInformerMetrics("appprojects")))


### PR DESCRIPTION
Register client-go's request latency, rate-limiter latency, request totals, and retry counters into the default Prometheus registry.

Uses the conventional rest_client_* metric names so existing k8s controller dashboards work without modification. Registration is gated on metricsPort > 0 for both principal and agent, consistent with how all other metrics are initialized.

**What does this PR do / why we need it**:

**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:


**Checklist**

* [ ] Documentation update is required by this PR (and has been updated) OR no documentation update is required.

<img width="1496" height="653" alt="image" src="https://github.com/user-attachments/assets/13303108-c89b-4b09-9ca7-4674bf0b0e0e" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Kubernetes client metrics for monitoring REST client operations, including request latency, request totals, and retry counts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->