### PR TITLE
feat: add queue latency instrumentation to principal

### DIFF
--- a/agent/connection.go
+++ b/agent/connection.go
@@ -93,6 +93,16 @@ func (a *Agent) sender(stream eventstreamapi.EventStream_SubscribeClient) error 
 		"resource_id":  event.ResourceID(ev),
 		"event_id":     event.EventID(ev),
 	})
+
+	if a.metrics != nil {
+		target := event.Target(ev)
+		if target != event.TargetEventAck && target != event.TargetHeartbeat {
+			if enqueuedAt := event.EnqueuedAt(ev); enqueuedAt != nil {
+				a.metrics.ObserveSendQueueDwell(ev.DataSchema(), time.Since(*enqueuedAt).Seconds())
+			}
+		}
+	}
+
 	logCtx.Trace("Adding an event to the event writer")
 	a.eventWriter.Add(ev)
 
@@ -135,6 +145,15 @@ func (a *Agent) receiver(stream eventstreamapi.EventStream_SubscribeClient) erro
 		rawEvent, err := format.FromProto(rcvd.Event)
 		if err != nil {
 			return err
+		}
+		if a.metrics != nil {
+			resourceType := a.eventWriter.SentResourceType(ev.ResourceID())
+			if resourceType == "" {
+				resourceType = rawEvent.DataSchema()
+			}
+			if sentAt := event.SentAt(rawEvent); sentAt != nil {
+				a.metrics.ObserveAckRoundtrip(resourceType, time.Since(*sentAt).Seconds())
+			}
 		}
 		a.eventWriter.Remove(rawEvent)
 		logCtx.Trace("Removed an event from the event writer")
@@ -180,6 +199,7 @@ func (a *Agent) handleStreamEvents() error {
 	} else {
 		a.eventWriter.UpdateTarget(stream)
 	}
+	a.eventWriter.SetMetrics(a.metrics)
 	go a.eventWriter.SendWaitingEvents(streamCtx)
 
 	logCtx := log().WithFields(logrus.Fields{

--- a/agent/connection_test.go
+++ b/agent/connection_test.go
@@ -138,15 +138,27 @@ func TestAgentHopMetricsObservations(t *testing.T) {
 		beforeAck := histogramSampleCount(t, a.metrics.AckRoundtrip, event.TargetEventAck.String())
 
 		original := a.emitter.ApplicationEvent(event.Create, app)
+		resourceID := event.ResourceID(original)
 		a.eventWriter.Add(original)
 
 		ctx, cancel := context.WithCancel(context.Background())
-		defer cancel()
-		go a.eventWriter.SendWaitingEvents(ctx)
+		done := make(chan struct{})
+		go func() {
+			a.eventWriter.SendWaitingEvents(ctx)
+			close(done)
+		}()
 		require.Eventually(t, func() bool {
-			return a.eventWriter.SentResourceType(event.ResourceID(original)) == event.TargetApplication.String()
+			return a.eventWriter.SentResourceType(resourceID) == event.TargetApplication.String()
 		}, time.Second, 10*time.Millisecond)
 		cancel()
+		require.Eventually(t, func() bool {
+			select {
+			case <-done:
+				return true
+			default:
+				return false
+			}
+		}, time.Second, 10*time.Millisecond)
 
 		ack := a.emitter.ProcessedEvent(event.EventProcessed, event.New(original, event.TargetApplication))
 		wireAck, err := format.ToProto(ack)

--- a/agent/connection_test.go
+++ b/agent/connection_test.go
@@ -15,11 +15,23 @@
 package agent
 
 import (
+	"context"
+	"io"
 	"testing"
+	"time"
 
 	"github.com/argoproj-labs/argocd-agent/internal/event"
+	"github.com/argoproj-labs/argocd-agent/internal/metrics"
+	"github.com/argoproj-labs/argocd-agent/pkg/api/grpc/eventstreamapi"
 	"github.com/argoproj-labs/argocd-agent/pkg/types"
+	"github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
+	format "github.com/cloudevents/sdk-go/binding/format/protobuf/v2"
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/metadata"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/rest"
 )
 
@@ -69,4 +81,156 @@ func TestResyncOnStart(t *testing.T) {
 		assert.Equal(t, event.SyncedResourceList.String(), ev.Type())
 		assert.True(t, a.resyncedOnStart)
 	})
+}
+
+func TestAgentHopMetricsObservations(t *testing.T) {
+	agentMetrics := metrics.NewAgentMetrics()
+
+	t.Run("sender observes send queue dwell", func(t *testing.T) {
+		a, _ := newAgent(t)
+		a.metrics = agentMetrics
+		a.emitter = event.NewEventSource("test")
+		a.eventWriter = event.NewEventWriter(&fakeSubscribeClient{ctx: context.Background()})
+
+		app := &v1alpha1.Application{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:            "app",
+				Namespace:       "argocd",
+				ResourceVersion: "1",
+				UID:             "uid-1",
+			},
+		}
+
+		before := histogramSampleCount(t, a.metrics.SendQueueDwell, event.TargetApplication.String())
+
+		ev := a.emitter.ApplicationEvent(event.Create, app)
+		sendQ := a.queues.SendQ(defaultQueueName)
+		sendQ.Add(ev)
+
+		time.Sleep(5 * time.Millisecond)
+
+		err := a.sender(&fakeSubscribeClient{ctx: context.Background()})
+		require.NoError(t, err)
+
+		after := histogramSampleCount(t, a.metrics.SendQueueDwell, event.TargetApplication.String())
+		assert.Equal(t, before+1, after)
+	})
+
+	t.Run("receiver observes ack roundtrip by original resource type", func(t *testing.T) {
+		a, _ := newAgent(t)
+		a.metrics = agentMetrics
+		a.emitter = event.NewEventSource("test")
+
+		stream := &fakeSubscribeClient{ctx: context.Background()}
+		a.eventWriter = event.NewEventWriter(stream)
+		a.eventWriter.SetMetrics(a.metrics)
+
+		app := &v1alpha1.Application{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:            "app",
+				Namespace:       "argocd",
+				ResourceVersion: "1",
+				UID:             "uid-1",
+			},
+		}
+
+		beforeApp := histogramSampleCount(t, a.metrics.AckRoundtrip, event.TargetApplication.String())
+		beforeAck := histogramSampleCount(t, a.metrics.AckRoundtrip, event.TargetEventAck.String())
+
+		original := a.emitter.ApplicationEvent(event.Create, app)
+		a.eventWriter.Add(original)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		go a.eventWriter.SendWaitingEvents(ctx)
+		require.Eventually(t, func() bool {
+			return a.eventWriter.SentResourceType(event.ResourceID(original)) == event.TargetApplication.String()
+		}, time.Second, 10*time.Millisecond)
+		cancel()
+
+		ack := a.emitter.ProcessedEvent(event.EventProcessed, event.New(original, event.TargetApplication))
+		wireAck, err := format.ToProto(ack)
+		require.NoError(t, err)
+
+		err = a.receiver(&fakeSubscribeClient{
+			ctx:       context.Background(),
+			recvEvent: &eventstreamapi.Event{Event: wireAck},
+		})
+		require.NoError(t, err)
+
+		afterApp := histogramSampleCount(t, a.metrics.AckRoundtrip, event.TargetApplication.String())
+		afterAck := histogramSampleCount(t, a.metrics.AckRoundtrip, event.TargetEventAck.String())
+		assert.Equal(t, beforeApp+1, afterApp)
+		assert.Equal(t, beforeAck, afterAck)
+	})
+}
+
+func histogramSampleCount(t *testing.T, vec *prometheus.HistogramVec, label string) uint64 {
+	t.Helper()
+
+	observer, err := vec.GetMetricWithLabelValues(label)
+	require.NoError(t, err)
+
+	histogram, ok := observer.(prometheus.Histogram)
+	require.True(t, ok)
+
+	metric := &dto.Metric{}
+	require.NoError(t, histogram.Write(metric))
+
+	return metric.GetHistogram().GetSampleCount()
+}
+
+type fakeSubscribeClient struct {
+	ctx       context.Context
+	recvEvent *eventstreamapi.Event
+	recvErr   error
+	recvUsed  bool
+}
+
+func (f *fakeSubscribeClient) Send(*eventstreamapi.Event) error {
+	return nil
+}
+
+func (f *fakeSubscribeClient) Recv() (*eventstreamapi.Event, error) {
+	if f.recvUsed {
+		if f.recvErr != nil {
+			return nil, f.recvErr
+		}
+		return nil, io.EOF
+	}
+	f.recvUsed = true
+	if f.recvEvent != nil {
+		return f.recvEvent, nil
+	}
+	if f.recvErr != nil {
+		return nil, f.recvErr
+	}
+	return nil, io.EOF
+}
+
+func (f *fakeSubscribeClient) Header() (metadata.MD, error) {
+	return metadata.MD{}, nil
+}
+
+func (f *fakeSubscribeClient) Trailer() metadata.MD {
+	return metadata.MD{}
+}
+
+func (f *fakeSubscribeClient) CloseSend() error {
+	return nil
+}
+
+func (f *fakeSubscribeClient) Context() context.Context {
+	if f.ctx != nil {
+		return f.ctx
+	}
+	return context.Background()
+}
+
+func (f *fakeSubscribeClient) SendMsg(any) error {
+	return nil
+}
+
+func (f *fakeSubscribeClient) RecvMsg(any) error {
+	return nil
 }

