### PR TITLE
feat: extend label selectors to other agent resources

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -148,9 +148,9 @@ type Agent struct {
 	// destination-based mapping.
 	createNamespace bool
 
-	// appLabelSelector is an optional Kubernetes label selector that restricts
-	// which Applications the agent watches.
-	appLabelSelector string
+	// labelSelector is an optional Kubernetes label selector that restricts
+	// which resources the agent can process.
+	labelSelector string
 }
 
 const defaultQueueName = "default"
@@ -258,17 +258,12 @@ func NewAgent(ctx context.Context, client *kube.KubernetesClient, namespace stri
 		appNamespace = ""
 	}
 
-	appListOpts := config.AppLabelSelector(a.appLabelSelector)
-	if a.appLabelSelector != "" {
-		log().Infof("Application informer using label selector: %s", appListOpts.LabelSelector)
-	}
-
 	// appListFunc and watchFunc are anonymous functions for the informer
 	appListFunc := func(ctx context.Context, opts v1.ListOptions) (runtime.Object, error) {
-		return client.ApplicationsClientset.ArgoprojV1alpha1().Applications(appNamespace).List(ctx, appListOpts)
+		return client.ApplicationsClientset.ArgoprojV1alpha1().Applications(appNamespace).List(ctx, config.LabelSelector(a.labelSelector))
 	}
 	appWatchFunc := func(ctx context.Context, opts v1.ListOptions) (watch.Interface, error) {
-		return client.ApplicationsClientset.ArgoprojV1alpha1().Applications(appNamespace).Watch(ctx, appListOpts)
+		return client.ApplicationsClientset.ArgoprojV1alpha1().Applications(appNamespace).Watch(ctx, config.LabelSelector(a.labelSelector))
 	}
 
 	appInformerOptions := []informer.InformerOption[*v1alpha1.Application]{
@@ -311,11 +306,11 @@ func NewAgent(ctx context.Context, client *kube.KubernetesClient, namespace stri
 	appManagerOpts = append(appManagerOpts, application.WithAllowUpsert(allowUpsert))
 
 	projListFunc := func(ctx context.Context, opts v1.ListOptions) (runtime.Object, error) {
-		return client.ApplicationsClientset.ArgoprojV1alpha1().AppProjects(a.namespace).List(ctx, config.DefaultLabelSelector())
+		return client.ApplicationsClientset.ArgoprojV1alpha1().AppProjects(a.namespace).List(ctx, config.LabelSelector(a.labelSelector))
 	}
 
 	projWatchFunc := func(ctx context.Context, opts v1.ListOptions) (watch.Interface, error) {
-		return client.ApplicationsClientset.ArgoprojV1alpha1().AppProjects(a.namespace).Watch(ctx, config.DefaultLabelSelector())
+		return client.ApplicationsClientset.ArgoprojV1alpha1().AppProjects(a.namespace).Watch(ctx, config.LabelSelector(a.labelSelector))
 	}
 
 	projInformerOptions := []informer.InformerOption[*v1alpha1.AppProject]{
@@ -333,30 +328,33 @@ func NewAgent(ctx context.Context, client *kube.KubernetesClient, namespace stri
 		return nil, fmt.Errorf("could not instantiate project informer: %w", err)
 	}
 
+	appBackendOpts := []kubeapp.KubernetesBackendOption{
+		kubeapp.WithLabelSelector(a.labelSelector),
+	}
+	appBackend := kubeapp.NewKubernetesBackend(client.ApplicationsClientset, a.namespace, appInformer, true, appBackendOpts...)
+
 	// The agent only supports Kubernetes as application backend
-	a.appManager, err = application.NewApplicationManager(
-		kubeapp.NewKubernetesBackend(client.ApplicationsClientset, a.namespace, appInformer, true),
-		a.namespace,
-		appManagerOpts...,
-	)
+	a.appManager, err = application.NewApplicationManager(appBackend, a.namespace, appManagerOpts...)
 	if err != nil {
 		return nil, err
 	}
 
-	a.projectManager, err = appproject.NewAppProjectManager(
-		kubeappproject.NewKubernetesBackend(client.ApplicationsClientset, a.namespace, projInformer, true),
-		a.namespace,
-		appProjectManagerOption...)
+	projectBackendOpts := []kubeappproject.KubernetesBackendOption{
+		kubeappproject.WithLabelSelector(a.labelSelector),
+	}
+	projectBackend := kubeappproject.NewKubernetesBackend(client.ApplicationsClientset, a.namespace, projInformer, true, projectBackendOpts...)
+
+	a.projectManager, err = appproject.NewAppProjectManager(projectBackend, a.namespace, appProjectManagerOption...)
 	if err != nil {
 		return nil, err
 	}
 
 	repoInformerOptions := []informer.InformerOption[*corev1.Secret]{
 		informer.WithListHandler[*corev1.Secret](func(ctx context.Context, opts v1.ListOptions) (runtime.Object, error) {
-			return client.Clientset.CoreV1().Secrets(a.namespace).List(ctx, config.DefaultLabelSelector())
+			return client.Clientset.CoreV1().Secrets(a.namespace).List(ctx, config.LabelSelector(a.labelSelector))
 		}),
 		informer.WithWatchHandler[*corev1.Secret](func(ctx context.Context, opts v1.ListOptions) (watch.Interface, error) {
-			return client.Clientset.CoreV1().Secrets(a.namespace).Watch(ctx, config.DefaultLabelSelector())
+			return client.Clientset.CoreV1().Secrets(a.namespace).Watch(ctx, config.LabelSelector(a.labelSelector))
 		}),
 		informer.WithAddHandler[*corev1.Secret](a.handleRepositoryCreation),
 		informer.WithUpdateHandler[*corev1.Secret](a.handleRepositoryUpdate),
@@ -370,15 +368,19 @@ func NewAgent(ctx context.Context, client *kube.KubernetesClient, namespace stri
 		return nil, fmt.Errorf("could not instantiate repository informer: %w", err)
 	}
 
-	repoBackened := kuberepository.NewKubernetesBackend(client.Clientset, a.namespace, repoInformer, true)
+	repoBackendOpts := []kuberepository.KubernetesBackendOption{
+		kuberepository.WithLabelSelector(a.labelSelector),
+	}
+
+	repoBackened := kuberepository.NewKubernetesBackend(client.Clientset, a.namespace, repoInformer, true, repoBackendOpts...)
 	a.repoManager = repository.NewManager(repoBackened, a.namespace, true)
 
 	gpgKeyInformerOptions := []informer.InformerOption[*corev1.ConfigMap]{
 		informer.WithListHandler[*corev1.ConfigMap](func(ctx context.Context, opts v1.ListOptions) (runtime.Object, error) {
-			return client.Clientset.CoreV1().ConfigMaps(a.namespace).List(ctx, v1.ListOptions{})
+			return client.Clientset.CoreV1().ConfigMaps(a.namespace).List(ctx, config.LabelSelector(a.labelSelector))
 		}),
 		informer.WithWatchHandler[*corev1.ConfigMap](func(ctx context.Context, opts v1.ListOptions) (watch.Interface, error) {
-			return client.Clientset.CoreV1().ConfigMaps(a.namespace).Watch(ctx, v1.ListOptions{})
+			return client.Clientset.CoreV1().ConfigMaps(a.namespace).Watch(ctx, config.LabelSelector(a.labelSelector))
 		}),
 		informer.WithAddHandler[*corev1.ConfigMap](a.handleGPGKeyCreation),
 		informer.WithUpdateHandler[*corev1.ConfigMap](a.handleGPGKeyUpdate),
@@ -488,6 +490,10 @@ func (a *Agent) Start(ctx context.Context) error {
 	}
 
 	a.emitter = event.NewEventSource(fmt.Sprintf("agent://%s", "agent-managed"))
+
+	if a.labelSelector != "" {
+		log().Infof("Agent informers are using the label selector: %s", a.labelSelector)
+	}
 
 	// Start the Application backend in the background
 	go func() {

--- a/agent/options.go
+++ b/agent/options.go
@@ -171,12 +171,12 @@ func WithIgnoreUnmanagedApps(enabled bool) AgentOption {
 	}
 }
 
-// WithAppLabelSelector sets an optional Kubernetes label selector that restricts
-// which Applications the agent watches. Only Applications matching this selector
+// WithLabelSelector sets an optional Kubernetes label selector that restricts
+// which resources the agent watches. Only resources matching this selector
 // will be listed, watched, and processed by the agent.
-func WithAppLabelSelector(selector string) AgentOption {
+func WithLabelSelector(selector string) AgentOption {
 	return func(o *Agent) error {
-		o.appLabelSelector = selector
+		o.labelSelector = selector
 		return nil
 	}
 }

--- a/cmd/argocd-agent/agent.go
+++ b/cmd/argocd-agent/agent.go
@@ -98,7 +98,7 @@ func NewAgentRunCommand() *cobra.Command {
 		// Allowed namespaces for filtering applications
 		allowedNamespaces []string
 
-		appLabelSelector string
+		labelSelector string
 
 		// Redis TLS configuration
 		redisTLSEnabled      bool
@@ -298,7 +298,7 @@ func NewAgentRunCommand() *cobra.Command {
 			agentOpts = append(agentOpts, agent.WithDestinationBasedMapping(destinationBasedMapping))
 			agentOpts = append(agentOpts, agent.WithIgnoreUnmanagedApps(ignoreUnmanagedApps))
 			agentOpts = append(agentOpts, agent.WithAllowedNamespaces(allowedNamespaces...))
-			agentOpts = append(agentOpts, agent.WithAppLabelSelector(appLabelSelector))
+			agentOpts = append(agentOpts, agent.WithLabelSelector(labelSelector))
 
 			if metricsPort > 0 {
 				agentOpts = append(agentOpts, agent.WithMetricsPort(metricsPort))
@@ -450,9 +450,9 @@ func NewAgentRunCommand() *cobra.Command {
 		env.StringSliceWithDefault("ARGOCD_AGENT_ALLOWED_NAMESPACES", nil, []string{}),
 		"List of additional namespaces the agent is allowed to manage applications in (used with applications in any namespace feature)")
 
-	command.Flags().StringVar(&appLabelSelector, "app-label-selector",
-		env.StringWithDefault("ARGOCD_AGENT_APP_LABEL_SELECTOR", nil, ""),
-		"Kubernetes label selector to restrict which Applications the agent watches")
+	command.Flags().StringVar(&labelSelector, "label-selector",
+		env.StringWithDefault("ARGOCD_AGENT_LABEL_SELECTOR", nil, ""),
+		"Kubernetes label selector to restrict which resources the agent watches")
 
 	command.Flags().StringVar(&kubeConfig, "kubeconfig", "", "Path to a kubeconfig file to use")
 	command.Flags().StringVar(&kubeContext, "kubecontext", "", "Override the default kube context")

--- a/cmd/argocd-agent/principal.go
+++ b/cmd/argocd-agent/principal.go
@@ -108,7 +108,7 @@ func NewPrincipalRunCommand() *cobra.Command {
 		otlpInsecure bool
 
 		destinationBasedMapping bool
-		appLabelSelector        string
+		labelSelector           string
 
 		enableSelfClusterRegistration bool
 		selfRegClientCertSecretName   string
@@ -370,7 +370,7 @@ func NewPrincipalRunCommand() *cobra.Command {
 			}
 			opts = append(opts, principal.WithHealthzPort(healthzPort))
 			opts = append(opts, principal.WithDestinationBasedMapping(destinationBasedMapping))
-			opts = append(opts, principal.WithAppLabelSelector(appLabelSelector))
+			opts = append(opts, principal.WithLabelSelector(labelSelector))
 			opts = append(opts, principal.WithMaxGRPCMessageSize(maxGRPCMessageSize))
 			opts = append(opts, principal.WithEventProcessors(int64(numEventProcessors)))
 
@@ -650,9 +650,9 @@ func NewPrincipalRunCommand() *cobra.Command {
 		env.BoolWithDefault("ARGOCD_PRINCIPAL_DESTINATION_BASED_MAPPING", false),
 		"Map applications to agents based on spec.destination.name instead of namespace")
 
-	command.Flags().StringVar(&appLabelSelector, "app-label-selector",
-		env.StringWithDefault("ARGOCD_PRINCIPAL_APP_LABEL_SELECTOR", nil, ""),
-		"Kubernetes label selector to restrict which Applications the principal watches")
+	command.Flags().StringVar(&labelSelector, "label-selector",
+		env.StringWithDefault("ARGOCD_PRINCIPAL_LABEL_SELECTOR", nil, ""),
+		"Kubernetes label selector to restrict which resources the principal watches")
 
 	command.Flags().StringVar(&kubeConfig, "kubeconfig", "", "Path to a kubeconfig file to use")
 	command.Flags().StringVar(&kubeContext, "kubecontext", "", "Override the default kube context")

--- a/docs/configuration/reference/agent.md
+++ b/docs/configuration/reference/agent.md
@@ -407,16 +407,16 @@ Enable the resource proxy to allow access to live resources on this agent cluste
 
 | | |
 |---|---|
-| **CLI Flag** | `--app-label-selector` |
-| **Environment Variable** | `ARGOCD_AGENT_APP_LABEL_SELECTOR` |
-| **ConfigMap Entry** | `agent.app-label-selector` |
+| **CLI Flag** | `--label-selector` |
+| **Environment Variable** | `ARGOCD_AGENT_LABEL_SELECTOR` |
+| **ConfigMap Entry** | `agent.label-selector` |
 | **Type** | String |
 | **Default** | `""` (no additional filtering) |
 
-Kubernetes label selector that restricts which Applications the agent watches.
-Only Applications matching this selector will be listed, watched, and processed
+Kubernetes label selector that restricts which resources the agent watches.
+Only resources matching this selector will be listed, watched, and processed
 by the agent. This is combined with the default selector that already excludes
-applications with the ignore sync label.
+resources with the ignore sync label.
 
 ## Kubernetes Configuration
 

--- a/docs/configuration/reference/agent.md
+++ b/docs/configuration/reference/agent.md
@@ -401,9 +401,9 @@ Enable the resource proxy to allow access to live resources on this agent cluste
 - Performance optimization when live resource viewing is not needed
 - Troubleshooting resource proxy related issues
 
-## Application Filtering
+## Resource Filtering
 
-### Application Label Selector
+### Label Selector
 
 | | |
 |---|---|

--- a/docs/configuration/reference/principal.md
+++ b/docs/configuration/reference/principal.md
@@ -103,16 +103,16 @@ Labels to apply to auto-created namespaces.
 
 | | |
 |---|---|
-| **CLI Flag** | `--app-label-selector` |
-| **Environment Variable** | `ARGOCD_PRINCIPAL_APP_LABEL_SELECTOR` |
-| **ConfigMap Entry** | `principal.app-label-selector` |
+| **CLI Flag** | `--label-selector` |
+| **Environment Variable** | `ARGOCD_PRINCIPAL_LABEL_SELECTOR` |
+| **ConfigMap Entry** | `principal.label-selector` |
 | **Type** | String |
 | **Default** | `""` (no additional filtering) |
 
-Kubernetes label selector that restricts which Applications the principal
-watches. Only Applications matching this selector will be listed, watched, and
+Kubernetes label selector that restricts which resources the principal
+watches. Only resources matching this selector will be listed, watched, and
 processed by the principal. This is combined with the default selector that
-already excludes applications with the ignore sync label.
+already excludes resources with the ignore sync label.
 
 ## TLS Configuration
 

--- a/docs/configuration/reference/principal.md
+++ b/docs/configuration/reference/principal.md
@@ -97,9 +97,9 @@ Labels to apply to auto-created namespaces.
 
 **Example:** `managed-by=argocd-agent,environment=production`
 
-## Application Filtering
+## Resource Filtering
 
-### Application Label Selector
+### Label Selector
 
 | | |
 |---|---|

--- a/install/helm-repo/argocd-agent-agent/README.md
+++ b/install/helm-repo/argocd-agent-agent/README.md
@@ -27,7 +27,6 @@ Kubernetes: `>=1.24.0-0`
 | affinity | object | `{}` | Affinity rules for the agent Pod. |
 | agentMode | string | `"autonomous"` | Agent mode of operation. |
 | allowedNamespaces | string | `""` | Comma-separated list of additional namespaces the agent is allowed to manage applications in (used with applications in any namespace feature). Supports glob patterns (e.g., "team-*,prod-*"). |
-| appLabelSelector | string | `""` | Kubernetes label selector to restrict which Applications the agent watches. Only matching Applications will be listed, watched, and processed. |
 | argoCdRedisPasswordKey | string | `"auth"` | ArgoCD Redis password key. |
 | argoCdRedisSecretName | string | `"argocd-redis"` | ArgoCD Redis password secret name. |
 | auth | string | `"mtls:any"` | Authentication mode for connecting to the principal. |
@@ -42,6 +41,7 @@ Kubernetes: `>=1.24.0-0`
 | image.repository | string | `"ghcr.io/argoproj-labs/argocd-agent/argocd-agent"` | Container image repository for the agent. |
 | image.tag | string | `"latest"` | Container image tag for the agent. |
 | keepAliveInterval | string | `"50s"` | Keep-alive interval for connections. |
+| labelSelector | string | `""` | Kubernetes label selector to restrict which resources the agent watches. Only matching resources will be listed, watched, and processed. |
 | logFormat | string | `"text"` | Log format for the agent (text or json). |
 | logLevel | string | `"info"` | Log level for the agent. |
 | metricsPort | string | `"8181"` | Metrics server port exposed by the agent. |

--- a/install/helm-repo/argocd-agent-agent/templates/agent-deployment.yaml
+++ b/install/helm-repo/argocd-agent-agent/templates/agent-deployment.yaml
@@ -237,11 +237,11 @@ spec:
                 name: {{ include "argocd-agent-agent.paramsConfigMapName" . }}
                 key: agent.allowed-namespaces
                 optional: true
-          - name: ARGOCD_AGENT_APP_LABEL_SELECTOR
+          - name: ARGOCD_AGENT_LABEL_SELECTOR
             valueFrom:
               configMapKeyRef:
                 name: {{ include "argocd-agent-agent.paramsConfigMapName" . }}
-                key: agent.app-label-selector
+                key: agent.label-selector
                 optional: true
           name: argocd-agent-agent
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/install/helm-repo/argocd-agent-agent/templates/agent-params-cm.yaml
+++ b/install/helm-repo/argocd-agent-agent/templates/agent-params-cm.yaml
@@ -111,10 +111,10 @@ data:
   # agent.allowed-namespaces: Additional namespaces the agent can manage.
   # Default: ""
   agent.allowed-namespaces: {{ .Values.allowedNamespaces | quote }}
-  # agent.app-label-selector: Kubernetes label selector to restrict which
-  # Applications the agent watches.
+  # agent.label-selector: Kubernetes label selector to restrict which
+  # resources the agent watches.
   # Default: ""
-  agent.app-label-selector: {{ .Values.appLabelSelector | quote }}
+  agent.label-selector: {{ .Values.labelSelector | quote }}
   # agent.redis.tls.enabled: Whether to enable TLS for Redis connections.
   # Default: true
   agent.redis.tls.enabled: {{ .Values.redisTLS.enabled }}

--- a/install/helm-repo/argocd-agent-agent/values.schema.json
+++ b/install/helm-repo/argocd-agent-agent/values.schema.json
@@ -27,10 +27,10 @@
       "title": "argoCdRedisPasswordKey",
       "type": "string"
     },
-    "appLabelSelector": {
+    "labelSelector": {
       "default": "",
-      "description": "Kubernetes label selector to restrict which Applications the agent watches. Only matching Applications will be listed, watched, and processed.",
-      "title": "appLabelSelector",
+      "description": "Kubernetes label selector to restrict which resources the agent watches. Only matching resources will be listed, watched, and processed.",
+      "title": "labelSelector",
       "type": "string"
     },
     "argoCdRedisSecretName": {

--- a/install/helm-repo/argocd-agent-agent/values.yaml
+++ b/install/helm-repo/argocd-agent-agent/values.yaml
@@ -155,10 +155,10 @@ destinationBasedMapping: false
 # Used with destination-based mapping.
 createNamespace: false
 
-## @section Application Filtering
-# -- Kubernetes label selector to restrict which Applications the agent watches.
-# Only matching Applications will be listed, watched, and processed.
-appLabelSelector: ""
+## @section Resource Filtering
+# -- Kubernetes label selector to restrict which resources the agent watches.
+# Only matching resources will be listed, watched, and processed.
+labelSelector: ""
 
 ## @section Redis TLS
 # -- Redis TLS configuration.

--- a/install/kubernetes/agent/agent-deployment.yaml
+++ b/install/kubernetes/agent/agent-deployment.yaml
@@ -206,11 +206,11 @@ spec:
                 name: argocd-agent-params
                 key: agent.allowed-namespaces
                 optional: true
-          - name: ARGOCD_AGENT_APP_LABEL_SELECTOR
+          - name: ARGOCD_AGENT_LABEL_SELECTOR
             valueFrom:
               configMapKeyRef:
                 name: argocd-agent-params
-                key: agent.app-label-selector
+                key: agent.label-selector
                 optional: true
           - name: ARGOCD_AGENT_INSECURE_PLAINTEXT
             valueFrom:

--- a/install/kubernetes/agent/agent-params-cm.yaml
+++ b/install/kubernetes/agent/agent-params-cm.yaml
@@ -116,11 +116,11 @@ data:
   # the agent is allowed to manage applications in. Supports glob patterns.
   # Default: ""
   agent.allowed-namespaces: ""
-  # agent.app-label-selector: Kubernetes label selector to restrict which
-  # Applications the agent watches. Only matching Applications will be
+  # agent.label-selector: Kubernetes label selector to restrict which
+  # resources the agent watches. Only matching resources will be
   # listed, watched, and processed.
   # Default: ""
-  agent.app-label-selector: ""
+  agent.label-selector: ""
   # agent.redis.tls.enabled: Whether to enable TLS for Redis connections.
   # Default: false
   agent.redis.tls.enabled: "false"

--- a/install/kubernetes/principal/principal-deployment.yaml
+++ b/install/kubernetes/principal/principal-deployment.yaml
@@ -249,11 +249,11 @@ spec:
                 name: argocd-agent-params
                 key: principal.destination-based-mapping
                 optional: true
-          - name: ARGOCD_PRINCIPAL_APP_LABEL_SELECTOR
+          - name: ARGOCD_PRINCIPAL_LABEL_SELECTOR
             valueFrom:
               configMapKeyRef:
                 name: argocd-agent-params
-                key: principal.app-label-selector
+                key: principal.label-selector
                 optional: true
           - name: ARGOCD_PRINCIPAL_INSECURE_PLAINTEXT
             valueFrom:

--- a/install/kubernetes/principal/principal-params-cm.yaml
+++ b/install/kubernetes/principal/principal-params-cm.yaml
@@ -168,12 +168,12 @@ data:
   # for routing applications to agents based on spec.destination.name instead of namespace.
   # Default: false
   principal.destination-based-mapping: "false"
-  # principal.app-label-selector: Kubernetes label selector to restrict which
-  # Applications the principal watches. Only matching Applications will be
+  # principal.label-selector: Kubernetes label selector to restrict which
+  # resources the principal watches. Only matching resources will be
   # listed, watched, and processed. Used in hybrid architectures where a
   # traditional app-controller coexists with the principal.
   # Default: ""
-  principal.app-label-selector: ""
+  principal.label-selector: ""
   # principal.redis.tls.enabled: Whether to enable TLS for Redis connections.
   # Default: false
   principal.redis.tls.enabled: "false"

--- a/internal/backend/kubernetes/application/kubernetes.go
+++ b/internal/backend/kubernetes/application/kubernetes.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/argoproj-labs/argocd-agent/internal/backend"
+	"github.com/argoproj-labs/argocd-agent/internal/config"
 	"github.com/argoproj-labs/argocd-agent/internal/informer"
 	"github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
 	appclientset "github.com/argoproj/argo-cd/v3/pkg/client/clientset/versioned"
@@ -49,9 +50,11 @@ type KubernetesBackend struct {
 	// namespace is not currently read, is not guaranteed to be non-empty, and is not guaranteed to contain the source of Argo CD Application CRs in all cases
 	namespace string
 	usePatch  bool
+
+	labelSelector string
 }
 
-func NewKubernetesBackend(appClient appclientset.Interface, namespace string, appInformer informer.InformerInterface, usePatch bool) *KubernetesBackend {
+func NewKubernetesBackend(appClient appclientset.Interface, namespace string, appInformer informer.InformerInterface, usePatch bool, opts ...KubernetesBackendOption) *KubernetesBackend {
 	be := &KubernetesBackend{
 		appClient:   appClient,
 		appInformer: appInformer,
@@ -61,21 +64,35 @@ func NewKubernetesBackend(appClient appclientset.Interface, namespace string, ap
 	if specificInformer, ok := appInformer.(*informer.Informer[*v1alpha1.Application]); ok {
 		be.appLister = specificInformer.Lister()
 	}
+
+	for _, opt := range opts {
+		opt(be)
+	}
 	return be
+}
+
+type KubernetesBackendOption func(*KubernetesBackend)
+
+func WithLabelSelector(labelSelector string) KubernetesBackendOption {
+	return func(be *KubernetesBackend) {
+		be.labelSelector = labelSelector
+	}
 }
 
 func (be *KubernetesBackend) List(ctx context.Context, selector backend.ApplicationSelector) ([]v1alpha1.Application, error) {
 	res := make([]v1alpha1.Application, 0)
+
+	listOptions := config.LabelSelector(be.labelSelector)
 	if len(selector.Namespaces) > 0 {
 		for _, ns := range selector.Namespaces {
-			l, err := be.appClient.ArgoprojV1alpha1().Applications(ns).List(ctx, v1.ListOptions{})
+			l, err := be.appClient.ArgoprojV1alpha1().Applications(ns).List(ctx, listOptions)
 			if err != nil {
 				return nil, err
 			}
 			res = append(res, l.Items...)
 		}
 	} else {
-		l, err := be.appClient.ArgoprojV1alpha1().Applications("").List(ctx, v1.ListOptions{})
+		l, err := be.appClient.ArgoprojV1alpha1().Applications("").List(ctx, listOptions)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/backend/kubernetes/application/kubernetes_test.go
+++ b/internal/backend/kubernetes/application/kubernetes_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"github.com/argoproj-labs/argocd-agent/internal/backend"
+	"github.com/argoproj-labs/argocd-agent/internal/config"
 	"github.com/argoproj-labs/argocd-agent/internal/informer"
 	"github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
 	fakeappclient "github.com/argoproj/argo-cd/v3/pkg/client/clientset/versioned/fake"
@@ -32,6 +33,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/watch"
+	k8stesting "k8s.io/client-go/testing"
 	"k8s.io/client-go/tools/cache"
 )
 
@@ -46,7 +48,16 @@ func Test_NewKubernetes(t *testing.T) {
 		assert.NotNil(t, k)
 		assert.False(t, k.SupportsPatch())
 	})
-
+	t.Run("New with label selector option", func(t *testing.T) {
+		k := NewKubernetesBackend(nil, "", nil, true, WithLabelSelector("env=prod"))
+		assert.NotNil(t, k)
+		assert.Equal(t, "env=prod", k.labelSelector)
+	})
+	t.Run("New with empty label selector option", func(t *testing.T) {
+		k := NewKubernetesBackend(nil, "", nil, true, WithLabelSelector(""))
+		assert.NotNil(t, k)
+		assert.Empty(t, k.labelSelector)
+	})
 }
 
 func mkApps() []runtime.Object {
@@ -77,6 +88,14 @@ func Test_List(t *testing.T) {
 		apps, err := k.List(context.TODO(), backend.ApplicationSelector{})
 		require.NoError(t, err)
 		assert.Len(t, apps, 10)
+
+		actions := fakeAppC.Actions()
+		require.NotEmpty(t, actions)
+		listAction, ok := actions[0].(k8stesting.ListAction)
+		require.True(t, ok)
+		restrictions := listAction.GetListRestrictions()
+		expected := config.LabelSelector("")
+		assert.Equal(t, expected.LabelSelector, restrictions.Labels.String())
 	})
 	t.Run("Apps with matching selector", func(t *testing.T) {
 		fakeAppC := fakeappclient.NewSimpleClientset(apps...)
@@ -92,6 +111,19 @@ func Test_List(t *testing.T) {
 		apps, err := k.List(context.TODO(), backend.ApplicationSelector{Namespaces: []string{"ns11", "ns12"}})
 		require.NoError(t, err)
 		assert.Len(t, apps, 0)
+	})
+	t.Run("List uses custom label selector", func(t *testing.T) {
+		fakeAppC := fakeappclient.NewSimpleClientset()
+		k := NewKubernetesBackend(fakeAppC, "", nil, true, WithLabelSelector("env=prod"))
+		_, err := k.List(context.TODO(), backend.ApplicationSelector{})
+		require.NoError(t, err)
+		actions := fakeAppC.Actions()
+		require.NotEmpty(t, actions)
+		listAction, ok := actions[0].(k8stesting.ListAction)
+		require.True(t, ok)
+		restrictions := listAction.GetListRestrictions()
+		expected := config.LabelSelector("env=prod")
+		assert.Equal(t, expected.LabelSelector, restrictions.Labels.String())
 	})
 }
 

--- a/internal/backend/kubernetes/applicationset/applicationset.go
+++ b/internal/backend/kubernetes/applicationset/applicationset.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/argoproj-labs/argocd-agent/internal/backend"
+	"github.com/argoproj-labs/argocd-agent/internal/config"
 	"github.com/argoproj-labs/argocd-agent/internal/informer"
 	"github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
 	appclientset "github.com/argoproj/argo-cd/v3/pkg/client/clientset/versioned"
@@ -30,16 +31,29 @@ var _ backend.ApplicationSet = &KubernetesBackend{}
 
 // KubernetesBackend implements backend.ApplicationSet using a Kubernetes client for Argo CD ApplicationSet CRDs.
 type KubernetesBackend struct {
-	appClient appclientset.Interface
-	informer  informer.InformerInterface
-	namespace string
+	appClient     appclientset.Interface
+	informer      informer.InformerInterface
+	namespace     string
+	labelSelector string
 }
 
-func NewKubernetesBackend(appClient appclientset.Interface, namespace string, inf informer.InformerInterface) *KubernetesBackend {
-	return &KubernetesBackend{
+func NewKubernetesBackend(appClient appclientset.Interface, namespace string, inf informer.InformerInterface, opts ...KubernetesBackendOption) *KubernetesBackend {
+	be := &KubernetesBackend{
 		appClient: appClient,
 		informer:  inf,
 		namespace: namespace,
+	}
+	for _, opt := range opts {
+		opt(be)
+	}
+	return be
+}
+
+type KubernetesBackendOption func(*KubernetesBackend)
+
+func WithLabelSelector(labelSelector string) KubernetesBackendOption {
+	return func(be *KubernetesBackend) {
+		be.labelSelector = labelSelector
 	}
 }
 
@@ -50,7 +64,8 @@ func (be *KubernetesBackend) List(ctx context.Context, selector backend.Applicat
 	}
 	var result []v1alpha1.ApplicationSet
 	for _, ns := range namespaces {
-		l, err := be.appClient.ArgoprojV1alpha1().ApplicationSets(ns).List(ctx, v1.ListOptions{})
+		listOptions := config.LabelSelector(be.labelSelector)
+		l, err := be.appClient.ArgoprojV1alpha1().ApplicationSets(ns).List(ctx, listOptions)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/backend/kubernetes/applicationset/applicationset_test.go
+++ b/internal/backend/kubernetes/applicationset/applicationset_test.go
@@ -1,0 +1,74 @@
+// Copyright 2026 The argocd-agent Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package applicationset
+
+import (
+	"context"
+	"testing"
+
+	"github.com/argoproj-labs/argocd-agent/internal/backend"
+	"github.com/argoproj-labs/argocd-agent/internal/config"
+	fakeappclient "github.com/argoproj/argo-cd/v3/pkg/client/clientset/versioned/fake"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	k8stesting "k8s.io/client-go/testing"
+)
+
+func Test_NewKubernetesBackend(t *testing.T) {
+	t.Run("New with label selector option", func(t *testing.T) {
+		k := NewKubernetesBackend(nil, "argocd", nil, WithLabelSelector("env=prod"))
+		assert.NotNil(t, k)
+		assert.Equal(t, "env=prod", k.labelSelector)
+	})
+	t.Run("New with empty label selector option", func(t *testing.T) {
+		k := NewKubernetesBackend(nil, "argocd", nil, WithLabelSelector(""))
+		assert.NotNil(t, k)
+		assert.Empty(t, k.labelSelector)
+	})
+	t.Run("New without options", func(t *testing.T) {
+		k := NewKubernetesBackend(nil, "argocd", nil)
+		assert.NotNil(t, k)
+		assert.Empty(t, k.labelSelector)
+	})
+}
+
+func Test_List(t *testing.T) {
+	t.Run("List uses default label selector when no custom selector", func(t *testing.T) {
+		fakeAppC := fakeappclient.NewSimpleClientset()
+		be := NewKubernetesBackend(fakeAppC, "argocd", nil)
+		_, err := be.List(context.TODO(), backend.ApplicationSetSelector{})
+		require.NoError(t, err)
+		actions := fakeAppC.Actions()
+		require.NotEmpty(t, actions)
+		listAction, ok := actions[0].(k8stesting.ListAction)
+		require.True(t, ok)
+		restrictions := listAction.GetListRestrictions()
+		expected := config.LabelSelector("")
+		assert.Equal(t, expected.LabelSelector, restrictions.Labels.String())
+	})
+	t.Run("List uses custom label selector", func(t *testing.T) {
+		fakeAppC := fakeappclient.NewSimpleClientset()
+		be := NewKubernetesBackend(fakeAppC, "argocd", nil, WithLabelSelector("env=prod"))
+		_, err := be.List(context.TODO(), backend.ApplicationSetSelector{})
+		require.NoError(t, err)
+		actions := fakeAppC.Actions()
+		require.NotEmpty(t, actions)
+		listAction, ok := actions[0].(k8stesting.ListAction)
+		require.True(t, ok)
+		restrictions := listAction.GetListRestrictions()
+		expected := config.LabelSelector("env=prod")
+		assert.Equal(t, expected.LabelSelector, restrictions.Labels.String())
+	})
+}

--- a/internal/backend/kubernetes/appproject/kubernetes.go
+++ b/internal/backend/kubernetes/appproject/kubernetes.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/argoproj-labs/argocd-agent/internal/backend"
+	"github.com/argoproj-labs/argocd-agent/internal/config"
 	"github.com/argoproj-labs/argocd-agent/internal/informer"
 	"github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
 	appclientset "github.com/argoproj/argo-cd/v3/pkg/client/clientset/versioned"
@@ -46,20 +47,36 @@ type KubernetesBackend struct {
 	// namespace to contain the source of Argo CD AppProject CRs in all cases, mainly used by agents
 	namespace string
 	usePatch  bool
+
+	labelSelector string
 }
 
-func NewKubernetesBackend(appClient appclientset.Interface, namespace string, appProjectInformer informer.InformerInterface, usePatch bool) *KubernetesBackend {
-	return &KubernetesBackend{
+func NewKubernetesBackend(appClient appclientset.Interface, namespace string, appProjectInformer informer.InformerInterface, usePatch bool, opts ...KubernetesBackendOption) *KubernetesBackend {
+	be := &KubernetesBackend{
 		appClient:          appClient,
 		appProjectInformer: appProjectInformer,
 		namespace:          namespace,
 		usePatch:           usePatch,
 	}
+
+	for _, opt := range opts {
+		opt(be)
+	}
+	return be
+}
+
+type KubernetesBackendOption func(*KubernetesBackend)
+
+func WithLabelSelector(labelSelector string) KubernetesBackendOption {
+	return func(be *KubernetesBackend) {
+		be.labelSelector = labelSelector
+	}
 }
 
 func (be *KubernetesBackend) List(ctx context.Context, selector backend.AppProjectSelector) ([]v1alpha1.AppProject, error) {
 
-	l, err := be.appClient.ArgoprojV1alpha1().AppProjects(be.namespace).List(ctx, v1.ListOptions{})
+	listOptions := config.LabelSelector(be.labelSelector)
+	l, err := be.appClient.ArgoprojV1alpha1().AppProjects(be.namespace).List(ctx, listOptions)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/backend/kubernetes/appproject/kubernetes_test.go
+++ b/internal/backend/kubernetes/appproject/kubernetes_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"github.com/argoproj-labs/argocd-agent/internal/backend"
+	"github.com/argoproj-labs/argocd-agent/internal/config"
 	"github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
 	fakeclient "github.com/argoproj/argo-cd/v3/pkg/client/clientset/versioned/fake"
 	"github.com/stretchr/testify/assert"
@@ -28,6 +29,7 @@ import (
 	"github.com/wI2L/jsondiff"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	k8stesting "k8s.io/client-go/testing"
 )
 
 func Test_NewKubernetes(t *testing.T) {
@@ -41,7 +43,16 @@ func Test_NewKubernetes(t *testing.T) {
 		assert.NotNil(t, k)
 		assert.False(t, k.SupportsPatch())
 	})
-
+	t.Run("New with label selector option", func(t *testing.T) {
+		k := NewKubernetesBackend(nil, "", nil, true, WithLabelSelector("env=prod"))
+		assert.NotNil(t, k)
+		assert.Equal(t, "env=prod", k.labelSelector)
+	})
+	t.Run("New with empty label selector option", func(t *testing.T) {
+		k := NewKubernetesBackend(nil, "", nil, true, WithLabelSelector(""))
+		assert.NotNil(t, k)
+		assert.Empty(t, k.labelSelector)
+	})
 }
 
 func mkAppProjects() []runtime.Object {
@@ -161,6 +172,27 @@ func Test_List(t *testing.T) {
 		projectList, err := be.List(context.TODO(), backend.AppProjectSelector{})
 		require.NoError(t, err)
 		assert.Len(t, projectList, 10)
+
+		actions := fakeAppClient.Actions()
+		require.NotEmpty(t, actions)
+		listAction, ok := actions[0].(k8stesting.ListAction)
+		require.True(t, ok)
+		restrictions := listAction.GetListRestrictions()
+		expected := config.LabelSelector("")
+		assert.Equal(t, expected.LabelSelector, restrictions.Labels.String())
 	})
 
+	t.Run("List uses custom label selector", func(t *testing.T) {
+		fakeAppClient := fakeclient.NewSimpleClientset()
+		be := NewKubernetesBackend(fakeAppClient, "argocd", nil, true, WithLabelSelector("env=prod"))
+		_, err := be.List(context.TODO(), backend.AppProjectSelector{})
+		require.NoError(t, err)
+		actions := fakeAppClient.Actions()
+		require.NotEmpty(t, actions)
+		listAction, ok := actions[0].(k8stesting.ListAction)
+		require.True(t, ok)
+		restrictions := listAction.GetListRestrictions()
+		expected := config.LabelSelector("env=prod")
+		assert.Equal(t, expected.LabelSelector, restrictions.Labels.String())
+	})
 }

--- a/internal/backend/kubernetes/repository/kubernetes.go
+++ b/internal/backend/kubernetes/repository/kubernetes.go
@@ -28,7 +28,6 @@ import (
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
 )
@@ -48,21 +47,40 @@ type KubernetesBackend struct {
 	namespace string
 	// usePatch is used to indicate whether the KubernetesBackend should use JSON Patch for updates
 	usePatch bool
+
+	labelSelector string
 }
 
-func NewKubernetesBackend(kubeclient kubernetes.Interface, namespace string, repoInformer informer.InformerInterface, usePatch bool) *KubernetesBackend {
-	return &KubernetesBackend{
+func NewKubernetesBackend(kubeclient kubernetes.Interface, namespace string, repoInformer informer.InformerInterface, usePatch bool, opts ...KubernetesBackendOption) *KubernetesBackend {
+	be := &KubernetesBackend{
 		kubeclient:         kubeclient,
 		repositoryInformer: repoInformer,
 		namespace:          namespace,
 		usePatch:           usePatch,
 	}
+	for _, opt := range opts {
+		opt(be)
+	}
+	return be
+}
+
+type KubernetesBackendOption func(*KubernetesBackend)
+
+func WithLabelSelector(labelSelector string) KubernetesBackendOption {
+	return func(be *KubernetesBackend) {
+		be.labelSelector = labelSelector
+	}
 }
 
 func (be *KubernetesBackend) List(ctx context.Context, selector backend.RepositorySelector) ([]corev1.Secret, error) {
-	l, err := be.kubeclient.CoreV1().Secrets(selector.Namespace).List(ctx, v1.ListOptions{
-		LabelSelector: labels.SelectorFromSet(selector.Labels).String(),
-	})
+	labelSelector := common.LabelKeySecretType + "=" + common.LabelValueSecretTypeRepository
+
+	if be.labelSelector != "" {
+		labelSelector = fmt.Sprintf("%s,%s", labelSelector, be.labelSelector)
+	}
+
+	listOptions := config.LabelSelector(labelSelector)
+	l, err := be.kubeclient.CoreV1().Secrets(selector.Namespace).List(ctx, listOptions)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/backend/kubernetes/repository/kubernetes_test.go
+++ b/internal/backend/kubernetes/repository/kubernetes_test.go
@@ -15,12 +15,19 @@
 package repository
 
 import (
+	"context"
+	"fmt"
 	"testing"
 
+	"github.com/argoproj-labs/argocd-agent/internal/backend"
+	"github.com/argoproj-labs/argocd-agent/internal/config"
 	"github.com/argoproj/argo-cd/v3/common"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
 )
 
 func Test_isValidRepositorySecret(t *testing.T) {
@@ -270,4 +277,35 @@ func Test_isValidRepositorySecret(t *testing.T) {
 			assert.Equal(t, tt.want, got, "isValidRepositorySecret() validation failed")
 		})
 	}
+}
+
+func Test_List(t *testing.T) {
+	t.Run("List uses repo type label and skip-sync in selector", func(t *testing.T) {
+		fakeClient := fake.NewSimpleClientset()
+		be := NewKubernetesBackend(fakeClient, "argocd", nil, true)
+		_, err := be.List(context.TODO(), backend.RepositorySelector{Namespace: "argocd"})
+		require.NoError(t, err)
+		actions := fakeClient.Actions()
+		require.NotEmpty(t, actions)
+		listAction, ok := actions[0].(k8stesting.ListAction)
+		require.True(t, ok)
+		restrictions := listAction.GetListRestrictions()
+		expectedBase := fmt.Sprintf("%s=%s", common.LabelKeySecretType, common.LabelValueSecretTypeRepository)
+		expected := config.LabelSelector(expectedBase)
+		assert.Equal(t, expected.LabelSelector, restrictions.Labels.String())
+	})
+	t.Run("List appends custom label selector", func(t *testing.T) {
+		fakeClient := fake.NewSimpleClientset()
+		be := NewKubernetesBackend(fakeClient, "argocd", nil, true, WithLabelSelector("env=prod"))
+		_, err := be.List(context.TODO(), backend.RepositorySelector{Namespace: "argocd"})
+		require.NoError(t, err)
+		actions := fakeClient.Actions()
+		require.NotEmpty(t, actions)
+		listAction, ok := actions[0].(k8stesting.ListAction)
+		require.True(t, ok)
+		restrictions := listAction.GetListRestrictions()
+		expectedBase := fmt.Sprintf("%s=%s,%s", common.LabelKeySecretType, common.LabelValueSecretTypeRepository, "env=prod")
+		expected := config.LabelSelector(expectedBase)
+		assert.Equal(t, expected.LabelSelector, restrictions.Labels.String())
+	})
 }

--- a/internal/config/selectors.go
+++ b/internal/config/selectors.go
@@ -13,10 +13,10 @@ func DefaultLabelSelector() v1.ListOptions {
 	}
 }
 
-// AppLabelSelector returns a ListOptions combining the default label selector
+// LabelSelector returns a ListOptions combining the default label selector
 // with an additional user-provided selector. The two selectors are AND-ed
 // together (comma-separated in Kubernetes label selector syntax).
-func AppLabelSelector(extra string) v1.ListOptions {
+func LabelSelector(extra string) v1.ListOptions {
 	base := fmt.Sprintf("%s!=%s", SkipSyncLabel, "true")
 	if extra != "" {
 		base = base + "," + extra

--- a/internal/config/selectors_test.go
+++ b/internal/config/selectors_test.go
@@ -36,21 +36,21 @@ func TestDefaultLabelSelector(t *testing.T) {
 		"DefaultLabelSelector should return a v1.ListOptions")
 }
 
-func TestAppLabelSelector(t *testing.T) {
+func TestLabelSelector(t *testing.T) {
 	t.Run("empty extra selector returns default only", func(t *testing.T) {
-		selector := AppLabelSelector("")
+		selector := LabelSelector("")
 		expected := fmt.Sprintf("%s!=true", SkipSyncLabel)
 		assert.Equal(t, expected, selector.LabelSelector)
 	})
 	t.Run("extra selector is appended", func(t *testing.T) {
 		extra := "argocd-agent.argoproj-labs.io/managed=true"
-		selector := AppLabelSelector(extra)
+		selector := LabelSelector(extra)
 		expected := fmt.Sprintf("%s!=true,%s", SkipSyncLabel, extra)
 		assert.Equal(t, expected, selector.LabelSelector)
 	})
 	t.Run("complex extra selector", func(t *testing.T) {
 		extra := "env=prod,team=platform"
-		selector := AppLabelSelector(extra)
+		selector := LabelSelector(extra)
 		expected := fmt.Sprintf("%s!=true,%s", SkipSyncLabel, extra)
 		assert.Equal(t, expected, selector.LabelSelector)
 	})

--- a/principal/options.go
+++ b/principal/options.go
@@ -88,11 +88,10 @@ type ServerOptions struct {
 	// spec.destination.name instead of the application's namespace
 	destinationBasedMapping bool
 
-	// appLabelSelector is an optional Kubernetes label selector that restricts
-	// which Applications the principal watches. When set, only Applications
-	// matching this selector are processed. This enables hybrid architectures
-	// where a traditional app-controller and the principal coexist.
-	appLabelSelector string
+	// labelSelector is an optional Kubernetes label selector that restricts
+	// which resources the principal watches. Only resources matching this selector
+	// will be listed, watched, and processed by the principal.
+	labelSelector string
 
 	selfAgentRegistrationEnabled bool
 	resourceProxyAddress         string
@@ -595,14 +594,14 @@ func WithDestinationBasedMapping(enabled bool) ServerOption {
 	}
 }
 
-// WithAppLabelSelector sets an optional Kubernetes label selector that restricts
-// which Applications the principal watches. Only Applications matching this
+// WithLabelSelector sets an optional Kubernetes label selector that restricts
+// which resources the principal watches. Only resources matching this selector
 // selector will be listed, watched, and processed by the principal. This is
 // used in hybrid architectures where a traditional app-controller coexists
 // with the principal on the same control plane.
-func WithAppLabelSelector(selector string) ServerOption {
+func WithLabelSelector(selector string) ServerOption {
 	return func(o *Server) error {
-		o.options.appLabelSelector = selector
+		o.options.labelSelector = selector
 		return nil
 	}
 }

--- a/principal/server.go
+++ b/principal/server.go
@@ -289,18 +289,12 @@ func NewServer(ctx context.Context, kubeClient *kube.KubernetesClient, namespace
 	}
 
 	appFilters := s.defaultAppFilterChain()
-
-	appListOpts := config.AppLabelSelector(s.options.appLabelSelector)
-	if s.options.appLabelSelector != "" {
-		log().Infof("Application informer using label selector: %s", appListOpts.LabelSelector)
-	}
-
 	appInformerOpts := []informer.InformerOption[*v1alpha1.Application]{
 		informer.WithListHandler[*v1alpha1.Application](func(ctx context.Context, opts v1.ListOptions) (runtime.Object, error) {
-			return kubeClient.ApplicationsClientset.ArgoprojV1alpha1().Applications("").List(ctx, appListOpts)
+			return kubeClient.ApplicationsClientset.ArgoprojV1alpha1().Applications("").List(ctx, config.LabelSelector(s.options.labelSelector))
 		}),
 		informer.WithWatchHandler[*v1alpha1.Application](func(ctx context.Context, opts v1.ListOptions) (watch.Interface, error) {
-			return kubeClient.ApplicationsClientset.ArgoprojV1alpha1().Applications("").Watch(ctx, appListOpts)
+			return kubeClient.ApplicationsClientset.ArgoprojV1alpha1().Applications("").Watch(ctx, config.LabelSelector(s.options.labelSelector))
 		}),
 		informer.WithAddHandler[*v1alpha1.Application](s.newAppCallback),
 		informer.WithUpdateHandler[*v1alpha1.Application](s.updateAppCallback),
@@ -317,10 +311,10 @@ func NewServer(ctx context.Context, kubeClient *kube.KubernetesClient, namespace
 
 	projInformerOpts := []informer.InformerOption[*v1alpha1.AppProject]{
 		informer.WithListHandler[*v1alpha1.AppProject](func(ctx context.Context, opts v1.ListOptions) (runtime.Object, error) {
-			return kubeClient.ApplicationsClientset.ArgoprojV1alpha1().AppProjects(namespace).List(ctx, config.DefaultLabelSelector())
+			return kubeClient.ApplicationsClientset.ArgoprojV1alpha1().AppProjects(namespace).List(ctx, config.LabelSelector(s.options.labelSelector))
 		}),
 		informer.WithWatchHandler[*v1alpha1.AppProject](func(ctx context.Context, opts v1.ListOptions) (watch.Interface, error) {
-			return kubeClient.ApplicationsClientset.ArgoprojV1alpha1().AppProjects(namespace).Watch(ctx, config.DefaultLabelSelector())
+			return kubeClient.ApplicationsClientset.ArgoprojV1alpha1().AppProjects(namespace).Watch(ctx, config.LabelSelector(s.options.labelSelector))
 		}),
 		informer.WithAddHandler[*v1alpha1.AppProject](s.newAppProjectCallback),
 		informer.WithUpdateHandler[*v1alpha1.AppProject](s.updateAppProjectCallback),
@@ -354,24 +348,34 @@ func NewServer(ctx context.Context, kubeClient *kube.KubernetesClient, namespace
 		return nil, err
 	}
 
-	s.appManager, err = application.NewApplicationManager(kubeapp.NewKubernetesBackend(kubeClient.ApplicationsClientset, s.namespace, appInformer, true), s.namespace,
+	appBackendOpts := []kubeapp.KubernetesBackendOption{
+		kubeapp.WithLabelSelector(s.options.labelSelector),
+	}
+	appBackend := kubeapp.NewKubernetesBackend(kubeClient.ApplicationsClientset, s.namespace, appInformer, true, appBackendOpts...)
+
+	s.appManager, err = application.NewApplicationManager(appBackend, s.namespace,
 		appManagerOpts...,
 	)
 	if err != nil {
 		return nil, err
 	}
 
-	s.projectManager, err = appproject.NewAppProjectManager(kubeappproject.NewKubernetesBackend(kubeClient.ApplicationsClientset, s.namespace, projectInformer, true), s.namespace, projManagerOpts...)
+	projectBackendOpts := []kubeappproject.KubernetesBackendOption{
+		kubeappproject.WithLabelSelector(s.options.labelSelector),
+	}
+	projectBackend := kubeappproject.NewKubernetesBackend(kubeClient.ApplicationsClientset, s.namespace, projectInformer, true, projectBackendOpts...)
+
+	s.projectManager, err = appproject.NewAppProjectManager(projectBackend, s.namespace, projManagerOpts...)
 	if err != nil {
 		return nil, err
 	}
 
 	appSetInformerOpts := []informer.InformerOption[*v1alpha1.ApplicationSet]{
 		informer.WithListHandler[*v1alpha1.ApplicationSet](func(ctx context.Context, opts v1.ListOptions) (runtime.Object, error) {
-			return kubeClient.ApplicationsClientset.ArgoprojV1alpha1().ApplicationSets("").List(ctx, v1.ListOptions{})
+			return kubeClient.ApplicationsClientset.ArgoprojV1alpha1().ApplicationSets("").List(ctx, config.LabelSelector(s.options.labelSelector))
 		}),
 		informer.WithWatchHandler[*v1alpha1.ApplicationSet](func(ctx context.Context, opts v1.ListOptions) (watch.Interface, error) {
-			return kubeClient.ApplicationsClientset.ArgoprojV1alpha1().ApplicationSets("").Watch(ctx, v1.ListOptions{})
+			return kubeClient.ApplicationsClientset.ArgoprojV1alpha1().ApplicationSets("").Watch(ctx, config.LabelSelector(s.options.labelSelector))
 		}),
 		informer.WithAddHandler[*v1alpha1.ApplicationSet](s.newAppSetCallback),
 		informer.WithUpdateHandler[*v1alpha1.ApplicationSet](s.updateAppSetCallback),
@@ -384,10 +388,11 @@ func NewServer(ctx context.Context, kubeClient *kube.KubernetesClient, namespace
 		return nil, err
 	}
 
-	s.appSetManager = applicationset.NewApplicationSetManager(
-		kubeappset.NewKubernetesBackend(kubeClient.ApplicationsClientset, s.namespace, appSetInformer),
-		s.namespace,
-	)
+	appSetBackendOpts := []kubeappset.KubernetesBackendOption{
+		kubeappset.WithLabelSelector(s.options.labelSelector),
+	}
+	appSetBackend := kubeappset.NewKubernetesBackend(kubeClient.ApplicationsClientset, s.namespace, appSetInformer, appSetBackendOpts...)
+	s.appSetManager = applicationset.NewApplicationSetManager(appSetBackend, s.namespace)
 
 	nsInformerOpts := []informer.InformerOption[*corev1.Namespace]{
 		informer.WithListHandler[*corev1.Namespace](func(ctx context.Context, opts v1.ListOptions) (runtime.Object, error) {
@@ -408,10 +413,10 @@ func NewServer(ctx context.Context, kubeClient *kube.KubernetesClient, namespace
 
 	repoInformerOpts := []informer.InformerOption[*corev1.Secret]{
 		informer.WithListHandler[*corev1.Secret](func(ctx context.Context, opts v1.ListOptions) (runtime.Object, error) {
-			return kubeClient.Clientset.CoreV1().Secrets(namespace).List(ctx, config.DefaultLabelSelector())
+			return kubeClient.Clientset.CoreV1().Secrets(namespace).List(ctx, config.LabelSelector(s.options.labelSelector))
 		}),
 		informer.WithWatchHandler[*corev1.Secret](func(ctx context.Context, opts v1.ListOptions) (watch.Interface, error) {
-			return kubeClient.Clientset.CoreV1().Secrets(namespace).Watch(ctx, config.DefaultLabelSelector())
+			return kubeClient.Clientset.CoreV1().Secrets(namespace).Watch(ctx, config.LabelSelector(s.options.labelSelector))
 		}),
 		informer.WithAddHandler[*corev1.Secret](s.newRepositoryCallback),
 		informer.WithUpdateHandler[*corev1.Secret](s.updateRepositoryCallback),
@@ -425,15 +430,19 @@ func NewServer(ctx context.Context, kubeClient *kube.KubernetesClient, namespace
 		return nil, err
 	}
 
-	repoBackened := kuberepository.NewKubernetesBackend(kubeClient.Clientset, namespace, repoInformer, false)
+	repoBackendOpts := []kuberepository.KubernetesBackendOption{
+		kuberepository.WithLabelSelector(s.options.labelSelector),
+	}
+
+	repoBackened := kuberepository.NewKubernetesBackend(kubeClient.Clientset, namespace, repoInformer, false, repoBackendOpts...)
 	s.repoManager = repository.NewManager(repoBackened, namespace, false)
 
 	gpgKeyInformerOpts := []informer.InformerOption[*corev1.ConfigMap]{
 		informer.WithListHandler[*corev1.ConfigMap](func(ctx context.Context, opts v1.ListOptions) (runtime.Object, error) {
-			return kubeClient.Clientset.CoreV1().ConfigMaps(namespace).List(ctx, v1.ListOptions{})
+			return kubeClient.Clientset.CoreV1().ConfigMaps(namespace).List(ctx, config.LabelSelector(s.options.labelSelector))
 		}),
 		informer.WithWatchHandler[*corev1.ConfigMap](func(ctx context.Context, opts v1.ListOptions) (watch.Interface, error) {
-			return kubeClient.Clientset.CoreV1().ConfigMaps(namespace).Watch(ctx, v1.ListOptions{})
+			return kubeClient.Clientset.CoreV1().ConfigMaps(namespace).Watch(ctx, config.LabelSelector(s.options.labelSelector))
 		}),
 		informer.WithAddHandler[*corev1.ConfigMap](s.newGPGKeyCallback),
 		informer.WithUpdateHandler[*corev1.ConfigMap](s.updateGPGKeyCallback),
@@ -691,6 +700,10 @@ func (s *Server) Start(ctx context.Context, errch chan error) error {
 	}
 
 	s.events = event.NewEventSource(s.options.serverName)
+
+	if s.options.labelSelector != "" {
+		log().Infof("Principal informers are using the label selector: %s", s.options.labelSelector)
+	}
 
 	// The application informer lives in its own go routine
 	go func() {


### PR DESCRIPTION
**What does this PR do / why we need it**:
In this PR, we replace the `--app-label-selector` with a generic `--label-selector` that applies to all the resources the agent/principal reconciles. This prevents the agent/principal from syncing any non-agent resources.

The previous `--app-label-selector` is not part of any release yet. So, I think we can replace it without causing any backwards compatibility issues.

**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:
1. Set `ARGOCD_AGENT_LABEL_SELECTOR` on the agent and `ARGOCD_PRINCIPAL_LABEL_SELECTOR` on the principal
2. The agent/principal will only process the resources that match this label selector

**Checklist**

* [ ] Documentation update is required by this PR (and has been updated) OR no documentation update is required.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Renamed and generalized configuration from app-label-selector → label-selector, expanding scope to filter all watched Kubernetes resources (Applications, Projects, ApplicationSets, Repository Secrets) instead of Applications only.

* **Documentation**
  * Updated CLI flag, env var, ConfigMap keys, Helm values, and docs to reflect the rename and broader resource-filtering semantics.

* **Other**
  * Startup now logs the active label selector when set.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->