### PR TITLE
fix: data race between Server.Start() and informer goroutines in principal

### DIFF
--- a/principal/server.go
+++ b/principal/server.go
@@ -669,6 +669,8 @@ func (s *Server) Start(ctx context.Context, errch chan error) error {
 		return nil
 	}
 
+	s.events = event.NewEventSource(s.options.serverName)
+
 	// The application informer lives in its own go routine
 	go func() {
 		if err := s.appManager.StartBackend(s.ctx); err != nil {
@@ -730,8 +732,6 @@ func (s *Server) Start(ctx context.Context, errch chan error) error {
 			log().Info("GPG key informer has exited")
 		}
 	}()
-
-	s.events = event.NewEventSource(s.options.serverName)
 
 	syncTimeout := s.options.informerSyncTimeout
 	if syncTimeout == 0 {


### PR DESCRIPTION
This PR has a minor change for a data race between `Server.Start()` and app project informer, when app project goroutine started but `s.events` is still being initialized.

To reproduce it, add `go -race` parameter to start-principal.sh.

```
time="2026-04-01T16:05:09+05:30" level=info msg="Starting watcher" module=Informer type="*v1.Namespace"
time="2026-04-01T16:05:09+05:30" level=info msg="Starting watcher" module=Informer type="*v1alpha1.AppProject"
==================
WARNING: DATA RACE
Read at 0x00c00033dcf8 by goroutine 98:
  github.com/argoproj-labs/argocd-agent/principal.(*Server).newAppProjectCallback()
      /home/jparsai/MyFolder/WorkSpaces/operator/argocd-agent/principal/callbacks.go:326 +0x1564
  github.com/argoproj-labs/argocd-agent/principal.(*Server).newAppProjectCallback-fm()
      <autogenerated>:1 +0x3d
  github.com/argoproj-labs/argocd-agent/internal/informer.(*Informer[go.shape.*uint8]).installEventHandlers.func2()
      /home/jparsai/MyFolder/WorkSpaces/operator/argocd-agent/internal/informer/informer.go:206 +0x98
  k8s.io/client-go/tools/cache.ResourceEventHandlerFuncs.OnAdd()
      /home/jparsai/go/pkg/mod/k8s.io/client-go@v0.34.0/tools/cache/controller.go:259 +0x63
  k8s.io/client-go/tools/cache.(*ResourceEventHandlerFuncs).OnAdd()
      <autogenerated>:1 +0x1b
  k8s.io/client-go/tools/cache.FilteringResourceEventHandler.OnAdd()
      /home/jparsai/go/pkg/mod/k8s.io/client-go@v0.34.0/tools/cache/controller.go:322 +0x82
  k8s.io/client-go/tools/cache.(*FilteringResourceEventHandler).OnAdd()
      <autogenerated>:1 +0x75
  k8s.io/client-go/tools/cache.(*processorListener).run.func1()
      /home/jparsai/go/pkg/mod/k8s.io/client-go@v0.34.0/tools/cache/shared_informer.go:1076 +0x1e4
  k8s.io/client-go/tools/cache.(*processorListener).run()
      /home/jparsai/go/pkg/mod/k8s.io/client-go@v0.34.0/tools/cache/shared_informer.go:1086 +0x5e
  k8s.io/client-go/tools/cache.(*processorListener).run-fm()
      <autogenerated>:1 +0x33
  k8s.io/apimachinery/pkg/util/wait.(*Group).Start.func1()
      /home/jparsai/go/pkg/mod/k8s.io/apimachinery@v0.34.0/pkg/util/wait/wait.go:72 +0x82

Previous write at 0x00c00033dcf8 by main goroutine:
  github.com/argoproj-labs/argocd-agent/principal.(*Server).Start()
      /home/jparsai/MyFolder/WorkSpaces/operator/argocd-agent/principal/server.go:734 +0x10b8
  main.NewPrincipalRunCommand.func1()
      /home/jparsai/MyFolder/WorkSpaces/operator/argocd-agent/cmd/argocd-agent/principal.go:462 +0x8764
  github.com/spf13/cobra.(*Command).execute()
      /home/jparsai/go/pkg/mod/github.com/spf13/cobra@v1.10.2/command.go:1019 +0x11d3
  github.com/spf13/cobra.(*Command).ExecuteC()
      /home/jparsai/go/pkg/mod/github.com/spf13/cobra@v1.10.2/command.go:1148 +0x797
  github.com/spf13/cobra.(*Command).Execute()
      /home/jparsai/go/pkg/mod/github.com/spf13/cobra@v1.10.2/command.go:1071 +0x2a
  main.main()
      /home/jparsai/MyFolder/WorkSpaces/operator/argocd-agent/cmd/argocd-agent/root.go:27 +0x25

Goroutine 98 (running) created at:
  k8s.io/apimachinery/pkg/util/wait.(*Group).Start()
      /home/jparsai/go/pkg/mod/k8s.io/apimachinery@v0.34.0/pkg/util/wait/wait.go:70 +0xdc
  k8s.io/client-go/tools/cache.(*sharedProcessor).run.func1()
      /home/jparsai/go/pkg/mod/k8s.io/client-go@v0.34.0/tools/cache/shared_informer.go:888 +0x1e7
  k8s.io/client-go/tools/cache.(*sharedProcessor).run()
      /home/jparsai/go/pkg/mod/k8s.io/client-go@v0.34.0/tools/cache/shared_informer.go:892 +0x4b
  k8s.io/client-go/tools/cache.(*sharedProcessor).run-fm()
      <autogenerated>:1 +0x47
  k8s.io/client-go/tools/cache.(*sharedIndexInformer).RunWithContext.(*Group).StartWithContext.func4()
      /home/jparsai/go/pkg/mod/k8s.io/apimachinery@v0.34.0/pkg/util/wait/wait.go:63 +0x46
  k8s.io/apimachinery/pkg/util/wait.(*Group).Start.func1()
      /home/jparsai/go/pkg/mod/k8s.io/apimachinery@v0.34.0/pkg/util/wait/wait.go:72 +0x82
==================
time="2026-04-01T16:05:09+05:30" level=info msg="New GPG key ConfigMap event" component=EventCallback event=gpgkey_create module=server
==================
WARNING: DATA RACE
Read at 0x00c00068d360 by goroutine 98:
  github.com/argoproj-labs/argocd-agent/principal.(*Server).newAppProjectCallback()
      /home/jparsai/MyFolder/WorkSpaces/operator/argocd-agent/principal/callbacks.go:326 +0x1584
  github.com/argoproj-labs/argocd-agent/principal.(*Server).newAppProjectCallback-fm()
      <autogenerated>:1 +0x3d
  github.com/argoproj-labs/argocd-agent/internal/informer.(*Informer[go.shape.*uint8]).installEventHandlers.func2()
      /home/jparsai/MyFolder/WorkSpaces/operator/argocd-agent/internal/informer/informer.go:206 +0x98
  k8s.io/client-go/tools/cache.ResourceEventHandlerFuncs.OnAdd()
      /home/jparsai/go/pkg/mod/k8s.io/client-go@v0.34.0/tools/cache/controller.go:259 +0x63
  k8s.io/client-go/tools/cache.(*ResourceEventHandlerFuncs).OnAdd()
      <autogenerated>:1 +0x1b
  k8s.io/client-go/tools/cache.FilteringResourceEventHandler.OnAdd()
      /home/jparsai/go/pkg/mod/k8s.io/client-go@v0.34.0/tools/cache/controller.go:322 +0x82
  k8s.io/client-go/tools/cache.(*FilteringResourceEventHandler).OnAdd()
      <autogenerated>:1 +0x75
  k8s.io/client-go/tools/cache.(*processorListener).run.func1()
      /home/jparsai/go/pkg/mod/k8s.io/client-go@v0.34.0/tools/cache/shared_informer.go:1076 +0x1e4
  k8s.io/client-go/tools/cache.(*processorListener).run()
      /home/jparsai/go/pkg/mod/k8s.io/client-go@v0.34.0/tools/cache/shared_informer.go:1086 +0x5e
  k8s.io/client-go/tools/cache.(*processorListener).run-fm()
      <autogenerated>:1 +0x33
  k8s.io/apimachinery/pkg/util/wait.(*Group).Start.func1()
      /home/jparsai/go/pkg/mod/k8s.io/apimachinery@v0.34.0/pkg/util/wait/wait.go:72 +0x82

Previous write at 0x00c00068d360 by main goroutine:
  github.com/argoproj-labs/argocd-agent/internal/event.NewEventSource()
      /home/jparsai/MyFolder/WorkSpaces/operator/argocd-agent/internal/event/event.go:148 +0x1031
  github.com/argoproj-labs/argocd-agent/principal.(*Server).Start()
      /home/jparsai/MyFolder/WorkSpaces/operator/argocd-agent/principal/server.go:734 +0xfd1
  main.NewPrincipalRunCommand.func1()
      /home/jparsai/MyFolder/WorkSpaces/operator/argocd-agent/cmd/argocd-agent/principal.go:462 +0x8764
  github.com/spf13/cobra.(*Command).execute()
      /home/jparsai/go/pkg/mod/github.com/spf13/cobra@v1.10.2/command.go:1019 +0x11d3
  github.com/spf13/cobra.(*Command).ExecuteC()
      /home/jparsai/go/pkg/mod/github.com/spf13/cobra@v1.10.2/command.go:1148 +0x797
  github.com/spf13/cobra.(*Command).Execute()
      /home/jparsai/go/pkg/mod/github.com/spf13/cobra@v1.10.2/command.go:1071 +0x2a
  main.main()
      /home/jparsai/MyFolder/WorkSpaces/operator/argocd-agent/cmd/argocd-agent/root.go:27 +0x25

Goroutine 98 (running) created at:
  k8s.io/apimachinery/pkg/util/wait.(*Group).Start()
      /home/jparsai/go/pkg/mod/k8s.io/apimachinery@v0.34.0/pkg/util/wait/wait.go:70 +0xdc
  k8s.io/client-go/tools/cache.(*sharedProcessor).run.func1()
      /home/jparsai/go/pkg/mod/k8s.io/client-go@v0.34.0/tools/cache/shared_informer.go:888 +0x1e7
  k8s.io/client-go/tools/cache.(*sharedProcessor).run()
      /home/jparsai/go/pkg/mod/k8s.io/client-go@v0.34.0/tools/cache/shared_informer.go:892 +0x4b
  k8s.io/client-go/tools/cache.(*sharedProcessor).run-fm()
      <autogenerated>:1 +0x47
  k8s.io/client-go/tools/cache.(*sharedIndexInformer).RunWithContext.(*Group).StartWithContext.func4()
      /home/jparsai/go/pkg/mod/k8s.io/apimachinery@v0.34.0/pkg/util/wait/wait.go:63 +0x46
  k8s.io/apimachinery/pkg/util/wait.(*Group).Start.func1()
      /home/jparsai/go/pkg/mod/k8s.io/apimachinery@v0.34.0/pkg/util/wait/wait.go:72 +0x82
==================
time="2026-04-01T16:05:09+05:30" level=info msg="Starting watcher" module=Informer type="*v1.ConfigMap"
time="2026-04-01T16:05:09+05:30" level=info msg="Starting watcher" module=Informer type="*v1.Secret"
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized server initialization sequence to enhance startup reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->