--- a/docs/operations/metrics.md
+++ b/docs/operations/metrics.md
@@ -10,34 +10,70 @@ Similarly for agent metrics are exposed at `http://0.0.0.0:8181/metrics` endpoin
 Here is the list of available metrics:
 
 ### Principal Metrics
-|   Metric  |   Type    |   Description |
-|---------------------------------------------------|:---------:|---------------------------------------------------------------------------------------------------------------------------------------------|
-|   `agent_connected_with_principal`    |   gauge   |   The total number of agents connected with principal.    |
-|   `principal_agent_avg_connection_time`   |   gauge   |   The average time all agents are connected for (in minutes). |
-|   `principal_applications_created`    |   counter |   The total number of applications created by agents. |
-|   `principal_applications_updated`    |   counter |   The total number of applications updated by agents. |
-|   `principal_applications_deleted`    |   counter |   The total number of applications deleted by agents. |
-|   `principal_app_projects_created`    |   counter |   The total number of app project created by agents.  |
-|   `principal_app_projects_updated`    |   counter |   The total number of app project updated by agents.  |
-|   `principal_app_projects_deleted`    |	counter |   The total number of app project deleted by agents.  |
-|   `principal_events_received` |	counter |   The total number of events sent by principal.   |
-|   `principal_events_sent` |   counter |   The total number of events sent by principal.   |
-|   `principal_event_processing_time`   |   histogramVec    |   Histogram of time taken to process events (in seconds). |
-|   `principal_errors`  |	counterVec  |   The total number of errors occurred in principal.   |
+
+#### General
+
+| Metric | Type | Labels | Description |
+|--------|:----:|--------|-------------|
+| `agent_connected_with_principal` | gauge | | Number of agents currently connected to the principal. |
+| `principal_agent_avg_connection_time` | gauge | | Average duration all connected agents have been connected (minutes). |
+| `principal_applications_created` | counter | | Total applications created by agents on the control plane. |
+| `principal_applications_updated` | counter | | Total applications updated by agents on the control plane. |
+| `principal_applications_deleted` | counter | | Total applications deleted by agents on the control plane. |
+| `principal_app_projects_created` | counter | | Total AppProjects created by agents on the control plane. |
+| `principal_app_projects_updated` | counter | | Total AppProjects updated by agents on the control plane. |
+| `principal_app_projects_deleted` | counter | | Total AppProjects deleted by agents on the control plane. |
+| `principal_events_received` | counter | | Total events received from agents. |
+| `principal_events_sent` | counter | | Total events sent to agents. |
+| `principal_event_processing_time` | histogramVec | `status`, `agent_name`, `resource_type` | Time taken to process inbound events (seconds). |
+| `principal_errors` | counterVec | `resource_type` | Total errors occurred in principal. |
+
+#### Hop-by-Hop Event Latency
+
+These metrics instrument each stage of the principal → agent event delivery pipeline, making it possible to identify where latency accumulates when propagation is slow.
+
+```
+principal send queue  →  event writer  →  wire send  →  agent  →  ACK received
+        ↑                     ↑                              ↑
+  SendQueueDwell        EventWriterDwell               AckRoundtrip
+```
+
+| Metric | Type | Labels | Description |
+|--------|:----:|--------|-------------|
+| `principal_send_queue_dwell_seconds` | histogramVec | `resource_type` | Time an outbound event spends in the principal send queue from enqueue until the event writer picks it up. Elevated values indicate the send goroutine or event writer are a bottleneck. Buckets: 1ms–60s. |
+| `principal_event_writer_dwell_seconds` | histogramVec | `resource_type` | Time an outbound event spends inside the event writer from when it is added until it is sent on the wire. The event writer polls every 100ms, so a baseline of 0–100ms is expected. Sustained elevation indicates gRPC stream backpressure or a large number of resources cycling through the writer. Buckets: 1ms–60s. |
+| `principal_ack_roundtrip_seconds` | histogramVec | `resource_type` | Time from when an event is written to the wire until the corresponding ACK is received back from the agent. Measures network latency plus agent-side processing time. If no new observations appear, ACKs have stopped (agent disconnected or events are being dropped after max retries). Buckets: 1ms–60s. |
+
+#### Kubernetes API Client Metrics
+
+Standard `client-go` metrics exposed under the conventional `rest_client_*` names. Useful for detecting Kubernetes API server rate limiting, which can cause principal or agent to fall behind on reconciliation.
+
+| Metric | Type | Labels | Description |
+|--------|:----:|--------|-------------|
+| `rest_client_request_duration_seconds` | histogramVec | `verb`, `host` | Latency of outbound Kubernetes API requests. |
+| `rest_client_rate_limiter_duration_seconds` | histogramVec | `verb`, `host` | Time spent waiting in the client-side rate limiter before a request is dispatched. Sustained values here indicate the agent or principal is being throttled by the Kubernetes API server. |
+| `rest_client_requests_total` | counterVec | `code`, `method`, `host` | Total Kubernetes API requests, partitioned by HTTP status code, method, and host. |
+| `rest_client_request_retries_total` | counterVec | `code`, `method`, `host` | Total Kubernetes API request retries, partitioned by HTTP status code, method, and host. A rising `429` count is the clearest signal of active rate limiting. |
 
 ### Agent Metrics
