### PR TITLE
docs: Add doc for web-based terminal

### DIFF
--- a/docs/user-guide/web-terminal.md
+++ b/docs/user-guide/web-terminal.md
@@ -1,0 +1,99 @@
+# Web-Based Terminal
+
+This document explains how to enable and use the web-based terminal feature in argocd-agent, which allows users to get a shell inside a running pod on an agent cluster directly from the Argo CD UI.
+
+## Overview
+
+The web-based terminal provides `kubectl exec`-style access to pods running on remote managed clusters, accessible through the Argo CD UI. The terminal session is bridged from the browser through the principal to the agent via gRPC, and the agent executes into the target pod using the Kubernetes exec API.
+
+```text
+Browser ──WebSocket──► Argo CD Server ──HTTPS──► Principal ──gRPC──► Agent ──K8s Exec──► Pod
+```
+
+## Prerequisites
+
+- The agent is running in managed mode.
+- The resource-proxy is enabled on both the principal and agent.
+
+## Enabling the Terminal
+
+### Step 1: Enable the Exec Feature in Argo CD (Control Plane)
+
+Set `exec.enabled` to `"true"` in the `argocd-cm` ConfigMap:
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: argocd-cm
+  namespace: argocd
+data:
+  exec.enabled: "true"
+```
+
+### Step 2: Grant `pods/exec` Permission to `argocd-server` (Control Plane)
+
+The `argocd-server` ServiceAccount needs `pods/exec` permission to allow argocd-server to `exec` into pods. Patch these permissions in the existing ClusterRole or create a custom ClusterRole with the following permissions.
+
+```yaml
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods/exec
+  verbs:
+  - create
+```
+
+### Step 3: Configure Argo CD RBAC for Users (Control Plane)
+
+Grant the `exec/create` permission to the appropriate roles in Argo CD's RBAC configuration. Add this to the `argocd-rbac-cm` ConfigMap or an `AppProject` manifest:
+
+```text
+p, role:myrole, exec, create, */*, allow
+```
+
+Users also need the `applications/get` permission on the target application.
+
+### Step 4: Grant `pods/exec` Permission to the Agent (Workload Cluster)
+
+The agent's ServiceAccount needs permission to exec into pods. Add the following to the agent's ClusterRole:
+
+```yaml
+- apiGroups:
+  - ""
+  resources:
+  - pods/exec
+  verbs:
+  - create
+```
+
+## Using the Terminal
+
+1. Open the Argo CD UI and navigate to an application deployed on a managed agent cluster
+2. Click on a **Pod** resource in the application resource tree
+3. Select the **Terminal** tab in the pod details panel
+4. A shell session opens inside the selected container
+
+## Changing Allowed Shells (Control Plane)
+
+By default, Argo CD tries these shells in order: `bash`, `sh`, `powershell`, `cmd`. If the first shell is not found in the container, it falls back to the next one.
+
+To customize the allowed shells, set the `exec.shells` key in the `argocd-cm` ConfigMap on the control plane:
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: argocd-cm
+  namespace: argocd
+data:
+  exec.enabled: "true"
+  exec.shells: "bash,sh"
+```
+
+## Related Documentation
+
+- [Argo CD Web-Terminal Documentation](https://argo-cd.readthedocs.io/en/stable/operator-manual/web_based_terminal/) - Argo CD documentation for web-terminal configurations
+- [Accessing live resources on workload clusters](live-resources.md) - Resource proxy configuration and RBAC setup
+- [Web Terminal Architecture](../technical/web-terminal-workflow.md) - Technical architecture diagram

--- a/docs/user-guide/web-terminal.md
+++ b/docs/user-guide/web-terminal.md
@@ -31,21 +31,7 @@ data:
   exec.enabled: "true"
 ```
 
-### Step 2: Grant `pods/exec` Permission to `argocd-server` (Control Plane)
-
-The `argocd-server` ServiceAccount needs `pods/exec` permission to allow argocd-server to `exec` into pods. Patch these permissions in the existing ClusterRole or create a custom ClusterRole with the following permissions.
-
-```yaml
-rules:
-- apiGroups:
-  - ""
-  resources:
-  - pods/exec
-  verbs:
-  - create
-```
-
-### Step 3: Configure Argo CD RBAC for Users (Control Plane)
+### Step 2: Configure Argo CD RBAC for Users (Control Plane)
 
 Grant the `exec/create` permission to the appropriate roles in Argo CD's RBAC configuration. Add this to the `argocd-rbac-cm` ConfigMap or an `AppProject` manifest:
 
@@ -55,7 +41,7 @@ p, role:myrole, exec, create, */*, allow
 
 Users also need the `applications/get` permission on the target application.
 
-### Step 4: Grant `pods/exec` Permission to the Agent (Workload Cluster)
+### Step 3: Grant `pods/exec` Permission to the Agent (Workload Cluster)
 
 The agent's ServiceAccount needs permission to exec into pods. Add the following to the agent's ClusterRole:
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -50,6 +50,7 @@ nav:
     - GPG Key Synchronization: user-guide/gpg-keys.md
     - Adding an agent: user-guide/adding-agents.md
     - Accessing live resources on workload clusters: user-guide/live-resources.md
+    - Web-based terminal: user-guide/web-terminal.md
     - Migration from classical multi-cluster Argo CD: user-guide/migration.md
   - Configuration:
     - Overview: configuration/index.md


### PR DESCRIPTION
This PR is to add user guide document for using web-based terminal in argocd-agent.

Assisted by: Cursor



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a user guide for the web-based terminal: explains end-to-end session flow, prerequisites for managed agents and resource-proxy, required control-plane and cluster permissions, UI workflow to open a pod Terminal, and how to customize shell fallback behavior.
  * Updated site navigation to include the new Web-based Terminal guide for easier discovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->