### PR TITLE
fix: Fall back to SPDY when WebSocket exec is rejected for web-terminal (#848)

### DIFF
--- a/agent/terminal.go
+++ b/agent/terminal.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"net/url"
 	"strings"
 	"sync"
 
@@ -26,8 +27,19 @@ import (
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/remotecommand"
 )
+
+// newWebSocketExecutor and newSPDYExecutor are package-level variables so that
+// tests can inject fake executors without starting a real Kubernetes cluster.
+var newWebSocketExecutor = func(config *rest.Config, method, rawURL string) (remotecommand.Executor, error) {
+	return remotecommand.NewWebSocketExecutor(config, method, rawURL)
+}
+
+var newSPDYExecutor = func(config *rest.Config, method string, u *url.URL) (remotecommand.Executor, error) {
+	return remotecommand.NewSPDYExecutor(config, method, u)
+}
 
 // processIncomingTerminalRequest handles incoming web terminal requests from the principal.
 // It establishes a Kubernetes exec session with a shell running inside the application pod
@@ -129,13 +141,6 @@ func (a *Agent) terminalInPod(ctx context.Context, stream terminalstreamapi.Term
 
 	logCtx.Infof("Executing command: %v", execOptions.Command)
 
-	// Create WebSocket executor,
-	// it connects agent to the shell running inside the application pod and streams data back and forth.
-	exec, err := remotecommand.NewWebSocketExecutor(a.kubeClient.RestConfig, "GET", req.URL().String())
-	if err != nil {
-		return fmt.Errorf("failed to create WebSocket executor: %w", err)
-	}
-
 	// Create cancellable context for the exec
 	// This allows us to terminate the exec when EOF is received from principal
 	execCtx, cancelExec := context.WithCancel(ctx)
@@ -167,17 +172,36 @@ func (a *Agent) terminalInPod(ctx context.Context, stream terminalstreamapi.Term
 	// Start goroutine to receive stdin from principal and forward to K8s
 	go streamHandler.receiveFromPrincipal()
 
-	// Execute the command in the pod using the stream handler
-	err = exec.StreamWithContext(execCtx, remotecommand.StreamOptions{
+	// Close the stream to signal the end of the terminal session
+	defer streamHandler.close()
+
+	streamOpts := remotecommand.StreamOptions{
 		Stdin:             streamHandler,
 		Stdout:            streamHandler,
 		Stderr:            streamHandler,
 		Tty:               terminalReq.TTY,
 		TerminalSizeQueue: sizeQueue,
-	})
+	}
 
-	// Close the stream to signal the end of the terminal session
-	streamHandler.close()
+	// Try WebSocket executor first, fall back to SPDY if the cluster does not
+	// support WebSocket-based exec (e.g. TranslateStreamCloseWebsocketRequests
+	// feature gate is disabled).
+	exec, err := newWebSocketExecutor(a.kubeClient.RestConfig, "GET", req.URL().String())
+	if err != nil {
+		return fmt.Errorf("failed to create WebSocket executor: %w", err)
+	}
+
+	err = exec.StreamWithContext(execCtx, streamOpts)
+
+	if err != nil && isWebSocketHandshakeError(err) {
+		logCtx.WithError(err).Warn("WebSocket exec failed, retrying with SPDY")
+
+		spdyExec, spdyErr := newSPDYExecutor(a.kubeClient.RestConfig, "POST", req.URL())
+		if spdyErr != nil {
+			return fmt.Errorf("failed to create SPDY executor: %w", spdyErr)
+		}
+		err = spdyExec.StreamWithContext(execCtx, streamOpts)
+	}
 
 	if err != nil {
 		if !isShellNotFoundError(err) {
@@ -342,6 +366,13 @@ func isContextCanceledError(err error) bool {
 		return true
 	}
 	return strings.Contains(err.Error(), "context canceled")
+}
+
+func isWebSocketHandshakeError(err error) bool {
+	if err == nil {
+		return false
+	}
+	return strings.Contains(err.Error(), "websocket: bad handshake")
 }
 
 // isShellNotFoundError checks if the error is due to a shell executable not being found in container.

--- a/agent/terminal_test.go
+++ b/agent/terminal_test.go
@@ -18,18 +18,25 @@ import (
 	"context"
 	"errors"
 	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/argoproj-labs/argocd-agent/internal/event"
+	"github.com/argoproj-labs/argocd-agent/internal/kube"
 	"github.com/argoproj-labs/argocd-agent/pkg/api/grpc/terminalstreamapi"
 	"github.com/argoproj-labs/argocd-agent/principal/apis/terminalstream/mock"
 	"github.com/google/uuid"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/remotecommand"
 )
 
@@ -43,6 +50,22 @@ func createTestTerminalAgent() *Agent {
 		inflightMu:       sync.Mutex{},
 	}
 	return agent
+}
+
+func createTestTerminalAgentWithKube(t *testing.T, ctx context.Context, cancel context.CancelFunc) *Agent {
+	t.Helper()
+	cfg := &rest.Config{Host: "https://fake-k8s:6443"}
+	clientset, err := kubernetes.NewForConfig(cfg)
+	require.NoError(t, err)
+	return &Agent{
+		context:  ctx,
+		cancelFn: cancel,
+		kubeClient: &kube.KubernetesClient{
+			RestConfig: cfg,
+			Clientset:  clientset,
+		},
+		inflightTerminal: make(map[string]struct{}),
+	}
 }
 
 func createTestTerminalRequest() *event.ContainerTerminalRequest {
@@ -593,5 +616,207 @@ func TestConcurrentTerminalOperations(t *testing.T) {
 		count := len(agent.inflightTerminal)
 		agent.inflightMu.Unlock()
 		assert.Equal(t, numGoroutines, count)
+	})
+}
+
+// TestWebSocketToSPDYFallback exercises the real WebSocket and SPDY executors
+// against a test HTTP server that rejects WebSocket upgrades with 403 Forbidden,
+func TestWebSocketToSPDYFallback(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "Forbidden", http.StatusForbidden)
+	}))
+	defer server.Close()
+
+	config := &rest.Config{
+		Host: server.URL,
+		TLSClientConfig: rest.TLSClientConfig{
+			Insecure: true,
+		},
+	}
+
+	execPath := "/api/v1/namespaces/test/pods/test-pod/exec?command=sh&stdin=true&stdout=true&tty=true"
+	wsURL := server.URL + execPath
+	spdyURL, err := url.Parse(wsURL)
+	require.NoError(t, err)
+
+	streamOpts := remotecommand.StreamOptions{
+		Stdin:  strings.NewReader(""),
+		Stdout: io.Discard,
+		Stderr: io.Discard,
+		Tty:    true,
+	}
+
+	t.Run("WebSocket executor returns handshake error on 403", func(t *testing.T) {
+		wsExec, err := remotecommand.NewWebSocketExecutor(config, "GET", wsURL)
+		require.NoError(t, err)
+
+		err = wsExec.StreamWithContext(context.Background(), streamOpts)
+		require.Error(t, err)
+		assert.True(t, isWebSocketHandshakeError(err),
+			"expected WebSocket handshake error, got: %v", err)
+	})
+
+	t.Run("SPDY executor error is not a WebSocket handshake error", func(t *testing.T) {
+		spdyExec, err := remotecommand.NewSPDYExecutor(config, "POST", spdyURL)
+		require.NoError(t, err)
+
+		err = spdyExec.StreamWithContext(context.Background(), streamOpts)
+		require.Error(t, err, "SPDY should also fail against the test server")
+		assert.False(t, isWebSocketHandshakeError(err),
+			"SPDY error must not be mistaken for a WebSocket handshake error, got: %v", err)
+	})
+
+	t.Run("full fallback flow: WebSocket 403 then SPDY retry", func(t *testing.T) {
+		wsExec, err := remotecommand.NewWebSocketExecutor(config, "GET", wsURL)
+		require.NoError(t, err)
+
+		err = wsExec.StreamWithContext(context.Background(), streamOpts)
+
+		// Verify the condition that triggers the fallback
+		require.Error(t, err)
+		require.True(t, isWebSocketHandshakeError(err),
+			"expected handshake error to trigger SPDY fallback, got: %v", err)
+
+		// Execute the fallback path
+		spdyExec, spdyErr := remotecommand.NewSPDYExecutor(config, "POST", spdyURL)
+		require.NoError(t, spdyErr, "SPDY executor creation must succeed during fallback")
+
+		err = spdyExec.StreamWithContext(context.Background(), streamOpts)
+		if err != nil {
+			assert.False(t, isWebSocketHandshakeError(err),
+				"SPDY fallback error should not re-trigger WebSocket fallback, got: %v", err)
+		}
+	})
+}
+
+type fakeExecutor struct{ err error }
+
+func (f *fakeExecutor) Stream(_ remotecommand.StreamOptions) error { return f.err }
+func (f *fakeExecutor) StreamWithContext(_ context.Context, _ remotecommand.StreamOptions) error {
+	return f.err
+}
+
+// patchExecutors swaps the package-level executor constructors for the
+// duration of a single test and restores the originals via t.Cleanup.
+func patchExecutors(
+	t *testing.T,
+	wsFunc func(*rest.Config, string, string) (remotecommand.Executor, error),
+	spdyFunc func(*rest.Config, string, *url.URL) (remotecommand.Executor, error),
+) {
+	t.Helper()
+	origWS, origSPDY := newWebSocketExecutor, newSPDYExecutor
+	newWebSocketExecutor = wsFunc
+	newSPDYExecutor = spdyFunc
+	t.Cleanup(func() {
+		newWebSocketExecutor = origWS
+		newSPDYExecutor = origSPDY
+	})
+}
+
+// TestTerminalInPodFallback drives the production terminalInPod control flow
+// by injecting fake executors through the package-level constructor vars.
+func TestTerminalInPodFallback(t *testing.T) {
+	t.Run("WebSocket bad-handshake triggers SPDY fallback and succeeds", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		agent := createTestTerminalAgentWithKube(t, ctx, cancel)
+		mockStream := mock.NewMockTerminalStreamClient(ctx)
+		mockStream.SetRecvFunc(func() (*terminalstreamapi.TerminalStreamData, error) {
+			return nil, io.EOF
+		})
+
+		spdyCalled := false
+		patchExecutors(t,
+			func(_ *rest.Config, _, _ string) (remotecommand.Executor, error) {
+				return &fakeExecutor{err: errors.New("websocket: bad handshake")}, nil
+			},
+			func(_ *rest.Config, _ string, _ *url.URL) (remotecommand.Executor, error) {
+				spdyCalled = true
+				return &fakeExecutor{err: nil}, nil
+			},
+		)
+
+		err := agent.terminalInPod(ctx, mockStream, createTestTerminalRequest(), logrus.NewEntry(logrus.New()))
+		require.NoError(t, err)
+		assert.True(t, spdyCalled, "SPDY executor must be invoked as fallback")
+	})
+
+	t.Run("SPDY fallback error is propagated to caller", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		agent := createTestTerminalAgentWithKube(t, ctx, cancel)
+		mockStream := mock.NewMockTerminalStreamClient(ctx)
+		mockStream.SetRecvFunc(func() (*terminalstreamapi.TerminalStreamData, error) {
+			return nil, io.EOF
+		})
+
+		spdyErr := errors.New("spdy: connection refused")
+		patchExecutors(t,
+			func(_ *rest.Config, _, _ string) (remotecommand.Executor, error) {
+				return &fakeExecutor{err: errors.New("websocket: bad handshake")}, nil
+			},
+			func(_ *rest.Config, _ string, _ *url.URL) (remotecommand.Executor, error) {
+				return &fakeExecutor{err: spdyErr}, nil
+			},
+		)
+
+		err := agent.terminalInPod(ctx, mockStream, createTestTerminalRequest(), logrus.NewEntry(logrus.New()))
+		require.Error(t, err)
+		assert.ErrorIs(t, err, spdyErr)
+	})
+
+	t.Run("WebSocket success skips SPDY fallback entirely", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		agent := createTestTerminalAgentWithKube(t, ctx, cancel)
+		mockStream := mock.NewMockTerminalStreamClient(ctx)
+		mockStream.SetRecvFunc(func() (*terminalstreamapi.TerminalStreamData, error) {
+			return nil, io.EOF
+		})
+
+		spdyCalled := false
+		patchExecutors(t,
+			func(_ *rest.Config, _, _ string) (remotecommand.Executor, error) {
+				return &fakeExecutor{err: nil}, nil
+			},
+			func(_ *rest.Config, _ string, _ *url.URL) (remotecommand.Executor, error) {
+				spdyCalled = true
+				return &fakeExecutor{err: nil}, nil
+			},
+		)
+
+		err := agent.terminalInPod(ctx, mockStream, createTestTerminalRequest(), logrus.NewEntry(logrus.New()))
+		require.NoError(t, err)
+		assert.False(t, spdyCalled, "SPDY must not be called when WebSocket succeeds")
+	})
+
+	t.Run("WebSocket creation failure is returned immediately without SPDY", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		agent := createTestTerminalAgentWithKube(t, ctx, cancel)
+		mockStream := mock.NewMockTerminalStreamClient(ctx)
+		mockStream.SetRecvFunc(func() (*terminalstreamapi.TerminalStreamData, error) {
+			return nil, io.EOF
+		})
+
+		wsCreateErr := errors.New("failed to create ws executor")
+		spdyCalled := false
+		patchExecutors(t,
+			func(_ *rest.Config, _, _ string) (remotecommand.Executor, error) {
+				return nil, wsCreateErr
+			},
+			func(_ *rest.Config, _ string, _ *url.URL) (remotecommand.Executor, error) {
+				spdyCalled = true
+				return &fakeExecutor{}, nil
+			},
+		)
+
+		err := agent.terminalInPod(ctx, mockStream, createTestTerminalRequest(), logrus.NewEntry(logrus.New()))
+		require.Error(t, err)
+		assert.False(t, spdyCalled, "SPDY must not be called when WS executor creation fails")
 	})
 }


### PR DESCRIPTION
This PR is to cherry pick https://github.com/argoproj-labs/argocd-agent/commit/8d3a3d46906e9a09903ae68de357a2b5696ca3a3 in release-0.7.
gitope-operator PR has been merged to ensure fix is working.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced terminal session reliability with intelligent fallback: if WebSocket connection fails, the system automatically attempts SPDY protocol for seamless connectivity.

* **Tests**
  * Added comprehensive test coverage for terminal connection fallback behavior and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->