### PR TITLE
fix(principal): Only accept agent connections after initialization is complete

### DIFF
--- a/principal/server.go
+++ b/principal/server.go
@@ -674,12 +674,6 @@ func (s *Server) Start(ctx context.Context, errch chan error) error {
 		}
 	}
 
-	if s.options.serveGRPC {
-		if err := s.serveGRPC(ctx, s.metrics, errch); err != nil {
-			return err
-		}
-	}
-
 	if s.options.metricsPort > 0 {
 		metrics.StartMetricsServer(metrics.WithListener("", s.options.metricsPort))
 
@@ -831,6 +825,13 @@ func (s *Server) Start(ctx context.Context, errch chan error) error {
 		log().Infof("Starting healthz server on %s", healthzAddr)
 		//nolint:errcheck
 		go http.ListenAndServe(healthzAddr, nil)
+	}
+
+	// Finally, start accepting connections from agents
+	if s.options.serveGRPC {
+		if err := s.serveGRPC(ctx, s.metrics, errch); err != nil {
+			return err
+		}
 	}
 
 	return nil


### PR DESCRIPTION
**What does this PR do / why we need it**:

The principal would start accepting agent connections before it had fully initialized (i.e. started all informers, warmed up all caches, loaded all agent configurations). This can lead to a lot of errors during startup.

This PR moves the start of the gRPC server to the end of the initialization process.

**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:


**Checklist**

* [ ] Documentation update is required by this PR (and has been updated) OR no documentation update is required.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted internal server initialization sequence to optimize startup timing during agent connection acceptance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->