### PR TITLE
fix(ctl): allow certificate chains in TLS secret validation

### DIFF
--- a/cmd/ctl/validate.go
+++ b/cmd/ctl/validate.go
@@ -864,8 +864,9 @@ func namespaceMatchesAgentSubject(ctx context.Context, agentKube kubernetes.Inte
 	return nil
 }
 
-// x509FromTLSSecret retrieves a Kubernetes TLS secret and parses the certificate
-// into an *x509.Certificate. The secret must contain exactly one certificate.
+// x509FromTLSSecret retrieves a Kubernetes TLS secret and parses the leaf certificate
+// into an *x509.Certificate. If the secret contains a certificate chain (e.g. leaf +
+// intermediate CA), only the first (leaf) certificate is returned.
 func x509FromTLSSecret(ctx context.Context, kubeClient kubernetes.Interface, ns, name string) (*x509.Certificate, error) {
 	cert, err := tlsutil.TLSCertFromSecret(ctx, kubeClient, ns, name)
 	if err != nil {
@@ -873,9 +874,6 @@ func x509FromTLSSecret(ctx context.Context, kubeClient kubernetes.Interface, ns,
 	}
 	if len(cert.Certificate) == 0 || cert.Certificate[0] == nil {
 		return nil, fmt.Errorf("%s/%s: secret does not contain certificate data", ns, name)
-	}
-	if len(cert.Certificate) > 1 {
-		return nil, fmt.Errorf("%s/%s: secret contains %d certificates, expected exactly one", ns, name, len(cert.Certificate))
 	}
 	parsed, err := x509.ParseCertificate(cert.Certificate[0])
 	if err != nil {

--- a/cmd/ctl/validate_test.go
+++ b/cmd/ctl/validate_test.go
@@ -1668,3 +1668,75 @@ func TestCheckConfigCombined(t *testing.T) {
 		require.True(t, caughtMissing)
 	})
 }
+
+func TestX509FromTLSSecret(t *testing.T) {
+	ctx := context.TODO()
+
+	// Generate a root CA
+	rootCACertPEM, rootCAKeyPEM, err := tlsutil.GenerateCaCertificate("root-ca")
+	require.NoError(t, err)
+	cl := fake.NewSimpleClientset()
+	mustCreateTLSSecret(t, cl, "default", "root-ca", rootCACertPEM, rootCAKeyPEM)
+	rootCACert, err := tlsutil.TLSCertFromSecret(ctx, cl, "default", "root-ca")
+	require.NoError(t, err)
+	rootCASigner, err := x509.ParseCertificate(rootCACert.Certificate[0])
+	require.NoError(t, err)
+
+	// Generate an intermediate CA signed by root CA
+	intermCACertPEM, intermCAKeyPEM, err := tlsutil.GenerateCaCertificate("intermediate-ca")
+	require.NoError(t, err)
+	mustCreateTLSSecret(t, cl, "default", "interm-ca", intermCACertPEM, intermCAKeyPEM)
+	intermCACert, err := tlsutil.TLSCertFromSecret(ctx, cl, "default", "interm-ca")
+	require.NoError(t, err)
+	intermCASigner, err := x509.ParseCertificate(intermCACert.Certificate[0])
+	require.NoError(t, err)
+	_ = rootCASigner
+
+	// Generate a leaf certificate signed by the intermediate CA
+	leafCertPEM, leafKeyPEM, err := tlsutil.GenerateServerCertificate("leaf", intermCASigner, intermCACert.PrivateKey, []string{"127.0.0.1"}, []string{"localhost"})
+	require.NoError(t, err)
+
+	// Parse the expected leaf cert DER for strict identity checks
+	leafPEMBlock, _ := pem.Decode([]byte(leafCertPEM))
+	require.NotNil(t, leafPEMBlock)
+	expectedLeaf, err := x509.ParseCertificate(leafPEMBlock.Bytes)
+	require.NoError(t, err)
+
+	t.Run("Single certificate is accepted", func(t *testing.T) {
+		c := fake.NewSimpleClientset()
+		mustCreateTLSSecret(t, c, "default", "single", leafCertPEM, leafKeyPEM)
+		cert, err := x509FromTLSSecret(ctx, c, "default", "single")
+		require.NoError(t, err)
+		require.Equal(t, expectedLeaf.Raw, cert.Raw)
+	})
+
+	t.Run("Certificate chain (leaf + intermediate) returns leaf cert", func(t *testing.T) {
+		chainPEM := leafCertPEM + intermCACertPEM
+		c := fake.NewSimpleClientset()
+		mustCreateTLSSecret(t, c, "default", "chain", chainPEM, leafKeyPEM)
+		cert, err := x509FromTLSSecret(ctx, c, "default", "chain")
+		require.NoError(t, err)
+		require.Equal(t, expectedLeaf.Raw, cert.Raw)
+	})
+
+	t.Run("Certificate chain (leaf + intermediate + root) returns leaf cert", func(t *testing.T) {
+		chainPEM := leafCertPEM + intermCACertPEM + rootCACertPEM
+		c := fake.NewSimpleClientset()
+		mustCreateTLSSecret(t, c, "default", "full-chain", chainPEM, leafKeyPEM)
+		cert, err := x509FromTLSSecret(ctx, c, "default", "full-chain")
+		require.NoError(t, err)
+		require.Equal(t, expectedLeaf.Raw, cert.Raw)
+	})
+
+	t.Run("Empty secret returns error", func(t *testing.T) {
+		c := fake.NewSimpleClientset()
+		_, err := c.CoreV1().Secrets("default").Create(ctx, &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: "empty", Namespace: "default"},
+			Type:       corev1.SecretTypeTLS,
+			Data:       map[string][]byte{"tls.crt": {}, "tls.key": {}},
+		}, metav1.CreateOptions{})
+		require.NoError(t, err)
+		_, err = x509FromTLSSecret(ctx, c, "default", "empty")
+		require.Error(t, err)
+	})
+}


