### PR TITLE
revert(ci): revert slsa generators to be referenced by tag on release pipeline

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -130,7 +130,8 @@ jobs:
       id-token: write
       packages: write
     if: github.repository == 'argoproj-labs/argocd-agent' || needs.setup-variables.outputs.allow_fork_releases == 'true'
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@f7dd8c54c2067bafc12ca7a55595d5ee9b75204a # v2.1.0
+    # Must be referenced by tag (https://github.com/slsa-framework/slsa-github-generator/blob/main/internal/builders/container/README.md#referencing-the-slsa-generator)
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@v2.1.0
     with:
       image: ${{ needs.setup-variables.outputs.image_uri }}
       digest: ${{ needs.container-image.outputs.digest }}
@@ -203,7 +204,8 @@ jobs:
       id-token: write
       contents: write
     if: github.repository == 'argoproj-labs/argocd-agent' || needs.setup-variables.outputs.allow_fork_releases == 'true'
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@f7dd8c54c2067bafc12ca7a55595d5ee9b75204a # v2.1.0
+    # Must be referenced by tag (https://github.com/slsa-framework/slsa-github-generator/blob/main/internal/builders/container/README.md#referencing-the-slsa-generator)
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.1.0
     with:
       base64-subjects: "${{ needs.cli-binaries.outputs.hashes }}"
       provenance-name: "argocd-agentctl_${{ needs.setup-variables.outputs.trimmed_tag }}.intoto.jsonl"
@@ -276,7 +278,8 @@ jobs:
       id-token: write
       contents: write
     if: github.repository == 'argoproj-labs/argocd-agent' || needs.setup-variables.outputs.allow_fork_releases == 'true'
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@f7dd8c54c2067bafc12ca7a55595d5ee9b75204a # v2.1.0
+    # Must be referenced by tag (https://github.com/slsa-framework/slsa-github-generator/blob/main/internal/builders/container/README.md#referencing-the-slsa-generator)
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.1.0
     with:
       base64-subjects: "${{ needs.sbom.outputs.hash }}"
       provenance-name: "argocd-agent_${{ needs.setup-variables.outputs.trimmed_tag }}_sbom.intoto.jsonl"


### PR DESCRIPTION
**What does this PR do / why we need it**:

Reverts slsa generator calls to be referenced by tag due to the below reason:

https://github.com/slsa-framework/slsa-github-generator/blob/main/internal/builders/container/README.md#referencing-the-slsa-generator

**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:


**Checklist**

* [ ] Documentation update is required by this PR (and has been updated) OR no documentation update is required.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release workflow configuration to reference generator dependencies by version tag instead of commit SHA for consistency and clarity.
  * Added clarifying comments to workflow steps for improved maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->