### PR TITLE
feat(helm): Improve agent helm

### DIFF
--- a/install/helm-repo/argocd-agent-agent/README.md
+++ b/install/helm-repo/argocd-agent-agent/README.md
@@ -33,22 +33,29 @@ Kubernetes: `>=1.24.0-0`
 | cacheRefreshInterval | string | `"10s"` | Cache refresh interval. |
 | createNamespace | bool | `false` | Whether to create target namespaces automatically when they don't exist. Used with destination-based mapping. |
 | destinationBasedMapping | bool | `false` | Whether to enable destination-based mapping. When enabled, the agent creates applications in their original namespace (preserving the namespace from the principal) instead of the agent's own namespace. |
+| dnsConfig | object | `{}` | DNS config for the Pod. Only honored when `dnsPolicy` is "None". |
+| dnsPolicy | string | `""` | DNS policy for the Pod (e.g. ClusterFirst, None). Empty leaves the default. |
 | enableCompression | bool | `false` | Whether to enable gRPC compression. |
 | enableResourceProxy | bool | `true` | Whether to enable resource proxy. |
 | enableWebSocket | bool | `false` | Whether to enable WebSocket connections. |
+| fullnameOverride | string | `""` | Override the fully-qualified resource name (defaults to `<release>-agent-helm`). |
 | healthzPort | string | `"8002"` | Healthz server port exposed by the agent. |
+| hostAliases | list | `[]` | Host aliases injected into /etc/hosts of the agent Pod. |
 | image.pullPolicy | string | `"IfNotPresent"` | Image pull policy for the agent container. |
 | image.repository | string | `"ghcr.io/argoproj-labs/argocd-agent/argocd-agent"` | Container image repository for the agent. |
 | image.tag | string | `""` | Overrides the image tag whose default is the chart appVersion. |
+| imagePullSecrets | list | `[]` | Image pull secrets for private registries. |
 | keepAliveInterval | string | `"50s"` | Keep-alive interval for connections. |
 | labelSelector | string | `""` | Kubernetes label selector to restrict which resources the agent watches. Only matching resources will be listed, watched, and processed. |
 | logFormat | string | `"text"` | Log format for the agent (text or json). |
 | logLevel | string | `"info"` | Log level for the agent. |
 | metricsPort | string | `"8181"` | Metrics server port exposed by the agent. |
+| nameOverride | string | `""` |  |
 | namespaceOverride | string | `""` | Override namespace to deploy the agent into. Leave empty to use the release namespace. |
 | nodeSelector | object | `{}` | Node selector for scheduling the agent Pod. |
 | podAnnotations | object | `{}` | Additional annotations to add to the agent Pod. |
 | podLabels | object | `{}` | Additional labels to add to the agent Pod. |
+| podSecurityContext | object | `{"fsGroup":999,"fsGroupChangePolicy":"OnRootMismatch","runAsGroup":999,"runAsNonRoot":true,"runAsUser":999,"seccompProfile":{"type":"RuntimeDefault"}}` | Pod-level securityContext. Applied to the Pod spec. |
 | pprofPort | string | `"0"` | Port for pprof server (0 disables pprof). |
 | priorityClassName | string | `""` | PriorityClassName for the agent Pod. |
 | probes | object | `{"liveness":{"enabled":true,"failureThreshold":3,"httpGet":{"path":"/healthz","port":"healthz"},"initialDelaySeconds":10,"periodSeconds":10,"timeoutSeconds":2},"readiness":{"enabled":true,"failureThreshold":3,"httpGet":{"path":"/healthz","port":"healthz"},"initialDelaySeconds":5,"periodSeconds":10,"timeoutSeconds":2}}` | Liveness and readiness probe configuration. |
@@ -62,6 +69,9 @@ Kubernetes: `>=1.24.0-0`
 | probes.readiness.initialDelaySeconds | int | `5` | Initial delay before the first readiness probe. |
 | probes.readiness.periodSeconds | int | `10` | Frequency of readiness probes. |
 | probes.readiness.timeoutSeconds | int | `2` | Timeout for readiness probe. |