-|   Metric  |   Type    |   Description |
-|---------------------------------------------------|:---------:|---------------------------------------------------------------------------------------------------------------------------------------------|
-|   `agent_events_received` |   counter |   The total number of events received by agent.   |
-|   `agent_events_sent` |   counter |   The total number of events sent by agent.   |
-|   `agent_event_processing_time`   |	histogramVec    | Histogram of time taken to process events (in seconds).   |
-|   `agent_errors`  |   counterVec	| The total number of errors occurred in agent. |
 
-Here is the list of available labels:
+| Metric | Type | Labels | Description |
+|--------|:----:|--------|-------------|
+| `agent_events_received` | counter | | Total events received from the principal. |
+| `agent_events_sent` | counter | | Total events sent to the principal. |
+| `agent_event_processing_time` | histogramVec | `status`, `agent_mode`, `resource_type` | Time taken to process inbound events (seconds). |
+| `agent_event_propagation_latency_seconds` | histogramVec | `resource_type` | Time from when the principal sent an event on the wire to when the agent begins processing it. Complements `principal_ack_roundtrip_seconds` to break down the ACK roundtrip into network transit and agent processing. |
+| `agent_errors` | counterVec | `resource_type` | Total errors occurred in the agent. |
 
 ### Labels
-|   Label Name  |   Example Value   |   Description |
-|--------------------|---------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-|   `call_status` | success   |   Status of event processing. Possible values are: success, failure, discarded, not-allowed.  |
-|   `agent_name`  |   agent-managed   |   Name of Agent. Possible values are: agent-managed, agent-autonomous.    |
-|   `resource_type`   |   application |   Type of resource. Possible values are: application, app project, resource, resourceResync.   |
+
+| Label | Example | Description |
+|-------|---------|-------------|
+| `status` | `success` | Outcome of event processing. Values: `success`, `failure`, `discarded`, `not-allowed`. |
+| `agent_name` | `agent-managed` | Name of the agent. |
+| `agent_mode` | `managed` | Agent mode. Values: `managed`, `autonomous`. |
+| `resource_type` | `application` | CloudEvent data schema identifying the resource type. Values: `application`, `appproject`, `repository`, `gpgkey`, `resource`, `resourceResync`, `redis`, `clusterCacheInfoUpdate`, `containerlog`, `heartbeat`, `terminal`, `applicationset`. |
+| `verb` | `GET` | HTTP verb used in a Kubernetes API request. |
+| `host` | `kubernetes.default.svc` | Target host of a Kubernetes API request. |
+| `code` | `429` | HTTP response code from a Kubernetes API request. |
+| `method` | `GET` | HTTP method of a Kubernetes API request. |

--- a/docs/operations/metrics.md
+++ b/docs/operations/metrics.md
@@ -23,6 +23,12 @@ Here is the list of available metrics:
 | `principal_app_projects_created` | counter | | Total AppProjects created by agents on the control plane. |
 | `principal_app_projects_updated` | counter | | Total AppProjects updated by agents on the control plane. |
 | `principal_app_projects_deleted` | counter | | Total AppProjects deleted by agents on the control plane. |
+| `principal_repositories_created` | counter | | Total repositories created by agents on the control plane. |
+| `principal_repositories_updated` | counter | | Total repositories updated by agents on the control plane. |
+| `principal_repositories_deleted` | counter | | Total repositories deleted by agents on the control plane. |
+| `principal_gpg_keys_created` | counter | | Total GPG keys created by agents on the control plane. |
+| `principal_gpg_keys_updated` | counter | | Total GPG keys updated by agents on the control plane. |
+| `principal_gpg_keys_deleted` | counter | | Total GPG keys deleted by agents on the control plane. |
 | `principal_events_received` | counter | | Total events received from agents. |
 | `principal_events_sent` | counter | | Total events sent to agents. |
 | `principal_event_processing_time` | histogramVec | `status`, `agent_name`, `resource_type` | Time taken to process inbound events (seconds). |
@@ -32,7 +38,7 @@ Here is the list of available metrics:
 
 These metrics instrument each stage of the principal → agent event delivery pipeline, making it possible to identify where latency accumulates when propagation is slow.
 
-```
+```text
 principal send queue  →  event writer  →  wire send  →  agent  →  ACK received
         ↑                     ↑                              ↑
   SendQueueDwell        EventWriterDwell               AckRoundtrip

--- a/docs/operations/metrics.md
+++ b/docs/operations/metrics.md
@@ -63,6 +63,9 @@ Standard `client-go` metrics exposed under the conventional `rest_client_*` name
 | `agent_events_sent` | counter | | Total events sent to the principal. |
 | `agent_event_processing_time` | histogramVec | `status`, `agent_mode`, `resource_type` | Time taken to process inbound events (seconds). |
 | `agent_event_propagation_latency_seconds` | histogramVec | `resource_type` | Time from when the principal sent an event on the wire to when the agent begins processing it. Complements `principal_ack_roundtrip_seconds` to break down the ACK roundtrip into network transit and agent processing. |
+| `agent_send_queue_dwell_seconds` | histogramVec | `resource_type` | Time an outbound event spends in the agent send queue from enqueue until the event writer picks it up. Elevated values indicate agent-side send-loop or queue pressure. Buckets: 1ms–60s. |
+| `agent_event_writer_dwell_seconds` | histogramVec | `resource_type` | Time an outbound event spends inside the agent event writer from when it is added until it is sent on the wire. The event writer polls every 100ms, so a baseline of 0–100ms is expected. Buckets: 1ms–60s. |
+| `agent_ack_roundtrip_seconds` | histogramVec | `resource_type` | Time from when an event is written by the agent to the wire until the corresponding ACK is received back from the principal. Measures network latency plus principal-side processing time. Buckets: 1ms–60s. |
 | `agent_errors` | counterVec | `resource_type` | Total errors occurred in the agent. |
 
 ### Labels

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674
 	github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.3.3
 	github.com/prometheus/client_golang v1.23.2
+	github.com/prometheus/client_model v0.6.2
 	github.com/redis/go-redis/v9 v9.18.0
 	github.com/rs/zerolog v1.35.0
 	github.com/sirupsen/logrus v1.9.4
@@ -148,7 +149,6 @@ require (
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
-	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.66.1 // indirect
 	github.com/prometheus/procfs v0.16.1 // indirect
 	github.com/r3labs/diff/v3 v3.0.2 // indirect

--- a/internal/event/event.go
+++ b/internal/event/event.go
@@ -140,7 +140,6 @@ func PrincipalUID(ev *cloudevents.Event) string {
 	}
 	return val
 }
