### PR TITLE
fix: data race between 'sendCurrentStateToAgent' and 'syncRepositoriesForProject'

### DIFF
--- a/principal/mapset.go
+++ b/principal/mapset.go
@@ -31,7 +31,15 @@ func NewMapToSet() *MapToSet {
 func (m *MapToSet) Get(key string) map[string]bool {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
-	return m.m[key]
+	s, exists := m.m[key]
+	if !exists {
+		return nil
+	}
+	cp := make(map[string]bool)
+	for k, v := range s {
+		cp[k] = v
+	}
+	return cp
 }
 
 func (m *MapToSet) Add(key string, value string) {

--- a/principal/mapset.go
+++ b/principal/mapset.go
@@ -35,7 +35,7 @@ func (m *MapToSet) Get(key string) map[string]bool {
 	if !exists {
 		return nil
 	}
-	cp := make(map[string]bool)
+	cp := make(map[string]bool, len(s))
 	for k, v := range s {
 		cp[k] = v
 	}

--- a/principal/mapset_test.go
+++ b/principal/mapset_test.go
@@ -116,6 +116,24 @@ func Test_mapToSet_Get(t *testing.T) {
 		assert.True(t, values["agent2"])
 		assert.Equal(t, 1, len(values))
 	})
+
+	t.Run("Get returns a copy of values for thread safety", func(t *testing.T) {
+		ms := NewMapToSet()
+		ms.Add("project1", "agent1")
+		ms.Add("project1", "agent2")
+
+		values := ms.Get("project1")
+		values["agent1"] = false
+
+		ms.Add("project1", "agent3")
+
+		_, exists := values["agent3"]
+		require.NotNil(t, values)
+		require.True(t, ms.m["project1"]["agent1"])
+		require.False(t, exists)
+		assert.Equal(t, 2, len(values))
+		assert.Equal(t, 3, len(ms.m["project1"]))
+	})
 }
 
 func Test_mapToSet_Delete(t *testing.T) {


### PR DESCRIPTION
**What does this PR do / why we need it**:
This PR fixes a data race between 'sendCurrentStateToAgent' and 'syncRepositoriesForProject.' This data race occurred because the `Get` function for `MapToSet` returned the actual value of the map which could have a data race is something is added to it. This is fixed by having the `Get` function just return a copy instead. From my searches, I don't think the map returned by `Get` was ever modified so a copy should suffice.

**Which issue(s) this PR fixes**:

Fixes #796 

**How to test changes / Special notes to the reviewer**:

To test these changes, add the `-race` flag to `hack/dev-env/start-principal.sh` and run the following test:
```
go test -count=1 -v -v -timeout 60m -run TestResyncTestSuite/Test_RepositoryResync_OnCreation github.com/argoproj-labs/argocd-agent/test/e2e
```

**Checklist**

* [ ] Documentation update is required by this PR (and has been updated) OR no documentation update is required.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented accidental modification of stored entries by returning independent snapshots and clarified behavior for missing keys.

* **Tests**
  * Added unit coverage verifying returned snapshots are copies and that internal state remains unchanged when callers mutate results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->