### PR TITLE
feat(debug): Add a debugging routine to the principal

### DIFF
--- a/internal/config/constants.go
+++ b/internal/config/constants.go
@@ -39,3 +39,6 @@ const EnvKubeBurst = "ARGOCD_AGENT_KUBE_BURST"
 
 // EnvQueueSize is the name of the environment variable for setting the size of the queue.
 const EnvQueueSize = "ARGOCD_AGENT_QUEUE_SIZE"
+
+// EnvRunPrincipalDebugRoutine is the name of the environment variable for setting whether to run the principal debug routine.
+const EnvRunPrincipalDebugRoutine = "ARGOCD_AGENT_RUN_PRINCIPAL_DEBUG_ROUTINE"

--- a/principal/debug.go
+++ b/principal/debug.go
@@ -51,7 +51,7 @@ func (s *Server) logDebugOutput() {
 	logCtx.Infof("TotalQueueDepth=%d", totalQueueDepth)
 }
 
-// scheduleDebugRoutine launches a goroutine that prints debug information about the server to the logs every 10 seconds
+// scheduleDebugRoutine launches a goroutine that prints debug information about the server to the logs at debugInterval
 func (s *Server) scheduleDebugRoutine() {
 	ticker := time.NewTicker(debugInterval)
 	go func() {

--- a/principal/debug.go
+++ b/principal/debug.go
@@ -18,23 +18,33 @@ import (
 	"time"
 )
 
+const debugInterval = 30 * time.Second
+
 // logDebugOutput prints some debugging information about the server to the logs
 func (s *Server) logDebugOutput() {
 	var m runtime.MemStats
 	runtime.ReadMemStats(&m)
 	logCtx := log().WithField("module", "debugRoutine")
-	logCtx.Infof("HeapAlloc=%d HeapSys=%d HeapIdle=%d HeapInuse=%d HeapReleased=%d HeapObjects=%d", m.Alloc/1024/1024, m.Sys/1024/1024, m.HeapIdle/1024/1024, m.HeapInuse/1024/1024, m.HeapReleased/1024/1024, m.HeapObjects)
+	logCtx.Infof("HeapAlloc=%dMiB HeapSys=%dMiB TotalSys=%dMiB HeapIdle=%dMiB HeapInuse=%dMiB HeapReleased=%dMiB HeapObjects=%d", m.Alloc/1024/1024, m.HeapSys/1024/1024, m.Sys/1024/1024, m.HeapIdle/1024/1024, m.HeapInuse/1024/1024, m.HeapReleased/1024/1024, m.HeapObjects)
 	logCtx.Infof("GoRoutines=%d", runtime.NumGoroutine())
 	logCtx.Infof("QueuePairs=%d", s.queues.Len())
 	totalQueueDepth := 0
 	for _, queueName := range s.queues.Names() {
-		sendLen := s.queues.SendQ(queueName).Len()
-		recvLen := s.queues.RecvQ(queueName).Len()
+		sendq := s.queues.SendQ(queueName)
+		recvq := s.queues.RecvQ(queueName)
+		var sendLen int
+		var recvLen int
+		if sendq != nil {
+			sendLen = sendq.Len()
+		}
+		if recvq != nil {
+			recvLen = recvq.Len()
+		}
 		if recvLen > 0 {
-			logCtx.Infof("RecvQueueDepth(%s)=%d", queueName, s.queues.RecvQ(queueName).Len())
+			logCtx.Infof("RecvQueueDepth(%s)=%d", queueName, recvLen)
 		}
 		if sendLen > 0 {
-			logCtx.Infof("SendQueueDepth(%s)=%d", queueName, s.queues.SendQ(queueName).Len())
+			logCtx.Infof("SendQueueDepth(%s)=%d", queueName, sendLen)
 		}
 		totalQueueDepth += sendLen + recvLen
 	}
@@ -43,13 +53,13 @@ func (s *Server) logDebugOutput() {
 
 // scheduleDebugRoutine launches a goroutine that prints debug information about the server to the logs every 10 seconds
 func (s *Server) scheduleDebugRoutine() {
-	ticker := time.NewTicker(10 * time.Second)
+	ticker := time.NewTicker(debugInterval)
 	go func() {
 		for {
 			select {
 			case <-ticker.C:
 				s.logDebugOutput()
-				ticker.Reset(30 * time.Second)
+				ticker.Reset(debugInterval)
 			case <-s.ctx.Done():
 				ticker.Stop()
 				return

--- a/principal/debug.go
+++ b/principal/debug.go
@@ -1,0 +1,59 @@
+// Copyright 2026 The argocd-agent Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package principal
+
+import (
+	"runtime"
+	"time"
+)
+
+// logDebugOutput prints some debugging information about the server to the logs
+func (s *Server) logDebugOutput() {
+	var m runtime.MemStats
+	runtime.ReadMemStats(&m)
+	logCtx := log().WithField("module", "debugRoutine")
+	logCtx.Infof("HeapAlloc=%d HeapSys=%d HeapIdle=%d HeapInuse=%d HeapReleased=%d HeapObjects=%d", m.Alloc/1024/1024, m.Sys/1024/1024, m.HeapIdle/1024/1024, m.HeapInuse/1024/1024, m.HeapReleased/1024/1024, m.HeapObjects)
+	logCtx.Infof("GoRoutines=%d", runtime.NumGoroutine())
+	logCtx.Infof("QueuePairs=%d", s.queues.Len())
+	totalQueueDepth := 0
+	for _, queueName := range s.queues.Names() {
+		sendLen := s.queues.SendQ(queueName).Len()
+		recvLen := s.queues.RecvQ(queueName).Len()
+		if recvLen > 0 {
+			logCtx.Infof("RecvQueueDepth(%s)=%d", queueName, s.queues.RecvQ(queueName).Len())
+		}
+		if sendLen > 0 {
+			logCtx.Infof("SendQueueDepth(%s)=%d", queueName, s.queues.SendQ(queueName).Len())
+		}
+		totalQueueDepth += sendLen + recvLen
+	}
+	logCtx.Infof("TotalQueueDepth=%d", totalQueueDepth)
+}
+
+// scheduleDebugRoutine launches a goroutine that prints debug information about the server to the logs every 10 seconds
+func (s *Server) scheduleDebugRoutine() {
+	ticker := time.NewTicker(10 * time.Second)
+	go func() {
+		for {
+			select {
+			case <-ticker.C:
+				s.logDebugOutput()
+				ticker.Reset(30 * time.Second)
+			case <-s.ctx.Done():
+				ticker.Stop()
+				return
+			}
+		}
+	}()
+}

--- a/principal/server.go
+++ b/principal/server.go
@@ -37,6 +37,7 @@ import (
 	kuberepository "github.com/argoproj-labs/argocd-agent/internal/backend/kubernetes/repository"
 	"github.com/argoproj-labs/argocd-agent/internal/cache"
 	"github.com/argoproj-labs/argocd-agent/internal/config"
+	"github.com/argoproj-labs/argocd-agent/internal/env"
 	"github.com/argoproj-labs/argocd-agent/internal/event"
 	"github.com/argoproj-labs/argocd-agent/internal/filter"
 	"github.com/argoproj-labs/argocd-agent/internal/informer"
@@ -214,6 +215,7 @@ var noAuthEndpoints = map[string]bool{
 	"/authapi.Authentication/RefreshToken": true,
 }
 
+// waitForSyncedDuration is the default duration to wait for the informer to be synced
 const waitForSyncedDuration = 60 * time.Second
 
 // defaultResourceProxyListenerAddr is the default listener address for the
@@ -766,16 +768,19 @@ func (s *Server) Start(ctx context.Context, errch chan error) error {
 		syncTimeout = waitForSyncedDuration
 	}
 
+	log().Info("Waiting for Application informer to be synced")
 	if err := s.appManager.EnsureSynced(syncTimeout); err != nil {
 		return fmt.Errorf("unable to sync Application informer: %w", err)
 	}
 	log().Infof("Application informer synced and ready")
 
+	log().Info("Waiting for AppProject informer to be synced")
 	if err := s.projectManager.EnsureSynced(syncTimeout); err != nil {
 		return fmt.Errorf("unable to sync AppProject informer: %w", err)
 	}
 	log().Infof("AppProject informer synced and ready")
 
+	log().Info("Waiting for ApplicationSet informer to be synced")
 	if s.ha != nil {
 		if err := s.appSetManager.EnsureSynced(syncTimeout); err != nil {
 			return fmt.Errorf("unable to sync ApplicationSet informer: %w", err)
@@ -783,11 +788,13 @@ func (s *Server) Start(ctx context.Context, errch chan error) error {
 		log().Infof("ApplicationSet informer synced and ready")
 	}
 
+	log().Info("Waiting for Repository informer to be synced")
 	if err := s.repoManager.EnsureSynced(syncTimeout); err != nil {
 		return fmt.Errorf("unable to sync Repository informer: %w", err)
 	}
 	log().Infof("Repository informer synced and ready")
 
+	log().Info("Waiting for GPG key informer to be synced")
 	if err := s.gpgKeyManager.EnsureSynced(syncTimeout); err != nil {
 		return fmt.Errorf("unable to sync GPG key informer: %w", err)
 	}
@@ -825,6 +832,11 @@ func (s *Server) Start(ctx context.Context, errch chan error) error {
 		log().Infof("Starting healthz server on %s", healthzAddr)
 		//nolint:errcheck
 		go http.ListenAndServe(healthzAddr, nil)
+	}
+
+	// Enable debug routine if the environment variable is set
+	if env.BoolWithDefault(config.EnvRunPrincipalDebugRoutine, false) {
+		s.scheduleDebugRoutine()
 	}
 
 	// Finally, start accepting connections from agents


### PR DESCRIPTION
**What does this PR do / why we need it**:

After chasing some alleged memory issues with pprof and the like, I thought it would make sense to have an optional debug printout every once in a while to have an insight into the principal.

This is more or less thought for development environments, where you might not have metrics collection and don't want to pull out pprof for every piece of information you are seeking.

**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:


**Checklist**

* [ ] Documentation update is required by this PR (and has been updated) OR no documentation update is required.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional debug routine (toggleable via environment) that periodically logs runtime memory metrics, goroutine count, and per-queue depth totals (~30s).

* **Improvements**
  * Enhanced startup logging to give clearer visibility into informer synchronization progress.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->