-
 var (
 	ErrEventDiscarded    error = errors.New("event discarded")
 	ErrEventNotAllowed   error = errors.New("event not allowed in this agent mode")

--- a/internal/event/event.go
+++ b/internal/event/event.go
@@ -87,6 +87,7 @@ const (
 	resourceID   string = "resourceid"
 	eventID      string = "eventid"
 	sentAt       string = "sentat"
+	enqueuedAt   string = "enqueuedat"
 	principalUID string = "principaluid"
 )
 
@@ -98,6 +99,24 @@ func SetSentAt(ev *cloudevents.Event) {
 // SentAt returns the send timestamp from an event, or nil if not set.
 func SentAt(ev *cloudevents.Event) *time.Time {
 	val, ok := ev.Extensions()[sentAt].(string)
+	if !ok {
+		return nil
+	}
+	t, err := time.Parse(time.RFC3339Nano, val)
+	if err != nil {
+		return nil
+	}
+	return &t
+}
+
+// SetEnqueuedAt stamps the current time on an event as the principal send-queue enqueue time.
+func SetEnqueuedAt(ev *cloudevents.Event) {
+	ev.SetExtension(enqueuedAt, time.Now().UTC().Format(time.RFC3339Nano))
+}
+
+// EnqueuedAt returns the principal send-queue enqueue timestamp from an event, or nil if not set.
+func EnqueuedAt(ev *cloudevents.Event) *time.Time {
+	val, ok := ev.Extensions()[enqueuedAt].(string)
 	if !ok {
 		return nil
 	}

--- a/internal/event/event_writer.go
+++ b/internal/event/event_writer.go
@@ -8,6 +8,7 @@ import (
 	"github.com/argoproj-labs/argocd-agent/internal/grpcutil"
 	"github.com/argoproj-labs/argocd-agent/internal/logging"
 	"github.com/argoproj-labs/argocd-agent/internal/logging/logfields"
+	"github.com/argoproj-labs/argocd-agent/internal/metrics"
 	"github.com/argoproj-labs/argocd-agent/pkg/api/grpc/eventstreamapi"
 	format "github.com/cloudevents/sdk-go/binding/format/protobuf/v2"
 	cloudevents "github.com/cloudevents/sdk-go/v2"
@@ -43,8 +44,20 @@ type EventWriter struct {
 	// target refers to the specified gRPC stream.
 	target streamWriter
 
+	// principalMetrics is optional; when set, hop-by-hop latency histograms are observed.
+	principalMetrics *metrics.PrincipalMetrics
+
 	log *logrus.Entry
 }
+
+// SetMetrics attaches principal metrics to this EventWriter so it can observe
+// EventWriterDwell latency. Safe to call at any time.
+func (ew *EventWriter) SetMetrics(m *metrics.PrincipalMetrics) {
+	ew.mu.Lock()
+	defer ew.mu.Unlock()
+	ew.principalMetrics = m
+}
+
 
 type eventMessage struct {
 	// when this lock is owned, never attempt to THEN acquire `eventWriter.mu`, as this will lead to a deadlock.
@@ -63,6 +76,9 @@ type eventMessage struct {
 
 	// track number of retries attempted
 	retryCount int
+
+	// time when the event was added to the EventWriter (immutable once set)
+	writerAddedAt time.Time
 }
 
 func NewEventWriter(target streamWriter) *EventWriter {
@@ -113,14 +129,17 @@ func (ew *EventWriter) Add(ev *cloudevents.Event) {
 		return
 	}
 
+	now := time.Now()
+
 	// Once an app is being deleted, no other updates matter
 	if ev.Type() == Delete.String() {
 		delete(ew.sentEvents, resID)
 		// Clear any existing unsent events and add only the DELETE event
 		eq := newEventQueue()
 		eq.add(&eventMessage{
-			event:   ev,
-			backoff: &defaultBackoff,
+			event:         ev,
+			backoff:       &defaultBackoff,
+			writerAddedAt: now,
 		})
 		ew.unsentEvents[resID] = eq
 		logCtx.Trace("cleared all events and added DELETE event")
@@ -132,8 +151,9 @@ func (ew *EventWriter) Add(ev *cloudevents.Event) {
 	if !exists {
 		eq = newEventQueue()
 		eq.add(&eventMessage{
-			event:   ev,
-			backoff: &defaultBackoff,
+			event:         ev,
+			backoff:       &defaultBackoff,
+			writerAddedAt: now,
 		})
 		ew.unsentEvents[resID] = eq
 		logCtx.Trace("added a new event to the event writer")
@@ -142,9 +162,10 @@ func (ew *EventWriter) Add(ev *cloudevents.Event) {
 
 	// The queue's add() coalesces events of the same type.
 	eq.add(&eventMessage{
-		event:      ev,
-		backoff:    &defaultBackoff,
-		retryAfter: nil,
+		event:         ev,
+		backoff:       &defaultBackoff,
+		retryAfter:    nil,
+		writerAddedAt: now,
 	})
 
 	logCtx.Trace("updated an existing event in the event writer")
@@ -396,6 +417,15 @@ func (ew *EventWriter) sendUnsentEvent(resID string) {
 	if err != nil {
 		logCtx.Errorf("Could not wire event: %v\n", err)
 		return
+	}
+
+	if !isFireAndForget {
+		ew.mu.RLock()
+		m := ew.principalMetrics
+		ew.mu.RUnlock()
+		if m != nil && !eventMsg.writerAddedAt.IsZero() {
+			m.EventWriterDwell.WithLabelValues(eventMsg.event.DataSchema()).Observe(time.Since(eventMsg.writerAddedAt).Seconds())
+		}
 	}
 
 	// A Send() on the stream is actually not blocking.

--- a/internal/event/event_writer.go
+++ b/internal/event/event_writer.go
@@ -349,6 +349,7 @@ func (ew *EventWriter) retrySentEvent(resID string, sentMsg *eventMessage) {
 	sentMsg.retryAfter = &retryAfter
 
 	// Resend the event
+	SetSentAt(sentMsg.event)
 	pev, err := format.ToProto(sentMsg.event)
 	if err != nil {
 		logCtx.Errorf("Could not wire event: %v\n", err)
@@ -436,6 +437,13 @@ func (ew *EventWriter) sendUnsentEvent(resID string) {
 		return
 	}
 
+	// A Send() on the stream is actually not blocking.
+	err = ew.target.Send(&eventstreamapi.Event{Event: pev})
+	if err != nil {
+		logCtx.Errorf("Error while sending: %v\n", err)
+		return
+	}
+
 	if !isFireAndForget {
 		ew.mu.RLock()
 		m := ew.outboundMetrics
@@ -443,13 +451,6 @@ func (ew *EventWriter) sendUnsentEvent(resID string) {
 		if m != nil && !eventMsg.writerAddedAt.IsZero() {
 			m.ObserveEventWriterDwell(eventMsg.event.DataSchema(), time.Since(eventMsg.writerAddedAt).Seconds())
 		}
-	}
-
-	// A Send() on the stream is actually not blocking.
-	err = ew.target.Send(&eventstreamapi.Event{Event: pev})
-	if err != nil {
-		logCtx.Errorf("Error while sending: %v\n", err)
-		return
 	}
 
 	logCtx.Trace("event sent to target")
@@ -528,6 +529,7 @@ func (eq *eventQueue) add(ev *eventMessage) {
 			tail.event = ev.event
 			tail.backoff = ev.backoff
 			tail.retryAfter = ev.retryAfter
+			tail.writerAddedAt = ev.writerAddedAt
 			tail.mu.Unlock()
 			return
 		}

--- a/internal/event/event_writer.go
+++ b/internal/event/event_writer.go
@@ -44,20 +44,19 @@ type EventWriter struct {
 	// target refers to the specified gRPC stream.
 	target streamWriter
 
-	// principalMetrics is optional; when set, hop-by-hop latency histograms are observed.
-	principalMetrics *metrics.PrincipalMetrics
+	// outboundMetrics is optional; when set, hop-by-hop writer dwell is observed.
+	outboundMetrics metrics.OutboundHopMetrics
 
 	log *logrus.Entry
 }
 
-// SetMetrics attaches principal metrics to this EventWriter so it can observe
+// SetMetrics attaches outbound hop metrics to this EventWriter so it can observe
 // EventWriterDwell latency. Safe to call at any time.
-func (ew *EventWriter) SetMetrics(m *metrics.PrincipalMetrics) {
+func (ew *EventWriter) SetMetrics(m metrics.OutboundHopMetrics) {
 	ew.mu.Lock()
 	defer ew.mu.Unlock()
-	ew.principalMetrics = m
+	ew.outboundMetrics = m
 }
-
 
 type eventMessage struct {
 	// when this lock is owned, never attempt to THEN acquire `eventWriter.mu`, as this will lead to a deadlock.
@@ -185,6 +184,24 @@ func (ew *EventWriter) Get(resID string) *eventMessage {
 		return eq.get()
 	}
 	return nil
+}
+
+// SentResourceType returns the resource type for an in-flight sent event, or an
+// empty string if the event is not currently awaiting an ACK.
+func (ew *EventWriter) SentResourceType(resID string) string {
+	ew.mu.RLock()
+	msg, exists := ew.sentEvents[resID]
+	ew.mu.RUnlock()
+	if !exists || msg == nil {
+		return ""
+	}
+
+	msg.mu.RLock()
+	defer msg.mu.RUnlock()
+	if msg.event == nil {
+		return ""
+	}
+	return msg.event.DataSchema()
 }
 
 func (ew *EventWriter) Remove(ev *cloudevents.Event) {
@@ -421,10 +438,10 @@ func (ew *EventWriter) sendUnsentEvent(resID string) {
 
 	if !isFireAndForget {
 		ew.mu.RLock()
-		m := ew.principalMetrics
+		m := ew.outboundMetrics
 		ew.mu.RUnlock()
 		if m != nil && !eventMsg.writerAddedAt.IsZero() {
-			m.EventWriterDwell.WithLabelValues(eventMsg.event.DataSchema()).Observe(time.Since(eventMsg.writerAddedAt).Seconds())
+			m.ObserveEventWriterDwell(eventMsg.event.DataSchema(), time.Since(eventMsg.writerAddedAt).Seconds())
 		}
 	}
 

--- a/internal/event/event_writer.go
+++ b/internal/event/event_writer.go
@@ -76,8 +76,13 @@ type eventMessage struct {
 	// track number of retries attempted
 	retryCount int
 
-	// time when the event was added to the EventWriter (immutable once set)
+	// time when the current queued event was added to the EventWriter; this is
+	// refreshed when tail coalescing replaces the queued event with a newer one.
 	writerAddedAt time.Time
+
+	// writerDwellObserved ensures dwell is only emitted once, including messages
+	// that succeed on a retry after an initial send failure.
+	writerDwellObserved bool
 }
 
 func NewEventWriter(target streamWriter) *EventWriter {
@@ -365,6 +370,7 @@ func (ew *EventWriter) retrySentEvent(resID string, sentMsg *eventMessage) {
 		return
 	}
 
+	ew.observeEventWriterDwell(sentMsg)
 	logCtx.Trace("event sent to target")
 }
 
@@ -374,6 +380,28 @@ func (ew *EventWriter) scheduleRetry(eventMsg *eventMessage) {
 	defer eventMsg.mu.Unlock()
 	retryAfter := time.Now().Add(eventMsg.backoff.Step())
 	eventMsg.retryAfter = &retryAfter
+}
+
+func (ew *EventWriter) observeEventWriterDwell(eventMsg *eventMessage) {
+	ew.mu.RLock()
+	m := ew.outboundMetrics
+	ew.mu.RUnlock()
+	if m == nil {
+		return
+	}
+
+	eventMsg.mu.Lock()
+	if eventMsg.writerDwellObserved || eventMsg.writerAddedAt.IsZero() || eventMsg.event == nil {
+		eventMsg.mu.Unlock()
+		return
+	}
+
+	eventMsg.writerDwellObserved = true
+	resourceType := eventMsg.event.DataSchema()
+	addedAt := eventMsg.writerAddedAt
+	eventMsg.mu.Unlock()
+
+	m.ObserveEventWriterDwell(resourceType, time.Since(addedAt).Seconds())
 }
 
 // sendUnsentEvent pops an event from the unsent queue and sends it for the first time
@@ -445,12 +473,7 @@ func (ew *EventWriter) sendUnsentEvent(resID string) {
 	}
 
 	if !isFireAndForget {
-		ew.mu.RLock()
-		m := ew.outboundMetrics
-		ew.mu.RUnlock()
-		if m != nil && !eventMsg.writerAddedAt.IsZero() {
-			m.ObserveEventWriterDwell(eventMsg.event.DataSchema(), time.Since(eventMsg.writerAddedAt).Seconds())
-		}
+		ew.observeEventWriterDwell(eventMsg)
 	}
 
 	logCtx.Trace("event sent to target")

--- a/internal/event/event_writer_test.go
+++ b/internal/event/event_writer_test.go
@@ -16,6 +16,7 @@ package event
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 	"testing"
@@ -286,6 +287,40 @@ func TestEventWriter(t *testing.T) {
 		require.Equal(t, 1, sentMsg.retryCount)
 	})
 
+	t.Run("should refresh sent timestamp on retries", func(t *testing.T) {
+		fs := &fakeStream{}
+		evSender := NewEventWriter(fs)
+
+		ev := es.ApplicationEvent(Create, app1)
+		resID := createResourceID(app1.ObjectMeta)
+		evSender.Add(ev)
+		evSender.sendEvent(resID)
+
+		sentMsg := evSender.sentEvents[resID]
+		require.NotNil(t, sentMsg)
+
+		sentMsg.mu.RLock()
+		firstSentAt := SentAt(sentMsg.event)
+		sentMsg.mu.RUnlock()
+		require.NotNil(t, firstSentAt)
+
+		time.Sleep(5 * time.Millisecond)
+
+		pastTime := time.Now().Add(-1 * time.Second)
+		sentMsg.mu.Lock()
+		sentMsg.retryAfter = &pastTime
+		sentMsg.mu.Unlock()
+
+		evSender.retrySentEvent(resID, sentMsg)
+		require.Len(t, fs.events[resID], 2)
+
+		sentMsg.mu.RLock()
+		retriedSentAt := SentAt(sentMsg.event)
+		sentMsg.mu.RUnlock()
+		require.NotNil(t, retriedSentAt)
+		require.True(t, retriedSentAt.After(*firstSentAt))
+	})
+
 	t.Run("should give up after max retries", func(t *testing.T) {
 		fs := &fakeStream{}
 		evSender := NewEventWriter(fs)
@@ -476,6 +511,38 @@ func TestEventWriter(t *testing.T) {
 		require.Contains(t, eventID, "_5") // Should be version 5
 	})
 
+	t.Run("should refresh writer dwell timestamp when coalescing the queue tail", func(t *testing.T) {
+		fs := &fakeStream{}
+		evSender := NewEventWriter(fs)
+
+		app1.ResourceVersion = "1"
+		firstEvent := es.ApplicationEvent(SpecUpdate, app1)
+		evSender.Add(firstEvent)
+
+		firstMsg := evSender.Get(createResourceID(app1.ObjectMeta))
+		require.NotNil(t, firstMsg)
+		firstMsg.mu.RLock()
+		firstWriterAddedAt := firstMsg.writerAddedAt
+		firstMsg.mu.RUnlock()
+		require.False(t, firstWriterAddedAt.IsZero())
+
+		time.Sleep(5 * time.Millisecond)
+
+		app1.ResourceVersion = "2"
+		secondEvent := es.ApplicationEvent(SpecUpdate, app1)
+		evSender.Add(secondEvent)
+
+		coalescedMsg := evSender.Get(createResourceID(app1.ObjectMeta))
+		require.NotNil(t, coalescedMsg)
+		coalescedMsg.mu.RLock()
+		coalescedWriterAddedAt := coalescedMsg.writerAddedAt
+		eventID := EventID(coalescedMsg.event)
+		coalescedMsg.mu.RUnlock()
+
+		require.True(t, coalescedWriterAddedAt.After(firstWriterAddedAt))
+		require.Contains(t, eventID, "_2")
+	})
+
 	t.Run("should observe event writer dwell when metrics are attached", func(t *testing.T) {
 		fs := &fakeStream{}
 		evSender := NewEventWriter(fs)
@@ -492,14 +559,34 @@ func TestEventWriter(t *testing.T) {
 		require.Equal(t, TargetApplication.String(), hopMetrics.eventWriterDwell[0].resourceType)
 		require.GreaterOrEqual(t, hopMetrics.eventWriterDwell[0].seconds, 0.0)
 	})
+
+	t.Run("should not observe event writer dwell when send fails", func(t *testing.T) {
+		fs := &fakeStream{sendErr: errors.New("boom")}
+		evSender := NewEventWriter(fs)
+		hopMetrics := &fakeOutboundHopMetrics{}
+		evSender.SetMetrics(hopMetrics)
+
+		ev := es.ApplicationEvent(Create, app1)
+		evSender.Add(ev)
+		time.Sleep(5 * time.Millisecond)
+
+		evSender.sendEvent(createResourceID(app1.ObjectMeta))
+
+		require.Empty(t, hopMetrics.eventWriterDwell)
+	})
 }
 
 type fakeStream struct {
-	mu     sync.RWMutex
-	events map[string][]string
+	mu      sync.RWMutex
+	events  map[string][]string
+	sendErr error
 }
 
 func (fs *fakeStream) Send(event *eventstreamapi.Event) error {
+	if fs.sendErr != nil {
+		return fs.sendErr
+	}
+
 	fs.mu.Lock()
 	defer fs.mu.Unlock()
 	ev, err := FromWire(event.Event)

--- a/internal/event/event_writer_test.go
+++ b/internal/event/event_writer_test.go
@@ -475,6 +475,23 @@ func TestEventWriter(t *testing.T) {
 		eventID := EventID(latestEvent.event)
 		require.Contains(t, eventID, "_5") // Should be version 5
 	})
+
+	t.Run("should observe event writer dwell when metrics are attached", func(t *testing.T) {
+		fs := &fakeStream{}
+		evSender := NewEventWriter(fs)
+		hopMetrics := &fakeOutboundHopMetrics{}
+		evSender.SetMetrics(hopMetrics)
+
+		ev := es.ApplicationEvent(Create, app1)
+		evSender.Add(ev)
+		time.Sleep(5 * time.Millisecond)
+
+		evSender.sendEvent(createResourceID(app1.ObjectMeta))
+
+		require.Len(t, hopMetrics.eventWriterDwell, 1)
+		require.Equal(t, TargetApplication.String(), hopMetrics.eventWriterDwell[0].resourceType)
+		require.GreaterOrEqual(t, hopMetrics.eventWriterDwell[0].seconds, 0.0)
+	})
 }
 
 type fakeStream struct {
@@ -501,3 +518,26 @@ func (fs *fakeStream) Send(event *eventstreamapi.Event) error {
 func (fs *fakeStream) Context() context.Context {
 	return context.Background()
 }
+
+type fakeOutboundHopMetrics struct {
+	mu               sync.Mutex
+	eventWriterDwell []metricObservation
+}
+
+type metricObservation struct {
+	resourceType string
+	seconds      float64
+}
+
+func (f *fakeOutboundHopMetrics) ObserveSendQueueDwell(string, float64) {}
+
+func (f *fakeOutboundHopMetrics) ObserveEventWriterDwell(resourceType string, seconds float64) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.eventWriterDwell = append(f.eventWriterDwell, metricObservation{
+		resourceType: resourceType,
+		seconds:      seconds,
+	})
+}
+
+func (f *fakeOutboundHopMetrics) ObserveAckRoundtrip(string, float64) {}

--- a/internal/event/event_writer_test.go
+++ b/internal/event/event_writer_test.go
@@ -574,21 +574,86 @@ func TestEventWriter(t *testing.T) {
 
 		require.Empty(t, hopMetrics.eventWriterDwell)
 	})
+
+	t.Run("should observe event writer dwell on first successful retry", func(t *testing.T) {
+		fs := &fakeStream{sendErrs: []error{errors.New("boom")}}
+		evSender := NewEventWriter(fs)
+		hopMetrics := &fakeOutboundHopMetrics{}
+		evSender.SetMetrics(hopMetrics)
+
+		ev := es.ApplicationEvent(Create, app1)
+		resID := createResourceID(app1.ObjectMeta)
+		evSender.Add(ev)
+		time.Sleep(5 * time.Millisecond)
+
+		evSender.sendEvent(resID)
+		require.Empty(t, hopMetrics.eventWriterDwell)
+
+		sentMsg := evSender.sentEvents[resID]
+		require.NotNil(t, sentMsg)
+
+		pastTime := time.Now().Add(-1 * time.Second)
+		sentMsg.mu.Lock()
+		sentMsg.retryAfter = &pastTime
+		sentMsg.mu.Unlock()
+
+		evSender.retrySentEvent(resID, sentMsg)
+
+		require.Len(t, hopMetrics.eventWriterDwell, 1)
+		require.Equal(t, TargetApplication.String(), hopMetrics.eventWriterDwell[0].resourceType)
+	})
+
+	t.Run("should observe event writer dwell only once across retries", func(t *testing.T) {
+		fs := &fakeStream{}
+		evSender := NewEventWriter(fs)
+		hopMetrics := &fakeOutboundHopMetrics{}
+		evSender.SetMetrics(hopMetrics)
+
+		ev := es.ApplicationEvent(Create, app1)
+		resID := createResourceID(app1.ObjectMeta)
+		evSender.Add(ev)
+		time.Sleep(5 * time.Millisecond)
+
+		evSender.sendEvent(resID)
+		require.Len(t, hopMetrics.eventWriterDwell, 1)
+
+		sentMsg := evSender.sentEvents[resID]
+		require.NotNil(t, sentMsg)
+
+		pastTime := time.Now().Add(-1 * time.Second)
+		sentMsg.mu.Lock()
+		sentMsg.retryAfter = &pastTime
+		sentMsg.mu.Unlock()
+
+		evSender.retrySentEvent(resID, sentMsg)
+
+		require.Len(t, hopMetrics.eventWriterDwell, 1)
+	})
 }
 
 type fakeStream struct {
-	mu      sync.RWMutex
-	events  map[string][]string
-	sendErr error
+	mu       sync.RWMutex
+	events   map[string][]string
+	sendErr  error
+	sendErrs []error
 }
 
 func (fs *fakeStream) Send(event *eventstreamapi.Event) error {
+	fs.mu.Lock()
+	defer fs.mu.Unlock()
+
+	if len(fs.sendErrs) > 0 {
+		err := fs.sendErrs[0]
+		fs.sendErrs = fs.sendErrs[1:]
+		if err != nil {
+			return err
+		}
+	}
+
 	if fs.sendErr != nil {
 		return fs.sendErr
 	}
 
-	fs.mu.Lock()
-	defer fs.mu.Unlock()
 	ev, err := FromWire(event.Event)
 	if err != nil {
 		return err

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -39,6 +39,15 @@ type InformerMetrics struct {
 	DeleteDuration  *prometheus.GaugeVec
 }
 
+var outboundHopLatencyBuckets = []float64{0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30, 60}
+
+// OutboundHopMetrics records per-stage latency for outbound event delivery.
+type OutboundHopMetrics interface {
+	ObserveSendQueueDwell(resourceType string, seconds float64)
+	ObserveEventWriterDwell(resourceType string, seconds float64)
+	ObserveAckRoundtrip(resourceType string, seconds float64)
+}
+
 // PrincipalMetrics holds metrics of principal
 type PrincipalMetrics struct {
 	AgentConnected         prometheus.Gauge
@@ -82,6 +91,9 @@ type AgentMetrics struct {
 	EventSent           prometheus.Counter
 	EventProcessingTime *prometheus.HistogramVec
 	PropagationLatency  *prometheus.HistogramVec
+	SendQueueDwell      *prometheus.HistogramVec
+	EventWriterDwell    *prometheus.HistogramVec
+	AckRoundtrip        *prometheus.HistogramVec
 	AgentErrors         *prometheus.CounterVec
 }
 
@@ -179,19 +191,19 @@ func NewPrincipalMetrics() *PrincipalMetrics {
 		SendQueueDwell: promauto.NewHistogramVec(prometheus.HistogramOpts{
 			Name:    "principal_send_queue_dwell_seconds",
 			Help:    "Time an outbound event spends in the principal send queue before the event writer picks it up",
-			Buckets: []float64{0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30, 60},
+			Buckets: outboundHopLatencyBuckets,
 		}, []string{"resource_type"}),
 
 		EventWriterDwell: promauto.NewHistogramVec(prometheus.HistogramOpts{
 			Name:    "principal_event_writer_dwell_seconds",
 			Help:    "Time an outbound event spends in the event writer between being queued and actually sent on the wire",
-			Buckets: []float64{0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30, 60},
+			Buckets: outboundHopLatencyBuckets,
 		}, []string{"resource_type"}),
 
 		AckRoundtrip: promauto.NewHistogramVec(prometheus.HistogramOpts{
 			Name:    "principal_ack_roundtrip_seconds",
 			Help:    "Time from when an outbound event is sent on the wire to when the ACK is received back from the agent",
-			Buckets: []float64{0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30, 60},
+			Buckets: outboundHopLatencyBuckets,
 		}, []string{"resource_type"}),
 
 		PrincipalErrors: promauto.NewCounterVec(prometheus.CounterOpts{
@@ -223,11 +235,71 @@ func NewAgentMetrics() *AgentMetrics {
 			Buckets: prometheus.DefBuckets,
 		}, []string{"resource_type"}),
 
+		SendQueueDwell: promauto.NewHistogramVec(prometheus.HistogramOpts{
+			Name:    "agent_send_queue_dwell_seconds",
+			Help:    "Time an outbound event spends in the agent send queue before the event writer picks it up",
+			Buckets: outboundHopLatencyBuckets,
+		}, []string{"resource_type"}),
+
+		EventWriterDwell: promauto.NewHistogramVec(prometheus.HistogramOpts{
+			Name:    "agent_event_writer_dwell_seconds",
+			Help:    "Time an outbound event spends in the agent event writer between being queued and actually sent on the wire",
+			Buckets: outboundHopLatencyBuckets,
+		}, []string{"resource_type"}),
+
+		AckRoundtrip: promauto.NewHistogramVec(prometheus.HistogramOpts{
+			Name:    "agent_ack_roundtrip_seconds",
+			Help:    "Time from when an outbound event is sent on the wire to when the ACK is received back from the principal",
+			Buckets: outboundHopLatencyBuckets,
+		}, []string{"resource_type"}),
+
 		AgentErrors: promauto.NewCounterVec(prometheus.CounterOpts{
 			Name: "agent_errors",
 			Help: "The total number of errors occurred in agent",
 		}, []string{"resource_type"}),
 	}
+}
+
+func (m *PrincipalMetrics) ObserveSendQueueDwell(resourceType string, seconds float64) {
+	if m == nil || m.SendQueueDwell == nil {
+		return
+	}
+	m.SendQueueDwell.WithLabelValues(resourceType).Observe(seconds)
+}
+
+func (m *PrincipalMetrics) ObserveEventWriterDwell(resourceType string, seconds float64) {
+	if m == nil || m.EventWriterDwell == nil {
+		return
+	}
+	m.EventWriterDwell.WithLabelValues(resourceType).Observe(seconds)
+}
+
+func (m *PrincipalMetrics) ObserveAckRoundtrip(resourceType string, seconds float64) {
+	if m == nil || m.AckRoundtrip == nil {
+		return
+	}
+	m.AckRoundtrip.WithLabelValues(resourceType).Observe(seconds)
+}
+
+func (m *AgentMetrics) ObserveSendQueueDwell(resourceType string, seconds float64) {
+	if m == nil || m.SendQueueDwell == nil {
+		return
+	}
+	m.SendQueueDwell.WithLabelValues(resourceType).Observe(seconds)
+}
+
+func (m *AgentMetrics) ObserveEventWriterDwell(resourceType string, seconds float64) {
+	if m == nil || m.EventWriterDwell == nil {
+		return
+	}
+	m.EventWriterDwell.WithLabelValues(resourceType).Observe(seconds)
+}
+
+func (m *AgentMetrics) ObserveAckRoundtrip(resourceType string, seconds float64) {
+	if m == nil || m.AckRoundtrip == nil {
+		return
+	}
+	m.AckRoundtrip.WithLabelValues(resourceType).Observe(seconds)
 }
 
 // AvgCalculationInterval is time interval for agent connection time calculation

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -65,6 +65,14 @@ type PrincipalMetrics struct {
 
 	EventProcessingTime *prometheus.HistogramVec
 
+	// Hop-by-hop latency for outbound events (principal → agent).
+	// SendQueueDwell measures time from SendQ.Add to EventWriter.Add.
+	// EventWriterDwell measures time from EventWriter.Add to wire send.
+	// AckRoundtrip measures time from wire send to ACK received back.
+	SendQueueDwell   *prometheus.HistogramVec
+	EventWriterDwell *prometheus.HistogramVec
+	AckRoundtrip     *prometheus.HistogramVec
+
 	PrincipalErrors *prometheus.CounterVec
 }
 
@@ -167,6 +175,24 @@ func NewPrincipalMetrics() *PrincipalMetrics {
 			Name: "principal_event_processing_time",
 			Help: "Histogram of time taken to process events (in seconds)",
 		}, []string{"status", "agent_name", "resource_type"}),
+
+		SendQueueDwell: promauto.NewHistogramVec(prometheus.HistogramOpts{
+			Name:    "principal_send_queue_dwell_seconds",
+			Help:    "Time an outbound event spends in the principal send queue before the event writer picks it up",
+			Buckets: []float64{0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10},
+		}, []string{"resource_type"}),
+
+		EventWriterDwell: promauto.NewHistogramVec(prometheus.HistogramOpts{
+			Name:    "principal_event_writer_dwell_seconds",
+			Help:    "Time an outbound event spends in the event writer between being queued and actually sent on the wire",
+			Buckets: []float64{0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10},
+		}, []string{"resource_type"}),
+
+		AckRoundtrip: promauto.NewHistogramVec(prometheus.HistogramOpts{
+			Name:    "principal_ack_roundtrip_seconds",
+			Help:    "Time from when an outbound event is sent on the wire to when the ACK is received back from the agent",
+			Buckets: []float64{0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10},
+		}, []string{"resource_type"}),
 
 		PrincipalErrors: promauto.NewCounterVec(prometheus.CounterOpts{
 			Name: "principal_errors",

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -179,19 +179,19 @@ func NewPrincipalMetrics() *PrincipalMetrics {
 		SendQueueDwell: promauto.NewHistogramVec(prometheus.HistogramOpts{
 			Name:    "principal_send_queue_dwell_seconds",
 			Help:    "Time an outbound event spends in the principal send queue before the event writer picks it up",
-			Buckets: []float64{0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10},
+			Buckets: []float64{0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30, 60},
 		}, []string{"resource_type"}),
 
 		EventWriterDwell: promauto.NewHistogramVec(prometheus.HistogramOpts{
 			Name:    "principal_event_writer_dwell_seconds",
 			Help:    "Time an outbound event spends in the event writer between being queued and actually sent on the wire",
-			Buckets: []float64{0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10},
+			Buckets: []float64{0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30, 60},
 		}, []string{"resource_type"}),
 
 		AckRoundtrip: promauto.NewHistogramVec(prometheus.HistogramOpts{
 			Name:    "principal_ack_roundtrip_seconds",
 			Help:    "Time from when an outbound event is sent on the wire to when the ACK is received back from the agent",
-			Buckets: []float64{0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10},
+			Buckets: []float64{0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30, 60},
 		}, []string{"resource_type"}),
 
 		PrincipalErrors: promauto.NewCounterVec(prometheus.CounterOpts{

--- a/internal/queue/queue.go
+++ b/internal/queue/queue.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"sync"
 
+	aeevent "github.com/argoproj-labs/argocd-agent/internal/event"
 	"github.com/cloudevents/sdk-go/v2/event"
 	"k8s.io/client-go/util/workqueue"
 )
@@ -69,6 +70,7 @@ func (bq *boundedQueue) Add(item *event.Event) {
 		bq.Done(old)
 	}
 
+	aeevent.SetEnqueuedAt(item)
 	bq.TypedRateLimitingInterface.Add(item)
 
 	// Notify any waiting goroutines that an item has been added to the queue.

--- a/principal/apis/eventstream/eventstream.go
+++ b/principal/apis/eventstream/eventstream.go
@@ -278,6 +278,11 @@ func (s *Server) recvFunc(c *client, subs eventstreamapi.EventStream_SubscribeSe
 		if eventWriter == nil {
 			return fmt.Errorf("panic: event writer not found for agent %s", c.agentName)
 		}
+		if s.metrics != nil {
+			if sentAt := event.SentAt(incomingEvent); sentAt != nil {
+				s.metrics.AckRoundtrip.WithLabelValues(incomingEvent.DataSchema()).Observe(time.Since(*sentAt).Seconds())
+			}
+		}
 		eventWriter.Remove(incomingEvent)
 		logCtx.Trace("Removed the ACK from the event writer")
 		return nil
@@ -318,6 +323,15 @@ func (s *Server) sendFunc(c *client, subs eventstreamapi.EventStream_SubscribeSe
 		return fmt.Errorf("panic: nil item in queue")
 	}
 	logCtx.WithField("event_target", ev.DataSchema()).WithField("event_type", ev.Type()).Trace("Grabbed an item")
+
+	if s.metrics != nil {
+		target := event.Target(ev)
+		if target != event.TargetEventAck && target != event.TargetHeartbeat {
+			if enqueuedAt := event.EnqueuedAt(ev); enqueuedAt != nil {
+				s.metrics.SendQueueDwell.WithLabelValues(ev.DataSchema()).Observe(time.Since(*enqueuedAt).Seconds())
+			}
+		}
+	}
 
 	mode, err := session.ClientModeFromContext(c.ctx)
 	if err != nil {
@@ -388,6 +402,7 @@ func (s *Server) Subscribe(subs eventstreamapi.EventStream_SubscribeServer) erro
 		eventWriter.UpdateTarget(subs)
 	} else {
 		eventWriter = event.NewEventWriter(subs)
+		eventWriter.SetMetrics(s.metrics)
 		s.eventWriters.Add(c.agentName, eventWriter)
 	}
 

--- a/principal/apis/eventstream/eventstream.go
+++ b/principal/apis/eventstream/eventstream.go
@@ -399,6 +399,7 @@ func (s *Server) Subscribe(subs eventstreamapi.EventStream_SubscribeServer) erro
 
 	eventWriter := s.eventWriters.Get(c.agentName)
 	if eventWriter != nil {
+		eventWriter.SetMetrics(s.metrics)
 		eventWriter.UpdateTarget(subs)
 	} else {
 		eventWriter = event.NewEventWriter(subs)


### PR DESCRIPTION
Add three new principal-side histograms to isolate which stage owns propagation latency:

- principal_send_queue_dwell_seconds: time from SendQ.Add to EventWriter.Add
- principal_event_writer_dwell_seconds: time from EventWriter.Add to wire send
- principal_ack_roundtrip_seconds: time from wire send to ACK received

Implementation:
- enqueuedAt CloudEvents extension stamped in boundedQueue.Add (single site covers all enqueue call sites throughout the codebase)
- writerAddedAt field on eventMessage set in EventWriter.Add
- EventWriter gains optional principalMetrics field via SetMetrics; nil-safe so agent-side and test call sites are unaffected
- Observations wired in sendFunc (SendQueueDwell) and recvFunc (AckRoundtrip) in the eventstream server

**What does this PR do / why we need it**:

**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:


**Checklist**

* [ ] Documentation update is required by this PR (and has been updated) OR no documentation update is required.

<img width="2005" height="340" alt="image" src="https://github.com/user-attachments/assets/2d4b66de-ef55-4fb6-afda-06d89930ec19" />




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added hop-by-hop timing metrics (send-queue dwell, writer dwell, ACK roundtrip).
  * Events now record an enqueued timestamp; send timestamp is refreshed on retry.
  * Event writers can be wired at runtime to emit dwell/roundtrip observations and report resource type for ACKs.

* **Documentation**
  * Expanded metrics docs with hop-by-hop sections, new metric names, and updated labels/catalog.

* **Tests**
  * Added tests validating histogram observations and writer/retry metric behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->