### PR TITLE
fix(informer): Check the correct underlying implementation for being synced

### DIFF
--- a/internal/informer/informer.go
+++ b/internal/informer/informer.go
@@ -275,7 +275,7 @@ func (i *Informer[T]) Stop() error {
 
 // HasSynced returns true if the informer is synced
 func (i *Informer[T]) HasSynced() bool {
-	return i.evHandler.HasSynced()
+	return i.informer.HasSynced()
 }
 
 // WaitForSync blocks until either the informer has synced, or the context ctx

--- a/internal/informer/informer_test.go
+++ b/internal/informer/informer_test.go
@@ -17,6 +17,7 @@ package informer
 import (
 	"context"
 	"errors"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -133,51 +134,51 @@ func Test_NewInformer(t *testing.T) {
 func Test_InformerScope(t *testing.T) {
 	t.Run("It adheres to namespace scope", func(t *testing.T) {
 		client := fake.NewSimpleClientset(apps[0], apps[1])
-		added := 0
-		listed := 0
+		var added atomic.Int32
+		var listed atomic.Int32
 		i, err := NewInformer[*v1alpha1.Application](context.TODO(),
 			WithListHandler[*v1alpha1.Application](func(ctx context.Context, opts v1.ListOptions) (runtime.Object, error) {
 				objs, err := client.ArgoprojV1alpha1().Applications("argocd").List(ctx, opts)
-				listed = len(objs.Items)
+				listed.Store(int32(len(objs.Items)))
 				return objs, err
 			}),
 			WithWatchHandler[*v1alpha1.Application](func(ctx context.Context, opts v1.ListOptions) (watch.Interface, error) {
 				return client.ArgoprojV1alpha1().Applications("argocd").Watch(ctx, opts)
 			}),
 			WithAddHandler[*v1alpha1.Application](func(obj *v1alpha1.Application) {
-				added += 1
+				added.Add(int32(1))
 			}),
 		)
 		require.NotNil(t, i)
 		require.NoError(t, err)
 		go i.Start(context.TODO())
 		i.WaitForSync(context.TODO())
-		assert.Equal(t, 1, listed)
-		assert.Equal(t, 1, added)
+		assert.Equal(t, int32(1), listed.Load())
+		assert.Equal(t, int32(1), added.Load())
 	})
 	t.Run("It adheres to cluster scope", func(t *testing.T) {
-		listed := 0
-		added := 0
+		var added atomic.Int32
+		var listed atomic.Int32
 		client := fake.NewSimpleClientset(apps[0], apps[1])
 		i, err := NewInformer[*v1alpha1.Application](context.TODO(),
 			WithListHandler[*v1alpha1.Application](func(ctx context.Context, opts v1.ListOptions) (runtime.Object, error) {
 				objs, err := client.ArgoprojV1alpha1().Applications("").List(ctx, opts)
-				listed = len(objs.Items)
+				listed.Store(int32(len(objs.Items)))
 				return objs, err
 			}),
 			WithWatchHandler[*v1alpha1.Application](func(ctx context.Context, opts v1.ListOptions) (watch.Interface, error) {
 				return client.ArgoprojV1alpha1().Applications("").Watch(ctx, opts)
 			}),
 			WithAddHandler[*v1alpha1.Application](func(obj *v1alpha1.Application) {
-				added += 1
+				added.Add(int32(1))
 			}),
 		)
 		require.NotNil(t, i)
 		require.NoError(t, err)
 		go i.Start(context.TODO())
 		i.WaitForSync(context.TODO())
-		assert.Equal(t, 2, listed)
-		assert.Equal(t, 2, added)
+		assert.Equal(t, int32(2), listed.Load())
+		assert.Equal(t, int32(2), added.Load())
 	})
 
 	t.Run("It adheres to filters on all callbacks", func(t *testing.T) {


### PR DESCRIPTION
**What does this PR do / why we need it**:

Small bugfix that uses the right underlying implementation to check for the informer's sync status. With a lot of Application resources (16k), it turns out the previous call of `HasSynced` would never succeed.

**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:


**Checklist**

* [ ] Documentation update is required by this PR (and has been updated) OR no documentation update is required.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved internal synchronization status tracking to rely on the underlying sync source.
* **Tests**
  * Hardened unit tests by switching counters to atomic operations for safer concurrent assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->