### PR TITLE
fix: data race between WaitForCompletion and closeChannels in log streaming

### DIFF
--- a/principal/apis/logstreamapi/logstream.go
+++ b/principal/apis/logstreamapi/logstream.go
@@ -365,13 +365,16 @@ func (s *Server) processLogMessage(c *logClient, msg *logstreamapi.LogStreamData
 func (s *Server) WaitForCompletion(requestUUID string, timeout time.Duration) bool {
 	s.mu.RLock()
 	sess := s.sessions[requestUUID]
-	s.mu.RUnlock()
-
 	if sess == nil || sess.completeCh == nil {
+		s.mu.RUnlock()
 		return false
 	}
+
+	ch := sess.completeCh
+	s.mu.RUnlock()
+
 	select {
-	case <-sess.completeCh:
+	case <-ch:
 		return true
 	case <-time.After(timeout):
 		return false

--- a/principal/apis/logstreamapi/logstream_test.go
+++ b/principal/apis/logstreamapi/logstream_test.go
@@ -564,6 +564,32 @@ func TestConcurrentAccess(t *testing.T) {
 	wg.Wait()
 }
 
+func TestWaitForCompletion_RaceWithFinalizeSession(t *testing.T) {
+	for i := 0; i < 100; i++ {
+		server := NewServer()
+		reqID := "race-test"
+
+		w := mock.NewMockHTTPResponseWriter()
+		r := httptest.NewRequest("GET", "/logs", nil)
+		require.NoError(t, server.RegisterHTTP(reqID, w, r))
+
+		var wg sync.WaitGroup
+		wg.Add(2)
+
+		go func() {
+			defer wg.Done()
+			server.WaitForCompletion(reqID, 50*time.Millisecond)
+		}()
+
+		go func() {
+			defer wg.Done()
+			server.finalizeSession(reqID)
+		}()
+
+		wg.Wait()
+	}
+}
+
 func init() {
 	// Set log level to reduce noise during testing
 	logrus.SetLevel(logrus.ErrorLevel)


### PR DESCRIPTION
This PR is to fix a race condition where `WaitForCompletion()` releases the read lock before reading the `completeCh` channel and during this read operation, `closeChannels()` may set `completeCh` to `nil`, causing a race condition.

Fixes https://github.com/argoproj-labs/argocd-agent/issues/803

Assisted by: Cursor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a concurrency issue in log stream completion handling that could occur during simultaneous session operations, improving stability and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->