### PR TITLE
chore: fix doc whitespace and bullets

### DIFF
--- a/docs/concepts/sync-protocol.md
+++ b/docs/concepts/sync-protocol.md
@@ -27,7 +27,7 @@ The protocol uses a **hub-and-spoke** architecture where:
 │   Agent 1       │──────────────────►│   Principal     │
 │  (Workload)     │                   │ (Control Plane) │
 └─────────────────┘                   └─────────────────┘
-                                              ▲
+                                             ▲
 ┌─────────────────┐                          │
 │   Agent 2       │──────────────────────────┘
 │  (Workload)     │
@@ -142,14 +142,14 @@ Principal                           Agent
     │                                │
     │  ◄─── create/update/delete ────│  (Configuration changes)
     │                                │
-    │─── status-update ─────────────► │  (Status sync)
+    │─── status-update ────────────► │  (Status sync)
     │                                │
     │─── request-synced-resource ──► │  (On principal restart)
     │     -list                      │
     │                                │
     │  ◄─── response-synced-resource │  (For each resource)
     │                                │
-    │─── request-update ────────────► │  (Request specific updates)
+    │─── request-update ───────────► │  (Request specific updates)
 ```
 
 ## Synchronization Modes

--- a/docs/configuration/ctl.md
+++ b/docs/configuration/ctl.md
@@ -4,7 +4,7 @@ This document will explain how to use argocd-agentctl to assist in management of
 
 ## Available Commands
 
-+These are the available commands for argocd-agentctl. Some commands have subcommands, which are detailed in the sections below.
+These are the available commands for argocd-agentctl. Some commands have subcommands, which are detailed in the sections below.
 
 `agent` - Inspect and manage agent configuration
 

--- a/docs/contributing/logging.md
+++ b/docs/contributing/logging.md
@@ -232,6 +232,7 @@ func TestMyFunction(t *testing.T) {
 ## Getting Help
 
 If you're unsure about:
+
 - Which field constant to use
 - Whether to create a new field constant
 - Which specialized logger is appropriate
@@ -242,6 +243,7 @@ Please ask in your PR or create an issue for discussion.
 ## Summary
 
 Remember the key principles:
+
 1. **Use field constants** - never string literals for field names
 2. **Use centralized logging** - no package-level log() functions
 3. **Add missing constants** - don't work around missing field constants

--- a/docs/user-guide/migration.md
+++ b/docs/user-guide/migration.md
@@ -252,11 +252,13 @@ AppProjects in argocd-agent work differently from traditional Argo CD due to the
 #### Understanding AppProject Distribution
 
 **Traditional Argo CD:**
+
 - AppProjects are created once on the control plane
 - All clusters share the same AppProject definitions
 - Projects can reference multiple clusters directly
 
 **argocd-agent:**
+
 - **Managed Mode**: AppProjects created on control plane, distributed to matching agents
 - **Autonomous Mode**: AppProjects created on agents, synchronized back to control plane
 - Projects are transformed for each agent's local context


### PR DESCRIPTION
**What does this PR do / why we need it**:
- Misc doc PR to:
    - Fix whitespace from LLM generated text diagrams
    - Fix markdown bullets which mkdocs renders differently from GH flavoured markdown, e.g.:
<img width="1600" height="422" alt="Screenshot From 2026-03-27 08-53-45" src="https://github.com/user-attachments/assets/33746940-a59c-432c-a754-297879e649e6" />



* [X] Documentation update is required by this PR (and has been updated) OR no documentation update is required.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Fixed ASCII diagram alignment in sync protocol documentation
  * Corrected formatting artifact in command reference
  * Improved spacing and readability across contributing and migration guides

<!-- end of auto-generated comment: release notes by coderabbit.ai -->