### PR TITLE
build: update build configs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ GIT_COMMIT=$(shell git rev-parse HEAD)
 VERSION=$(shell cat VERSION)
 
 VERSION_PACKAGE=github.com/argoproj-labs/argocd-agent/internal/version
-override LDFLAGS += -extldflags "-static"
+LDFLAGS += -extldflags "-static"
 override LDFLAGS += \
         -X ${VERSION_PACKAGE}.version=${VERSION} \
         -X ${VERSION_PACKAGE}.gitRevision=${GIT_COMMIT}


### PR DESCRIPTION
This PR is to drop `override` keyword from the LDFLAGS, so that konflux can supply
custom LDFLAGS. This would fix the build issue mentioned in https://github.com/rh-gitops-midstream/release/pull/738

Here are old PR that were merged to address initial FIPS requirements 
- https://github.com/argoproj-labs/argocd-agent/pull/725
- https://github.com/rh-gitops-midstream/release/pull/620



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted build configuration settings for improved build process compatibility.

---

**Note:** This release contains no user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->