### PR TITLE
fix: filter repositories and gpg cm with the ignore-sync label

### DIFF
--- a/internal/backend/kubernetes/gpgkey/kubernetes.go
+++ b/internal/backend/kubernetes/gpgkey/kubernetes.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/argoproj-labs/argocd-agent/internal/backend"
+	"github.com/argoproj-labs/argocd-agent/internal/config"
 	"github.com/argoproj-labs/argocd-agent/internal/filter"
 	"github.com/argoproj-labs/argocd-agent/internal/informer"
 	"github.com/argoproj/argo-cd/v3/common"
@@ -88,6 +89,15 @@ func (be *KubernetesBackend) EnsureSynced(timeout time.Duration) error {
 
 func DefaultFilterChain(namespace string) *filter.Chain[*corev1.ConfigMap] {
 	c := filter.NewFilterChain[*corev1.ConfigMap]()
+
+	// Ignore the GPG key ConfigMap if it has the skip sync label
+	c.AppendAdmitFilter(func(res *corev1.ConfigMap) bool {
+		if v, ok := res.Labels[config.SkipSyncLabel]; ok && v == "true" {
+			return false
+		}
+		return true
+	})
+
 	c.AppendAdmitFilter(func(res *corev1.ConfigMap) bool {
 		return isValidGPGKeysConfigMap(res, namespace)
 	})

--- a/internal/backend/kubernetes/gpgkey/kubernetes_test.go
+++ b/internal/backend/kubernetes/gpgkey/kubernetes_test.go
@@ -17,6 +17,7 @@ package gpgkey
 import (
 	"testing"
 
+	"github.com/argoproj-labs/argocd-agent/internal/config"
 	"github.com/argoproj/argo-cd/v3/common"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
@@ -167,6 +168,17 @@ func TestDefaultFilterChain_GPGKeyFiltering(t *testing.T) {
 			},
 			expected: true,
 			reason:   "GPG keys ConfigMap with nil data should still be admitted based on name/namespace",
+		},
+		{
+			name: "ConfigMap with skip sync label should be rejected",
+			cm: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      common.ArgoCDGPGKeysConfigMapName,
+					Namespace: namespace,
+					Labels:    map[string]string{config.SkipSyncLabel: "true"},
+				},
+			},
+			expected: false,
 		},
 	}
 

--- a/internal/backend/kubernetes/repository/filters_test.go
+++ b/internal/backend/kubernetes/repository/filters_test.go
@@ -54,7 +54,7 @@ func TestDefaultFilterChain_RepositoryFiltering(t *testing.T) {
 			reason:   "Valid repository secret with all required fields",
 		},
 		{
-			name: "Repository secret with skip sync label=true should be filtered by informer (not this filter)",
+			name: "Repository secret with skip sync label=true should be rejected",
 			secret: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-repo",
@@ -69,8 +69,8 @@ func TestDefaultFilterChain_RepositoryFiltering(t *testing.T) {
 					"url":     []byte("https://github.com/example/repo.git"),
 				},
 			},
