### PR TITLE
fix: memory leak at agent component

### DIFF
--- a/agent/connection.go
+++ b/agent/connection.go
@@ -85,8 +85,10 @@ func (a *Agent) sender(stream eventstreamapi.EventStream_SubscribeClient) error 
 	logCtx.Trace("Grabbed an item")
 	if ev == nil {
 		// TODO: Is this really the right thing to do?
+		q.Done(ev)
 		return nil
 	}
+	defer q.Done(ev)
 	logCtx = logCtx.WithFields(logrus.Fields{
 		"event_target": ev.DataSchema(),
 		"event_type":   ev.Type(),

--- a/agent/inbound_redis.go
+++ b/agent/inbound_redis.go
@@ -195,6 +195,13 @@ func (a *Agent) handleRedisSubscribeMessage(logCtx *logrus.Entry, rreq *event.Re
 func (a *Agent) forwardRedisSubscribeNotificationsToPrincipal(pubsub *redis.PubSub, rreq *event.RedisRequest, channelName string, logCtx *logrus.Entry) {
 	ticker := time.NewTicker(1 * time.Minute)
 	defer ticker.Stop()
+	defer pubsub.Close()
+	defer func() {
+		connections := a.redisProxyMsgHandler.connections
+		connections.lock.Lock()
+		delete(connections.connMap, rreq.ConnectionUUID)
+		connections.lock.Unlock()
+	}()
 
 	ch := pubsub.Channel()
 
@@ -222,13 +229,6 @@ func (a *Agent) forwardRedisSubscribeNotificationsToPrincipal(pubsub *redis.PubS
 
 			// If the connection has not been active for X minutes, close the connection
 			if time.Since(*lastPing) >= principalRedisConnectionTimeout {
-				pubsub.Close()
-
-				// Clean up the connection map entry to prevent memory accumulation
-				connLifecycle.lock.Lock()
-				delete(connLifecycle.connMap, rreq.ConnectionUUID)
-				connLifecycle.lock.Unlock()
-
 				logCtx.WithField(logfields.LastPing, lastPing).Trace("closing redis connection due to inactivity")
 				return
 			}

--- a/agent/inbound_redis.go
+++ b/agent/inbound_redis.go
@@ -223,6 +223,12 @@ func (a *Agent) forwardRedisSubscribeNotificationsToPrincipal(pubsub *redis.PubS
 			// If the connection has not been active for X minutes, close the connection
 			if time.Since(*lastPing) >= principalRedisConnectionTimeout {
 				pubsub.Close()
+
+				// Clean up the connection map entry to prevent memory accumulation
+				connLifecycle.lock.Lock()
+				delete(connLifecycle.connMap, rreq.ConnectionUUID)
+				connLifecycle.lock.Unlock()
+
 				logCtx.WithField(logfields.LastPing, lastPing).Trace("closing redis connection due to inactivity")
 				return
 			}


### PR DESCRIPTION
**What does this PR do / why we need it**:

1. Fix  memory leak - missing `q.Done(ev)` in `sender()` 
The workqueue's Get() moves items into an internal processing set. Without Done(), every event stayed referenced forever. Over 7 days with continuous Application sync events (each ~KB), this accumulates to ~1GB. 

<img width="1406" height="448" alt="image" src="https://github.com/user-attachments/assets/ee9f77a0-8d21-4381-8fbf-7266404352dc" />

Added:
`q.Done(ev)` for the nil-event early return path
`defer q.Done(ev)` for the normal path

This matches the pattern already used on the principal side at [event.go:138](https://github.com/argoproj-labs/argocd-agent/blob/d7ac642cd416d04c6852d8448a3952f866beddaf/principal/event.go#L138).

2. connMap never cleaned up
When a Redis subscription connection times out due to inactivity, the goroutine closed the pubsub but left the connectionEntry in connMap. Over time with many agent reconnections, this map grows unbounded. 

Added `defer pubsub.Close()` and `defer delete(connMap)` at function top, so cleanup runs on every exit path (timeout at line 231, queue-gone at line 252)

**Which issue(s) this PR fixes**:
N/A

**How to test changes / Special notes to the reviewer**:


**Checklist**

* [X] Documentation update is required by this PR (and has been updated) OR no documentation update is required.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved connection lifecycle management to ensure queue completion is always signaled, preventing stuck items when events are absent.
  * Ensured reliable cleanup of subscription resources and removal of stale connection entries on inactivity to prevent resource leaks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->