+| progressDeadlineSeconds | int | `600` | Time allowed for the Deployment to make progress before the controller reports failure. |
+| rbac.create | bool | `true` | Create namespace-scoped Role and RoleBinding for the agent. |
+| rbac.createClusterRole | bool | `true` | Create cluster-scoped ClusterRole and ClusterRoleBinding. Required for destination-based mapping, create-namespace, and resource-proxy discovery across multiple namespaces. Leave `false` to keep the agent strictly namespace-scoped. |
 | redisAddress | string | `"argocd-redis:6379"` | Redis address used by the agent. |
 | redisTLS | object | `{"caPath":"/app/config/redis-tls/ca.crt","enabled":false,"insecure":false,"secretName":"argocd-redis-tls"}` | Redis TLS configuration. |
 | redisTLS.caPath | string | `"/app/config/redis-tls/ca.crt"` | Path to CA certificate for verifying Redis TLS certificate. This path is where the CA certificate will be mounted inside the container. |
@@ -71,6 +81,8 @@ Kubernetes: `>=1.24.0-0`
 | redisUsername | string | `""` | Redis username for authentication. |
 | replicaCount | int | `1` | Number of replicas for the agent Deployment. |
 | resources | object | `{"limits":{"cpu":"500m","memory":"512Mi"},"requests":{"cpu":"100m","memory":"128Mi"}}` | Resource requests and limits for the agent Pod. |
