### PR TITLE
feat: Allow setting number of event processors

### DIFF
--- a/cmd/argocd-agent/principal.go
+++ b/cmd/argocd-agent/principal.go
@@ -101,6 +101,8 @@ func NewPrincipalRunCommand() *cobra.Command {
 
 		maxGRPCMessageSize int
 
+		numEventProcessors int
+
 		// OpenTelemetry configuration
 		otlpAddress  string
 		otlpInsecure bool
@@ -370,6 +372,7 @@ func NewPrincipalRunCommand() *cobra.Command {
 			opts = append(opts, principal.WithDestinationBasedMapping(destinationBasedMapping))
 			opts = append(opts, principal.WithAppLabelSelector(appLabelSelector))
 			opts = append(opts, principal.WithMaxGRPCMessageSize(maxGRPCMessageSize))
+			opts = append(opts, principal.WithEventProcessors(int64(numEventProcessors)))
 
 			// Self agent registration validation and options
 			if enableSelfClusterRegistration {
@@ -610,6 +613,9 @@ func NewPrincipalRunCommand() *cobra.Command {
 	command.Flags().IntVar(&maxGRPCMessageSize, "grpc-max-message-size",
 		env.NumWithDefault("ARGOCD_PRINCIPAL_GRPC_MAX_MESSAGE_SIZE", nil, grpcutil.DefaultGRPCMaxMessageSize),
 		"Maximum gRPC message size in bytes for send and receive (default: 200MB)")
+	command.Flags().IntVar(&numEventProcessors, "event-processors",
+		env.NumWithDefault("ARGOCD_PRINCIPAL_EVENT_PROCESSORS", nil, 10),
+		"Number of concurrent event processors")
 
 	command.Flags().StringVar(&otlpAddress, "otlp-address",
 		env.StringWithDefault("ARGOCD_PRINCIPAL_OTLP_ADDRESS", nil, ""),

--- a/docs/configuration/reference/principal.md
+++ b/docs/configuration/reference/principal.md
@@ -515,6 +515,19 @@ Drop agent connections that send keepalive pings more often than specified inter
 
 **Example:** `30s`
 
+### Event Processors
+
+| | |
+|---|---|
+| **CLI Flag** | `--event-processors` |
+| **Environment Variable** | `ARGOCD_PRINCIPAL_EVENT_PROCESSORS` |
+| **ConfigMap Entry** | `principal.event-processors` |
+| **Type** | Integer |
+| **Default** | `10` |
+| **Range** | > 0 |
+
+Number of concurrent event processors. Increasing this value allows the principal to handle more agent events in parallel at the cost of higher resource usage.
+
 ## Redis Configuration
 
 ### Redis Server Address

--- a/install/kubernetes/principal/principal-deployment.yaml
+++ b/install/kubernetes/principal/principal-deployment.yaml
@@ -261,6 +261,12 @@ spec:
                 name: argocd-agent-params
                 key: principal.tls.insecure-plaintext
                 optional: true
+          - name: ARGOCD_PRINCIPAL_EVENT_PROCESSORS
+            valueFrom:
+              configMapKeyRef:
+                name: argocd-agent-params
+                key: principal.event-processors
+                optional: true
           - name: REDIS_PASSWORD
             valueFrom:
               secretKeyRef:

--- a/install/kubernetes/principal/principal-params-cm.yaml
+++ b/install/kubernetes/principal/principal-params-cm.yaml
@@ -198,3 +198,6 @@ data:
   # principal.redis.tls.insecure: INSECURE: Do not verify Redis TLS certificate.
   # Default: false
   principal.redis.tls.insecure: "false"
+  # principal.event-processors: Number of concurrent event processors.
+  # Default: 10
+  principal.event-processors: "10"

--- a/principal/options.go
+++ b/principal/options.go
@@ -132,6 +132,9 @@ func defaultOptions() *ServerOptions {
 // concurrently.
 func WithEventProcessors(numProcessors int64) ServerOption {
 	return func(o *Server) error {
+		if numProcessors <= 0 {
+			return fmt.Errorf("event processors must be greater than 0")
+		}
 		o.options.eventProcessors = numProcessors
 		return nil
 	}


### PR DESCRIPTION
**What does this PR do / why we need it**:

Adds `--event-processors` command line switch and accompanying references that will allow setting the number of concurrent event processors for the principal.

**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:


**Checklist**

* [ ] Documentation update is required by this PR (and has been updated) OR no documentation update is required.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configurable "event processors" setting to control concurrent event processing in the principal server (default: 10). Available via CLI flag (--event-processors), environment variable (ARGOCD_PRINCIPAL_EVENT_PROCESSORS), or Kubernetes ConfigMap.

* **Documentation**
  * Added configuration reference documentation for the event processors parameter, including default and validation (>0).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->