### PR TITLE
feat: Allow sizing recv and send queues independently

### DIFF
--- a/internal/config/constants.go
+++ b/internal/config/constants.go
@@ -37,5 +37,8 @@ const EnvKubeQPS = "ARGOCD_AGENT_KUBE_QPS"
 // EnvKubeBurst is the name of the environment variable for setting the Kubernetes API Burst.
 const EnvKubeBurst = "ARGOCD_AGENT_KUBE_BURST"
 
-// EnvQueueSize is the name of the environment variable for setting the size of the queue.
-const EnvQueueSize = "ARGOCD_AGENT_QUEUE_SIZE"
+// EnvRecvQueueSize is the name of the environment variable for setting the size of the queue.
+const EnvRecvQueueSize = "ARGOCD_AGENT_RECV_QUEUE_SIZE"
+
+// EnvSendQueueSize is the name of the environment variable for setting the size of the queue.
+const EnvSendQueueSize = "ARGOCD_AGENT_SEND_QUEUE_SIZE"

--- a/internal/queue/queue.go
+++ b/internal/queue/queue.go
@@ -156,15 +156,22 @@ func (q *SendRecvQueues) Create(name string) error {
 	if ok {
 		return fmt.Errorf("cannot initialize queue for %s: queue already exists", name)
 	}
-	queueSize := env.NumWithDefault(config.EnvQueueSize, func(size int) error {
+	recvQueueSize := env.NumWithDefault(config.EnvRecvQueueSize, func(size int) error {
+		if size <= 0 {
+			return fmt.Errorf("queue size must be greater than 0")
+		}
+		return nil
+	}, defaultMaxQueueSize)
+	sendQueueSize := env.NumWithDefault(config.EnvSendQueueSize, func(size int) error {
 		if size <= 0 {
 			return fmt.Errorf("queue size must be greater than 0")
 		}
 		return nil
 	}, defaultMaxQueueSize)
 	qp := &queuepair{}
-	qp.sendq = newBoundedQueue(queueSize)
-	qp.recvq = newBoundedQueue(queueSize)
+	// Send queue is non-blocking, to keep up with the informer
+	qp.sendq = newBoundedQueue(sendQueueSize)
+	qp.recvq = newBoundedQueue(recvQueueSize)
 	q.queues[name] = qp
 
 	return nil

--- a/internal/queue/queue_test.go
+++ b/internal/queue/queue_test.go
@@ -81,26 +81,33 @@ func Test_Queue(t *testing.T) {
 		assert.Equal(t, "2", front.ID())
 	})
 
-	t.Run("Ensure that the queue size can be configured via environment variable", func(t *testing.T) {
+	t.Run("Ensure that the queue sizes can be configured via environment variable", func(t *testing.T) {
 		queueSize := 100
-		t.Setenv(config.EnvQueueSize, strconv.Itoa(queueSize))
+		t.Setenv(config.EnvRecvQueueSize, strconv.Itoa(queueSize))
+		t.Setenv(config.EnvSendQueueSize, strconv.Itoa(queueSize+20))
 		q := NewSendRecvQueues()
 		err := q.Create("agent1")
 		assert.NoError(t, err)
-		queue := q.RecvQ("agent1")
+		recvQueue := q.RecvQ("agent1")
+		sendQueue := q.SendQ("agent1")
 
-		for i := 1; i <= queueSize; i++ {
+		for i := 1; i <= queueSize+20; i++ {
 			ev := event.New()
 			ev.SetID(strconv.Itoa(i))
-			queue.Add(&ev)
+			recvQueue.Add(&ev)
+			sendQueue.Add(&ev)
 		}
 
 		// Since the queue is full, check if the oldest item is popped before adding a new item.
 		ev := event.New()
 		ev.SetID(strconv.Itoa(queueSize + 1))
-		queue.Add(&ev)
-		assert.Equal(t, queueSize, queue.Len())
-		front, _ := queue.Get()
+		recvQueue.Add(&ev)
+		sendQueue.Add(&ev)
+		assert.Equal(t, queueSize, recvQueue.Len())
+		assert.Equal(t, queueSize+20, sendQueue.Len())
+		front, _ := recvQueue.Get()
+		assert.Equal(t, "22", front.ID())
+		front, _ = sendQueue.Get()
 		assert.Equal(t, "2", front.ID())
 	})
 


### PR DESCRIPTION
**What does this PR do / why we need it**:

https://github.com/argoproj-labs/argocd-agent/pull/882 introduced configuring the event queue size. The setting affects both recv and send queues, however this is not optimal because one might want to have different queue sizes for each.

This lets users set the recv and send queue sizes independently.

Documentation update will be sent seperately.

**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:


**Checklist**

* [ ] Documentation update is required by this PR (and has been updated) OR no documentation update is required.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Queue configuration now uses separate environment variables to control send and receive queue capacities independently.
* **Tests**
  * Updated tests to validate independent send/receive queue sizing and overflow behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->