### PR TITLE
fix(build): add BuildKit cache mounts and pin alpine version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,18 @@
+# syntax=docker/dockerfile:1
 FROM docker.io/library/golang:1.25 AS builder
 WORKDIR /src
-COPY . .
-RUN make argocd-agent
-	
-FROM docker.io/library/alpine:latest
 
+COPY go.mod go.sum ./
+RUN --mount=type=cache,target=/go/pkg/mod \
+    go mod download
+
+COPY . .
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    make argocd-agent
+
+FROM docker.io/library/alpine:3.23
+RUN apk upgrade --no-cache
 COPY --from=builder /src/dist/argocd-agent /bin/argocd-agent
 USER 999
 ENTRYPOINT ["/bin/argocd-agent"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,13 +3,10 @@ FROM docker.io/library/golang:1.25 AS builder
 WORKDIR /src
 
 COPY go.mod go.sum ./
-RUN --mount=type=cache,target=/go/pkg/mod \
-    go mod download
+RUN go mod download
 
 COPY . .
-RUN --mount=type=cache,target=/go/pkg/mod \
-    --mount=type=cache,target=/root/.cache/go-build \
-    make argocd-agent
+RUN make argocd-agent
 
 FROM docker.io/library/alpine:3.23
 RUN apk upgrade --no-cache


### PR DESCRIPTION
**What does this PR do / why we need it**:
Optimizes the Dockerfile for faster incremental builds and better security. Currently make image takes a full go mod download + rebuild every time since there's no layer caching. This PR separates the dependency download into its own layer, so incremental builds reuse cached modules when only source code changes. Also pins alpine from latest to 3.23 and patches known CVEs with apk upgrade.

Note: BuildKit cache mounts were initially considered (as suggested in #702) but removed since CI uses podman build which doesn't support --mount=type=cache.


**Which issue(s) this PR fixes**:
Fixes #702

**How to test changes / Special notes to the reviewer**:
DOCKER_BUILDKIT=1 make image — first build works as before
Change any .go file and rebuild — go mod download layer is cached, build is significantly faster
Verified with:

hadolint: 0 warnings
dive: 100% efficiency, 0 wasted bytes
trivy: 0 vulnerabilities (HIGH/CRITICAL)
dockle: 2 INFO-level (HEALTHCHECK and content trust — both handled at K8s/registry level)

read-only fs: docker run --rm --read-only --user 999 works fine

**Checklist**

* [x] Documentation update is required by this PR (and has been updated) OR no documentation update is required.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized Docker build performance through improved dependency caching, reducing build times.
  * Updated to pinned Alpine Linux 3.23 base image for consistent and reliable deployments.
  * Enhanced container security with automated package updates during the build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->