### PR DESCRIPTION
**What does this PR do / why we need it:**                                                                                                                                                                                                              
                                                                                                                                                                                                                                                      
  The argocd-agentctl validate command was failing when TLS secrets contained a certificate chain (leaf + intermediate CA), which is the standard output of automated certificate managers like cert-manager with a step-ca issuer. The validation    
  logic was enforcing an "exactly one certificate" rule, causing false-positive errors even when the agent itself was functioning correctly.                                                                                                          
                                                                                                                                                                                                                                                      
  This PR removes that restriction so that x509FromTLSSecret accepts certificate bundles and always validates the first (leaf) certificate, ignoring any intermediate or root CA certificates that follow it.                                         
                                                                                                                                                                                                                                                      
  Which issue(s) this PR fixes:                                                                                                                                                                                                                       
                                                                                                                                                                                                                                                      
  Fixes #879                                                                                                                                                                                                                                          
                                                                                                                                                                                                                                                      
  **How to test changes / Special notes to the reviewer:**                                                                                                                                                                                                
                                                                                                                                                                                                                                                      
  - Unit tests added in TestX509FromTLSSecret covering: single cert, leaf+intermediate chain, leaf+intermediate+root chain, and empty secret.                                                                                                         
  - To reproduce manually: create a Kubernetes TLS secret whose tls.crt contains two PEM blocks (leaf + intermediate), then run argocd-agentctl validate — it should no longer report secret contains 2 certificates, expected exactly one.           


**Checklist**

* [ ] Documentation update is required by this PR (and has been updated) OR no documentation update is required.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved TLS certificate handling so uploaded TLS secrets with certificate chains are accepted and the correct leaf certificate is used for validation, removing false errors for multi-entry chains.

* **Tests**
  * Added unit tests covering TLS secret parsing across single-leaf, chained (leaf+intermediate), full-chain, and empty-data scenarios to prevent regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->