### PR TITLE
feat: Add additional logging/detail granularity to logging

### DIFF
--- a/agent/connection.go
+++ b/agent/connection.go
@@ -22,6 +22,7 @@ import (
 	"github.com/argoproj-labs/argocd-agent/internal/event"
 	"github.com/argoproj-labs/argocd-agent/internal/grpcutil"
 	"github.com/argoproj-labs/argocd-agent/internal/kube"
+	"github.com/argoproj-labs/argocd-agent/internal/logging"
 	"github.com/argoproj-labs/argocd-agent/internal/logging/logfields"
 	"github.com/argoproj-labs/argocd-agent/internal/manager"
 	"github.com/argoproj-labs/argocd-agent/internal/resync"
@@ -97,6 +98,7 @@ func (a *Agent) sender(stream eventstreamapi.EventStream_SubscribeClient) error 
 	})
 	logCtx.Trace("Adding an event to the event writer")
 	a.eventWriter.Add(ev)
+	logging.LogEventSent(logCtx, ev)
 
 	return nil
 }
@@ -130,7 +132,7 @@ func (a *Agent) receiver(stream eventstreamapi.EventStream_SubscribeClient) erro
 		"type":        ev.Type(),
 	})
 
-	logCtx.Debugf("Received a new event from stream")
+	logging.LogEventReceived(logCtx, ev.CloudEvent())
 
 	if ev.Target() == event.TargetEventAck {
 		logCtx.Trace("Received an ACK for an event")
@@ -145,7 +147,7 @@ func (a *Agent) receiver(stream eventstreamapi.EventStream_SubscribeClient) erro
 
 	err = a.processIncomingEvent(ev)
 	if err != nil {
-		logCtx.WithError(err).Errorf("Unable to process incoming event")
+		logging.LogEventError(logCtx, ev.CloudEvent(), err)
 		// Don't send an ACK if it is a retryable error.
 		if kube.IsRetryableError(err) {
 			logCtx.Trace("Skipping ACK for retryable errors")

--- a/agent/inbound.go
+++ b/agent/inbound.go
@@ -23,6 +23,7 @@ import (
 	"github.com/argoproj-labs/argocd-agent/internal/backend"
 	"github.com/argoproj-labs/argocd-agent/internal/checkpoint"
 	"github.com/argoproj-labs/argocd-agent/internal/event"
+	"github.com/argoproj-labs/argocd-agent/internal/logging"
 	"github.com/argoproj-labs/argocd-agent/internal/manager"
 	"github.com/argoproj-labs/argocd-agent/internal/manager/application"
 	"github.com/argoproj-labs/argocd-agent/internal/metrics"
@@ -149,7 +150,9 @@ func (a *Agent) processIncomingEvent(ev *event.Event) error {
 
 func (a *Agent) processIncomingApplication(ev *event.Event) error {
 	logCtx := a.logGrpcEvent().WithFields(logrus.Fields{
-		"method": "processIncomingEvents",
+		"method":      "processIncomingEvents",
+		"event_id":    ev.EventID(),
+		"resource_id": ev.ResourceID(),
 	})
 	incomingApp, err := ev.Application()
 	if err != nil {
@@ -192,7 +195,7 @@ func (a *Agent) processIncomingApplication(ev *event.Event) error {
 		} else {
 			_, err = a.createApplication(incomingApp, principalUID)
 			if err != nil {
-				logCtx.Errorf("Error creating application: %v", err)
+				logging.LogActionError(logCtx, "application", "create", incomingApp, err)
 			}
 		}
 	case event.SpecUpdate:
@@ -201,7 +204,7 @@ func (a *Agent) processIncomingApplication(ev *event.Event) error {
 		} else {
 			_, err = a.updateApplication(incomingApp)
 			if err != nil {
-				logCtx.Errorf("Error updating application: %v", err)
+				logging.LogActionError(logCtx, "application", "update", incomingApp, err)
 			}
 		}
 	case event.SetOperation:
@@ -217,18 +220,18 @@ func (a *Agent) processIncomingApplication(ev *event.Event) error {
 
 		_, err = a.appManager.SetOperation(a.context, incomingApp)
 		if err != nil {
-			logCtx.Errorf("Error setting operation: %v", err)
+			logging.LogActionError(logCtx, "application", "set-operation", incomingApp, err)
 		}
 	case event.TerminateOperation:
 		logCtx.Trace("Received a TerminateOperation event")
 		_, err = a.appManager.TerminateOperation(a.context, incomingApp)
 		if err != nil {
-			logCtx.Errorf("Error terminating application operation: %v", err)
+			logging.LogActionError(logCtx, "application", "terminate-operation", incomingApp, err)
 		}
 	case event.Delete:
 		err = a.deleteApplication(incomingApp)
 		if err != nil {
-			logCtx.Errorf("Error deleting application: %v", err)
+			logging.LogActionError(logCtx, "application", "delete", incomingApp, err)
 		}
 	default:
 		logCtx.Warnf("Received an unknown event: %s. Protocol mismatch?", ev.Type())
@@ -361,7 +364,9 @@ func identityAction(r *application.IdentityCompareResult) identityActionType {
 
 func (a *Agent) processIncomingAppProject(ev *event.Event) error {
 	logCtx := a.logGrpcEvent().WithFields(logrus.Fields{
-		"method": "processIncomingEvents",
+		"method":      "processIncomingEvents",
+		"event_id":    ev.EventID(),
+		"resource_id": ev.ResourceID(),
 	})
 	incomingAppProject, err := ev.AppProject()
 	if err != nil {
@@ -405,7 +410,7 @@ func (a *Agent) processIncomingAppProject(ev *event.Event) error {
 
 		_, err = a.createAppProject(incomingAppProject)
 		if err != nil {
-			logCtx.Errorf("Error creating appproject: %v", err)
+			logging.LogActionError(logCtx, "appproject", "create", incomingAppProject, err)
 		}
 	case event.SpecUpdate:
 		if !exists {
@@ -431,12 +436,12 @@ func (a *Agent) processIncomingAppProject(ev *event.Event) error {
 
 		_, err = a.updateAppProject(incomingAppProject)
 		if err != nil {
-			logCtx.Errorf("Error updating appproject: %v", err)
+			logging.LogActionError(logCtx, "appproject", "update", incomingAppProject, err)
 		}
 	case event.Delete:
 		err = a.deleteAppProject(incomingAppProject)
 		if err != nil {
-			logCtx.Errorf("Error deleting appproject: %v", err)
+			logging.LogActionError(logCtx, "appproject", "delete", incomingAppProject, err)
 		}
 	default:
 		logCtx.Warnf("Received an unknown event: %s. Protocol mismatch?", ev.Type())
@@ -447,7 +452,9 @@ func (a *Agent) processIncomingAppProject(ev *event.Event) error {
 
 func (a *Agent) processIncomingRepository(ev *event.Event) error {
 	logCtx := a.logGrpcEvent().WithFields(logrus.Fields{
-		"method": "processIncomingEvents",
+		"method":      "processIncomingEvents",
+		"event_id":    ev.EventID(),
+		"resource_id": ev.ResourceID(),
 	})
 
 	incomingRepo, err := ev.Repository()
@@ -491,7 +498,7 @@ func (a *Agent) processIncomingRepository(ev *event.Event) error {
 
 		_, err = a.createRepository(incomingRepo)
 		if err != nil {
-			logCtx.Errorf("Error creating repository: %v", err)
+			logging.LogActionError(logCtx, "repository", "create", incomingRepo, err)
 		}
 
 	case event.SpecUpdate:
@@ -518,13 +525,13 @@ func (a *Agent) processIncomingRepository(ev *event.Event) error {
 
 		_, err = a.updateRepository(incomingRepo)
 		if err != nil {
-			logCtx.Errorf("Error updating repository: %v", err)
+			logging.LogActionError(logCtx, "repository", "update", incomingRepo, err)
 		}
 
 	case event.Delete:
 		err = a.deleteRepository(incomingRepo)
 		if err != nil {
-			logCtx.Errorf("Error deleting repository: %v", err)
+			logging.LogActionError(logCtx, "repository", "delete", incomingRepo, err)
 		}
 	default:
 		logCtx.Warnf("Received an unknown event: %s. Protocol mismatch?", ev.Type())
@@ -661,8 +668,6 @@ func (a *Agent) createApplication(incoming *v1alpha1.Application, principalUID s
 		}
 	}
 
-	logCtx.Infof("Creating a new application on behalf of an incoming event")
-
 	// Get rid of some fields that we do not want to have on the application
 	// as we start fresh.
 	if incoming.Annotations != nil {
@@ -724,8 +729,6 @@ func (a *Agent) updateApplication(incoming *v1alpha1.Application) (*v1alpha1.App
 	incoming.Spec.Destination.Server = ""
 	incoming.Spec.Destination.Name = "in-cluster"
 
-	logCtx.Infof("Updating application")
-
 	var err error
 	var napp *v1alpha1.Application
 	switch a.mode {
@@ -762,8 +765,6 @@ func (a *Agent) deleteApplication(app *v1alpha1.Application) error {
 	if !a.appManager.IsManaged(app.QualifiedName()) {
 		return fmt.Errorf("application %s is not managed", app.QualifiedName())
 	}
-
-	logCtx.Infof("Deleting application")
 
 	// Fetch the source UID of the existing app to mark it as expected deletion.
 	app, err := a.appManager.Get(a.context, app.Name, app.Namespace)
@@ -862,8 +863,6 @@ func (a *Agent) updateAppProject(incoming *v1alpha1.AppProject) (*v1alpha1.AppPr
 		logCtx.Tracef("New resource version: %s", incoming.ResourceVersion)
 	}
 
-	logCtx.Infof("Updating appProject")
-
 	a.sourceCache.AppProject.Set(incoming.UID, incoming.Spec)
 
 	logCtx.Tracef("Calling update spec for this event")
@@ -886,8 +885,6 @@ func (a *Agent) deleteAppProject(project *v1alpha1.AppProject) error {
 	if !a.projectManager.IsManaged(project.Name) {
 		return fmt.Errorf("appProject %s is not managed", project.Name)
 	}
-
-	logCtx.Infof("Deleting appProject")
 
 	// Fetch the source UID of the existing appProject to mark it as expected deletion.
 	project, err := a.projectManager.Get(a.context, project.Name, project.Namespace)
@@ -942,8 +939,6 @@ func (a *Agent) createRepository(incoming *corev1.Secret) (*corev1.Secret, error
 		return a.updateRepository(incoming)
 	}
 
-	logCtx.Infof("Creating a new repository on behalf of an incoming event")
-
 	if incoming.Annotations == nil {
 		incoming.Annotations = make(map[string]string)
 	}
@@ -984,8 +979,6 @@ func (a *Agent) updateRepository(incoming *corev1.Secret) (*corev1.Secret, error
 		logCtx.Tracef("New resource version: %s", incoming.ResourceVersion)
 	}
 
-	logCtx.Infof("Updating repository")
-
 	a.sourceCache.Repository.Set(incoming.UID, incoming.Data)
 
 	return a.repoManager.UpdateManagedRepository(a.context, incoming)
@@ -1003,8 +996,6 @@ func (a *Agent) deleteRepository(repo *corev1.Secret) error {
 	if !a.repoManager.IsManaged(repo.Name) {
 		return fmt.Errorf("repository %s is not managed", repo.Name)
 	}
-
-	logCtx.Infof("Deleting repository")
 
 	// Fetch the source UID of the existing repository to mark it as expected deletion.
 	repo, err := a.repoManager.Get(a.context, repo.Name, repo.Namespace)
@@ -1039,7 +1030,9 @@ func (a *Agent) deleteRepository(repo *corev1.Secret) error {
 // processIncomingGPGKey processes an incoming GPG key event.
 func (a *Agent) processIncomingGPGKey(ev *event.Event) error {
 	logCtx := a.logGrpcEvent().WithFields(logrus.Fields{
-		"method": "processIncomingGPGKey",
+		"method":      "processIncomingGPGKey",
+		"event_id":    ev.EventID(),
+		"resource_id": ev.ResourceID(),
 	})
 
 	incomingCM, err := ev.GPGKey()
@@ -1079,7 +1072,7 @@ func (a *Agent) processIncomingGPGKey(ev *event.Event) error {
 
 		_, err = a.createGPGKey(incomingCM)
 		if err != nil {
-			logCtx.Errorf("Error creating GPG key: %v", err)
+			logging.LogActionError(logCtx, "gpgkey", "create", incomingCM, err)
 		}
 
 	case event.SpecUpdate:
@@ -1106,13 +1099,13 @@ func (a *Agent) processIncomingGPGKey(ev *event.Event) error {
 
 		_, err = a.updateGPGKey(incomingCM)
 		if err != nil {
-			logCtx.Errorf("Error updating GPG key: %v", err)
+			logging.LogActionError(logCtx, "gpgkey", "update", incomingCM, err)
 		}
 
 	case event.Delete:
 		err = a.deleteGPGKey(incomingCM)
 		if err != nil {
-			logCtx.Errorf("Error deleting GPG key: %v", err)
+			logging.LogActionError(logCtx, "gpgkey", "delete", incomingCM, err)
 		}
 	default:
 		logCtx.Warnf("Received an unknown event: %s. Protocol mismatch?", ev.Type())
@@ -1133,8 +1126,6 @@ func (a *Agent) createGPGKey(incoming *corev1.ConfigMap) (*corev1.ConfigMap, err
 		logCtx.Trace("GPG key is already managed on this agent. Updating the existing GPG key")
 		return a.updateGPGKey(incoming)
 	}
-
-	logCtx.Infof("Creating a new GPG key on behalf of an incoming event")
 
 	if incoming.Annotations == nil {
 		incoming.Annotations = make(map[string]string)
@@ -1173,8 +1164,6 @@ func (a *Agent) updateGPGKey(incoming *corev1.ConfigMap) (*corev1.ConfigMap, err
 		logCtx.Tracef("New resource version: %s", incoming.ResourceVersion)
 	}
 
-	logCtx.Infof("Updating GPG key")
-
 	a.sourceCache.GPGKey.Set(incoming.UID, incoming.Data)
 	return a.gpgKeyManager.UpdateManagedGPGKey(a.context, incoming)
 }
@@ -1190,8 +1179,6 @@ func (a *Agent) deleteGPGKey(cm *corev1.ConfigMap) error {
 	if !a.gpgKeyManager.IsManaged(cm.Name) {
 		return fmt.Errorf("GPG key ConfigMap %s is not managed", cm.Name)
 	}
-
-	logCtx.Infof("Deleting GPG key ConfigMap")
 
 	existing, err := a.gpgKeyManager.Get(a.context, cm.Name, cm.Namespace)
 	if err != nil {

--- a/agent/inbound.go
+++ b/agent/inbound.go
@@ -150,7 +150,7 @@ func (a *Agent) processIncomingEvent(ev *event.Event) error {
 
 func (a *Agent) processIncomingApplication(ev *event.Event) error {
 	logCtx := a.logGrpcEvent().WithFields(logrus.Fields{
-		"method":      "processIncomingEvents",
+		"method":      "processIncomingApplication",
 		"event_id":    ev.EventID(),
 		"resource_id": ev.ResourceID(),
 	})
@@ -364,7 +364,7 @@ func identityAction(r *application.IdentityCompareResult) identityActionType {
 
 func (a *Agent) processIncomingAppProject(ev *event.Event) error {
 	logCtx := a.logGrpcEvent().WithFields(logrus.Fields{
-		"method":      "processIncomingEvents",
+		"method":      "processIncomingAppProject",
 		"event_id":    ev.EventID(),
 		"resource_id": ev.ResourceID(),
 	})
@@ -452,7 +452,7 @@ func (a *Agent) processIncomingAppProject(ev *event.Event) error {
 
 func (a *Agent) processIncomingRepository(ev *event.Event) error {
 	logCtx := a.logGrpcEvent().WithFields(logrus.Fields{
-		"method":      "processIncomingEvents",
+		"method":      "processIncomingRepository",
 		"event_id":    ev.EventID(),
 		"resource_id": ev.ResourceID(),
 	})
@@ -544,7 +544,7 @@ func (a *Agent) processIncomingRepository(ev *event.Event) error {
 // exchanged with the agent/principal restarts
 func (a *Agent) processIncomingResourceResyncEvent(ev *event.Event) error {
 	logCtx := a.logGrpcEvent().WithFields(logrus.Fields{
-		"method":      "processIncomingEvents",
+		"method":      "processIncomingResourceResyncEvent",
 		"agent":       a.remote.ClientID(),
 		"mode":        a.mode,
 		"event":       ev.Type(),

--- a/agent/inbound.go
+++ b/agent/inbound.go
@@ -23,6 +23,7 @@ import (
 	"github.com/argoproj-labs/argocd-agent/internal/backend"
 	"github.com/argoproj-labs/argocd-agent/internal/checkpoint"
 	"github.com/argoproj-labs/argocd-agent/internal/event"
+	"github.com/argoproj-labs/argocd-agent/internal/logging"
 	"github.com/argoproj-labs/argocd-agent/internal/manager"
 	"github.com/argoproj-labs/argocd-agent/internal/manager/application"
 	"github.com/argoproj-labs/argocd-agent/internal/metrics"
@@ -149,7 +150,9 @@ func (a *Agent) processIncomingEvent(ev *event.Event) error {
 
 func (a *Agent) processIncomingApplication(ev *event.Event) error {
 	logCtx := a.logGrpcEvent().WithFields(logrus.Fields{
-		"method": "processIncomingEvents",
+		"method":      "processIncomingEvents",
+		"event_id":    ev.EventID(),
+		"resource_id": ev.ResourceID(),
 	})
 	incomingApp, err := ev.Application()
 	if err != nil {
@@ -195,7 +198,7 @@ func (a *Agent) processIncomingApplication(ev *event.Event) error {
 		} else {
 			_, err = a.createApplication(incomingApp, principalUID)
 			if err != nil {
-				logCtx.Errorf("Error creating application: %v", err)
+				logging.LogActionError(logCtx, "application", "create", incomingApp, err)
 			}
 		}
 	case event.SpecUpdate:
@@ -204,7 +207,7 @@ func (a *Agent) processIncomingApplication(ev *event.Event) error {
 		} else {
 			_, err = a.updateApplication(incomingApp)
 			if err != nil {
-				logCtx.Errorf("Error updating application: %v", err)
+				logging.LogActionError(logCtx, "application", "update", incomingApp, err)
 			}
 		}
 	case event.SetOperation:
@@ -220,18 +223,18 @@ func (a *Agent) processIncomingApplication(ev *event.Event) error {
 
 		_, err = a.appManager.SetOperation(a.context, incomingApp)
 		if err != nil {
-			logCtx.Errorf("Error setting operation: %v", err)
+			logging.LogActionError(logCtx, "application", "set-operation", incomingApp, err)
 		}
 	case event.TerminateOperation:
 		logCtx.Trace("Received a TerminateOperation event")
 		_, err = a.appManager.TerminateOperation(a.context, incomingApp)
 		if err != nil {
-			logCtx.Errorf("Error terminating application operation: %v", err)
+			logging.LogActionError(logCtx, "application", "terminate-operation", incomingApp, err)
 		}
 	case event.Delete:
 		err = a.deleteApplication(incomingApp)
 		if err != nil {
-			logCtx.Errorf("Error deleting application: %v", err)
+			logging.LogActionError(logCtx, "application", "delete", incomingApp, err)
 		}
 	default:
 		logCtx.Warnf("Received an unknown event: %s. Protocol mismatch?", ev.Type())
@@ -397,7 +400,9 @@ func identityAction(r *application.IdentityCompareResult) identityActionType {
 
 func (a *Agent) processIncomingAppProject(ev *event.Event) error {
 	logCtx := a.logGrpcEvent().WithFields(logrus.Fields{
-		"method": "processIncomingEvents",
+		"method":      "processIncomingEvents",
+		"event_id":    ev.EventID(),
+		"resource_id": ev.ResourceID(),
 	})
 	incomingAppProject, err := ev.AppProject()
 	if err != nil {
@@ -447,7 +452,7 @@ func (a *Agent) processIncomingAppProject(ev *event.Event) error {
 
 		_, err = a.createAppProject(incomingAppProject)
 		if err != nil {
-			logCtx.Errorf("Error creating appproject: %v", err)
+			logging.LogActionError(logCtx, "appproject", "create", incomingAppProject, err)
 		}
 	case event.SpecUpdate:
 		if !exists {
@@ -478,12 +483,12 @@ func (a *Agent) processIncomingAppProject(ev *event.Event) error {
 
 		_, err = a.updateAppProject(incomingAppProject)
 		if err != nil {
-			logCtx.Errorf("Error updating appproject: %v", err)
+			logging.LogActionError(logCtx, "appproject", "update", incomingAppProject, err)
 		}
 	case event.Delete:
 		err = a.deleteAppProject(incomingAppProject)
 		if err != nil {
-			logCtx.Errorf("Error deleting appproject: %v", err)
+			logging.LogActionError(logCtx, "appproject", "delete", incomingAppProject, err)
 		}
 	default:
 		logCtx.Warnf("Received an unknown event: %s. Protocol mismatch?", ev.Type())
@@ -494,7 +499,9 @@ func (a *Agent) processIncomingAppProject(ev *event.Event) error {
 
 func (a *Agent) processIncomingRepository(ev *event.Event) error {
 	logCtx := a.logGrpcEvent().WithFields(logrus.Fields{
-		"method": "processIncomingEvents",
+		"method":      "processIncomingEvents",
+		"event_id":    ev.EventID(),
+		"resource_id": ev.ResourceID(),
 	})
 
 	incomingRepo, err := ev.Repository()
@@ -544,7 +551,7 @@ func (a *Agent) processIncomingRepository(ev *event.Event) error {
 
 		_, err = a.createRepository(incomingRepo)
 		if err != nil {
-			logCtx.Errorf("Error creating repository: %v", err)
+			logging.LogActionError(logCtx, "repository", "create", incomingRepo, err)
 		}
 
 	case event.SpecUpdate:
@@ -576,13 +583,13 @@ func (a *Agent) processIncomingRepository(ev *event.Event) error {
 
 		_, err = a.updateRepository(incomingRepo)
 		if err != nil {
-			logCtx.Errorf("Error updating repository: %v", err)
+			logging.LogActionError(logCtx, "repository", "update", incomingRepo, err)
 		}
 
 	case event.Delete:
 		err = a.deleteRepository(incomingRepo)
 		if err != nil {
-			logCtx.Errorf("Error deleting repository: %v", err)
+			logging.LogActionError(logCtx, "repository", "delete", incomingRepo, err)
 		}
 	default:
 		logCtx.Warnf("Received an unknown event: %s. Protocol mismatch?", ev.Type())
@@ -720,8 +727,6 @@ func (a *Agent) createApplication(incoming *v1alpha1.Application, principalUID s
 		}
 	}
 
-	logCtx.Infof("Creating a new application on behalf of an incoming event")
-
 	// Get rid of some fields that we do not want to have on the application
 	// as we start fresh.
 	if incoming.Annotations != nil {
@@ -783,8 +788,6 @@ func (a *Agent) updateApplication(incoming *v1alpha1.Application) (*v1alpha1.App
 	incoming.Spec.Destination.Server = ""
 	incoming.Spec.Destination.Name = "in-cluster"
 
-	logCtx.Infof("Updating application")
-
 	var err error
 	var napp *v1alpha1.Application
 	switch a.mode {
@@ -821,8 +824,6 @@ func (a *Agent) deleteApplication(app *v1alpha1.Application) error {
 	if !a.appManager.IsManaged(app.QualifiedName()) {
 		return fmt.Errorf("application %s is not managed", app.QualifiedName())
 	}
-
-	logCtx.Infof("Deleting application")
 
 	// Fetch the source UID of the existing app to mark it as expected deletion.
 	app, err := a.appManager.Get(a.context, app.Name, app.Namespace)
@@ -921,8 +922,6 @@ func (a *Agent) updateAppProject(incoming *v1alpha1.AppProject) (*v1alpha1.AppPr
 		logCtx.Tracef("New resource version: %s", incoming.ResourceVersion)
 	}
 
-	logCtx.Infof("Updating appProject")
-
 	a.sourceCache.AppProject.Set(incoming.UID, incoming.Spec)
 
 	logCtx.Tracef("Calling update spec for this event")
@@ -945,8 +944,6 @@ func (a *Agent) deleteAppProject(project *v1alpha1.AppProject) error {
 	if !a.projectManager.IsManaged(project.Name) {
 		return fmt.Errorf("appProject %s is not managed", project.Name)
 	}
-
-	logCtx.Infof("Deleting appProject")
 
 	// Fetch the source UID of the existing appProject to mark it as expected deletion.
 	project, err := a.projectManager.Get(a.context, project.Name, project.Namespace)
@@ -1001,8 +998,6 @@ func (a *Agent) createRepository(incoming *corev1.Secret) (*corev1.Secret, error
 		return a.updateRepository(incoming)
 	}
 
-	logCtx.Infof("Creating a new repository on behalf of an incoming event")
-
 	if incoming.Annotations == nil {
 		incoming.Annotations = make(map[string]string)
 	}
@@ -1043,8 +1038,6 @@ func (a *Agent) updateRepository(incoming *corev1.Secret) (*corev1.Secret, error
 		logCtx.Tracef("New resource version: %s", incoming.ResourceVersion)
 	}
 
-	logCtx.Infof("Updating repository")
-
 	a.sourceCache.Repository.Set(incoming.UID, incoming.Data)
 
 	return a.repoManager.UpdateManagedRepository(a.context, incoming)
@@ -1062,8 +1055,6 @@ func (a *Agent) deleteRepository(repo *corev1.Secret) error {
 	if !a.repoManager.IsManaged(repo.Name) {
 		return fmt.Errorf("repository %s is not managed", repo.Name)
 	}
-
-	logCtx.Infof("Deleting repository")
 
 	// Fetch the source UID of the existing repository to mark it as expected deletion.
 	repo, err := a.repoManager.Get(a.context, repo.Name, repo.Namespace)
@@ -1098,7 +1089,9 @@ func (a *Agent) deleteRepository(repo *corev1.Secret) error {
 // processIncomingGPGKey processes an incoming GPG key event.
 func (a *Agent) processIncomingGPGKey(ev *event.Event) error {
 	logCtx := a.logGrpcEvent().WithFields(logrus.Fields{
-		"method": "processIncomingGPGKey",
+		"method":      "processIncomingGPGKey",
+		"event_id":    ev.EventID(),
+		"resource_id": ev.ResourceID(),
 	})
 
 	incomingCM, err := ev.GPGKey()
@@ -1145,7 +1138,7 @@ func (a *Agent) processIncomingGPGKey(ev *event.Event) error {
 
 		_, err = a.createGPGKey(incomingCM)
 		if err != nil {
-			logCtx.Errorf("Error creating GPG key: %v", err)
+			logging.LogActionError(logCtx, "gpgkey", "create", incomingCM, err)
 		}
 
 	case event.SpecUpdate:
@@ -1178,13 +1171,13 @@ func (a *Agent) processIncomingGPGKey(ev *event.Event) error {
 
 		_, err = a.updateGPGKey(incomingCM)
 		if err != nil {
-			logCtx.Errorf("Error updating GPG key: %v", err)
+			logging.LogActionError(logCtx, "gpgkey", "update", incomingCM, err)
 		}
 
 	case event.Delete:
 		err = a.deleteGPGKey(incomingCM)
 		if err != nil {
-			logCtx.Errorf("Error deleting GPG key: %v", err)
+			logging.LogActionError(logCtx, "gpgkey", "delete", incomingCM, err)
 		}
 	default:
 		logCtx.Warnf("Received an unknown event: %s. Protocol mismatch?", ev.Type())
@@ -1205,8 +1198,6 @@ func (a *Agent) createGPGKey(incoming *corev1.ConfigMap) (*corev1.ConfigMap, err
 		logCtx.Trace("GPG key is already managed on this agent. Updating the existing GPG key")
 		return a.updateGPGKey(incoming)
 	}
-
-	logCtx.Infof("Creating a new GPG key on behalf of an incoming event")
 
 	if incoming.Annotations == nil {
 		incoming.Annotations = make(map[string]string)
@@ -1245,8 +1236,6 @@ func (a *Agent) updateGPGKey(incoming *corev1.ConfigMap) (*corev1.ConfigMap, err
 		logCtx.Tracef("New resource version: %s", incoming.ResourceVersion)
 	}
 
-	logCtx.Infof("Updating GPG key")
-
 	a.sourceCache.GPGKey.Set(incoming.UID, incoming.Data)
 	return a.gpgKeyManager.UpdateManagedGPGKey(a.context, incoming)
 }
@@ -1262,8 +1251,6 @@ func (a *Agent) deleteGPGKey(cm *corev1.ConfigMap) error {
 	if !a.gpgKeyManager.IsManaged(cm.Name) {
 		return fmt.Errorf("GPG key ConfigMap %s is not managed", cm.Name)
 	}
-
-	logCtx.Infof("Deleting GPG key ConfigMap")
 
 	existing, err := a.gpgKeyManager.Get(a.context, cm.Name, cm.Namespace)
 	if err != nil {

--- a/agent/inbound.go
+++ b/agent/inbound.go
@@ -150,7 +150,7 @@ func (a *Agent) processIncomingEvent(ev *event.Event) error {
 
 func (a *Agent) processIncomingApplication(ev *event.Event) error {
 	logCtx := a.logGrpcEvent().WithFields(logrus.Fields{
-		"method":      "processIncomingEvents",
+		"method":      "processIncomingApplication",
 		"event_id":    ev.EventID(),
 		"resource_id": ev.ResourceID(),
 	})
@@ -400,7 +400,7 @@ func identityAction(r *application.IdentityCompareResult) identityActionType {
 
 func (a *Agent) processIncomingAppProject(ev *event.Event) error {
 	logCtx := a.logGrpcEvent().WithFields(logrus.Fields{
-		"method":      "processIncomingEvents",
+		"method":      "processIncomingAppProject",
 		"event_id":    ev.EventID(),
 		"resource_id": ev.ResourceID(),
 	})
@@ -499,7 +499,7 @@ func (a *Agent) processIncomingAppProject(ev *event.Event) error {
 
 func (a *Agent) processIncomingRepository(ev *event.Event) error {
 	logCtx := a.logGrpcEvent().WithFields(logrus.Fields{
-		"method":      "processIncomingEvents",
+		"method":      "processIncomingRepository",
 		"event_id":    ev.EventID(),
 		"resource_id": ev.ResourceID(),
 	})
@@ -602,7 +602,7 @@ func (a *Agent) processIncomingRepository(ev *event.Event) error {
 // exchanged with the agent/principal restarts
 func (a *Agent) processIncomingResourceResyncEvent(ev *event.Event) error {
 	logCtx := a.logGrpcEvent().WithFields(logrus.Fields{
-		"method":      "processIncomingEvents",
+		"method":      "processIncomingResourceResyncEvent",
 		"agent":       a.remote.ClientID(),
 		"mode":        a.mode,
 		"event":       ev.Type(),

--- a/cmd/argocd-agent/agent.go
+++ b/cmd/argocd-agent/agent.go
@@ -43,35 +43,36 @@ import (
 // NewAgentRunCommand returns a new agent run command.
 func NewAgentRunCommand() *cobra.Command {
 	var (
-		serverAddress       string
-		serverPort          int
-		logLevels           []string
-		logFormat           string
-		insecure            bool
-		insecurePlaintext   bool
-		rootCASecretName    string
-		rootCAPath          string
-		kubeConfig          string
-		kubeContext         string
-		namespace           string
-		agentMode           string
-		creds               string
-		tlsSecretName       string
-		tlsClientCrt        string
-		tlsClientKey        string
-		tlsMinVersion       string
-		tlsMaxVersion       string
-		tlsCipherSuites     []string
-		enableWebSocket     bool
-		metricsPort         int
-		healthzPort         int
-		enableCompression   bool
-		pprofPort           int
-		redisAddr           string
-		redisUsername       string
-		redisPassword       string
-		redisCredsDirPath   string
-		enableResourceProxy bool
+		serverAddress        string
+		serverPort           int
+		logLevels            []string
+		logFormat            string
+		fullDetailCategories []string
+		insecure             bool
+		insecurePlaintext    bool
+		rootCASecretName     string
+		rootCAPath           string
+		kubeConfig           string
+		kubeContext          string
+		namespace            string
+		agentMode            string
+		creds                string
+		tlsSecretName        string
+		tlsClientCrt         string
+		tlsClientKey         string
+		tlsMinVersion        string
+		tlsMaxVersion        string
+		tlsCipherSuites      []string
+		enableWebSocket      bool
+		metricsPort          int
+		healthzPort          int
+		enableCompression    bool
+		pprofPort            int
+		redisAddr            string
+		redisUsername        string
+		redisPassword        string
+		redisCredsDirPath    string
+		enableResourceProxy  bool
 
 		// Time interval for agent to principal ping
 		// Ex: "30m", "1h" or "1h20m10s". Valid time units are "s", "m", "h".
@@ -161,6 +162,9 @@ func NewAgentRunCommand() *cobra.Command {
 			}
 
 			agentOpts = append(agentOpts, agent.WithSubsystemLoggers(subLoggers.ResourceProxyLogger, subLoggers.RedisProxyLogger, subLoggers.GrpcEventLogger))
+
+			cmdutil.ParseFullDetail(fullDetailCategories)
+
 			if namespace == "" {
 				cmdutil.Fatal("namespace value is empty and must be specified")
 			}
@@ -324,6 +328,9 @@ func NewAgentRunCommand() *cobra.Command {
 	command.Flags().StringSliceVar(&logLevels, "log-level",
 		env.StringSliceWithDefault("ARGOCD_AGENT_LOG_LEVEL", nil, []string{"info"}),
 		"The log level to use. Comma-separated list of components in the format [<component>=]level")
+	command.Flags().StringSliceVar(&fullDetailCategories, "full-detail",
+		env.StringSliceWithDefault("ARGOCD_AGENT_FULL_DETAIL", nil, nil),
+		"Enable full detail logging for specified categories. Comma-separated list of: "+cmdutil.AvailableFullDetailCategories)
 
 	command.Flags().StringVar(&redisAddr, "redis-addr",
 		env.StringWithDefault("REDIS_ADDR", nil, "argocd-redis:6379"),

--- a/cmd/argocd-agent/agent.go
+++ b/cmd/argocd-agent/agent.go
@@ -43,35 +43,36 @@ import (
 // NewAgentRunCommand returns a new agent run command.
 func NewAgentRunCommand() *cobra.Command {
 	var (
-		serverAddress       string
-		serverPort          int
-		logLevels           []string
-		logFormat           string
-		insecure            bool
-		insecurePlaintext   bool
-		rootCASecretName    string
-		rootCAPath          string
-		kubeConfig          string
-		kubeContext         string
-		namespace           string
-		agentMode           string
-		creds               string
-		tlsSecretName       string
-		tlsClientCrt        string
-		tlsClientKey        string
-		tlsMinVersion       string
-		tlsMaxVersion       string
-		tlsCipherSuites     []string
-		enableWebSocket     bool
-		metricsPort         int
-		healthzPort         int
-		enableCompression   bool
-		pprofPort           int
-		redisAddr           string
-		redisUsername       string
-		redisPassword       string
-		redisCredsDirPath   string
-		enableResourceProxy bool
+		serverAddress        string
+		serverPort           int
+		logLevels            []string
+		logFormat            string
+		fullDetailCategories []string
+		insecure             bool
+		insecurePlaintext    bool
+		rootCASecretName     string
+		rootCAPath           string
+		kubeConfig           string
+		kubeContext          string
+		namespace            string
+		agentMode            string
+		creds                string
+		tlsSecretName        string
+		tlsClientCrt         string
+		tlsClientKey         string
+		tlsMinVersion        string
+		tlsMaxVersion        string
+		tlsCipherSuites      []string
+		enableWebSocket      bool
+		metricsPort          int
+		healthzPort          int
+		enableCompression    bool
+		pprofPort            int
+		redisAddr            string
+		redisUsername        string
+		redisPassword        string
+		redisCredsDirPath    string
+		enableResourceProxy  bool
 
 		// Time interval for agent to principal ping
 		// Ex: "30m", "1h" or "1h20m10s". Valid time units are "s", "m", "h".
@@ -165,6 +166,9 @@ func NewAgentRunCommand() *cobra.Command {
 			}
 
 			agentOpts = append(agentOpts, agent.WithSubsystemLoggers(subLoggers.ResourceProxyLogger, subLoggers.RedisProxyLogger, subLoggers.GrpcEventLogger))
+
+			cmdutil.ParseFullDetail(fullDetailCategories)
+
 			if namespace == "" {
 				cmdutil.Fatal("namespace value is empty and must be specified")
 			}
@@ -331,6 +335,9 @@ func NewAgentRunCommand() *cobra.Command {
 	command.Flags().StringSliceVar(&logLevels, "log-level",
 		env.StringSliceWithDefault("ARGOCD_AGENT_LOG_LEVEL", nil, []string{"info"}),
 		"The log level to use. Comma-separated list of components in the format [<component>=]level")
+	command.Flags().StringSliceVar(&fullDetailCategories, "full-detail",
+		env.StringSliceWithDefault("ARGOCD_AGENT_FULL_DETAIL", nil, nil),
+		"Enable full detail logging for specified categories. Comma-separated list of: "+cmdutil.AvailableFullDetailCategories)
 
 	command.Flags().StringVar(&redisAddr, "redis-addr",
 		env.StringWithDefault("REDIS_ADDR", nil, "argocd-redis:6379"),

--- a/cmd/argocd-agent/agent.go
+++ b/cmd/argocd-agent/agent.go
@@ -368,7 +368,7 @@ func NewAgentRunCommand() *cobra.Command {
 		"INSECURE: Do not verify Redis TLS certificate")
 
 	command.Flags().StringVar(&logFormat, "log-format",
-		env.StringWithDefault("ARGOCD_PRINCIPAL_LOG_FORMAT", nil, "text"),
+		env.StringWithDefault("ARGOCD_AGENT_LOG_FORMAT", nil, "text"),
 		"The log format to use (one of: text, json)")
 	command.Flags().BoolVar(&insecure, "insecure-tls",
 		env.BoolWithDefault("ARGOCD_AGENT_TLS_INSECURE", false),

--- a/cmd/argocd-agent/principal.go
+++ b/cmd/argocd-agent/principal.go
@@ -52,6 +52,7 @@ func NewPrincipalRunCommand() *cobra.Command {
 		listenPort                int
 		logLevels                 []string
 		logFormat                 string
+		fullDetailCategories      []string
 		metricsPort               int
 		namespace                 string
 		allowedNamespaces         []string
@@ -183,6 +184,8 @@ func NewPrincipalRunCommand() *cobra.Command {
 			}
 
 			opts = append(opts, principal.WithSubsystemLoggers(subLoggers.ResourceProxyLogger, subLoggers.RedisProxyLogger, subLoggers.GrpcEventLogger))
+
+			cmdutil.ParseFullDetail(fullDetailCategories)
 
 			kubeConfig, err := cmdutil.GetKubeConfig(ctx, namespace, kubeConfig, kubeContext)
 			if err != nil {
@@ -482,6 +485,9 @@ func NewPrincipalRunCommand() *cobra.Command {
 	command.Flags().StringVar(&logFormat, "log-format",
 		env.StringWithDefault("ARGOCD_PRINCIPAL_LOG_FORMAT", nil, "text"),
 		"The log format to use (one of: text, json)")
+	command.Flags().StringSliceVar(&fullDetailCategories, "full-detail",
+		env.StringSliceWithDefault("ARGOCD_PRINCIPAL_FULL_DETAIL", nil, nil),
+		"Enable full detail logging for specified categories. Comma-separated list of: "+cmdutil.AvailableFullDetailCategories)
 
 	command.Flags().IntVar(&metricsPort, "metrics-port",
 		env.NumWithDefault("ARGOCD_PRINCIPAL_METRICS_PORT", cmdutil.ValidPort, 8000),

--- a/cmd/cmdutil/log.go
+++ b/cmd/cmdutil/log.go
@@ -21,6 +21,7 @@ import (
 	"slices"
 	"strings"
 
+	"github.com/argoproj-labs/argocd-agent/internal/logging"
 	"github.com/sirupsen/logrus"
 	"github.com/sirupsen/logrus/hooks/writer"
 )
@@ -191,4 +192,34 @@ func ParseLogLevels(input []string, ss *SubSystemLoggers) {
 			logrus.Warnf("an invalid subsystem %s was specified. subsystems are %s, skipping", split[0], AvailableSubSystems)
 		}
 	}
+}
+
+const AvailableFullDetailCategories = "all, actions, events, informers"
+
+// ParseFullDetail parses a comma-separated list of category names and sets
+// the global full detail logging configuration. The special value "all"
+// enables every category.
+func ParseFullDetail(input []string) {
+	cfg := logging.FullDetailConfig{}
+	for _, e := range input {
+		category := strings.TrimSpace(strings.ToLower(e))
+		if category == "" {
+			continue
+		}
+		switch category {
+		case "all":
+			cfg.Actions = true
+			cfg.Events = true
+			cfg.Informers = true
+		case "actions":
+			cfg.Actions = true
+		case "events":
+			cfg.Events = true
+		case "informers":
+			cfg.Informers = true
+		default:
+			logrus.Warnf("an invalid full-detail category %q was specified. Available categories are: %s, skipping", category, AvailableFullDetailCategories)
+		}
+	}
+	logging.SetFullDetailConfig(cfg)
 }

--- a/cmd/cmdutil/log_test.go
+++ b/cmd/cmdutil/log_test.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/argoproj-labs/argocd-agent/internal/logging"
 )
 
 func Test_parseLogLevels(t *testing.T) {
@@ -145,6 +147,86 @@ func Test_parseLogLevels(t *testing.T) {
 			if tt.expectedMessage != "" {
 				output := buf.String()
 				assert.Contains(t, output, tt.expectedMessage)
+			}
+		})
+	}
+}
+
+func Test_ParseFullDetail(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     []string
+		expected  logging.FullDetailConfig
+		warnAbout string
+	}{
+		{
+			name:     "empty input",
+			input:    []string{},
+			expected: logging.FullDetailConfig{},
+		},
+		{
+			name:     "all enables everything",
+			input:    []string{"all"},
+			expected: logging.FullDetailConfig{Actions: true, Events: true, Informers: true},
+		},
+		{
+			name:     "actions only",
+			input:    []string{"actions"},
+			expected: logging.FullDetailConfig{Actions: true},
+		},
+		{
+			name:     "events only",
+			input:    []string{"events"},
+			expected: logging.FullDetailConfig{Events: true},
+		},
+		{
+			name:     "informers only",
+			input:    []string{"informers"},
+			expected: logging.FullDetailConfig{Informers: true},
+		},
+		{
+			name:     "multiple categories",
+			input:    []string{"actions", "events"},
+			expected: logging.FullDetailConfig{Actions: true, Events: true},
+		},
+		{
+			name:     "case insensitive",
+			input:    []string{"ACTIONS", "Events"},
+			expected: logging.FullDetailConfig{Actions: true, Events: true},
+		},
+		{
+			name:     "whitespace trimmed",
+			input:    []string{" actions ", " informers "},
+			expected: logging.FullDetailConfig{Actions: true, Informers: true},
+		},
+		{
+			name:      "invalid category warns",
+			input:     []string{"invalid"},
+			expected:  logging.FullDetailConfig{},
+			warnAbout: "invalid full-detail category",
+		},
+		{
+			name:     "empty strings are ignored",
+			input:    []string{"", "actions", ""},
+			expected: logging.FullDetailConfig{Actions: true},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			defer logging.SetFullDetailConfig(logging.FullDetailConfig{})
+
+			var buf bytes.Buffer
+			logrus.SetOutput(&buf)
+			defer logrus.SetOutput(os.Stdout)
+
+			ParseFullDetail(tt.input)
+
+			got := logging.GetFullDetailConfig()
+			assert.Equal(t, tt.expected, got)
+
+			if tt.warnAbout != "" {
+				assert.Contains(t, buf.String(), tt.warnAbout)
 			}
 		})
 	}

--- a/docs/configuration/observability.md
+++ b/docs/configuration/observability.md
@@ -73,6 +73,104 @@ export ARGOCD_AGENT_LOG_LEVEL=info
 INFO[0001] Agent connected                               agent=production-cluster
 ```
 
+### Full-Detail Logging
+
+Full-detail logging adds verbose resource payloads, diffs, and event data to structured log fields. It is independent of the log level and can be enabled per category.
+
+**Categories:**
+
+| Category | What it adds |
+|----------|-------------|
+| `actions` | Full JSON of created resources, diffs for updates (secrets are redacted) |
+| `events` | Full CloudEvent payloads for messages exchanged between agent and principal |
+| `informers` | Full JSON on add, diffs on update for K8s informer events (secrets are redacted) |
+
+**Enable on the principal:**
+
+```bash
+# Single category
+argocd-agent principal --full-detail=actions
+
+# Multiple categories (comma-separated)
+argocd-agent principal --full-detail=actions,events
+
+# All categories
+argocd-agent principal --full-detail=all
+```
+
+Via environment variable:
+
+```bash
+# Comma-separated list
+export ARGOCD_PRINCIPAL_FULL_DETAIL="actions,events,informers"
+
+# Or enable everything
+export ARGOCD_PRINCIPAL_FULL_DETAIL="all"
+```
+
+**Enable on the agent:**
+
+```bash
+argocd-agent agent --full-detail=all
+```
+
+Via environment variable:
+
+```bash
+export ARGOCD_AGENT_FULL_DETAIL="actions,events"
+```
+
+**Example output with `--full-detail=actions`:**
+
+```
+level=info msg="Created application default/my-app" action=create detail="{\"metadata\":{\"name\":\"my-app\",...}}" log_category=actions name=my-app namespace=default resource_type=application
+```
+
+Without full detail, the same log omits the `detail` field:
+
+```
+level=info msg="Created application default/my-app" action=create log_category=actions name=my-app namespace=default resource_type=application
+```
+
+!!! note "Secret Redaction"
+    Kubernetes Secrets are never included in the `detail` field. Create/add logs show `<redacted: Secret>` and update diffs are skipped entirely.
+
+### Structured Log Fields
+
+All action, event, and informer logs include structured fields for filtering and dashboard queries.
+
+**Common fields across all categories:**
+
+| Field | Description | Example values |
+|-------|-------------|----------------|
+| `log_category` | Log category | `actions`, `events`, `informers` |
+| `action` | The operation performed | `create`, `update`, `delete` |
+| `name` | Resource name | `my-app`, `default` |
+| `namespace` | Resource namespace | `argocd`, `default` |
+
+**Action-specific fields:**
+
+| Field | Description | Example values |
+|-------|-------------|----------------|
+| `resource_type` | Kubernetes resource type | `application`, `appproject`, `secret`, `configmap` |
+| `detail` | Full JSON or diff (when full detail enabled) | `{"metadata":...}` |
+
+**Event-specific fields:**
+
+| Field | Description | Example values |
+|-------|-------------|----------------|
+| `direction` | Event direction | `send`, `recv` |
+| `event_target` | Target resource type | `application`, `appproject`, `repository` |
+| `event_type` | CloudEvent type | `io.argoproj.argocd-agent.event.create` |
+| `detail` | Event payload (when full detail enabled) | `{"metadata":...}` |
+
+**Informer-specific fields:**
+
+| Field | Description | Example values |
+|-------|-------------|----------------|
+| `resource_type` | Kubernetes resource type (lowercase) | `application`, `configmap`, `secret` |
+| `detail` | Full JSON or diff (when full detail enabled) | `{"metadata":...}` |
+
 ### Debugging Tips
 
 1. **Enable debug logging temporarily** to troubleshoot issues:
@@ -89,6 +187,11 @@ INFO[0001] Agent connected                               agent=production-cluste
 3. **Filter logs by agent**:
    ```bash
    kubectl logs -n argocd deployment/argocd-agent-principal | grep "agent=my-cluster"
+   ```
+
+5. **Trace a resource through all categories**:
+   ```bash
+   kubectl logs -n argocd deployment/argocd-agent-agent | grep 'name=my-app' | grep -E 'log_category=(actions|events|informers)'
    ```
 
 ## Metrics
@@ -378,6 +481,7 @@ For detailed profiling guidance, see the [Operations: Profiling](../operations/p
 |-----------|----------|--------------|-----------|---------|
 | Log Level | `--log-level` | `ARGOCD_PRINCIPAL_LOG_LEVEL` | `principal.log.level` | `info` |
 | Log Format | `--log-format` | `ARGOCD_PRINCIPAL_LOG_FORMAT` | N/A | `text` |
+| Full Detail | `--full-detail` | `ARGOCD_PRINCIPAL_FULL_DETAIL` | N/A | disabled |
 | Metrics Port | `--metrics-port` | `ARGOCD_PRINCIPAL_METRICS_PORT` | `principal.metrics.port` | `8000` |
 | Health Port | `--healthz-port` | `ARGOCD_PRINCIPAL_HEALTH_CHECK_PORT` | `principal.healthz.port` | `8003` |
 | Profiling Port | `--pprof-port` | `ARGOCD_PRINCIPAL_PPROF_PORT` | N/A | `0` (disabled) |
@@ -388,6 +492,7 @@ For detailed profiling guidance, see the [Operations: Profiling](../operations/p
 |-----------|----------|--------------|-----------|---------|
 | Log Level | `--log-level` | `ARGOCD_AGENT_LOG_LEVEL` | `agent.log.level` | `info` |
 | Log Format | `--log-format` | `ARGOCD_PRINCIPAL_LOG_FORMAT` | N/A | `text` |
+| Full Detail | `--full-detail` | `ARGOCD_AGENT_FULL_DETAIL` | N/A | disabled |
 | Metrics Port | `--metrics-port` | `ARGOCD_AGENT_METRICS_PORT` | `agent.metrics.port` | `8181` |
 | Health Port | `--healthz-port` | `ARGOCD_AGENT_HEALTH_CHECK_PORT` | `agent.healthz.port` | `8001` |
 | Profiling Port | `--pprof-port` | `ARGOCD_AGENT_PPROF_PORT` | N/A | `0` (disabled) |

--- a/docs/configuration/observability.md
+++ b/docs/configuration/observability.md
@@ -122,13 +122,13 @@ export ARGOCD_AGENT_FULL_DETAIL="actions,events"
 
 **Example output with `--full-detail=actions`:**
 
-```
+```text
 level=info msg="Created application default/my-app" action=create detail="{\"metadata\":{\"name\":\"my-app\",...}}" log_category=actions name=my-app namespace=default resource_type=application
 ```
 
 Without full detail, the same log omits the `detail` field:
 
-```
+```text
 level=info msg="Created application default/my-app" action=create log_category=actions name=my-app namespace=default resource_type=application
 ```
 
@@ -189,7 +189,7 @@ All action, event, and informer logs include structured fields for filtering and
    kubectl logs -n argocd deployment/argocd-agent-principal | grep "agent=my-cluster"
    ```
 
-5. **Trace a resource through all categories**:
+4. **Trace a resource through all categories**:
    ```bash
    kubectl logs -n argocd deployment/argocd-agent-agent | grep 'name=my-app' | grep -E 'log_category=(actions|events|informers)'
    ```

--- a/docs/configuration/observability.md
+++ b/docs/configuration/observability.md
@@ -491,7 +491,7 @@ For detailed profiling guidance, see the [Operations: Profiling](../operations/p
 | Parameter | CLI Flag | Env Variable | ConfigMap | Default |
 |-----------|----------|--------------|-----------|---------|
 | Log Level | `--log-level` | `ARGOCD_AGENT_LOG_LEVEL` | `agent.log.level` | `info` |
-| Log Format | `--log-format` | `ARGOCD_PRINCIPAL_LOG_FORMAT` | N/A | `text` |
+| Log Format | `--log-format` | `ARGOCD_AGENT_LOG_FORMAT` | N/A | `text` |
 | Full Detail | `--full-detail` | `ARGOCD_AGENT_FULL_DETAIL` | N/A | disabled |
 | Metrics Port | `--metrics-port` | `ARGOCD_AGENT_METRICS_PORT` | `agent.metrics.port` | `8181` |
 | Health Port | `--healthz-port` | `ARGOCD_AGENT_HEALTH_CHECK_PORT` | `agent.healthz.port` | `8001` |

--- a/docs/contributing/logging.md
+++ b/docs/contributing/logging.md
@@ -163,7 +163,11 @@ const (
 
 ## Full-Detail Logging Helpers
 
-The logging package provides helpers for structured logging of resource actions, events, and K8s informer activity. These emit consistent structured fields (`log_category`, `action`, `resource_type`, `name`, `namespace`) and conditionally include a `detail` field when full-detail logging is enabled.
+The logging package provides helpers for structured logging of resource actions, events, and K8s informer activity. Each helper emits `log_category` and conditionally includes a `detail` field when full-detail logging is enabled. The remaining structured fields vary by category:
+
+- **Action helpers**: `action`, `resource_type`, `name`, `namespace`
+- **Event helpers**: `direction`, `event_target`, `event_type`, `name`, `namespace` (parsed from CloudEvent subject)
+- **Informer helpers**: `action`, `resource_type`, `name`, `namespace`
 
 ### Action Logging (resource create/update/delete)
 

--- a/docs/contributing/logging.md
+++ b/docs/contributing/logging.md
@@ -161,6 +161,70 @@ const (
 )
 ```
 
+## Full-Detail Logging Helpers
+
+The logging package provides helpers for structured logging of resource actions, events, and K8s informer activity. These emit consistent structured fields (`log_category`, `action`, `resource_type`, `name`, `namespace`) and conditionally include a `detail` field when full-detail logging is enabled.
+
+### Action Logging (resource create/update/delete)
+
+Use these in resource manager code when a K8s resource is created, updated, or deleted:
+
+```go
+import "github.com/argoproj-labs/argocd-agent/internal/logging"
+
+// On create - logs full JSON in detail when --full-detail=actions
+logging.LogActionCreate(logCtx, "application", app)
+
+// On update - logs diff in detail when --full-detail=actions (secrets skipped)
+logging.LogActionUpdate(logCtx, "application", oldApp, newApp)
+
+// On delete - no detail field (only name/namespace/type)
+logging.LogActionDelete(logCtx, "application", app.Namespace, app.Name)
+
+// On error - logs full JSON in detail when --full-detail=actions
+logging.LogActionError(logCtx, "application", "create", app, err)
+```
+
+### Event Logging (CloudEvent sent/received)
+
+Use these when sending or receiving CloudEvents between agent and principal:
+
+```go
+// On event sent
+logging.LogEventSent(logCtx, cloudEvent)
+
+// On event received
+logging.LogEventReceived(logCtx, cloudEvent)
+
+// On event processing error
+logging.LogEventError(logCtx, cloudEvent, err)
+```
+
+Meta-events (`eventProcessed`, `heartbeat`, `clusterCacheInfoUpdate`) are automatically skipped by `LogEventSent` and `LogEventReceived` to reduce noise.
+
+### Informer Logging (K8s informer add/update/delete)
+
+Use these in informer callbacks:
+
+```go
+// On informer add
+logging.LogInformerAdd(logCtx, obj)
+
+// On informer update - logs diff in detail (secrets skipped)
+logging.LogInformerUpdate(logCtx, oldObj, newObj)
+
+// On informer delete
+logging.LogInformerDelete(logCtx, obj)
+```
+
+### Security: Secret Redaction
+
+All helpers automatically redact Kubernetes Secrets:
+
+- `LogActionCreate` / `LogInformerAdd`: `detail` shows `<redacted: Secret>` instead of the payload
+- `LogActionUpdate` / `LogInformerUpdate`: diff is skipped entirely for Secrets
+- `LogActionError`: same redaction as create
+
 ## Code Review Checklist
 
 Before submitting your PR, verify:

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/go-redis/cache/v9 v9.0.0
 	github.com/go-redis/redismock/v9 v9.2.0
 	github.com/golang-jwt/jwt/v5 v5.3.1
+	github.com/google/go-cmp v0.7.0
 	github.com/google/uuid v1.6.1-0.20241114170450-2d3c2a9cc518
 	github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674
 	github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.3.3
@@ -112,7 +113,6 @@ require (
 	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/google/btree v1.1.3 // indirect
 	github.com/google/gnostic-models v0.7.0 // indirect
-	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/google/go-github/v69 v69.2.0 // indirect
 	github.com/google/go-github/v75 v75.0.0 // indirect
 	github.com/google/go-querystring v1.1.0 // indirect

--- a/install/helm-repo/argocd-agent-agent/Chart.yaml
+++ b/install/helm-repo/argocd-agent-agent/Chart.yaml
@@ -5,7 +5,7 @@ description: Argo CD Agent for connecting managed clusters to a Principal
 type: application
 
 # chart version
-version: 0.2.1
+version: 0.2.2
 
 # application version, ArgoCD Agent version
 appVersion: v0.8.1

--- a/install/helm-repo/argocd-agent-agent/README.md
+++ b/install/helm-repo/argocd-agent-agent/README.md
@@ -1,6 +1,6 @@
 # argocd-agent-agent
 
-![Version: 0.2.1](https://img.shields.io/badge/Version-0.2.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.8.1](https://img.shields.io/badge/AppVersion-v0.8.1-informational?style=flat-square)
+![Version: 0.2.2](https://img.shields.io/badge/Version-0.2.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.8.1](https://img.shields.io/badge/AppVersion-v0.8.1-informational?style=flat-square)
 
 Argo CD Agent for connecting managed clusters to a Principal
 

--- a/install/helm-repo/argocd-agent-agent/templates/agent-deployment.yaml
+++ b/install/helm-repo/argocd-agent-agent/templates/agent-deployment.yaml
@@ -201,7 +201,7 @@ spec:
                 name: {{ include "argocd-agent-agent.paramsConfigMapName" . }}
                 key: agent.redis.tls.insecure
                 optional: true
-          - name: ARGOCD_PRINCIPAL_LOG_FORMAT
+          - name: ARGOCD_AGENT_LOG_FORMAT
             valueFrom:
               configMapKeyRef:
                 name: {{ include "argocd-agent-agent.paramsConfigMapName" . }}

--- a/install/kubernetes/agent/agent-deployment.yaml
+++ b/install/kubernetes/agent/agent-deployment.yaml
@@ -123,7 +123,7 @@ spec:
                 name: argocd-agent-params
                 key: agent.healthz.port
                 optional: true
-          - name: ARGOCD_PRINCIPAL_LOG_FORMAT
+          - name: ARGOCD_AGENT_LOG_FORMAT
             valueFrom:
               configMapKeyRef:
                 name: argocd-agent-params

--- a/internal/event/event.go
+++ b/internal/event/event.go
@@ -190,6 +190,7 @@ func (evs EventSource) ApplicationEvent(evType EventType, app *v1alpha1.Applicat
 	cev.SetExtension(eventID, createEventID(app.ObjectMeta))
 	cev.SetExtension(resourceID, createResourceID(app.ObjectMeta))
 	cev.SetDataSchema(TargetApplication.String())
+	cev.SetSubject(fmt.Sprintf("%s/%s", app.Namespace, app.Name))
 	// TODO: Handle this error situation?
 	_ = cev.SetData(cloudevents.ApplicationJSON, app)
 	return &cev
@@ -211,6 +212,7 @@ func (evs EventSource) AppProjectEvent(evType EventType, appProject *v1alpha1.Ap
 	cev.SetExtension(eventID, createEventID(appProject.ObjectMeta))
 	cev.SetExtension(resourceID, createResourceID(appProject.ObjectMeta))
 	cev.SetDataSchema(TargetAppProject.String())
+	cev.SetSubject(fmt.Sprintf("%s/%s", appProject.Namespace, appProject.Name))
 	// TODO: Handle this error situation?
 	_ = cev.SetData(cloudevents.ApplicationJSON, appProject)
 	return &cev
@@ -224,6 +226,7 @@ func (evs EventSource) ApplicationSetEvent(evType EventType, appSet *v1alpha1.Ap
 	cev.SetExtension(eventID, createEventID(appSet.ObjectMeta))
 	cev.SetExtension(resourceID, createResourceID(appSet.ObjectMeta))
 	cev.SetDataSchema(TargetApplicationSet.String())
+	cev.SetSubject(fmt.Sprintf("%s/%s", appSet.Namespace, appSet.Name))
 	_ = cev.SetData(cloudevents.ApplicationJSON, appSet)
 	return &cev
 }
@@ -255,7 +258,7 @@ func (evs EventSource) RepositoryEvent(evType EventType, repository *corev1.Secr
 	cev.SetExtension(eventID, createEventID(repository.ObjectMeta))
 	cev.SetExtension(resourceID, createResourceID(repository.ObjectMeta))
 	cev.SetDataSchema(TargetRepository.String())
-
+	cev.SetSubject(fmt.Sprintf("%s/%s", repository.Namespace, repository.Name))
 	_ = cev.SetData(cloudevents.ApplicationJSON, repository)
 	return &cev
 }
@@ -268,6 +271,7 @@ func (evs EventSource) GPGKeyEvent(evType EventType, cm *corev1.ConfigMap) *clou
 	cev.SetExtension(eventID, createEventID(cm.ObjectMeta))
 	cev.SetExtension(resourceID, createResourceID(cm.ObjectMeta))
 	cev.SetDataSchema(TargetGPGKey.String())
+	cev.SetSubject(fmt.Sprintf("%s/%s", cm.Namespace, cm.Name))
 	_ = cev.SetData(cloudevents.ApplicationJSON, cm)
 	return &cev
 }

--- a/internal/informer/informer.go
+++ b/internal/informer/informer.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/argoproj-labs/argocd-agent/internal/filter"
+	"github.com/argoproj-labs/argocd-agent/internal/logging"
 	"github.com/argoproj-labs/argocd-agent/internal/metrics"
 	"github.com/sirupsen/logrus"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -202,6 +203,7 @@ func (i *Informer[T]) installEventHandlers() error {
 				if !ok {
 					return
 				}
+				logging.LogInformerAdd(i.logger, obj)
 				if i.onAdd != nil {
 					i.onAdd(res)
 				}
@@ -212,6 +214,7 @@ func (i *Informer[T]) installEventHandlers() error {
 				if !oldOk || !newOk {
 					return
 				}
+				logging.LogInformerUpdate(i.logger, oldObj, newObj)
 				if i.onUpdate != nil {
 					i.onUpdate(oldRes, newRes)
 				}
@@ -221,6 +224,7 @@ func (i *Informer[T]) installEventHandlers() error {
 				if !ok {
 					return
 				}
+				logging.LogInformerDelete(i.logger, obj)
 				if i.onDelete != nil {
 					i.onDelete(res)
 				}

--- a/internal/logging/logfields/logfields.go
+++ b/internal/logging/logfields/logfields.go
@@ -54,6 +54,14 @@ const (
 	Repository    = "repository"
 	Namespace     = "namespace"
 
+	// Logging categories and actions
+	LogCategory  = "log_category"
+	Action       = "action"
+	ResourceType = "resource_type"
+	EventTarget  = "event_target"
+	EventType    = "event_type"
+	Detail       = "detail"
+
 	// Kubernetes resources
 	Kind               = "kind"
 	Name               = "name"

--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -21,11 +21,17 @@
 package logging
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
+	"reflect"
 	"strings"
 
+	cloudevents "github.com/cloudevents/sdk-go/v2"
+	"github.com/google/go-cmp/cmp"
 	"github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
 
 	"github.com/argoproj-labs/argocd-agent/internal/logging/logfields"
 )
@@ -58,6 +64,26 @@ const (
 
 // defaultLogger is a CentralizedLogger for the global logger instance
 var defaultLogger *CentralizedLogger
+
+// FullDetailConfig controls whether verbose resource content (.spec/.status/diffs)
+// is included in log messages, independently of log level.
+type FullDetailConfig struct {
+	Actions   bool
+	Events    bool
+	Informers bool
+}
+
+var fullDetailConfig FullDetailConfig
+
+// SetFullDetailConfig sets the global full detail logging configuration.
+func SetFullDetailConfig(cfg FullDetailConfig) {
+	fullDetailConfig = cfg
+}
+
+// GetFullDetailConfig returns the current global full detail logging configuration.
+func GetFullDetailConfig() FullDetailConfig {
+	return fullDetailConfig
+}
 
 func init() {
 	// Use the process-wide standard logger so that CLI flags and InitLogging() apply here too
@@ -343,4 +369,277 @@ func SelectLogger(l *CentralizedLogger) *CentralizedLogger {
 		return GetDefaultLogger()
 	}
 	return l
+}
+
+// LogActionCreate logs a resource creation
+func LogActionCreate(logCtx *logrus.Entry, resourceType string, obj any) {
+	name, namespace := resourceMeta(obj)
+
+	logCtx = logCtx.WithFields(logrus.Fields{
+		logfields.LogCategory:  "actions",
+		logfields.Action:       "create",
+		logfields.ResourceType: resourceType,
+		logfields.Name:         name,
+		logfields.Namespace:    namespace,
+	})
+
+	// Include the full resource in the log if full detail is enabled
+	if fullDetailConfig.Actions {
+		logCtx = logCtx.WithField(logfields.Detail, marshalResource(obj))
+	}
+
+	logCtx.Infof("Created %s %s/%s", resourceType, namespace, name)
+}
+
+// LogActionUpdate logs a resource update
+func LogActionUpdate(logCtx *logrus.Entry, resourceType string, oldObj, newObj any) {
+	name, namespace := resourceMeta(newObj)
+
+	logCtx = logCtx.WithFields(logrus.Fields{
+		logfields.LogCategory:  "actions",
+		logfields.Action:       "update",
+		logfields.ResourceType: resourceType,
+		logfields.Name:         name,
+		logfields.Namespace:    namespace,
+	})
+
+	// Include the diff in the log if full detail is enabled
+	if fullDetailConfig.Actions && oldObj != nil && newObj != nil && !isSecret(newObj) {
+		// Only include the diff if it is non-empty
+		if diff := cmp.Diff(oldObj, newObj); diff != "" {
+			logCtx = logCtx.WithField(logfields.Detail, diff)
+		}
+	}
+
+	logCtx.Infof("Updated %s %s/%s", resourceType, namespace, name)
+}
+
+// LogActionDelete logs a resource deletion.
+func LogActionDelete(logCtx *logrus.Entry, resourceType, namespace, name string) {
+	logCtx = logCtx.WithFields(logrus.Fields{
+		logfields.LogCategory:  "actions",
+		logfields.Action:       "delete",
+		logfields.ResourceType: resourceType,
+		logfields.Name:         name,
+		logfields.Namespace:    namespace,
+	})
+
+	logCtx.Infof("Deleted %s %s/%s", resourceType, namespace, name)
+}
+
+// LogActionError logs resource action error. When full detail is enabled,
+// the incoming resource payload is included in logs.
+func LogActionError(logCtx *logrus.Entry, resourceType, action string, obj any, err error) {
+	name, namespace := resourceMeta(obj)
+
+	logCtx = logCtx.WithFields(logrus.Fields{
+		logfields.LogCategory:  "actions",
+		logfields.Action:       action,
+		logfields.ResourceType: resourceType,
+		logfields.Name:         name,
+		logfields.Namespace:    namespace,
+	})
+
+	// Include the full resource in the log if full detail is enabled
+	if fullDetailConfig.Actions {
+		logCtx = logCtx.WithField(logfields.Detail, marshalResource(obj))
+	}
+	logCtx.WithError(err).Errorf("Error performing action %s on %s %s/%s", action, resourceType, namespace, name)
+}
+
+// LogEventSent logs an outbound event
+func LogEventSent(logCtx *logrus.Entry, ev *cloudevents.Event) {
+
+	// Skip meta events (ACKs, heartbeats, periodic cache updates), they do not need verbose logging
+	// and are handled by the agent and principal respectively
+	if isMetaEvent(ev) {
+		return
+	}
+
+	target := ev.DataSchema()
+	action := shortType(ev.Type())
+
+	logCtx = logCtx.WithFields(logrus.Fields{
+		logfields.LogCategory: "events",
+		logfields.Direction:   "send",
+		logfields.EventTarget: target,
+		logfields.EventType:   ev.Type(),
+	})
+
+	logCtx = parseEventSubject(logCtx, ev)
+
+	// Include the event data in the log if full detail is enabled and event data is not empty
+	if fullDetailConfig.Events && hasEventData(ev.Data()) {
+		logCtx = logCtx.WithField(logfields.Detail, string(ev.Data()))
+	}
+	logCtx.Infof("Event sent: %s %s", target, action)
+}
+
+// LogEventReceived logs an inbound event
+func LogEventReceived(logCtx *logrus.Entry, ev *cloudevents.Event) {
+	// Skip meta events
+	if isMetaEvent(ev) {
+		return
+	}
+
+	target := ev.DataSchema()
+	action := shortType(ev.Type())
+
+	logCtx = logCtx.WithFields(logrus.Fields{
+		logfields.LogCategory: "events",
+		logfields.Direction:   "recv",
+		logfields.EventTarget: target,
+		logfields.EventType:   ev.Type(),
+	})
+
+	logCtx = parseEventSubject(logCtx, ev)
+
+	// Include the event data in the log if full detail is enabled and event data is not empty
+	if fullDetailConfig.Events && hasEventData(ev.Data()) {
+		logCtx = logCtx.WithField(logfields.Detail, string(ev.Data()))
+	}
+	logCtx.Infof("Event received: %s %s", target, action)
+}
+
+// LogEventError logs event error
+func LogEventError(logCtx *logrus.Entry, ev *cloudevents.Event, err error) {
+	target := ev.DataSchema()
+	action := shortType(ev.Type())
+
+	logCtx = logCtx.WithFields(logrus.Fields{
+		logfields.LogCategory: "events",
+		logfields.EventTarget: target,
+		logfields.EventType:   ev.Type(),
+	})
+	logCtx = parseEventSubject(logCtx, ev)
+
+	// Include the event data in the log if full detail is enabled and event data is not empty
+	if fullDetailConfig.Events && hasEventData(ev.Data()) {
+		logCtx = logCtx.WithField(logfields.Detail, string(ev.Data()))
+	}
+	logCtx.WithError(err).Errorf("Error processing event: %s %s", target, action)
+}
+
+// LogInformerAdd logs a K8s informer add event
+func LogInformerAdd(logCtx *logrus.Entry, obj any) {
+	name, namespace := resourceMeta(obj)
+	resType := resourceType(obj)
+
+	logCtx = logCtx.WithFields(logrus.Fields{
+		logfields.LogCategory:  "informers",
+		logfields.Action:       "create",
+		logfields.ResourceType: resType,
+		logfields.Name:         name,
+		logfields.Namespace:    namespace,
+	})
+
+	if fullDetailConfig.Informers {
+		logCtx = logCtx.WithField(logfields.Detail, marshalResource(obj))
+	}
+	logCtx.Infof("Informer add: %s %s/%s", resType, namespace, name)
+}
+
+// LogInformerUpdate logs a K8s informer update event
+func LogInformerUpdate(logCtx *logrus.Entry, oldObj, newObj any) {
+	name, namespace := resourceMeta(newObj)
+	resType := resourceType(newObj)
+
+	logCtx = logCtx.WithFields(logrus.Fields{
+		logfields.LogCategory:  "informers",
+		logfields.Action:       "update",
+		logfields.ResourceType: resType,
+		logfields.Name:         name,
+		logfields.Namespace:    namespace,
+	})
+
+	// Include the diff in the log if full detail is enabled
+	// but not for secret as they are confidential
+	if fullDetailConfig.Informers && !isSecret(newObj) {
+		if diff := cmp.Diff(oldObj, newObj); diff != "" {
+			logCtx = logCtx.WithField(logfields.Detail, diff)
+		}
+	}
+	logCtx.Infof("Informer update: %s %s/%s", resType, namespace, name)
+}
+
+// LogInformerDelete logs a K8s informer delete event
+func LogInformerDelete(logCtx *logrus.Entry, obj any) {
+	name, namespace := resourceMeta(obj)
+	resType := resourceType(obj)
+
+	logCtx = logCtx.WithFields(logrus.Fields{
+		logfields.LogCategory:  "informers",
+		logfields.Action:       "delete",
+		logfields.ResourceType: resType,
+		logfields.Name:         name,
+		logfields.Namespace:    namespace,
+	})
+
+	logCtx.Infof("Informer delete: %s %s/%s", resType, namespace, name)
+}
+
+// parseEventSubject is to parse and add name and namespace fields from the CloudEvent Subject
+func parseEventSubject(logCtx *logrus.Entry, ev *cloudevents.Event) *logrus.Entry {
+	if ns, name, ok := strings.Cut(ev.Subject(), "/"); ok && name != "" {
+		return logCtx.WithFields(logrus.Fields{
+			logfields.Name:      name,
+			logfields.Namespace: ns,
+		})
+	}
+	return logCtx
+}
+
+// shortType strips the CloudEvent type prefix, returning just the action part
+func shortType(evType string) string {
+	const prefix = "io.argoproj.argocd-agent.event."
+	if strings.HasPrefix(evType, prefix) {
+		return evType[len(prefix):]
+	}
+	return evType
+}
+
+// isMetaEvent checks if the event is a meta event
+func isMetaEvent(ev *cloudevents.Event) bool {
+	target := ev.DataSchema()
+	return target == "eventProcessed" ||
+		target == "heartbeat" ||
+		target == "clusterCacheInfoUpdate"
+}
+
+// hasEventData checks if the event data is not empty
+func hasEventData(data []byte) bool {
+	s := strings.TrimSpace(string(data))
+	return len(s) > 0 && s != "{}" && s != "null"
+}
+
+// resourceMeta extracts name and namespace from a K8s runtime object.
+func resourceMeta(obj any) (name, namespace string) {
+	accessor, err := meta.Accessor(obj)
+	if err != nil {
+		return "<unknown>", "<unknown>"
+	}
+	return accessor.GetName(), accessor.GetNamespace()
+}
+
+// resourceType returns the lowercase type name of a K8s runtime object (e.g. "configmap", "application").
+func resourceType(obj any) string {
+	return strings.ToLower(reflect.TypeOf(obj).Elem().Name())
+}
+
+func isSecret(obj any) bool {
+	_, ok := obj.(*corev1.Secret)
+	return ok
+}
+
+// marshalResource marshals a resource to JSON string
+func marshalResource(obj any) string {
+	// Secrets are confidentials and should not log data
+	if isSecret(obj) {
+		return "<redacted: Secret>"
+	}
+	data, err := json.Marshal(obj)
+	if err != nil {
+		return fmt.Sprintf("<error marshalling resource: %v>", err)
+	}
+	return string(data)
 }

--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -449,13 +449,6 @@ func LogActionError(logCtx *logrus.Entry, resourceType, action string, obj any, 
 
 // LogEventSent logs an outbound event
 func LogEventSent(logCtx *logrus.Entry, ev *cloudevents.Event) {
-
-	// Skip meta events (ACKs, heartbeats, periodic cache updates), they do not need verbose logging
-	// and are handled by the agent and principal respectively
-	if isMetaEvent(ev) {
-		return
-	}
-
 	target := ev.DataSchema()
 	action := shortType(ev.Type())
 
@@ -468,8 +461,14 @@ func LogEventSent(logCtx *logrus.Entry, ev *cloudevents.Event) {
 
 	logCtx = parseEventSubject(logCtx, ev)
 
-	// Include the event data in the log if full detail is enabled and event data is not empty
-	if fullDetailConfig.Events && hasEventData(ev.Data()) {
+	// Meta events are logged at debug level to avoid noise.
+	if isMetaEvent(ev) {
+		logCtx.Debugf("Event sent: %s %s", target, action)
+		return
+	}
+
+	// Events for sensitive resources are never verbose logged to avoid leaking credentials.
+	if hasEventData(ev.Data()) && !isSensitiveEvent(ev) {
 		logCtx = logCtx.WithField(logfields.Detail, string(ev.Data()))
 	}
 	logCtx.Infof("Event sent: %s %s", target, action)
@@ -477,11 +476,6 @@ func LogEventSent(logCtx *logrus.Entry, ev *cloudevents.Event) {
 
 // LogEventReceived logs an inbound event
 func LogEventReceived(logCtx *logrus.Entry, ev *cloudevents.Event) {
-	// Skip meta events
-	if isMetaEvent(ev) {
-		return
-	}
-
 	target := ev.DataSchema()
 	action := shortType(ev.Type())
 
@@ -494,8 +488,14 @@ func LogEventReceived(logCtx *logrus.Entry, ev *cloudevents.Event) {
 
 	logCtx = parseEventSubject(logCtx, ev)
 
-	// Include the event data in the log if full detail is enabled and event data is not empty
-	if fullDetailConfig.Events && hasEventData(ev.Data()) {
+	// Meta events are logged at debug level to avoid noise.
+	if isMetaEvent(ev) {
+		logCtx.Debugf("Event received: %s %s", target, action)
+		return
+	}
+
+	// Events for sensitive resources are never verbose logged to avoid leaking credentials.
+	if hasEventData(ev.Data()) && !isSensitiveEvent(ev) {
 		logCtx = logCtx.WithField(logfields.Detail, string(ev.Data()))
 	}
 	logCtx.Infof("Event received: %s %s", target, action)
@@ -513,8 +513,8 @@ func LogEventError(logCtx *logrus.Entry, ev *cloudevents.Event, err error) {
 	})
 	logCtx = parseEventSubject(logCtx, ev)
 
-	// Include the event data in the log if full detail is enabled and event data is not empty
-	if fullDetailConfig.Events && hasEventData(ev.Data()) {
+	// Events for sensitive resources are never verbose logged to avoid leaking credentials.
+	if hasEventData(ev.Data()) && !isSensitiveEvent(ev) {
 		logCtx = logCtx.WithField(logfields.Detail, string(ev.Data()))
 	}
 	logCtx.WithError(err).Errorf("Error processing event: %s %s", target, action)
@@ -610,6 +610,18 @@ func isMetaEvent(ev *cloudevents.Event) bool {
 func hasEventData(data []byte) bool {
 	s := strings.TrimSpace(string(data))
 	return len(s) > 0 && s != "{}" && s != "null"
+}
+
+// isSensitiveEvent returns true if the event may carry sensitive data.
+// Repository events carry Secret objects directly. Redis and resource events
+// carry opaque payloads that could contain secrets (cached manifests, raw K8s
+// API responses), so they are treated as potentially sensitive.
+func isSensitiveEvent(ev *cloudevents.Event) bool {
+	switch ev.DataSchema() {
+	case "repository", "redis", "resource":
+		return true
+	}
+	return false
 }
 
 // resourceMeta extracts name and namespace from a K8s runtime object.

--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -467,8 +467,9 @@ func LogEventSent(logCtx *logrus.Entry, ev *cloudevents.Event) {
 		return
 	}
 
-	// Events for sensitive resources are never verbose logged to avoid leaking credentials.
-	if hasEventData(ev.Data()) && !isSensitiveEvent(ev) {
+	// Sensitive events never include detail. Large events only include detail
+	// when FULL_DETAIL is enabled. Small events always include detail.
+	if hasEventData(ev.Data()) && !isSensitiveEvent(ev) && (!isLargeEvent(ev) || fullDetailConfig.Events) {
 		logCtx = logCtx.WithField(logfields.Detail, string(ev.Data()))
 	}
 	logCtx.Infof("Event sent: %s %s", target, action)
@@ -494,8 +495,9 @@ func LogEventReceived(logCtx *logrus.Entry, ev *cloudevents.Event) {
 		return
 	}
 
-	// Events for sensitive resources are never verbose logged to avoid leaking credentials.
-	if hasEventData(ev.Data()) && !isSensitiveEvent(ev) {
+	// Sensitive events never include detail. Large events only include detail
+	// when FULL_DETAIL is enabled. Small events always include detail.
+	if hasEventData(ev.Data()) && !isSensitiveEvent(ev) && (!isLargeEvent(ev) || fullDetailConfig.Events) {
 		logCtx = logCtx.WithField(logfields.Detail, string(ev.Data()))
 	}
 	logCtx.Infof("Event received: %s %s", target, action)
@@ -513,8 +515,9 @@ func LogEventError(logCtx *logrus.Entry, ev *cloudevents.Event, err error) {
 	})
 	logCtx = parseEventSubject(logCtx, ev)
 
-	// Events for sensitive resources are never verbose logged to avoid leaking credentials.
-	if hasEventData(ev.Data()) && !isSensitiveEvent(ev) {
+	// Sensitive events never include detail. Large events only include detail
+	// when FULL_DETAIL is enabled. Small events always include detail.
+	if hasEventData(ev.Data()) && !isSensitiveEvent(ev) && (!isLargeEvent(ev) || fullDetailConfig.Events) {
 		logCtx = logCtx.WithField(logfields.Detail, string(ev.Data()))
 	}
 	logCtx.WithError(err).Errorf("Error processing event: %s %s", target, action)
@@ -619,6 +622,16 @@ func hasEventData(data []byte) bool {
 func isSensitiveEvent(ev *cloudevents.Event) bool {
 	switch ev.DataSchema() {
 	case "repository", "redis", "resource":
+		return true
+	}
+	return false
+}
+
+// isLargeEvent returns true if the event carries a large payload (full .spec/.status)
+// that should only be logged when FULL_DETAIL is enabled.
+func isLargeEvent(ev *cloudevents.Event) bool {
+	switch ev.DataSchema() {
+	case "application", "applicationset":
 		return true
 	}
 	return false

--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -539,7 +539,7 @@ func LogInformerAdd(logCtx *logrus.Entry, obj any) {
 	if fullDetailConfig.Informers {
 		logCtx = logCtx.WithField(logfields.Detail, marshalResource(obj))
 	}
-	logCtx.Infof("Informer add: %s %s/%s", resType, namespace, name)
+	logCtx.Debugf("Informer add: %s %s/%s", resType, namespace, name)
 }
 
 // LogInformerUpdate logs a K8s informer update event
@@ -562,7 +562,7 @@ func LogInformerUpdate(logCtx *logrus.Entry, oldObj, newObj any) {
 			logCtx = logCtx.WithField(logfields.Detail, diff)
 		}
 	}
-	logCtx.Infof("Informer update: %s %s/%s", resType, namespace, name)
+	logCtx.Debugf("Informer update: %s %s/%s", resType, namespace, name)
 }
 
 // LogInformerDelete logs a K8s informer delete event
@@ -578,7 +578,7 @@ func LogInformerDelete(logCtx *logrus.Entry, obj any) {
 		logfields.Namespace:    namespace,
 	})
 
-	logCtx.Infof("Informer delete: %s %s/%s", resType, namespace, name)
+	logCtx.Debugf("Informer delete: %s %s/%s", resType, namespace, name)
 }
 
 // parseEventSubject is to parse and add name and namespace fields from the CloudEvent Subject
@@ -631,7 +631,7 @@ func isSensitiveEvent(ev *cloudevents.Event) bool {
 // that should only be logged when FULL_DETAIL is enabled.
 func isLargeEvent(ev *cloudevents.Event) bool {
 	switch ev.DataSchema() {
-	case "application", "applicationset":
+	case "application", "applicationset", "appproject":
 		return true
 	}
 	return false

--- a/internal/logging/logging_test.go
+++ b/internal/logging/logging_test.go
@@ -17,11 +17,15 @@ package logging
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"testing"
 
+	cloudevents "github.com/cloudevents/sdk-go/v2"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/argoproj-labs/argocd-agent/internal/logging/logfields"
 )
@@ -450,4 +454,492 @@ func TestSeparateLoggerLevels(t *testing.T) {
 	assert.NotContains(t, warnOutput, "info message")
 	assert.Contains(t, warnOutput, "warn message")
 	assert.Contains(t, warnOutput, "error message")
+}
+
+func newTestEntry(buf *bytes.Buffer) *logrus.Entry {
+	logger := logrus.New()
+	logger.SetOutput(buf)
+	logger.SetFormatter(&logrus.JSONFormatter{})
+	logger.SetLevel(logrus.TraceLevel)
+	return logrus.NewEntry(logger)
+}
+
+func parseLogLine(t *testing.T, buf *bytes.Buffer) map[string]interface{} {
+	t.Helper()
+	var entry map[string]interface{}
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &entry))
+	return entry
+}
+
+func newConfigMap(name, namespace string) *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+	}
+}
+
+func newSecret(name, namespace string) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+		Data:       map[string][]byte{"password": []byte("s3cret")},
+	}
+}
+
+func newCloudEvent(evType, target, subject string, data []byte) *cloudevents.Event {
+	ev := cloudevents.NewEvent()
+	ev.SetType(evType)
+	ev.SetDataSchema(target)
+	ev.SetSubject(subject)
+	if data != nil {
+		ev.DataEncoded = data
+	}
+	return &ev
+}
+
+func TestMarshalResource(t *testing.T) {
+	t.Run("configmap produces JSON", func(t *testing.T) {
+		cm := newConfigMap("test-cm", "default")
+		result := marshalResource(cm)
+		assert.Contains(t, result, "test-cm")
+	})
+
+	t.Run("secret is redacted", func(t *testing.T) {
+		s := newSecret("my-secret", "default")
+		result := marshalResource(s)
+		assert.Equal(t, "<redacted: Secret>", result)
+		assert.NotContains(t, result, "s3cret")
+	})
+}
+
+func TestResourceMeta(t *testing.T) {
+	t.Run("valid k8s object", func(t *testing.T) {
+		cm := newConfigMap("my-cm", "my-ns")
+		name, ns := resourceMeta(cm)
+		assert.Equal(t, "my-cm", name)
+		assert.Equal(t, "my-ns", ns)
+	})
+
+	t.Run("non-k8s object returns unknown", func(t *testing.T) {
+		name, ns := resourceMeta("not-a-k8s-object")
+		assert.Equal(t, "<unknown>", name)
+		assert.Equal(t, "<unknown>", ns)
+	})
+}
+
+func TestHasEventData(t *testing.T) {
+	assert.False(t, hasEventData(nil))
+	assert.False(t, hasEventData([]byte("")))
+	assert.False(t, hasEventData([]byte("{}")))
+	assert.False(t, hasEventData([]byte("null")))
+	assert.False(t, hasEventData([]byte("  ")))
+	assert.True(t, hasEventData([]byte(`{"key":"value"}`)))
+}
+
+func TestShortType(t *testing.T) {
+	assert.Equal(t, "request-update", shortType("io.argoproj.argocd-agent.event.request-update"))
+	assert.Equal(t, "custom-type", shortType("custom-type"))
+}
+
+func TestIsMetaEvent(t *testing.T) {
+	assert.True(t, isMetaEvent(newCloudEvent("", "eventProcessed", "", nil)))
+	assert.True(t, isMetaEvent(newCloudEvent("", "heartbeat", "", nil)))
+	assert.True(t, isMetaEvent(newCloudEvent("", "clusterCacheInfoUpdate", "", nil)))
+	assert.False(t, isMetaEvent(newCloudEvent("", "application", "", nil)))
+}
+
+func TestParseEventSubject(t *testing.T) {
+	var buf bytes.Buffer
+	logCtx := newTestEntry(&buf)
+
+	t.Run("parses namespace/name from subject", func(t *testing.T) {
+		ev := newCloudEvent("", "", "my-ns/my-app", nil)
+		enriched := parseEventSubject(logCtx, ev)
+		enriched.Info("test")
+		entry := parseLogLine(t, &buf)
+		assert.Equal(t, "my-app", entry[logfields.Name])
+		assert.Equal(t, "my-ns", entry[logfields.Namespace])
+	})
+
+	t.Run("empty subject leaves fields absent", func(t *testing.T) {
+		buf.Reset()
+		ev := newCloudEvent("", "", "", nil)
+		enriched := parseEventSubject(logCtx, ev)
+		enriched.Info("test")
+		entry := parseLogLine(t, &buf)
+		assert.Nil(t, entry[logfields.Name])
+		assert.Nil(t, entry[logfields.Namespace])
+	})
+}
+
+func TestLogActionCreate(t *testing.T) {
+	defer SetFullDetailConfig(FullDetailConfig{})
+
+	t.Run("basic fields", func(t *testing.T) {
+		var buf bytes.Buffer
+		logCtx := newTestEntry(&buf)
+		cm := newConfigMap("my-cm", "default")
+
+		LogActionCreate(logCtx, "configmap", cm)
+
+		entry := parseLogLine(t, &buf)
+		assert.Equal(t, "actions", entry[logfields.LogCategory])
+		assert.Equal(t, "create", entry[logfields.Action])
+		assert.Equal(t, "configmap", entry[logfields.ResourceType])
+		assert.Equal(t, "my-cm", entry[logfields.Name])
+		assert.Equal(t, "default", entry[logfields.Namespace])
+		assert.Nil(t, entry[logfields.Detail])
+	})
+
+	t.Run("with full detail", func(t *testing.T) {
+		SetFullDetailConfig(FullDetailConfig{Actions: true})
+		var buf bytes.Buffer
+		logCtx := newTestEntry(&buf)
+		cm := newConfigMap("my-cm", "default")
+
+		LogActionCreate(logCtx, "configmap", cm)
+
+		entry := parseLogLine(t, &buf)
+		assert.NotNil(t, entry[logfields.Detail])
+		assert.Contains(t, entry[logfields.Detail], "my-cm")
+	})
+
+	t.Run("secret is redacted with full detail", func(t *testing.T) {
+		SetFullDetailConfig(FullDetailConfig{Actions: true})
+		var buf bytes.Buffer
+		logCtx := newTestEntry(&buf)
+		s := newSecret("my-secret", "default")
+
+		LogActionCreate(logCtx, "secret", s)
+
+		entry := parseLogLine(t, &buf)
+		detail := entry[logfields.Detail].(string)
+		assert.Equal(t, "<redacted: Secret>", detail)
+	})
+}
+
+func TestLogActionUpdate(t *testing.T) {
+	defer SetFullDetailConfig(FullDetailConfig{})
+
+	t.Run("basic fields without detail", func(t *testing.T) {
+		var buf bytes.Buffer
+		logCtx := newTestEntry(&buf)
+		oldCM := newConfigMap("my-cm", "default")
+		newCM := newConfigMap("my-cm", "default")
+		newCM.Data = map[string]string{"key": "value"}
+
+		LogActionUpdate(logCtx, "configmap", oldCM, newCM)
+
+		entry := parseLogLine(t, &buf)
+		assert.Equal(t, "actions", entry[logfields.LogCategory])
+		assert.Equal(t, "update", entry[logfields.Action])
+		assert.Nil(t, entry[logfields.Detail])
+	})
+
+	t.Run("with full detail includes diff", func(t *testing.T) {
+		SetFullDetailConfig(FullDetailConfig{Actions: true})
+		var buf bytes.Buffer
+		logCtx := newTestEntry(&buf)
+		oldCM := newConfigMap("my-cm", "default")
+		newCM := newConfigMap("my-cm", "default")
+		newCM.Data = map[string]string{"key": "value"}
+
+		LogActionUpdate(logCtx, "configmap", oldCM, newCM)
+
+		entry := parseLogLine(t, &buf)
+		assert.NotNil(t, entry[logfields.Detail])
+	})
+
+	t.Run("secret update skips diff", func(t *testing.T) {
+		SetFullDetailConfig(FullDetailConfig{Actions: true})
+		var buf bytes.Buffer
+		logCtx := newTestEntry(&buf)
+		oldSec := newSecret("my-secret", "default")
+		newSec := newSecret("my-secret", "default")
+		newSec.Data = map[string][]byte{"password": []byte("new")}
+
+		LogActionUpdate(logCtx, "secret", oldSec, newSec)
+
+		entry := parseLogLine(t, &buf)
+		assert.Nil(t, entry[logfields.Detail])
+	})
+}
+
+func TestLogActionDelete(t *testing.T) {
+	var buf bytes.Buffer
+	logCtx := newTestEntry(&buf)
+
+	LogActionDelete(logCtx, "configmap", "default", "my-cm")
+
+	entry := parseLogLine(t, &buf)
+	assert.Equal(t, "actions", entry[logfields.LogCategory])
+	assert.Equal(t, "delete", entry[logfields.Action])
+	assert.Equal(t, "configmap", entry[logfields.ResourceType])
+	assert.Equal(t, "my-cm", entry[logfields.Name])
+	assert.Equal(t, "default", entry[logfields.Namespace])
+}
+
+func TestLogActionError(t *testing.T) {
+	defer SetFullDetailConfig(FullDetailConfig{})
+
+	t.Run("basic error fields", func(t *testing.T) {
+		var buf bytes.Buffer
+		logCtx := newTestEntry(&buf)
+		cm := newConfigMap("my-cm", "default")
+
+		LogActionError(logCtx, "configmap", "create", cm, errors.New("test error"))
+
+		entry := parseLogLine(t, &buf)
+		assert.Equal(t, "actions", entry[logfields.LogCategory])
+		assert.Equal(t, "create", entry[logfields.Action])
+		assert.Equal(t, "my-cm", entry[logfields.Name])
+		assert.Equal(t, "error", entry["level"])
+		assert.Contains(t, entry["error"], "test error")
+		assert.Nil(t, entry[logfields.Detail])
+	})
+
+	t.Run("with full detail", func(t *testing.T) {
+		SetFullDetailConfig(FullDetailConfig{Actions: true})
+		var buf bytes.Buffer
+		logCtx := newTestEntry(&buf)
+		cm := newConfigMap("my-cm", "default")
+
+		LogActionError(logCtx, "configmap", "create", cm, errors.New("fail"))
+
+		entry := parseLogLine(t, &buf)
+		assert.NotNil(t, entry[logfields.Detail])
+		assert.Contains(t, entry[logfields.Detail], "my-cm")
+	})
+}
+
+func TestLogEventSent(t *testing.T) {
+	defer SetFullDetailConfig(FullDetailConfig{})
+
+	t.Run("skips meta events", func(t *testing.T) {
+		var buf bytes.Buffer
+		logCtx := newTestEntry(&buf)
+		ev := newCloudEvent("io.argoproj.argocd-agent.event.processed", "eventProcessed", "", nil)
+
+		LogEventSent(logCtx, ev)
+
+		assert.Empty(t, buf.String())
+	})
+
+	t.Run("logs non-meta event with fields", func(t *testing.T) {
+		var buf bytes.Buffer
+		logCtx := newTestEntry(&buf)
+		ev := newCloudEvent(
+			"io.argoproj.argocd-agent.event.request-update",
+			"application",
+			"default/my-app",
+			[]byte(`{"spec":{}}`),
+		)
+
+		LogEventSent(logCtx, ev)
+
+		entry := parseLogLine(t, &buf)
+		assert.Equal(t, "events", entry[logfields.LogCategory])
+		assert.Equal(t, "send", entry[logfields.Direction])
+		assert.Equal(t, "application", entry[logfields.EventTarget])
+		assert.Equal(t, "my-app", entry[logfields.Name])
+		assert.Equal(t, "default", entry[logfields.Namespace])
+		assert.Nil(t, entry[logfields.Detail])
+	})
+
+	t.Run("with full detail includes data", func(t *testing.T) {
+		SetFullDetailConfig(FullDetailConfig{Events: true})
+		var buf bytes.Buffer
+		logCtx := newTestEntry(&buf)
+		ev := newCloudEvent(
+			"io.argoproj.argocd-agent.event.request-update",
+			"application",
+			"default/my-app",
+			[]byte(`{"spec":{}}`),
+		)
+
+		LogEventSent(logCtx, ev)
+
+		entry := parseLogLine(t, &buf)
+		assert.NotNil(t, entry[logfields.Detail])
+	})
+
+	t.Run("with full detail skips empty data", func(t *testing.T) {
+		SetFullDetailConfig(FullDetailConfig{Events: true})
+		var buf bytes.Buffer
+		logCtx := newTestEntry(&buf)
+		ev := newCloudEvent(
+			"io.argoproj.argocd-agent.event.request-update",
+			"application",
+			"default/my-app",
+			[]byte("{}"),
+		)
+
+		LogEventSent(logCtx, ev)
+
+		entry := parseLogLine(t, &buf)
+		assert.Nil(t, entry[logfields.Detail])
+	})
+}
+
+func TestLogEventReceived(t *testing.T) {
+	defer SetFullDetailConfig(FullDetailConfig{})
+
+	t.Run("skips meta events", func(t *testing.T) {
+		var buf bytes.Buffer
+		logCtx := newTestEntry(&buf)
+		ev := newCloudEvent("", "heartbeat", "", nil)
+
+		LogEventReceived(logCtx, ev)
+
+		assert.Empty(t, buf.String())
+	})
+
+	t.Run("logs non-meta event", func(t *testing.T) {
+		var buf bytes.Buffer
+		logCtx := newTestEntry(&buf)
+		ev := newCloudEvent(
+			"io.argoproj.argocd-agent.event.request-update",
+			"application",
+			"ns/app",
+			nil,
+		)
+
+		LogEventReceived(logCtx, ev)
+
+		entry := parseLogLine(t, &buf)
+		assert.Equal(t, "events", entry[logfields.LogCategory])
+		assert.Equal(t, "recv", entry[logfields.Direction])
+	})
+}
+
+func TestLogEventError(t *testing.T) {
+	defer SetFullDetailConfig(FullDetailConfig{})
+
+	t.Run("basic error fields", func(t *testing.T) {
+		var buf bytes.Buffer
+		logCtx := newTestEntry(&buf)
+		ev := newCloudEvent(
+			"io.argoproj.argocd-agent.event.request-update",
+			"application",
+			"ns/app",
+			[]byte(`{"spec":{}}`),
+		)
+
+		LogEventError(logCtx, ev, errors.New("event failed"))
+
+		entry := parseLogLine(t, &buf)
+		assert.Equal(t, "events", entry[logfields.LogCategory])
+		assert.Equal(t, "error", entry["level"])
+		assert.Contains(t, entry["error"], "event failed")
+		assert.Equal(t, "app", entry[logfields.Name])
+		assert.Nil(t, entry[logfields.Detail])
+	})
+
+	t.Run("with full detail includes data", func(t *testing.T) {
+		SetFullDetailConfig(FullDetailConfig{Events: true})
+		var buf bytes.Buffer
+		logCtx := newTestEntry(&buf)
+		ev := newCloudEvent(
+			"io.argoproj.argocd-agent.event.request-update",
+			"application",
+			"ns/app",
+			[]byte(`{"spec":{}}`),
+		)
+
+		LogEventError(logCtx, ev, errors.New("event failed"))
+
+		entry := parseLogLine(t, &buf)
+		assert.NotNil(t, entry[logfields.Detail])
+	})
+}
+
+func TestLogInformerAdd(t *testing.T) {
+	defer SetFullDetailConfig(FullDetailConfig{})
+
+	t.Run("basic fields", func(t *testing.T) {
+		var buf bytes.Buffer
+		logCtx := newTestEntry(&buf)
+		cm := newConfigMap("my-cm", "default")
+
+		LogInformerAdd(logCtx, cm)
+
+		entry := parseLogLine(t, &buf)
+		assert.Equal(t, "informers", entry[logfields.LogCategory])
+		assert.Equal(t, "create", entry[logfields.Action])
+		assert.Equal(t, "configmap", entry[logfields.ResourceType])
+		assert.Equal(t, "my-cm", entry[logfields.Name])
+		assert.Equal(t, "default", entry[logfields.Namespace])
+		assert.Nil(t, entry[logfields.Detail])
+	})
+
+	t.Run("with full detail", func(t *testing.T) {
+		SetFullDetailConfig(FullDetailConfig{Informers: true})
+		var buf bytes.Buffer
+		logCtx := newTestEntry(&buf)
+		cm := newConfigMap("my-cm", "default")
+
+		LogInformerAdd(logCtx, cm)
+
+		entry := parseLogLine(t, &buf)
+		assert.NotNil(t, entry[logfields.Detail])
+	})
+}
+
+func TestLogInformerUpdate(t *testing.T) {
+	defer SetFullDetailConfig(FullDetailConfig{})
+
+	t.Run("basic fields", func(t *testing.T) {
+		var buf bytes.Buffer
+		logCtx := newTestEntry(&buf)
+		old := newConfigMap("my-cm", "default")
+		new := newConfigMap("my-cm", "default")
+
+		LogInformerUpdate(logCtx, old, new)
+
+		entry := parseLogLine(t, &buf)
+		assert.Equal(t, "informers", entry[logfields.LogCategory])
+		assert.Equal(t, "update", entry[logfields.Action])
+		assert.Equal(t, "configmap", entry[logfields.ResourceType])
+	})
+
+	t.Run("with full detail includes diff", func(t *testing.T) {
+		SetFullDetailConfig(FullDetailConfig{Informers: true})
+		var buf bytes.Buffer
+		logCtx := newTestEntry(&buf)
+		old := newConfigMap("my-cm", "default")
+		upd := newConfigMap("my-cm", "default")
+		upd.Data = map[string]string{"key": "val"}
+
+		LogInformerUpdate(logCtx, old, upd)
+
+		entry := parseLogLine(t, &buf)
+		assert.NotNil(t, entry[logfields.Detail])
+	})
+
+	t.Run("secret update skips diff", func(t *testing.T) {
+		SetFullDetailConfig(FullDetailConfig{Informers: true})
+		var buf bytes.Buffer
+		logCtx := newTestEntry(&buf)
+		old := newSecret("s", "ns")
+		upd := newSecret("s", "ns")
+		upd.Data = map[string][]byte{"password": []byte("new")}
+
+		LogInformerUpdate(logCtx, old, upd)
+
+		entry := parseLogLine(t, &buf)
+		assert.Nil(t, entry[logfields.Detail])
+	})
+}
+
+func TestLogInformerDelete(t *testing.T) {
+	var buf bytes.Buffer
+	logCtx := newTestEntry(&buf)
+	cm := newConfigMap("my-cm", "default")
+
+	LogInformerDelete(logCtx, cm)
+
+	entry := parseLogLine(t, &buf)
+	assert.Equal(t, "informers", entry[logfields.LogCategory])
+	assert.Equal(t, "delete", entry[logfields.Action])
+	assert.Equal(t, "configmap", entry[logfields.ResourceType])
+	assert.Equal(t, "my-cm", entry[logfields.Name])
+	assert.Equal(t, "default", entry[logfields.Namespace])
 }

--- a/internal/logging/logging_test.go
+++ b/internal/logging/logging_test.go
@@ -546,6 +546,15 @@ func TestIsMetaEvent(t *testing.T) {
 	assert.False(t, isMetaEvent(newCloudEvent("", "application", "", nil)))
 }
 
+func TestIsSensitiveEvent(t *testing.T) {
+	assert.True(t, isSensitiveEvent(newCloudEvent("", "repository", "", nil)))
+	assert.True(t, isSensitiveEvent(newCloudEvent("", "redis", "", nil)))
+	assert.True(t, isSensitiveEvent(newCloudEvent("", "resource", "", nil)))
+	assert.False(t, isSensitiveEvent(newCloudEvent("", "application", "", nil)))
+	assert.False(t, isSensitiveEvent(newCloudEvent("", "appProject", "", nil)))
+	assert.False(t, isSensitiveEvent(newCloudEvent("", "gpgkey", "", nil)))
+}
+
 func TestParseEventSubject(t *testing.T) {
 	var buf bytes.Buffer
 	logCtx := newTestEntry(&buf)
@@ -711,19 +720,20 @@ func TestLogActionError(t *testing.T) {
 }
 
 func TestLogEventSent(t *testing.T) {
-	defer SetFullDetailConfig(FullDetailConfig{})
 
-	t.Run("skips meta events", func(t *testing.T) {
+	t.Run("meta events logged at debug", func(t *testing.T) {
 		var buf bytes.Buffer
 		logCtx := newTestEntry(&buf)
 		ev := newCloudEvent("io.argoproj.argocd-agent.event.processed", "eventProcessed", "", nil)
 
 		LogEventSent(logCtx, ev)
 
-		assert.Empty(t, buf.String())
+		entry := parseLogLine(t, &buf)
+		assert.Equal(t, "debug", entry["level"])
+		assert.Equal(t, "events", entry[logfields.LogCategory])
 	})
 
-	t.Run("logs non-meta event with fields", func(t *testing.T) {
+	t.Run("logs non-meta event with fields and detail", func(t *testing.T) {
 		var buf bytes.Buffer
 		logCtx := newTestEntry(&buf)
 		ev := newCloudEvent(
@@ -741,28 +751,10 @@ func TestLogEventSent(t *testing.T) {
 		assert.Equal(t, "application", entry[logfields.EventTarget])
 		assert.Equal(t, "my-app", entry[logfields.Name])
 		assert.Equal(t, "default", entry[logfields.Namespace])
-		assert.Nil(t, entry[logfields.Detail])
+		assert.Equal(t, `{"spec":{}}`, entry[logfields.Detail])
 	})
 
-	t.Run("with full detail includes data", func(t *testing.T) {
-		SetFullDetailConfig(FullDetailConfig{Events: true})
-		var buf bytes.Buffer
-		logCtx := newTestEntry(&buf)
-		ev := newCloudEvent(
-			"io.argoproj.argocd-agent.event.request-update",
-			"application",
-			"default/my-app",
-			[]byte(`{"spec":{}}`),
-		)
-
-		LogEventSent(logCtx, ev)
-
-		entry := parseLogLine(t, &buf)
-		assert.NotNil(t, entry[logfields.Detail])
-	})
-
-	t.Run("with full detail skips empty data", func(t *testing.T) {
-		SetFullDetailConfig(FullDetailConfig{Events: true})
+	t.Run("skips empty data", func(t *testing.T) {
 		var buf bytes.Buffer
 		logCtx := newTestEntry(&buf)
 		ev := newCloudEvent(
@@ -777,19 +769,37 @@ func TestLogEventSent(t *testing.T) {
 		entry := parseLogLine(t, &buf)
 		assert.Nil(t, entry[logfields.Detail])
 	})
+
+	t.Run("redacts repository events", func(t *testing.T) {
+		var buf bytes.Buffer
+		logCtx := newTestEntry(&buf)
+		ev := newCloudEvent(
+			"io.argoproj.argocd-agent.event.create",
+			"repository",
+			"argocd/my-repo",
+			[]byte(`{"data":{"password":"s3cret"}}`),
+		)
+
+		LogEventSent(logCtx, ev)
+
+		entry := parseLogLine(t, &buf)
+		assert.Nil(t, entry[logfields.Detail])
+	})
 }
 
 func TestLogEventReceived(t *testing.T) {
 	defer SetFullDetailConfig(FullDetailConfig{})
 
-	t.Run("skips meta events", func(t *testing.T) {
+	t.Run("meta events logged at debug", func(t *testing.T) {
 		var buf bytes.Buffer
 		logCtx := newTestEntry(&buf)
 		ev := newCloudEvent("", "heartbeat", "", nil)
 
 		LogEventReceived(logCtx, ev)
 
-		assert.Empty(t, buf.String())
+		entry := parseLogLine(t, &buf)
+		assert.Equal(t, "debug", entry["level"])
+		assert.Equal(t, "events", entry[logfields.LogCategory])
 	})
 
 	t.Run("logs non-meta event", func(t *testing.T) {
@@ -811,9 +821,7 @@ func TestLogEventReceived(t *testing.T) {
 }
 
 func TestLogEventError(t *testing.T) {
-	defer SetFullDetailConfig(FullDetailConfig{})
-
-	t.Run("basic error fields", func(t *testing.T) {
+	t.Run("includes error fields and detail", func(t *testing.T) {
 		var buf bytes.Buffer
 		logCtx := newTestEntry(&buf)
 		ev := newCloudEvent(
@@ -830,24 +838,23 @@ func TestLogEventError(t *testing.T) {
 		assert.Equal(t, "error", entry["level"])
 		assert.Contains(t, entry["error"], "event failed")
 		assert.Equal(t, "app", entry[logfields.Name])
-		assert.Nil(t, entry[logfields.Detail])
+		assert.Equal(t, `{"spec":{}}`, entry[logfields.Detail])
 	})
 
-	t.Run("with full detail includes data", func(t *testing.T) {
-		SetFullDetailConfig(FullDetailConfig{Events: true})
+	t.Run("redacts secret events", func(t *testing.T) {
 		var buf bytes.Buffer
 		logCtx := newTestEntry(&buf)
 		ev := newCloudEvent(
-			"io.argoproj.argocd-agent.event.request-update",
-			"application",
-			"ns/app",
-			[]byte(`{"spec":{}}`),
+			"io.argoproj.argocd-agent.event.create",
+			"repository",
+			"argocd/my-repo",
+			[]byte(`{"data":{"password":"s3cret"}}`),
 		)
 
 		LogEventError(logCtx, ev, errors.New("event failed"))
 
 		entry := parseLogLine(t, &buf)
-		assert.NotNil(t, entry[logfields.Detail])
+		assert.Nil(t, entry[logfields.Detail])
 	})
 }
 

--- a/internal/logging/logging_test.go
+++ b/internal/logging/logging_test.go
@@ -720,6 +720,7 @@ func TestLogActionError(t *testing.T) {
 }
 
 func TestLogEventSent(t *testing.T) {
+	defer SetFullDetailConfig(FullDetailConfig{})
 
 	t.Run("meta events logged at debug", func(t *testing.T) {
 		var buf bytes.Buffer
@@ -733,7 +734,29 @@ func TestLogEventSent(t *testing.T) {
 		assert.Equal(t, "events", entry[logfields.LogCategory])
 	})
 
-	t.Run("logs non-meta event with fields and detail", func(t *testing.T) {
+	t.Run("small event always includes detail", func(t *testing.T) {
+		SetFullDetailConfig(FullDetailConfig{})
+		var buf bytes.Buffer
+		logCtx := newTestEntry(&buf)
+		ev := newCloudEvent(
+			"io.argoproj.argocd-agent.event.delete",
+			"gpgkey",
+			"argocd/argocd-gpg-keys-cm",
+			[]byte(`{"metadata":{"name":"argocd-gpg-keys-cm"}}`),
+		)
+
+		LogEventSent(logCtx, ev)
+
+		entry := parseLogLine(t, &buf)
+		assert.Equal(t, "events", entry[logfields.LogCategory])
+		assert.Equal(t, "send", entry[logfields.Direction])
+		assert.Equal(t, "gpgkey", entry[logfields.EventTarget])
+		assert.Equal(t, "argocd-gpg-keys-cm", entry[logfields.Name])
+		assert.Equal(t, `{"metadata":{"name":"argocd-gpg-keys-cm"}}`, entry[logfields.Detail])
+	})
+
+	t.Run("large event skips detail without full detail", func(t *testing.T) {
+		SetFullDetailConfig(FullDetailConfig{})
 		var buf bytes.Buffer
 		logCtx := newTestEntry(&buf)
 		ev := newCloudEvent(
@@ -746,11 +769,23 @@ func TestLogEventSent(t *testing.T) {
 		LogEventSent(logCtx, ev)
 
 		entry := parseLogLine(t, &buf)
-		assert.Equal(t, "events", entry[logfields.LogCategory])
-		assert.Equal(t, "send", entry[logfields.Direction])
-		assert.Equal(t, "application", entry[logfields.EventTarget])
-		assert.Equal(t, "my-app", entry[logfields.Name])
-		assert.Equal(t, "default", entry[logfields.Namespace])
+		assert.Nil(t, entry[logfields.Detail])
+	})
+
+	t.Run("large event includes detail with full detail", func(t *testing.T) {
+		SetFullDetailConfig(FullDetailConfig{Events: true})
+		var buf bytes.Buffer
+		logCtx := newTestEntry(&buf)
+		ev := newCloudEvent(
+			"io.argoproj.argocd-agent.event.request-update",
+			"application",
+			"default/my-app",
+			[]byte(`{"spec":{}}`),
+		)
+
+		LogEventSent(logCtx, ev)
+
+		entry := parseLogLine(t, &buf)
 		assert.Equal(t, `{"spec":{}}`, entry[logfields.Detail])
 	})
 
@@ -759,8 +794,8 @@ func TestLogEventSent(t *testing.T) {
 		logCtx := newTestEntry(&buf)
 		ev := newCloudEvent(
 			"io.argoproj.argocd-agent.event.request-update",
-			"application",
-			"default/my-app",
+			"gpgkey",
+			"default/my-cm",
 			[]byte("{}"),
 		)
 
@@ -770,7 +805,7 @@ func TestLogEventSent(t *testing.T) {
 		assert.Nil(t, entry[logfields.Detail])
 	})
 
-	t.Run("redacts repository events", func(t *testing.T) {
+	t.Run("redacts sensitive events", func(t *testing.T) {
 		var buf bytes.Buffer
 		logCtx := newTestEntry(&buf)
 		ev := newCloudEvent(
@@ -821,7 +856,30 @@ func TestLogEventReceived(t *testing.T) {
 }
 
 func TestLogEventError(t *testing.T) {
-	t.Run("includes error fields and detail", func(t *testing.T) {
+	defer SetFullDetailConfig(FullDetailConfig{})
+
+	t.Run("small event includes detail", func(t *testing.T) {
+		var buf bytes.Buffer
+		logCtx := newTestEntry(&buf)
+		ev := newCloudEvent(
+			"io.argoproj.argocd-agent.event.delete",
+			"gpgkey",
+			"ns/my-cm",
+			[]byte(`{"metadata":{}}`),
+		)
+
+		LogEventError(logCtx, ev, errors.New("event failed"))
+
+		entry := parseLogLine(t, &buf)
+		assert.Equal(t, "events", entry[logfields.LogCategory])
+		assert.Equal(t, "error", entry["level"])
+		assert.Contains(t, entry["error"], "event failed")
+		assert.Equal(t, "my-cm", entry[logfields.Name])
+		assert.Equal(t, `{"metadata":{}}`, entry[logfields.Detail])
+	})
+
+	t.Run("large event skips detail without full detail", func(t *testing.T) {
+		SetFullDetailConfig(FullDetailConfig{})
 		var buf bytes.Buffer
 		logCtx := newTestEntry(&buf)
 		ev := newCloudEvent(
@@ -834,14 +892,27 @@ func TestLogEventError(t *testing.T) {
 		LogEventError(logCtx, ev, errors.New("event failed"))
 
 		entry := parseLogLine(t, &buf)
-		assert.Equal(t, "events", entry[logfields.LogCategory])
-		assert.Equal(t, "error", entry["level"])
-		assert.Contains(t, entry["error"], "event failed")
-		assert.Equal(t, "app", entry[logfields.Name])
+		assert.Nil(t, entry[logfields.Detail])
+	})
+
+	t.Run("large event includes detail with full detail", func(t *testing.T) {
+		SetFullDetailConfig(FullDetailConfig{Events: true})
+		var buf bytes.Buffer
+		logCtx := newTestEntry(&buf)
+		ev := newCloudEvent(
+			"io.argoproj.argocd-agent.event.request-update",
+			"application",
+			"ns/app",
+			[]byte(`{"spec":{}}`),
+		)
+
+		LogEventError(logCtx, ev, errors.New("event failed"))
+
+		entry := parseLogLine(t, &buf)
 		assert.Equal(t, `{"spec":{}}`, entry[logfields.Detail])
 	})
 
-	t.Run("redacts secret events", func(t *testing.T) {
+	t.Run("redacts sensitive events", func(t *testing.T) {
 		var buf bytes.Buffer
 		logCtx := newTestEntry(&buf)
 		ev := newCloudEvent(

--- a/internal/manager/application/application.go
+++ b/internal/manager/application/application.go
@@ -802,8 +802,11 @@ func (m *ApplicationManager) Delete(ctx context.Context, namespace string, incom
 		}
 	}
 
-	logging.LogActionDelete(logCtx, "application", incoming.Namespace, incoming.Name)
-	return m.applicationBackend.Delete(ctx, incoming.Name, incoming.Namespace, deletionPropagation)
+	err = m.applicationBackend.Delete(ctx, incoming.Name, incoming.Namespace, deletionPropagation)
+	if err == nil {
+		logging.LogActionDelete(logCtx, "application", incoming.Namespace, incoming.Name)
+	}
+	return err
 }
 
 // update updates an existing Application resource on the Manager m's backend

--- a/internal/manager/application/application.go
+++ b/internal/manager/application/application.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/argoproj-labs/argocd-agent/internal/backend"
 	"github.com/argoproj-labs/argocd-agent/internal/cache"
+	"github.com/argoproj-labs/argocd-agent/internal/logging"
 	"github.com/argoproj-labs/argocd-agent/internal/logging/logfields"
 	"github.com/argoproj-labs/argocd-agent/internal/manager"
 	"github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
@@ -166,6 +167,7 @@ func (m *ApplicationManager) Create(ctx context.Context, app *v1alpha1.Applicati
 
 	created, err := m.applicationBackend.Create(ctx, app)
 	if err == nil {
+		logging.LogActionCreate(log().WithField("application", app.QualifiedName()), "application", created)
 		if err := m.Manage(created.QualifiedName()); err != nil {
 			log().Warnf("Could not manage app %s: %v", created.QualifiedName(), err)
 		}
@@ -226,6 +228,7 @@ func (m *ApplicationManager) Upsert(ctx context.Context, app *v1alpha1.Applicati
 	if err != nil {
 		return nil, err
 	}
+	logging.LogActionUpdate(log().WithField("application", updated.QualifiedName()), "application", app, updated)
 	if err := m.IgnoreChange(updated.QualifiedName(), updated.ResourceVersion); err != nil {
 		log().Warnf("Could not ignore change %s for app %s: %v", updated.ResourceVersion, updated.QualifiedName(), err)
 	}
@@ -351,10 +354,8 @@ func (m *ApplicationManager) UpdateManagedApp(ctx context.Context, incoming *v1a
 		return patch, err
 	})
 	if err == nil {
-		if updated.Generation == 1 {
-			logCtx.Infof("Created application")
-		} else {
-			logCtx.Infof("Updated application")
+		if updated.Generation > 1 {
+			logging.LogActionUpdate(logCtx, "application", incoming, updated)
 		}
 		if err := m.IgnoreChange(updated.QualifiedName(), updated.ResourceVersion); err != nil {
 			logCtx.Warnf("Couldn't unignore change %s for app %s: %v", updated.ResourceVersion, updated.QualifiedName(), err)
@@ -540,7 +541,7 @@ func (m *ApplicationManager) UpdateAutonomousApp(ctx context.Context, namespace 
 		if err := m.IgnoreChange(updated.QualifiedName(), updated.ResourceVersion); err != nil {
 			logCtx.Warnf("Could not unignore change %s for app %s: %v", updated.ResourceVersion, updated.QualifiedName(), err)
 		}
-		logCtx.WithField(logfields.NewResourceVersion, updated.ResourceVersion).Infof("Updated application status")
+		logging.LogActionUpdate(logCtx.WithField(logfields.NewResourceVersion, updated.ResourceVersion), "application", incoming, updated)
 	}
 	return updated, err
 }
@@ -801,6 +802,7 @@ func (m *ApplicationManager) Delete(ctx context.Context, namespace string, incom
 		}
 	}
 
+	logging.LogActionDelete(logCtx, "application", incoming.Namespace, incoming.Name)
 	return m.applicationBackend.Delete(ctx, incoming.Name, incoming.Namespace, deletionPropagation)
 }
 

--- a/internal/manager/application/application.go
+++ b/internal/manager/application/application.go
@@ -375,6 +375,7 @@ func (m *ApplicationManager) UpdateManagedApp(ctx context.Context, incoming *v1a
 		if err := m.applicationBackend.Delete(ctx, incoming.Name, incoming.Namespace, ptr.To(backend.DeletePropagationForeground)); err != nil {
 			return nil, err
 		}
+		logging.LogActionDelete(logCtx, "application", incoming.Namespace, incoming.Name)
 	}
 
 	return updated, err
@@ -615,7 +616,7 @@ func (m *ApplicationManager) UpdateStatus(ctx context.Context, namespace string,
 		if err := m.IgnoreChange(updated.QualifiedName(), updated.ResourceVersion); err != nil {
 			logCtx.Warnf("Could not ignore change %s for app %s: %v", updated.ResourceVersion, updated.QualifiedName(), err)
 		}
-		logCtx.WithField(logfields.NewResourceVersion, updated.ResourceVersion).Infof("Updated application status")
+		logging.LogActionUpdate(logCtx, "application", incoming, updated)
 	}
 	return updated, err
 }
@@ -673,7 +674,7 @@ func (m *ApplicationManager) UpdateOperation(ctx context.Context, incoming *v1al
 		if err := m.IgnoreChange(updated.QualifiedName(), updated.ResourceVersion); err != nil {
 			logCtx.Warnf("Could not ignore change %s for app %s: %v", updated.ResourceVersion, updated.QualifiedName(), err)
 		}
-		logCtx.WithField(logfields.NewResourceVersion, updated.ResourceVersion).Infof("Updated application status")
+		logging.LogActionUpdate(logCtx, "application", incoming, updated)
 	}
 	return updated, err
 }
@@ -709,7 +710,7 @@ func (m *ApplicationManager) SetOperation(ctx context.Context, incoming *v1alpha
 		if err := m.IgnoreChange(updated.QualifiedName(), updated.ResourceVersion); err != nil {
 			logCtx.Warnf("Could not ignore change %s for app %s: %v", updated.ResourceVersion, updated.QualifiedName(), err)
 		}
-		logCtx.Infof("Set operation on application")
+		logging.LogActionUpdate(logCtx, "application", incoming, updated)
 	}
 	return updated, err
 }
@@ -883,6 +884,9 @@ func (m *ApplicationManager) RemoveFinalizers(ctx context.Context, incoming *v1a
 		patch, err = jsondiff.Compare(source, target, jsondiff.SkipCompact())
 		return patch, err
 	})
+	if err == nil {
+		logging.LogActionUpdate(log().WithField("application", incoming.QualifiedName()), "application", incoming, updated)
+	}
 	return updated, err
 }
 

--- a/internal/manager/application/application.go
+++ b/internal/manager/application/application.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/argoproj-labs/argocd-agent/internal/backend"
 	"github.com/argoproj-labs/argocd-agent/internal/cache"
+	"github.com/argoproj-labs/argocd-agent/internal/logging"
 	"github.com/argoproj-labs/argocd-agent/internal/logging/logfields"
 	"github.com/argoproj-labs/argocd-agent/internal/manager"
 	"github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
@@ -166,6 +167,7 @@ func (m *ApplicationManager) Create(ctx context.Context, app *v1alpha1.Applicati
 
 	created, err := m.applicationBackend.Create(ctx, app)
 	if err == nil {
+		logging.LogActionCreate(log().WithField("application", app.QualifiedName()), "application", created)
 		if err := m.Manage(created.QualifiedName()); err != nil {
 			log().Warnf("Could not manage app %s: %v", created.QualifiedName(), err)
 		}
@@ -226,6 +228,7 @@ func (m *ApplicationManager) Upsert(ctx context.Context, app *v1alpha1.Applicati
 	if err != nil {
 		return nil, err
 	}
+	logging.LogActionUpdate(log().WithField("application", updated.QualifiedName()), "application", app, updated)
 	if err := m.IgnoreChange(updated.QualifiedName(), updated.ResourceVersion); err != nil {
 		log().Warnf("Could not ignore change %s for app %s: %v", updated.ResourceVersion, updated.QualifiedName(), err)
 	}
@@ -352,10 +355,8 @@ func (m *ApplicationManager) UpdateManagedApp(ctx context.Context, incoming *v1a
 		return patch, err
 	})
 	if err == nil {
-		if updated.Generation == 1 {
-			logCtx.Infof("Created application")
-		} else {
-			logCtx.Infof("Updated application")
+		if updated.Generation > 1 {
+			logging.LogActionUpdate(logCtx, "application", incoming, updated)
 		}
 		if err := m.IgnoreChange(updated.QualifiedName(), updated.ResourceVersion); err != nil {
 			logCtx.Warnf("Couldn't unignore change %s for app %s: %v", updated.ResourceVersion, updated.QualifiedName(), err)
@@ -541,7 +542,7 @@ func (m *ApplicationManager) UpdateAutonomousApp(ctx context.Context, namespace 
 		if err := m.IgnoreChange(updated.QualifiedName(), updated.ResourceVersion); err != nil {
 			logCtx.Warnf("Could not unignore change %s for app %s: %v", updated.ResourceVersion, updated.QualifiedName(), err)
 		}
-		logCtx.WithField(logfields.NewResourceVersion, updated.ResourceVersion).Infof("Updated application status")
+		logging.LogActionUpdate(logCtx.WithField(logfields.NewResourceVersion, updated.ResourceVersion), "application", incoming, updated)
 	}
 	return updated, err
 }
@@ -802,6 +803,7 @@ func (m *ApplicationManager) Delete(ctx context.Context, namespace string, incom
 		}
 	}
 
+	logging.LogActionDelete(logCtx, "application", incoming.Namespace, incoming.Name)
 	return m.applicationBackend.Delete(ctx, incoming.Name, incoming.Namespace, deletionPropagation)
 }
 

--- a/internal/manager/application/application.go
+++ b/internal/manager/application/application.go
@@ -803,8 +803,11 @@ func (m *ApplicationManager) Delete(ctx context.Context, namespace string, incom
 		}
 	}
 
-	logging.LogActionDelete(logCtx, "application", incoming.Namespace, incoming.Name)
-	return m.applicationBackend.Delete(ctx, incoming.Name, incoming.Namespace, deletionPropagation)
+	err = m.applicationBackend.Delete(ctx, incoming.Name, incoming.Namespace, deletionPropagation)
+	if err == nil {
+		logging.LogActionDelete(logCtx, "application", incoming.Namespace, incoming.Name)
+	}
+	return err
 }
 
 // update updates an existing Application resource on the Manager m's backend

--- a/internal/manager/applicationset/applicationset.go
+++ b/internal/manager/applicationset/applicationset.go
@@ -57,7 +57,7 @@ func (m *ApplicationSetManager) Create(ctx context.Context, appSet *v1alpha1.App
 	if err != nil {
 		return nil, err
 	}
-	log().WithField("applicationset", appSet.Name).Debug("Created ApplicationSet")
+	logging.LogActionCreate(log().WithField("applicationset", appSet.Name), "applicationset", created)
 	return created, nil
 }
 
@@ -92,7 +92,7 @@ func (m *ApplicationSetManager) Upsert(ctx context.Context, appSet *v1alpha1.App
 	if err != nil {
 		return nil, err
 	}
-	log().WithField("applicationset", appSet.Name).Debug("Updated ApplicationSet")
+	logging.LogActionUpdate(log().WithField("applicationset", appSet.Name), "applicationset", appSet, updated)
 	return updated, nil
 }
 
@@ -103,6 +103,7 @@ func (m *ApplicationSetManager) Get(ctx context.Context, name, namespace string)
 
 // Delete deletes an ApplicationSet.
 func (m *ApplicationSetManager) Delete(ctx context.Context, namespace string, appSet *v1alpha1.ApplicationSet, opts *backend.DeletionPropagation) error {
+	logging.LogActionDelete(log().WithField("applicationset", appSet.Name), "applicationset", namespace, appSet.Name)
 	return m.appSetBackend.Delete(ctx, appSet.Name, namespace, opts)
 }
 

--- a/internal/manager/applicationset/applicationset.go
+++ b/internal/manager/applicationset/applicationset.go
@@ -103,8 +103,11 @@ func (m *ApplicationSetManager) Get(ctx context.Context, name, namespace string)
 
 // Delete deletes an ApplicationSet.
 func (m *ApplicationSetManager) Delete(ctx context.Context, namespace string, appSet *v1alpha1.ApplicationSet, opts *backend.DeletionPropagation) error {
-	logging.LogActionDelete(log().WithField("applicationset", appSet.Name), "applicationset", namespace, appSet.Name)
-	return m.appSetBackend.Delete(ctx, appSet.Name, namespace, opts)
+	err := m.appSetBackend.Delete(ctx, appSet.Name, namespace, opts)
+	if err == nil {
+		logging.LogActionDelete(log().WithField("applicationset", appSet.Name), "applicationset", namespace, appSet.Name)
+	}
+	return err
 }
 
 // List lists ApplicationSets matching the given selector.

--- a/internal/manager/appproject/appproject.go
+++ b/internal/manager/appproject/appproject.go
@@ -154,6 +154,7 @@ func (m *AppProjectManager) Create(ctx context.Context, project *v1alpha1.AppPro
 func createAppProject(ctx context.Context, m *AppProjectManager, project *v1alpha1.AppProject) (*v1alpha1.AppProject, error) {
 	created, err := m.appprojectBackend.Create(ctx, project)
 	if err == nil {
+		logging.LogActionCreate(log().WithField("appProject", project.Name), "appproject", created)
 		if err := m.Manage(created.Name); err != nil {
 			log().Warnf("Could not manage app %s: %v", created.Name, err)
 		}
@@ -195,6 +196,7 @@ func (m *AppProjectManager) Upsert(ctx context.Context, project *v1alpha1.AppPro
 	if err != nil {
 		return nil, err
 	}
+	logging.LogActionUpdate(log().WithField("appProject", updated.Name), "appproject", project, updated)
 	if err := m.IgnoreChange(updated.Name, updated.ResourceVersion); err != nil {
 		log().Warnf("Could not ignore change %s for appproject %s: %v", updated.ResourceVersion, updated.Name, err)
 	}
@@ -267,10 +269,8 @@ func (m *AppProjectManager) UpdateAppProject(ctx context.Context, incoming *v1al
 		return patch, err
 	})
 	if err == nil {
-		if updated.Generation == 1 {
-			logCtx.Infof("Created AppProject")
-		} else {
-			logCtx.Infof("Updated AppProject")
+		if updated.Generation > 1 {
+			logging.LogActionUpdate(logCtx, "appproject", incoming, updated)
 		}
 		if err := m.IgnoreChange(updated.Name, updated.ResourceVersion); err != nil {
 			logCtx.Warnf("Couldn't unignore change %s for AppProject %s: %v", updated.ResourceVersion, updated.Name, err)
@@ -352,6 +352,7 @@ func (m *AppProjectManager) Delete(ctx context.Context, incoming *v1alpha1.AppPr
 		}
 	}
 
+	logging.LogActionDelete(logCtx, "appproject", incoming.Namespace, incoming.Name)
 	return m.appprojectBackend.Delete(ctx, incoming.Name, incoming.Namespace, deletionPropagation)
 }
 

--- a/internal/manager/appproject/appproject.go
+++ b/internal/manager/appproject/appproject.go
@@ -352,8 +352,11 @@ func (m *AppProjectManager) Delete(ctx context.Context, incoming *v1alpha1.AppPr
 		}
 	}
 
-	logging.LogActionDelete(logCtx, "appproject", incoming.Namespace, incoming.Name)
-	return m.appprojectBackend.Delete(ctx, incoming.Name, incoming.Namespace, deletionPropagation)
+	err = m.appprojectBackend.Delete(ctx, incoming.Name, incoming.Namespace, deletionPropagation)
+	if err == nil {
+		logging.LogActionDelete(logCtx, "appproject", incoming.Namespace, incoming.Name)
+	}
+	return err
 }
 
 // RemoveFinalizers will remove finalizers on an existing app project.

--- a/internal/manager/appproject/appproject.go
+++ b/internal/manager/appproject/appproject.go
@@ -379,7 +379,7 @@ func (m *AppProjectManager) RemoveFinalizers(ctx context.Context, incoming *v1al
 		patch, err = jsondiff.Compare(source, target, jsondiff.SkipCompact())
 		return patch, err
 	})
-	
+
 	if err == nil {
 		logging.LogActionUpdate(log().WithField("appProject", incoming.Name), "appproject", incoming, updated)
 	}

--- a/internal/manager/appproject/appproject.go
+++ b/internal/manager/appproject/appproject.go
@@ -379,6 +379,10 @@ func (m *AppProjectManager) RemoveFinalizers(ctx context.Context, incoming *v1al
 		patch, err = jsondiff.Compare(source, target, jsondiff.SkipCompact())
 		return patch, err
 	})
+	
+	if err == nil {
+		logging.LogActionUpdate(log().WithField("appProject", incoming.Name), "appproject", incoming, updated)
+	}
 	return updated, err
 }
 

--- a/internal/manager/gpgkey/gpgkey.go
+++ b/internal/manager/gpgkey/gpgkey.go
@@ -99,8 +99,11 @@ func (m *GPGKeyManager) Create(ctx context.Context, cm *corev1.ConfigMap) (*core
 }
 
 func (m *GPGKeyManager) Delete(ctx context.Context, name, namespace string, deletionPropagation *backend.DeletionPropagation) error {
-	logging.LogActionDelete(log(), "gpgkey", namespace, name)
-	return m.backend.Delete(ctx, name, namespace, deletionPropagation)
+	err := m.backend.Delete(ctx, name, namespace, deletionPropagation)
+	if err == nil {
+		logging.LogActionDelete(log(), "gpgkey", namespace, name)
+	}
+	return err
 }
 
 func (m *GPGKeyManager) UpdateManagedGPGKey(ctx context.Context, incoming *corev1.ConfigMap) (*corev1.ConfigMap, error) {

--- a/internal/manager/gpgkey/gpgkey.go
+++ b/internal/manager/gpgkey/gpgkey.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/argoproj-labs/argocd-agent/internal/backend"
 	"github.com/argoproj-labs/argocd-agent/internal/cache"
+	"github.com/argoproj-labs/argocd-agent/internal/logging"
 	"github.com/argoproj-labs/argocd-agent/internal/manager"
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
@@ -85,6 +86,7 @@ func (m *GPGKeyManager) Create(ctx context.Context, cm *corev1.ConfigMap) (*core
 
 	created, err := m.backend.Create(ctx, cm)
 	if err == nil {
+		logging.LogActionCreate(log().WithField("gpgkey", cm.Name), "gpgkey", created)
 		if err := m.Manage(created.Name); err != nil {
 			log().Warnf("Could not manage GPG keys configmap %s: %v", created.Name, err)
 		}
@@ -97,6 +99,7 @@ func (m *GPGKeyManager) Create(ctx context.Context, cm *corev1.ConfigMap) (*core
 }
 
 func (m *GPGKeyManager) Delete(ctx context.Context, name, namespace string, deletionPropagation *backend.DeletionPropagation) error {
+	logging.LogActionDelete(log(), "gpgkey", namespace, name)
 	return m.backend.Delete(ctx, name, namespace, deletionPropagation)
 }
 
@@ -126,10 +129,8 @@ func (m *GPGKeyManager) UpdateManagedGPGKey(ctx context.Context, incoming *corev
 
 	updated, err := m.backend.Update(ctx, existing)
 	if err == nil {
-		if updated.Generation == 1 {
-			logCtx.Infof("Created GPG keys ConfigMap")
-		} else {
-			logCtx.Infof("Updated GPG keys ConfigMap")
+		if updated.Generation > 1 {
+			logging.LogActionUpdate(logCtx, "gpgkey", incoming, updated)
 		}
 		if err := m.IgnoreChange(updated.Name, updated.ResourceVersion); err != nil {
 			logCtx.Warnf("Could not ignore change %s for GPG keys ConfigMap %s: %v", updated.ResourceVersion, updated.Name, err)

--- a/internal/manager/repository/repository.go
+++ b/internal/manager/repository/repository.go
@@ -113,8 +113,11 @@ func (m *RepositoryManager) Create(ctx context.Context, repo *corev1.Secret) (*c
 }
 
 func (m *RepositoryManager) Delete(ctx context.Context, name, namespace string, deletionPropagation *backend.DeletionPropagation) error {
-	logging.LogActionDelete(log(), "repository", namespace, name)
-	return m.backend.Delete(ctx, name, namespace, deletionPropagation)
+	err := m.backend.Delete(ctx, name, namespace, deletionPropagation)
+	if err == nil {
+		logging.LogActionDelete(log(), "repository", namespace, name)
+	}
+	return err
 }
 
 func (m *RepositoryManager) List(ctx context.Context, selector backend.RepositorySelector) ([]corev1.Secret, error) {

--- a/internal/manager/repository/repository.go
+++ b/internal/manager/repository/repository.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/argoproj-labs/argocd-agent/internal/backend"
 	"github.com/argoproj-labs/argocd-agent/internal/cache"
+	"github.com/argoproj-labs/argocd-agent/internal/logging"
 	"github.com/argoproj-labs/argocd-agent/internal/manager"
 	"github.com/sirupsen/logrus"
 	"github.com/wI2L/jsondiff"
@@ -99,6 +100,7 @@ func (m *RepositoryManager) Create(ctx context.Context, repo *corev1.Secret) (*c
 
 	created, err := m.backend.Create(ctx, repo)
 	if err == nil {
+		logging.LogActionCreate(log().WithField("repository", repo.Name), "repository", created)
 		if err := m.Manage(created.Name); err != nil {
 			log().Warnf("Could not manage repository %s: %v", created.Name, err)
 		}
@@ -111,6 +113,7 @@ func (m *RepositoryManager) Create(ctx context.Context, repo *corev1.Secret) (*c
 }
 
 func (m *RepositoryManager) Delete(ctx context.Context, name, namespace string, deletionPropagation *backend.DeletionPropagation) error {
+	logging.LogActionDelete(log(), "repository", namespace, name)
 	return m.backend.Delete(ctx, name, namespace, deletionPropagation)
 }
 
@@ -177,10 +180,8 @@ func (m *RepositoryManager) UpdateManagedRepository(ctx context.Context, incomin
 		return patch, err
 	})
 	if err == nil {
-		if updated.Generation == 1 {
-			logCtx.Infof("Created Repository")
-		} else {
-			logCtx.Infof("Updated Repository")
+		if updated.Generation > 1 {
+			logging.LogActionUpdate(logCtx, "repository", incoming, updated)
 		}
 		if err := m.IgnoreChange(updated.Name, updated.ResourceVersion); err != nil {
 			logCtx.Warnf("Couldn't unignore change %s for Repository %s: %v", updated.ResourceVersion, updated.Name, err)

--- a/pkg/ha/controller_test.go
+++ b/pkg/ha/controller_test.go
@@ -38,7 +38,7 @@ func TestNewController(t *testing.T) {
 	t.Run("creates controller with HA enabled", func(t *testing.T) {
 		ctx := context.Background()
 		c, err := NewController(ctx,
-			WithEnabled(true),			WithPeerAddress("peer.example.com:8404"),
+			WithEnabled(true), WithPeerAddress("peer.example.com:8404"),
 			WithPreferredRole("primary"),
 		)
 		require.NoError(t, err)
@@ -51,7 +51,7 @@ func TestNewController(t *testing.T) {
 	t.Run("fails with invalid options - replica without peer", func(t *testing.T) {
 		ctx := context.Background()
 		_, err := NewController(ctx,
-			WithEnabled(true),			WithPreferredRole("replica"),
+			WithEnabled(true), WithPreferredRole("replica"),
 			// Missing peer address
 		)
 		require.Error(t, err)
@@ -61,7 +61,7 @@ func TestNewController(t *testing.T) {
 	t.Run("primary without peer address succeeds", func(t *testing.T) {
 		ctx := context.Background()
 		c, err := NewController(ctx,
-			WithEnabled(true),			WithPreferredRole("primary"),
+			WithEnabled(true), WithPreferredRole("primary"),
 		)
 		require.NoError(t, err)
 		require.NotNil(t, c)
@@ -94,7 +94,7 @@ func TestControllerStart_Disabled(t *testing.T) {
 func TestControllerStart_PrimaryNoPeerAddress(t *testing.T) {
 	ctx := context.Background()
 	c, err := NewController(ctx,
-		WithEnabled(true),		WithPreferredRole("primary"),
+		WithEnabled(true), WithPreferredRole("primary"),
 	)
 	require.NoError(t, err)
 
@@ -112,7 +112,7 @@ func TestControllerStart_PrimaryNoPeerAddress(t *testing.T) {
 func TestControllerStart_PrimaryWithPeer(t *testing.T) {
 	ctx := context.Background()
 	c, err := NewController(ctx,
-		WithEnabled(true),		WithPeerAddress("peer.example.com:8404"),
+		WithEnabled(true), WithPeerAddress("peer.example.com:8404"),
 		WithPreferredRole("primary"),
 	)
 	require.NoError(t, err)
@@ -131,7 +131,7 @@ func TestControllerStart_PrimaryWithPeer(t *testing.T) {
 func TestControllerStart_Replica(t *testing.T) {
 	ctx := context.Background()
 	c, err := NewController(ctx,
-		WithEnabled(true),		WithPeerAddress("peer.example.com:8404"),
+		WithEnabled(true), WithPeerAddress("peer.example.com:8404"),
 		WithPreferredRole("replica"),
 	)
 	require.NoError(t, err)
@@ -159,7 +159,7 @@ func TestControllerOnAgentConnect(t *testing.T) {
 	t.Run("rejects connection in replicating state", func(t *testing.T) {
 		ctx := context.Background()
 		c, err := NewController(ctx,
-			WithEnabled(true),			WithPeerAddress("peer.example.com:8404"),
+			WithEnabled(true), WithPeerAddress("peer.example.com:8404"),
 		)
 		require.NoError(t, err)
 
@@ -175,7 +175,7 @@ func TestControllerOnAgentConnect(t *testing.T) {
 	t.Run("rejects connection in disconnected state", func(t *testing.T) {
 		ctx := context.Background()
 		c, err := NewController(ctx,
-			WithEnabled(true),			WithPeerAddress("peer.example.com:8404"),
+			WithEnabled(true), WithPeerAddress("peer.example.com:8404"),
 		)
 		require.NoError(t, err)
 
@@ -193,7 +193,7 @@ func TestControllerReplicationCallbacks(t *testing.T) {
 	t.Run("OnReplicationConnected transitions from disconnected to replicating", func(t *testing.T) {
 		ctx := context.Background()
 		c, err := NewController(ctx,
-			WithEnabled(true),			WithPeerAddress("peer.example.com:8404"),
+			WithEnabled(true), WithPeerAddress("peer.example.com:8404"),
 		)
 		require.NoError(t, err)
 
@@ -208,7 +208,7 @@ func TestControllerReplicationCallbacks(t *testing.T) {
 	t.Run("OnReplicationConnected transitions from syncing to replicating", func(t *testing.T) {
 		ctx := context.Background()
 		c, err := NewController(ctx,
-			WithEnabled(true),			WithPeerAddress("peer.example.com:8404"),
+			WithEnabled(true), WithPeerAddress("peer.example.com:8404"),
 		)
 		require.NoError(t, err)
 
@@ -223,7 +223,7 @@ func TestControllerReplicationCallbacks(t *testing.T) {
 	t.Run("OnReplicationDisconnected transitions to disconnected", func(t *testing.T) {
 		ctx := context.Background()
 		c, err := NewController(ctx,
-			WithEnabled(true),			WithPeerAddress("peer.example.com:8404"),
+			WithEnabled(true), WithPeerAddress("peer.example.com:8404"),
 		)
 		require.NoError(t, err)
 
@@ -238,7 +238,7 @@ func TestControllerReplicationCallbacks(t *testing.T) {
 	t.Run("OnSyncComplete transitions from syncing to replicating", func(t *testing.T) {
 		ctx := context.Background()
 		c, err := NewController(ctx,
-			WithEnabled(true),			WithPeerAddress("peer.example.com:8404"),
+			WithEnabled(true), WithPeerAddress("peer.example.com:8404"),
 		)
 		require.NoError(t, err)
 
@@ -255,7 +255,7 @@ func TestControllerPromote(t *testing.T) {
 	t.Run("promotes from disconnected without force", func(t *testing.T) {
 		ctx := context.Background()
 		c, err := NewController(ctx,
-			WithEnabled(true),			WithPeerAddress("peer.example.com:8404"),
+			WithEnabled(true), WithPeerAddress("peer.example.com:8404"),
 		)
 		require.NoError(t, err)
 
@@ -279,7 +279,7 @@ func TestControllerPromote(t *testing.T) {
 	t.Run("promotes from replicating with force", func(t *testing.T) {
 		ctx := context.Background()
 		c, err := NewController(ctx,
-			WithEnabled(true),			WithPeerAddress("peer.example.com:8404"),
+			WithEnabled(true), WithPeerAddress("peer.example.com:8404"),
 		)
 		require.NoError(t, err)
 
@@ -295,7 +295,7 @@ func TestControllerPromote(t *testing.T) {
 	t.Run("refuses promote from replicating without force", func(t *testing.T) {
 		ctx := context.Background()
 		c, err := NewController(ctx,
-			WithEnabled(true),			WithPeerAddress("peer.example.com:8404"),
+			WithEnabled(true), WithPeerAddress("peer.example.com:8404"),
 		)
 		require.NoError(t, err)
 
@@ -311,7 +311,7 @@ func TestControllerPromote(t *testing.T) {
 	t.Run("refuses if already active", func(t *testing.T) {
 		ctx := context.Background()
 		c, err := NewController(ctx,
-			WithEnabled(true),			WithPeerAddress("peer.example.com:8404"),
+			WithEnabled(true), WithPeerAddress("peer.example.com:8404"),
 		)
 		require.NoError(t, err)
 
@@ -327,7 +327,7 @@ func TestControllerPromote(t *testing.T) {
 	t.Run("refuses from recovering state", func(t *testing.T) {
 		ctx := context.Background()
 		c, err := NewController(ctx,
-			WithEnabled(true),			WithPeerAddress("peer.example.com:8404"),
+			WithEnabled(true), WithPeerAddress("peer.example.com:8404"),
 		)
 		require.NoError(t, err)
 
@@ -341,7 +341,7 @@ func TestControllerDemote(t *testing.T) {
 	t.Run("demotes from active to replicating", func(t *testing.T) {
 		ctx := context.Background()
 		c, err := NewController(ctx,
-			WithEnabled(true),			WithPeerAddress("peer.example.com:8404"),
+			WithEnabled(true), WithPeerAddress("peer.example.com:8404"),
 		)
 		require.NoError(t, err)
 
@@ -365,7 +365,7 @@ func TestControllerDemote(t *testing.T) {
 	t.Run("fails to demote from non-active state", func(t *testing.T) {
 		ctx := context.Background()
 		c, err := NewController(ctx,
-			WithEnabled(true),			WithPeerAddress("peer.example.com:8404"),
+			WithEnabled(true), WithPeerAddress("peer.example.com:8404"),
 		)
 		require.NoError(t, err)
 
@@ -393,7 +393,7 @@ func TestControllerHealthStatus(t *testing.T) {
 	t.Run("unhealthy in replicating state", func(t *testing.T) {
 		ctx := context.Background()
 		c, err := NewController(ctx,
-			WithEnabled(true),			WithPeerAddress("peer.example.com:8404"),
+			WithEnabled(true), WithPeerAddress("peer.example.com:8404"),
 		)
 		require.NoError(t, err)
 
@@ -408,7 +408,7 @@ func TestControllerHealthStatus(t *testing.T) {
 	t.Run("unhealthy in disconnected state", func(t *testing.T) {
 		ctx := context.Background()
 		c, err := NewController(ctx,
-			WithEnabled(true),			WithPeerAddress("peer.example.com:8404"),
+			WithEnabled(true), WithPeerAddress("peer.example.com:8404"),
 		)
 		require.NoError(t, err)
 
@@ -425,7 +425,7 @@ func TestControllerGetStatus(t *testing.T) {
 	t.Run("active state shows peer reachable false", func(t *testing.T) {
 		ctx := context.Background()
 		c, err := NewController(ctx,
-			WithEnabled(true),			WithPeerAddress("peer.example.com:8404"),
+			WithEnabled(true), WithPeerAddress("peer.example.com:8404"),
 			WithPreferredRole("primary"),
 		)
 		require.NoError(t, err)
@@ -444,7 +444,7 @@ func TestControllerGetStatus(t *testing.T) {
 	t.Run("replicating state shows peer reachable true", func(t *testing.T) {
 		ctx := context.Background()
 		c, err := NewController(ctx,
-			WithEnabled(true),			WithPeerAddress("peer.example.com:8404"),
+			WithEnabled(true), WithPeerAddress("peer.example.com:8404"),
 		)
 		require.NoError(t, err)
 
@@ -480,7 +480,7 @@ func TestControllerShutdown(t *testing.T) {
 func TestStateCallbacks(t *testing.T) {
 	ctx := context.Background()
 	c, err := NewController(ctx,
-		WithEnabled(true),		WithPeerAddress("peer.example.com:8404"),
+		WithEnabled(true), WithPeerAddress("peer.example.com:8404"),
 	)
 	require.NoError(t, err)
 

--- a/pkg/ha/options_test.go
+++ b/pkg/ha/options_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-
 func TestDefaultOptions(t *testing.T) {
 	opts := DefaultOptions()
 

--- a/principal/apis/eventstream/eventstream.go
+++ b/principal/apis/eventstream/eventstream.go
@@ -263,9 +263,7 @@ func (s *Server) recvFunc(c *client, subs eventstreamapi.EventStream_SubscribeSe
 		return fmt.Errorf("could not unserialize app data from wire: %w", err)
 	}
 
-	if app.Name != "" {
-		logCtx.Infof("Received update for application '%v'", app.QualifiedName())
-	}
+	logging.LogEventReceived(logCtx, incomingEvent)
 
 	q := s.queues.RecvQ(c.agentName)
 	if q == nil {
@@ -337,12 +335,13 @@ func (s *Server) sendFunc(c *client, subs eventstreamapi.EventStream_SubscribeSe
 		return fmt.Errorf("panic: event writer not found for agent %s", c.agentName)
 	}
 
-	logCtx.WithFields(logrus.Fields{
+	logCtx = logCtx.WithFields(logrus.Fields{
 		"resource_id": event.ResourceID(ev),
 		"event_id":    event.EventID(ev),
-		"type":        ev.Type(),
-	}).Trace("Adding an event to the event writer")
+	})
+	logCtx.Trace("Adding an event to the event writer")
 	eventWriter.Add(ev)
+	logging.LogEventSent(logCtx, ev)
 
 	q.Done(ev)
 

--- a/principal/apis/eventstream/eventstream.go
+++ b/principal/apis/eventstream/eventstream.go
@@ -310,9 +310,7 @@ func (s *Server) recvFunc(c *client, subs eventstreamapi.EventStream_SubscribeSe
 		return fmt.Errorf("could not unserialize app data from wire: %w", err)
 	}
 
-	if app.Name != "" {
-		logCtx.Infof("Received update for application '%v'", app.QualifiedName())
-	}
+	logging.LogEventReceived(logCtx, incomingEvent)
 
 	q := s.queues.RecvQ(c.agentName)
 	if q == nil {
@@ -384,12 +382,13 @@ func (s *Server) sendFunc(c *client, subs eventstreamapi.EventStream_SubscribeSe
 		return fmt.Errorf("panic: event writer not found for agent %s", c.agentName)
 	}
 
-	logCtx.WithFields(logrus.Fields{
+	logCtx = logCtx.WithFields(logrus.Fields{
 		"resource_id": event.ResourceID(ev),
 		"event_id":    event.EventID(ev),
-		"type":        ev.Type(),
-	}).Trace("Adding an event to the event writer")
+	})
+	logCtx.Trace("Adding an event to the event writer")
 	eventWriter.Add(ev)
+	logging.LogEventSent(logCtx, ev)
 
 	q.Done(ev)
 

--- a/principal/ha_integration_test.go
+++ b/principal/ha_integration_test.go
@@ -80,7 +80,7 @@ func TestNewHAComponents(t *testing.T) {
 		server := createTestServer()
 
 		components, err := NewHAComponents(ctx, server,
-			ha.WithEnabled(true),			ha.WithPreferredRole("primary"),
+			ha.WithEnabled(true), ha.WithPreferredRole("primary"),
 			ha.WithPeerAddress("peer.example.com:8443"),
 		)
 		require.NoError(t, err)
@@ -329,7 +329,7 @@ func TestGetHAStatus(t *testing.T) {
 		server := createTestServer()
 
 		components, err := NewHAComponents(ctx, server,
-			ha.WithEnabled(true),			ha.WithPreferredRole("primary"),
+			ha.WithEnabled(true), ha.WithPreferredRole("primary"),
 			ha.WithPeerAddress("peer:8443"),
 		)
 		require.NoError(t, err)
@@ -396,7 +396,7 @@ func TestForwardEventForReplication(t *testing.T) {
 		server := createTestServer()
 
 		components, err := NewHAComponents(ctx, server,
-			ha.WithEnabled(true),			ha.WithPreferredRole("replica"),
+			ha.WithEnabled(true), ha.WithPreferredRole("replica"),
 			ha.WithPeerAddress("peer:8443"),
 		)
 		require.NoError(t, err)
@@ -832,7 +832,7 @@ func newTestClusterSecret(name string) *corev1.Secret {
 			Namespace: "argocd",
 			UID:       k8stypes.UID("uid-" + name),
 			Labels: map[string]string{
-				common.LabelKeySecretType:                                "cluster",
+				common.LabelKeySecretType:                               "cluster",
 				"argocd-agent.argoproj-labs.io/self-registered-cluster": "true",
 			},
 		},


### PR DESCRIPTION
This PR updates logging mechanism and provides verbose logging. Introduces a --full-detail flag to enable it.

Here is how payload is attached: 
- **Actions:** Logs full JSON on create, diffs on update, name/namespace on delete. Logs about secrets don't have payload.
- **Events:** Logs event payloads for event exchanged between agent and principal. Meta-events (ACKs, heartbeats, cache updates) are ignored for verbose logging.
- **Informers:** Logs full JSON on add, diffs on update, name/namespace on delete and secrets don't have payload.

All logs include these fields for log filtering:
- log_category
- action
- resource_type
- name
- namespace
- direction
- event_target
- event_type .

Fixes https://github.com/argoproj-labs/argocd-agent/issues/864

Assisted by: Cursor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced category-based full-detail logging with a global config, structured log fields, helpers for actions/events/informers, CloudEvent subject enrichment, informer lifecycle logs, and Secret redaction/suppressed diffs.
  * Added CLI flag to enable full-detail categories at startup.

* **Documentation**
  * Added docs describing full-detail logging, structured fields, secret-redaction, and usage examples.

* **Tests**
  * Expanded tests for full-detail parsing, logging helpers, Secret handling, and event/informer behaviors.

* **Chores**
  * Renamed agent log-format env var to ARGOCD_AGENT_LOG_FORMAT in deployment manifests.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/argoproj-labs/argocd-agent/pull/914?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->