### PR TITLE
chore: Initialize logging early and print version at startup

### DIFF
--- a/cmd/argocd-agent/agent.go
+++ b/cmd/argocd-agent/agent.go
@@ -34,6 +34,7 @@ import (
 	"github.com/argoproj-labs/argocd-agent/internal/env"
 	"github.com/argoproj-labs/argocd-agent/internal/grpcutil"
 	"github.com/argoproj-labs/argocd-agent/internal/tracing"
+	"github.com/argoproj-labs/argocd-agent/internal/version"
 	"github.com/argoproj-labs/argocd-agent/pkg/client"
 	"github.com/argoproj-labs/argocd-agent/pkg/types"
 	"github.com/sirupsen/logrus"
@@ -113,6 +114,27 @@ func NewAgentRunCommand() *cobra.Command {
 			ctx, cancelFn := context.WithCancel(context.Background())
 			defer cancelFn()
 
+			if formatter, err := cmdutil.LogFormatter(logFormat); err != nil {
+				cmdutil.Fatal("%s", err.Error())
+			} else {
+				logrus.SetFormatter(formatter)
+			}
+
+			subLoggers := cmdutil.SubSystemLoggers{
+				ResourceProxyLogger: cmdutil.CreateLogger(logFormat),
+				RedisProxyLogger:    cmdutil.CreateLogger(logFormat),
+				GrpcEventLogger:     cmdutil.CreateLogger(logFormat),
+			}
+
+			if len(logLevels) == 0 {
+				logLevels = append(logLevels, "info")
+			}
+			if len(logLevels) > 0 {
+				cmdutil.ParseLogLevels(logLevels, &subLoggers)
+			}
+
+			logrus.Infof("Initializing argocd-agent v%s (agent)", version.New("argocd-agent").Version())
+
 			// Initialize OpenTelemetry tracing if enabled
 			if otlpAddress != "" {
 				shutdownTracer, err := tracing.InitTracer(ctx, "agent-"+agentMode, otlpAddress, otlpInsecure)
@@ -140,25 +162,6 @@ func NewAgentRunCommand() *cobra.Command {
 
 			agentOpts := []agent.AgentOption{}
 			remoteOpts := []client.RemoteOption{}
-
-			if formatter, err := cmdutil.LogFormatter(logFormat); err != nil {
-				cmdutil.Fatal("%s", err.Error())
-			} else {
-				logrus.SetFormatter(formatter)
-			}
-
-			subLoggers := cmdutil.SubSystemLoggers{
-				ResourceProxyLogger: cmdutil.CreateLogger(logFormat),
-				RedisProxyLogger:    cmdutil.CreateLogger(logFormat),
-				GrpcEventLogger:     cmdutil.CreateLogger(logFormat),
-			}
-
-			if len(logLevels) == 0 {
-				logLevels = append(logLevels, "info")
-			}
-			if len(logLevels) > 0 {
-				cmdutil.ParseLogLevels(logLevels, &subLoggers)
-			}
 
 			agentOpts = append(agentOpts, agent.WithSubsystemLoggers(subLoggers.ResourceProxyLogger, subLoggers.RedisProxyLogger, subLoggers.GrpcEventLogger))
 			if namespace == "" {

--- a/cmd/argocd-agent/principal.go
+++ b/cmd/argocd-agent/principal.go
@@ -37,6 +37,7 @@ import (
 	"github.com/argoproj-labs/argocd-agent/internal/labels"
 	"github.com/argoproj-labs/argocd-agent/internal/tlsutil"
 	"github.com/argoproj-labs/argocd-agent/internal/tracing"
+	"github.com/argoproj-labs/argocd-agent/internal/version"
 	"github.com/argoproj-labs/argocd-agent/pkg/ha"
 	"github.com/argoproj-labs/argocd-agent/principal"
 	cacheutil "github.com/argoproj/argo-cd/v3/util/cache"
@@ -135,6 +136,27 @@ func NewPrincipalRunCommand() *cobra.Command {
 			ctx, cancelFn := context.WithCancel(context.Background())
 			defer cancelFn()
 
+			if formatter, err := cmdutil.LogFormatter(logFormat); err != nil {
+				cmdutil.Fatal("%s", err.Error())
+			} else {
+				logrus.SetFormatter(formatter)
+			}
+
+			subLoggers := cmdutil.SubSystemLoggers{
+				ResourceProxyLogger: cmdutil.CreateLogger(logFormat),
+				RedisProxyLogger:    cmdutil.CreateLogger(logFormat),
+				GrpcEventLogger:     cmdutil.CreateLogger(logFormat),
+			}
+
+			if len(logLevels) == 0 {
+				logLevels = append(logLevels, "info")
+			}
+			if len(logLevels) > 0 {
+				cmdutil.ParseLogLevels(logLevels, &subLoggers)
+			}
+
+			logrus.Infof("Initializing argocd-agent v%s (principal)", version.New("argocd-agent").Version())
+
 			// Initialize OpenTelemetry tracing if enabled
 			if otlpAddress != "" {
 				shutdownTracer, err := tracing.InitTracer(ctx, "principal", otlpAddress, otlpInsecure)
@@ -161,25 +183,6 @@ func NewPrincipalRunCommand() *cobra.Command {
 			}
 
 			opts := []principal.ServerOption{}
-			if formatter, err := cmdutil.LogFormatter(logFormat); err != nil {
-				cmdutil.Fatal("%s", err.Error())
-			} else {
-				logrus.SetFormatter(formatter)
-			}
-
-			subLoggers := cmdutil.SubSystemLoggers{
-				ResourceProxyLogger: cmdutil.CreateLogger(logFormat),
-				RedisProxyLogger:    cmdutil.CreateLogger(logFormat),
-				GrpcEventLogger:     cmdutil.CreateLogger(logFormat),
-			}
-
-			if len(logLevels) == 0 {
-				logLevels = append(logLevels, "info")
-			}
-			if len(logLevels) > 0 {
-				cmdutil.ParseLogLevels(logLevels, &subLoggers)
-			}
-
 			opts = append(opts, principal.WithSubsystemLoggers(subLoggers.ResourceProxyLogger, subLoggers.RedisProxyLogger, subLoggers.GrpcEventLogger))
 
 			kubeConfig, err := cmdutil.GetKubeConfig(ctx, namespace, kubeConfig, kubeContext)


### PR DESCRIPTION
**What does this PR do / why we need it**:

This PR moves logging initialization to be the first thing on startup of both agent and principal, so that even a non-starting pod (i.e. due to missing certificates) will log its version information before any error aborts the execution.

**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:


**Checklist**

* [ ] Documentation update is required by this PR (and has been updated) OR no documentation update is required.