+| revisionHistoryLimit | int | `10` | Number of old ReplicaSets to retain for rollback. |
+| securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"privileged":false,"readOnlyRootFilesystem":true,"runAsGroup":999,"runAsNonRoot":true,"runAsUser":999,"seccompProfile":{"type":"RuntimeDefault"}}` | Container-level securityContext. Applied to the agent container. |
 | server | string | `"principal.server.address.com"` | Principal server address (hostname or host:port). |
 | serverPort | string | `"443"` | Principal server port. |
 | service | object | `{"healthz":{"annotations":{},"port":8002,"targetPort":8002},"metrics":{"annotations":{},"port":8181,"targetPort":8181}}` | Service configuration for metrics and healthz endpoints. |
@@ -97,6 +109,7 @@ Kubernetes: `>=1.24.0-0`
 | serviceMonitor.scheme | string | `""` | Prometheus ServiceMonitor scheme |
 | serviceMonitor.scrapeTimeout | string | `"10s"` | Prometheus scrape timeout. Must be a valid duration string (e.g. "10s"). |
 | serviceMonitor.tlsConfig | object | `{}` | Prometheus ServiceMonitor tlsConfig |
+| terminationGracePeriodSeconds | int | `30` | Grace period for Pod termination (seconds). |
 | tests | object | `{"enabled":false,"image":"bitnamilegacy/kubectl","tag":"1.33.4"}` | Configuration for helm-chart tests. |
 | tests.enabled | bool | `false` | By default, chart tests are disabled. |
 | tests.image | string | `"bitnamilegacy/kubectl"` | Test image. |
@@ -112,6 +125,8 @@ Kubernetes: `>=1.24.0-0`
 | tlsRootCASecretName | string | `"argocd-agent-ca"` | Name of the Secret containing root CA certificate. |
 | tlsSecretName | string | `"argocd-agent-client-tls"` | Name of the TLS Secret containing client cert/key for mTLS. |
 | tolerations | list | `[]` | Tolerations for the agent Pod. |
+| topologySpreadConstraints | list | `[]` | Topology spread constraints for the agent Pod. |
+| updateStrategy | object | `{"rollingUpdate":{"maxSurge":"25%","maxUnavailable":"25%"},"type":"RollingUpdate"}` | Deployment update strategy (passed through as `spec.strategy`). |
 | userPasswordSecretName | string | `"argocd-agent-agent-userpass"` | Name of the Secret containing agent username/password (if used). |
 
 ----------------------------------------------

--- a/install/helm-repo/argocd-agent-agent/README.md
+++ b/install/helm-repo/argocd-agent-agent/README.md
@@ -50,7 +50,7 @@ Kubernetes: `>=1.24.0-0`
 | logFormat | string | `"text"` | Log format for the agent (text or json). |
 | logLevel | string | `"info"` | Log level for the agent. |
 | metricsPort | string | `"8181"` | Metrics server port exposed by the agent. |
-| nameOverride | string | `""` |  |
+| nameOverride | string | `""` | Override the chart name used in `app.kubernetes.io/name` Also changes `spec.selector.matchLabels`, which is immutable — do not set after initial install unless you are prepared to delete+reinstall. |
 | namespaceOverride | string | `""` | Override namespace to deploy the agent into. Leave empty to use the release namespace. |
 | nodeSelector | object | `{}` | Node selector for scheduling the agent Pod. |
 | podAnnotations | object | `{}` | Additional annotations to add to the agent Pod. |

--- a/install/helm-repo/argocd-agent-agent/templates/_helpers.tpl
+++ b/install/helm-repo/argocd-agent-agent/templates/_helpers.tpl
@@ -123,10 +123,13 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end }}
 
 {{/*
-Selector labels
+Selector labels.
+NOTE: `spec.selector.matchLabels` is immutable on Deployments. Changing any
+value emitted here after the initial install (e.g. by setting
+`.Values.nameOverride`) requires deleting and reinstalling the release.
 */}}
 {{- define "argocd-agent-agent.selectorLabels" -}}
-app.kubernetes.io/name: argocd-agent-agent
+app.kubernetes.io/name: {{ include "argocd-agent-agent.name" . }}
 app.kubernetes.io/part-of: argocd-agent
 app.kubernetes.io/component: agent
 app.kubernetes.io/instance: {{ .Release.Name }}

--- a/install/helm-repo/argocd-agent-agent/templates/agent-clusterrole.yaml
+++ b/install/helm-repo/argocd-agent-agent/templates/agent-clusterrole.yaml
@@ -1,3 +1,4 @@
+{{- if and .Values.rbac.create .Values.rbac.createClusterRole }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -26,3 +27,4 @@ rules:
   - update
   - delete
   - patch
+{{- end }}

--- a/install/helm-repo/argocd-agent-agent/templates/agent-clusterrolebinding.yaml
+++ b/install/helm-repo/argocd-agent-agent/templates/agent-clusterrolebinding.yaml
@@ -1,3 +1,4 @@
+{{- if and .Values.rbac.create .Values.rbac.createClusterRole }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -12,3 +13,4 @@ subjects:
 - kind: ServiceAccount
   name: {{ include "argocd-agent-agent.serviceAccountName" . }}
   namespace: {{ include "argocd-agent-agent.namespace" . }}
+{{- end }}

--- a/install/helm-repo/argocd-agent-agent/templates/agent-deployment.yaml
+++ b/install/helm-repo/argocd-agent-agent/templates/agent-deployment.yaml
@@ -7,6 +7,12 @@ metadata:
     {{- include "argocd-agent-agent.labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.replicaCount }}
+  revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
+  progressDeadlineSeconds: {{ .Values.progressDeadlineSeconds }}
+  {{- with .Values.updateStrategy }}
+  strategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "argocd-agent-agent.selectorLabels" . | nindent 6 }}
@@ -19,19 +25,31 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       serviceAccountName: {{ include "argocd-agent-agent.serviceAccountName" . }}
       automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
       {{- with .Values.priorityClassName }}
       priorityClassName: {{ . }}
       {{- end }}
+      {{- with .Values.podSecurityContext }}
       securityContext:
-        fsGroup: 999
-        fsGroupChangePolicy: "OnRootMismatch"
-        runAsGroup: 999
-        runAsNonRoot: true
-        runAsUser: 999
-        seccompProfile:
-          type: RuntimeDefault
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.hostAliases }}
+      hostAliases:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.dnsPolicy }}
+      dnsPolicy: {{ . }}
+      {{- end }}
+      {{- with .Values.dnsConfig }}
+      dnsConfig:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
       containers:
         - name: argocd-agent-agent
           image: "{{ .Values.image.repository }}:{{ include "argocd-agent-agent.defaultTag" . }}"
@@ -270,18 +288,10 @@ spec:
             timeoutSeconds: {{ .Values.probes.readiness.timeoutSeconds }}
             failureThreshold: {{ .Values.probes.readiness.failureThreshold }}
           {{- end }}
+          {{- with .Values.securityContext }}
           securityContext:
-            allowPrivilegeEscalation: false
-            capabilities:
-              drop:
-                - ALL
-            privileged: false
-            readOnlyRootFilesystem: true
-            runAsGroup: 999
-            runAsNonRoot: true
-            runAsUser: 999
-            seccompProfile:
-              type: RuntimeDefault
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:
@@ -306,5 +316,9 @@ spec:
       {{- end }}
       {{- with .Values.tolerations }}
       tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/install/helm-repo/argocd-agent-agent/templates/agent-role.yaml
+++ b/install/helm-repo/argocd-agent-agent/templates/agent-role.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.rbac.create -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -40,3 +41,4 @@ rules:
   verbs:
   - create
   - list
+{{- end }}

--- a/install/helm-repo/argocd-agent-agent/templates/agent-role.yaml
+++ b/install/helm-repo/argocd-agent-agent/templates/agent-role.yaml
@@ -40,4 +40,5 @@ rules:
   - events
   verbs:
   - create
+  - list
 {{- end }}

--- a/install/helm-repo/argocd-agent-agent/templates/agent-role.yaml
+++ b/install/helm-repo/argocd-agent-agent/templates/agent-role.yaml
@@ -40,5 +40,4 @@ rules:
   - events
   verbs:
   - create
-  - list
 {{- end }}

--- a/install/helm-repo/argocd-agent-agent/templates/agent-rolebinding.yaml
+++ b/install/helm-repo/argocd-agent-agent/templates/agent-rolebinding.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.rbac.create -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
@@ -13,3 +14,4 @@ subjects:
 - kind: ServiceAccount
   name: {{ include "argocd-agent-agent.serviceAccountName" . }}
   namespace: {{ include "argocd-agent-agent.namespace" . }}
+{{- end }}

--- a/install/helm-repo/argocd-agent-agent/values.schema.json
+++ b/install/helm-repo/argocd-agent-agent/values.schema.json
@@ -261,14 +261,7 @@
           "type": "object"
         }
       },
-      "required": [
-        "fsGroup",
-        "fsGroupChangePolicy",
-        "runAsGroup",
-        "runAsNonRoot",
-        "runAsUser",
-        "seccompProfile"
-      ],
+      "required": [],
       "title": "podSecurityContext",
       "type": "object"
     },
@@ -638,16 +631,7 @@
           "type": "object"
         }
       },
-      "required": [
-        "allowPrivilegeEscalation",
-        "capabilities",
-        "privileged",
-        "readOnlyRootFilesystem",
-        "runAsGroup",
-        "runAsNonRoot",
-        "runAsUser",
-        "seccompProfile"
-      ],
+      "required": [],
       "title": "securityContext",
       "type": "object"
     },
@@ -1029,11 +1013,8 @@
   },
   "required": [
     "namespaceOverride",
-    "nameOverride",
-    "fullnameOverride",
     "image",
     "replicaCount",
-    "imagePullSecrets",
     "updateStrategy",
     "revisionHistoryLimit",
     "progressDeadlineSeconds",
@@ -1048,14 +1029,10 @@
     "nodeSelector",
     "affinity",
     "tolerations",
-    "topologySpreadConstraints",
     "podAnnotations",
     "podLabels",
     "priorityClassName",
     "terminationGracePeriodSeconds",
-    "hostAliases",
-    "dnsPolicy",
-    "dnsConfig",
     "probes",
     "agentMode",
     "auth",

--- a/install/helm-repo/argocd-agent-agent/values.schema.json
+++ b/install/helm-repo/argocd-agent-agent/values.schema.json
@@ -446,7 +446,7 @@
         },
         "createClusterRole": {
           "default": true,
-          "description": "Create cluster-scoped ClusterRole and ClusterRoleBinding. Required for\ndestination-based mapping, create-namespace, and resource-proxy discovery\nacross multiple namespaces. Leave `false` to keep the agent strictly\nnamespace-scoped (default).",
+          "description": "Create cluster-scoped ClusterRole and ClusterRoleBinding. Required for\ndestination-based mapping, create-namespace, and resource-proxy discovery\nacross multiple namespaces. Leave `false` to keep the agent strictly\nnamespace-scoped.",
           "title": "createClusterRole",
           "type": "boolean"
         }
@@ -1015,8 +1015,7 @@
         }
       },
       "required": [
-        "type",
-        "rollingUpdate"
+        "type"
       ],
       "title": "updateStrategy",
       "type": "object"

--- a/install/helm-repo/argocd-agent-agent/values.schema.json
+++ b/install/helm-repo/argocd-agent-agent/values.schema.json
@@ -63,6 +63,19 @@
       "title": "destinationBasedMapping",
       "type": "boolean"
     },
+    "dnsConfig": {
+      "additionalProperties": true,
+      "description": "DNS config for the Pod. Only honored when `dnsPolicy` is \"None\".",
+      "required": [],
+      "title": "dnsConfig",
+      "type": "object"
+    },
+    "dnsPolicy": {
+      "default": "",
+      "description": "DNS policy for the Pod (e.g. ClusterFirst, None). Empty leaves the default.",
+      "title": "dnsPolicy",
+      "type": "string"
+    },
     "enableCompression": {
       "default": false,
       "description": "Whether to enable gRPC compression.",
@@ -81,6 +94,12 @@
       "title": "enableWebSocket",
       "type": "boolean"
     },
+    "fullnameOverride": {
+      "default": "",
+      "description": "Override the fully-qualified resource name (defaults to `\u003crelease\u003e-agent-helm`).",
+      "title": "fullnameOverride",
+      "type": "string"
+    },
     "global": {
       "description": "Global values are values that can be accessed from any chart or subchart by exactly the same name.",
       "required": [],
@@ -92,6 +111,14 @@
       "description": "Healthz server port exposed by the agent.",
       "title": "healthzPort",
       "type": "string"
+    },
+    "hostAliases": {
+      "description": "Host aliases injected into /etc/hosts of the agent Pod.",
+      "items": {
+        "required": []
+      },
+      "title": "hostAliases",
+      "type": "array"
     },
     "image": {
       "additionalProperties": false,
@@ -124,6 +151,14 @@
       "title": "image",
       "type": "object"
     },
+    "imagePullSecrets": {
+      "description": "Image pull secrets for private registries.",
+      "items": {
+        "required": []
+      },
+      "title": "imagePullSecrets",
+      "type": "array"
+    },
     "keepAliveInterval": {
       "default": "50s",
       "description": "Keep-alive interval for connections.",
@@ -146,6 +181,12 @@
       "default": "8181",
       "description": "Metrics server port exposed by the agent.",
       "title": "metricsPort",
+      "type": "string"
+    },
+    "nameOverride": {
+      "default": "",
+      "description": "Override the chart name used in `app.kubernetes.io/name`\nAlso changes `spec.selector.matchLabels`, which is immutable — do not set after initial\ninstall unless you are prepared to delete+reinstall.",
+      "title": "nameOverride",
       "type": "string"
     },
     "namespaceOverride": {
@@ -173,6 +214,62 @@
       "description": "Additional labels to add to the agent Pod.",
       "required": [],
       "title": "podLabels",
+      "type": "object"
+    },
+    "podSecurityContext": {
+      "additionalProperties": true,
+      "description": "#\nPod-level securityContext. Applied to the Pod spec.",
+      "properties": {
+        "fsGroup": {
+          "default": 999,
+          "title": "fsGroup",
+          "type": "integer"
+        },
+        "fsGroupChangePolicy": {
+          "default": "OnRootMismatch",
+          "title": "fsGroupChangePolicy",
+          "type": "string"
+        },
+        "runAsGroup": {
+          "default": 999,
+          "title": "runAsGroup",
+          "type": "integer"
+        },
+        "runAsNonRoot": {
+          "default": true,
+          "title": "runAsNonRoot",
+          "type": "boolean"
+        },
+        "runAsUser": {
+          "default": 999,
+          "title": "runAsUser",
+          "type": "integer"
+        },
+        "seccompProfile": {
+          "additionalProperties": true,
+          "properties": {
+            "type": {
+              "default": "RuntimeDefault",
+              "title": "type",
+              "type": "string"
+            }
+          },
+          "required": [
+            "type"
+          ],
+          "title": "seccompProfile",
+          "type": "object"
+        }
+      },
+      "required": [
+        "fsGroup",
+        "fsGroupChangePolicy",
+        "runAsGroup",
+        "runAsNonRoot",
+        "runAsUser",
+        "seccompProfile"
+      ],
+      "title": "podSecurityContext",
       "type": "object"
     },
     "pprofPort": {
@@ -331,6 +428,36 @@
       "title": "probes",
       "type": "object"
     },
+    "progressDeadlineSeconds": {
+      "default": 600,
+      "description": "Time allowed for the Deployment to make progress before the controller reports failure.",
+      "title": "progressDeadlineSeconds",
+      "type": "integer"
+    },
+    "rbac": {
+      "additionalProperties": false,
+      "description": "#",
+      "properties": {
+        "create": {
+          "default": true,
+          "description": "Create namespace-scoped Role and RoleBinding for the agent.",
+          "title": "create",
+          "type": "boolean"
+        },
+        "createClusterRole": {
+          "default": true,
+          "description": "Create cluster-scoped ClusterRole and ClusterRoleBinding. Required for\ndestination-based mapping, create-namespace, and resource-proxy discovery\nacross multiple namespaces. Leave `false` to keep the agent strictly\nnamespace-scoped (default).",
+          "title": "createClusterRole",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "create",
+        "createClusterRole"
+      ],
+      "title": "rbac",
+      "type": "object"
+    },
     "redisAddress": {
       "default": "argocd-redis:6379",
       "description": "Redis address used by the agent.",
@@ -431,6 +558,97 @@
         "requests"
       ],
       "title": "resources",
+      "type": "object"
+    },
+    "revisionHistoryLimit": {
+      "default": 10,
+      "description": "Number of old ReplicaSets to retain for rollback.",
+      "title": "revisionHistoryLimit",
+      "type": "integer"
+    },
+    "securityContext": {
+      "additionalProperties": true,
+      "description": "#\nContainer-level securityContext. Applied to the agent container.",
+      "properties": {
+        "allowPrivilegeEscalation": {
+          "default": false,
+          "title": "allowPrivilegeEscalation",
+          "type": "boolean"
+        },
+        "capabilities": {
+          "additionalProperties": false,
+          "properties": {
+            "drop": {
+              "items": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  }
+                ],
+                "required": []
+              },
+              "title": "drop",
+              "type": "array"
+            }
+          },
+          "required": [
+            "drop"
+          ],
+          "title": "capabilities",
+          "type": "object"
+        },
+        "privileged": {
+          "default": false,
+          "title": "privileged",
+          "type": "boolean"
+        },
+        "readOnlyRootFilesystem": {
+          "default": true,
+          "title": "readOnlyRootFilesystem",
+          "type": "boolean"
+        },
+        "runAsGroup": {
+          "default": 999,
+          "title": "runAsGroup",
+          "type": "integer"
+        },
+        "runAsNonRoot": {
+          "default": true,
+          "title": "runAsNonRoot",
+          "type": "boolean"
+        },
+        "runAsUser": {
+          "default": 999,
+          "title": "runAsUser",
+          "type": "integer"
+        },
+        "seccompProfile": {
+          "additionalProperties": true,
+          "properties": {
+            "type": {
+              "default": "RuntimeDefault",
+              "title": "type",
+              "type": "string"
+            }
+          },
+          "required": [
+            "type"
+          ],
+          "title": "seccompProfile",
+          "type": "object"
+        }
+      },
+      "required": [
+        "allowPrivilegeEscalation",
+        "capabilities",
+        "privileged",
+        "readOnlyRootFilesystem",
+        "runAsGroup",
+        "runAsNonRoot",
+        "runAsUser",
+        "seccompProfile"
+      ],
+      "title": "securityContext",
       "type": "object"
     },
     "server": {
@@ -652,6 +870,12 @@
       "title": "serviceMonitor",
       "type": "object"
     },
+    "terminationGracePeriodSeconds": {
+      "default": 30,
+      "description": "Grace period for Pod termination (seconds).",
+      "title": "terminationGracePeriodSeconds",
+      "type": "integer"
+    },
     "tests": {
       "additionalProperties": false,
       "description": "#\nConfiguration for helm-chart tests.",
@@ -751,6 +975,52 @@
       "title": "tolerations",
       "type": "array"
     },
+    "topologySpreadConstraints": {
+      "description": "Topology spread constraints for the agent Pod.",
+      "items": {
+        "required": []
+      },
+      "title": "topologySpreadConstraints",
+      "type": "array"
+    },
+    "updateStrategy": {
+      "additionalProperties": true,
+      "description": "Deployment update strategy (passed through as `spec.strategy`).",
+      "properties": {
+        "rollingUpdate": {
+          "additionalProperties": true,
+          "properties": {
+            "maxSurge": {
+              "default": "25%",
+              "title": "maxSurge",
+              "type": "string"
+            },
+            "maxUnavailable": {
+              "default": "25%",
+              "title": "maxUnavailable",
+              "type": "string"
+            }
+          },
+          "required": [
+            "maxSurge",
+            "maxUnavailable"
+          ],
+          "title": "rollingUpdate",
+          "type": "object"
+        },
+        "type": {
+          "default": "RollingUpdate",
+          "title": "type",
+          "type": "string"
+        }
+      },
+      "required": [
+        "type",
+        "rollingUpdate"
+      ],
+      "title": "updateStrategy",
+      "type": "object"
+    },
     "userPasswordSecretName": {
       "default": "argocd-agent-agent-userpass",
       "description": "Name of the Secret containing agent username/password (if used).",
@@ -760,19 +1030,33 @@
   },
   "required": [
     "namespaceOverride",
+    "nameOverride",
+    "fullnameOverride",
     "image",
     "replicaCount",
+    "imagePullSecrets",
+    "updateStrategy",
+    "revisionHistoryLimit",
+    "progressDeadlineSeconds",
     "tlsSecretName",
     "tlsRootCASecretName",
     "userPasswordSecretName",
     "resources",
     "serviceAccount",
+    "podSecurityContext",
+    "securityContext",
+    "rbac",
     "nodeSelector",
     "affinity",
     "tolerations",
+    "topologySpreadConstraints",
     "podAnnotations",
     "podLabels",
     "priorityClassName",
+    "terminationGracePeriodSeconds",
+    "hostAliases",
+    "dnsPolicy",
+    "dnsConfig",
     "probes",
     "agentMode",
     "auth",

--- a/install/helm-repo/argocd-agent-agent/values.yaml
+++ b/install/helm-repo/argocd-agent-agent/values.yaml
@@ -5,6 +5,12 @@
 ## @section Global
 # -- Override namespace to deploy the agent into. Leave empty to use the release namespace.
 namespaceOverride: ""
+# Override the chart name used in `app.kubernetes.io/name`
+# Also changes `spec.selector.matchLabels`, which is immutable — do not set after initial
+# install unless you are prepared to delete+reinstall.
+nameOverride: ""
+# -- Override the fully-qualified resource name (defaults to `<release>-agent-helm`).
+fullnameOverride: ""
 
 ## @section Image
 image:
@@ -18,6 +24,18 @@ image:
 ## @section Deployment
 # -- Number of replicas for the agent Deployment.
 replicaCount: 1
+# -- Image pull secrets for private registries.
+imagePullSecrets: []
+# -- Deployment update strategy (passed through as `spec.strategy`).
+updateStrategy:
+  type: RollingUpdate
+  rollingUpdate:
+    maxSurge: 25%
+    maxUnavailable: 25%
+# -- Number of old ReplicaSets to retain for rollback.
+revisionHistoryLimit: 10
+# -- Time allowed for the Deployment to make progress before the controller reports failure.
+progressDeadlineSeconds: 600
 # -- Name of the TLS Secret containing client cert/key for mTLS.
 tlsSecretName: "argocd-agent-client-tls"
 # -- Name of the Secret containing root CA certificate.
@@ -45,6 +63,43 @@ serviceAccount:
   # -- Automount API credentials for the Service Account
   automountServiceAccountToken: true
 
+## @section Pod security context
+# -- Pod-level securityContext. Applied to the Pod spec.
+podSecurityContext:
+  fsGroup: 999
+  fsGroupChangePolicy: "OnRootMismatch"
+  runAsGroup: 999
+  runAsNonRoot: true
+  runAsUser: 999
+  seccompProfile:
+    type: RuntimeDefault
+
+## @section Container security context
+# -- Container-level securityContext. Applied to the agent container.
+securityContext:
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - ALL
+  privileged: false
+  readOnlyRootFilesystem: true
+  runAsGroup: 999
+  runAsNonRoot: true
+  runAsUser: 999
+  seccompProfile:
+    type: RuntimeDefault
+
+
+## @section RBAC
+rbac:
+  # -- Create namespace-scoped Role and RoleBinding for the agent.
+  create: true
+  # -- Create cluster-scoped ClusterRole and ClusterRoleBinding. Required for
+  # destination-based mapping, create-namespace, and resource-proxy discovery
+  # across multiple namespaces. Leave `false` to keep the agent strictly
+  # namespace-scoped.
+  createClusterRole: true
+
 ## @section Pod Scheduling and Metadata
 # -- Node selector for scheduling the agent Pod.
 nodeSelector: {}
@@ -52,12 +107,22 @@ nodeSelector: {}
 affinity: {}
 # -- Tolerations for the agent Pod.
 tolerations: []
+# -- Topology spread constraints for the agent Pod.
+topologySpreadConstraints: []
 # -- Additional annotations to add to the agent Pod.
 podAnnotations: {}
 # -- Additional labels to add to the agent Pod.
 podLabels: {}
 # -- PriorityClassName for the agent Pod.
 priorityClassName: ""
+# -- Grace period for Pod termination (seconds).
+terminationGracePeriodSeconds: 30
+# -- Host aliases injected into /etc/hosts of the agent Pod.
+hostAliases: []
+# -- DNS policy for the Pod (e.g. ClusterFirst, None). Empty leaves the default.
+dnsPolicy: ""
+# -- DNS config for the Pod. Only honored when `dnsPolicy` is "None".
+dnsConfig: {}
 
 ## @section Probes
 # -- Liveness and readiness probe configuration.

--- a/install/helm-repo/argocd-agent-agent/values.yaml
+++ b/install/helm-repo/argocd-agent-agent/values.yaml
@@ -5,7 +5,7 @@
 ## @section Global
 # -- Override namespace to deploy the agent into. Leave empty to use the release namespace.
 namespaceOverride: ""
-# Override the chart name used in `app.kubernetes.io/name`
+# -- Override the chart name used in `app.kubernetes.io/name`
 # Also changes `spec.selector.matchLabels`, which is immutable — do not set after initial
 # install unless you are prepared to delete+reinstall.
 nameOverride: ""


### PR DESCRIPTION
**What does this PR do / why we need it**:

The argocd-agent-agent chart hardcoded several production-critical pod settings (securityContext, update strategy, termination grace, DNS) and always rendered a ClusterRole/ClusterRoleBinding even when the agent was deployed strictly namespace-scoped. 
What changed:

1. `values.yaml` / `values.schema.json` / `README.md`: new fields — nameOverride, fullnameOverride, imagePullSecrets, updateStrategy, revisionHistoryLimit, progressDeadlineSeconds, podSecurityContext, securityContext, rbac.create, rbac.createClusterRole, topologySpreadConstraints, terminationGracePeriodSeconds, hostAliases, dnsPolicy, dnsConfig.
2. `agent-deployment.yaml`: renders the new values; pod/container securityContext moved from hardcoded blocks to chart values (defaults unchanged).
3. `agent-role.yaml` / `agent-rolebinding.yaml`: added toggle.
4. `agent-clusterrole.yaml` / `agent-clusterrolebinding.yaml`: gated on rbac.create && rbac.createClusterRole (default true) - to keep destination-based mapping, createNamespace, or cross-namespace resource-proxy discovery.

**Which issue(s) this PR fixes**:

N/A

**How to test changes / Special notes to the reviewer**:
`helm template`

**Checklist**

* [X] Documentation update is required by this PR (and has been updated) OR no documentation update is required.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added many Helm chart values to customize Pod/Deployment behavior: naming overrides, DNS, image pull secrets, pod/container security contexts, topology spread, termination/grace, rollout controls, and RBAC toggles.
  * RBAC resources (cluster- and namespace-scoped) are now only emitted when RBAC is enabled.

* **Documentation**
  * Values schema and chart README updated to document all new configuration options and selector-label caution for renames.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->