-			expected: true,
-			reason:   "DefaultFilterChain only validates repository format, skip sync filtering happens at informer level",
+			expected: false,
+			reason:   "Repository secret with skip sync label should be rejected",
 		},
 		{
 			name: "Repository secret in wrong namespace should be rejected",

--- a/internal/backend/kubernetes/repository/kubernetes.go
+++ b/internal/backend/kubernetes/repository/kubernetes.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/argoproj-labs/argocd-agent/internal/backend"
+	"github.com/argoproj-labs/argocd-agent/internal/config"
 	"github.com/argoproj-labs/argocd-agent/internal/filter"
 	"github.com/argoproj-labs/argocd-agent/internal/informer"
 	"github.com/argoproj-labs/argocd-agent/internal/logging"
@@ -127,6 +128,15 @@ func (be *KubernetesBackend) EnsureSynced(timeout time.Duration) error {
 
 func DefaultFilterChain(namespace string) *filter.Chain[*corev1.Secret] {
 	c := filter.NewFilterChain[*corev1.Secret]()
+
+	// Ignore repository secrets that have the skip sync label
+	c.AppendAdmitFilter(func(res *corev1.Secret) bool {
+		if v, ok := res.Labels[config.SkipSyncLabel]; ok && v == "true" {
+			return false
+		}
+		return true
+	})
+
 	c.AppendAdmitFilter(func(res *corev1.Secret) bool {
 		return isValidRepositorySecret(res, namespace)
 	})

--- a/principal/server.go
+++ b/principal/server.go
@@ -970,10 +970,8 @@ func (s *Server) sendCurrentStateToAgent(agent string) error {
 		}
 
 		// Don't send AppProjects that have SkipSyncLabel=true
-		if appProject.Labels != nil {
-			if val, ok := appProject.Labels[config.SkipSyncLabel]; ok && val == "true" {
-				continue
-			}
+		if hasSkipSyncLabel(appProject.Labels) {
+			continue
 		}
 
 		agentAppProject := appproject.AgentSpecificAppProject(appProject, agent, s.destinationBasedMapping)
@@ -1008,6 +1006,10 @@ func (s *Server) sendCurrentStateToAgent(agent string) error {
 			continue
 		}
 
+		if hasSkipSyncLabel(repository.Labels) || hasSkipSyncLabel(project.Labels) {
+			continue
+		}
+
 		if !appproject.DoesAgentMatchWithProject(agent, project) {
 			continue
 		}
@@ -1027,7 +1029,7 @@ func (s *Server) sendCurrentStateToAgent(agent string) error {
 		if !apierrors.IsNotFound(err) {
 			return fmt.Errorf("failed to get GPG key ConfigMap: %w", err)
 		}
-	} else {
+	} else if !hasSkipSyncLabel(gpgKeyCM.Labels) {
 		ev := s.events.GPGKeyEvent(event.SpecUpdate, gpgKeyCM)
 		tracing.PopulateSpanFromObject(span, gpgKeyCM)
 		tracing.InjectTraceContext(ctx, ev)
@@ -1035,6 +1037,17 @@ func (s *Server) sendCurrentStateToAgent(agent string) error {
 	}
 
 	return nil
+}
+
+func hasSkipSyncLabel(labels map[string]string) bool {
+	if labels == nil {
+		return false
+	}
+
+	if v, found := labels[config.SkipSyncLabel]; found && v == "true" {
+		return true
+	}
+	return false
 }
 
 // Shutdown shuts down the server s. If no server is running, or shutting down

--- a/principal/server_test.go
+++ b/principal/server_test.go
@@ -501,6 +501,104 @@ func Test_SendCurrentStateToAgent(t *testing.T) {
 		assert.Equal(t, 2, sendQ.Len())
 	})
 
+	t.Run("skips repository when it has SkipSyncLabel=true", func(t *testing.T) {
+		proj := generateAppProject("proj1")
+		repo := generateRepoSecret("repo1", "proj1")
+		repo.Labels = map[string]string{config.SkipSyncLabel: "true"}
+
+		mockProjBackend := &mocks.AppProject{}
+		mockRepoBackend := &mocks.Repository{}
+		mockProjBackend.On("List", mock.Anything, mock.Anything).Return([]v1alpha1.AppProject{proj}, nil)
+		mockRepoBackend.On("List", mock.Anything, mock.Anything).Return([]corev1.Secret{repo}, nil)
+
+		s := newServer(t, mockProjBackend, mockRepoBackend)
+		err := s.sendCurrentStateToAgent(agentName)
+		require.NoError(t, err)
+
+		sendQ := s.queues.SendQ(agentName)
+		assert.Equal(t, 1, sendQ.Len())
+		assert.Empty(t, s.repoToAgents.Get("repo1"))
+	})
+
+	t.Run("skips repository when its project has SkipSyncLabel=true", func(t *testing.T) {
+		proj := generateAppProject("proj1")
+		proj.Labels = map[string]string{config.SkipSyncLabel: "true"}
+		repo := generateRepoSecret("repo1", "proj1")
+
+		mockProjBackend := &mocks.AppProject{}
+		mockRepoBackend := &mocks.Repository{}
+		mockProjBackend.On("List", mock.Anything, mock.Anything).Return([]v1alpha1.AppProject{proj}, nil)
+		mockRepoBackend.On("List", mock.Anything, mock.Anything).Return([]corev1.Secret{repo}, nil)
+
+		s := newServer(t, mockProjBackend, mockRepoBackend)
+		err := s.sendCurrentStateToAgent(agentName)
+		require.NoError(t, err)
+
+		sendQ := s.queues.SendQ(agentName)
+		assert.Equal(t, 0, sendQ.Len())
+		assert.Empty(t, s.projectToRepos.Get("proj1"))
+		assert.Empty(t, s.repoToAgents.Get("repo1"))
+	})
+
+	t.Run("sends GPG key ConfigMap when it exists without skip-sync label", func(t *testing.T) {
+		proj := generateAppProject("proj1")
+		repo := generateRepoSecret("repo1", "proj1")
+
+		mockProjBackend := &mocks.AppProject{}
+		mockRepoBackend := &mocks.Repository{}
+		mockProjBackend.On("List", mock.Anything, mock.Anything).Return([]v1alpha1.AppProject{proj}, nil)
+		mockRepoBackend.On("List", mock.Anything, mock.Anything).Return([]corev1.Secret{repo}, nil)
+
+		mockGPGBackend := mocks.NewGPGKey(t)
+		gpgCM := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      common.ArgoCDGPGKeysConfigMapName,
+				Namespace: ns,
+			},
+			Data: map[string]string{"key1": "data1"},
+		}
+		mockGPGBackend.On("Get", mock.Anything, common.ArgoCDGPGKeysConfigMapName, ns).Return(gpgCM, nil)
+
+		s := newServer(t, mockProjBackend, mockRepoBackend)
+		s.gpgKeyManager = gpgkey.NewManager(mockGPGBackend, ns)
+		err := s.sendCurrentStateToAgent(agentName)
+		require.NoError(t, err)
+
+		// 1 project + 1 repo + 1 GPG key
+		sendQ := s.queues.SendQ(agentName)
+		assert.Equal(t, 3, sendQ.Len())
+	})
+
+	t.Run("skips GPG key ConfigMap when it has SkipSyncLabel=true", func(t *testing.T) {
+		proj := generateAppProject("proj1")
+		repo := generateRepoSecret("repo1", "proj1")
+
+		mockProjBackend := &mocks.AppProject{}
+		mockRepoBackend := &mocks.Repository{}
+		mockProjBackend.On("List", mock.Anything, mock.Anything).Return([]v1alpha1.AppProject{proj}, nil)
+		mockRepoBackend.On("List", mock.Anything, mock.Anything).Return([]corev1.Secret{repo}, nil)
+
+		mockGPGBackend := mocks.NewGPGKey(t)
+		gpgCM := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      common.ArgoCDGPGKeysConfigMapName,
+				Namespace: ns,
+				Labels:    map[string]string{config.SkipSyncLabel: "true"},
+			},
+			Data: map[string]string{"key1": "data1"},
+		}
+		mockGPGBackend.On("Get", mock.Anything, common.ArgoCDGPGKeysConfigMapName, ns).Return(gpgCM, nil)
+
+		s := newServer(t, mockProjBackend, mockRepoBackend)
+		s.gpgKeyManager = gpgkey.NewManager(mockGPGBackend, ns)
+		err := s.sendCurrentStateToAgent(agentName)
+		require.NoError(t, err)
+
+		// 1 project + 1 repo, GPG key skipped
+		sendQ := s.queues.SendQ(agentName)
+		assert.Equal(t, 2, sendQ.Len())
+	})
+
 }
 
 func init() {


### PR DESCRIPTION
**What does this PR do / why we need it**:

The agent/principal shouldn't reconcile repositories and the GPG CM with the ignore sync label set. This helps when running the agent/principal with the existing non-agent argocd resources. 

**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:


**Checklist**

* [ ] Documentation update is required by this PR (and has been updated) OR no documentation update is required.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Resources labeled with a skip-sync indicator can now be excluded from synchronization across GPG keys, repositories, and their associated projects. This allows selective opt-out of sync operations at the resource level.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->