### PR TITLE
feat: Metrics for queues and event writer

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -293,6 +293,8 @@ func NewAgent(ctx context.Context, client *kube.KubernetesClient, namespace stri
 	if a.options.metricsPort > 0 {
 		a.metrics = metrics.NewAgentMetrics()
 		metrics.RegisterK8sClientMetrics()
+		metrics.RegisterAgentEventQueueDepthCollector(a.queues)
+		metrics.RegisterAgentEventWriterMetrics(a)
 	}
 
 	appInformer, err := informer.NewInformer(ctx, appInformerOptions...)
@@ -635,6 +637,12 @@ func (a *Agent) IsConnected() bool {
 // SetConnected sets the connection state of the agent
 func (a *Agent) SetConnected(connected bool) {
 	a.connected.Store(connected)
+}
+
+// CurrentEventWriter returns the outbound event writer when connected, or nil.
+// It implements metrics.EventWriterLookup for Prometheus scraping.
+func (a *Agent) CurrentEventWriter() *event.EventWriter {
+	return a.eventWriter
 }
 
 func log() *logrus.Entry {

--- a/agent/connection.go
+++ b/agent/connection.go
@@ -24,6 +24,7 @@ import (
 	"github.com/argoproj-labs/argocd-agent/internal/kube"
 	"github.com/argoproj-labs/argocd-agent/internal/logging/logfields"
 	"github.com/argoproj-labs/argocd-agent/internal/manager"
+	"github.com/argoproj-labs/argocd-agent/internal/metrics"
 	"github.com/argoproj-labs/argocd-agent/internal/resync"
 	"github.com/argoproj-labs/argocd-agent/pkg/api/grpc/eventstreamapi"
 	"github.com/argoproj-labs/argocd-agent/pkg/types"
@@ -178,7 +179,13 @@ func (a *Agent) handleStreamEvents() error {
 	defer streamCancel()
 
 	if a.eventWriter == nil {
-		a.eventWriter = event.NewEventWriter("", stream)
+		var ewOpts []event.EventWriterOption
+		if a.metrics != nil {
+			ewOpts = append(ewOpts, event.WithOnRetryExhausted(func(string) {
+				metrics.IncAgentEventWriterRetriesExhaustedDrop()
+			}))
+		}
+		a.eventWriter = event.NewEventWriter("", stream, ewOpts...)
 	} else {
 		a.eventWriter.UpdateTarget(stream)
 	}

--- a/docs/operations/metrics.md
+++ b/docs/operations/metrics.md
@@ -24,6 +24,11 @@ Here is the list of available metrics:
 |   `principal_events_sent` |   counter |   The total number of events sent by principal.   |
 |   `principal_event_processing_time`   |   histogramVec    |   Histogram of time taken to process events (in seconds). |
 |   `principal_errors`  |	counterVec  |   The total number of errors occurred in principal.   |
+|   `principal_event_queue_depth` |   gaugeVec   |   Current number of CloudEvents in the principal send or receive queue for a queue pair (per connected agent / client).   |
+|   `principal_event_writer_sent_pending` |   gaugeVec   |   Resources with a CloudEvent sent to the agent and awaiting ACK or resend (principal EventWriter).   |
+|   `principal_event_writer_resend_due` |   gaugeVec   |   Subset of `sent_pending` where the retry timer has elapsed and a resend may run.   |
+|   `principal_event_writer_resend_backoff_wait` |   gaugeVec   |   Subset of `sent_pending` waiting on backoff before the next resend attempt.   |
+|   `principal_event_writer_retries_exhausted_drop_total` |   counterVec   |   CloudEvents dropped after exhausting send retries (principal to agent stream).   |
 
 ### Agent Metrics
 |   Metric  |   Type    |   Description |
@@ -32,6 +37,11 @@ Here is the list of available metrics:
 |   `agent_events_sent` |   counter |   The total number of events sent by agent.   |
 |   `agent_event_processing_time`   |	histogramVec    | Histogram of time taken to process events (in seconds).   |
 |   `agent_errors`  |   counterVec	| The total number of errors occurred in agent. |
+|   `agent_event_queue_depth` |   gaugeVec   |   Current number of CloudEvents in the agent send or receive queue for a queue pair.   |
+|   `agent_event_writer_sent_pending` |   gaugeVec   |   Resources with a CloudEvent sent to the principal and awaiting ACK or resend (agent EventWriter).   |
+|   `agent_event_writer_resend_due` |   gaugeVec   |   Subset of `sent_pending` where the retry timer has elapsed and a resend may run.   |
+|   `agent_event_writer_resend_backoff_wait` |   gaugeVec   |   Subset of `sent_pending` waiting on backoff before the next resend attempt.   |
+|   `agent_event_writer_retries_exhausted_drop_total` |   counterVec   |   CloudEvents dropped after exhausting send retries (agent to principal stream).   |
 
 Here is the list of available labels:
 
@@ -41,3 +51,6 @@ Here is the list of available labels:
 |   `call_status` | success   |   Status of event processing. Possible values are: success, failure, discarded, not-allowed.  |
 |   `agent_name`  |   agent-managed   |   Name of Agent. Possible values are: agent-managed, agent-autonomous.    |
 |   `resource_type`   |   application |   Type of resource. Possible values are: application, app project, resource, resourceResync.   |
+|   `queue`   |   default / agent name   |   Queue pair key: on the agent this is typically `default`; on the principal it identifies the agent or client queue pair.   |
+|   `direction`   |   send / recv   |   Whether the depth is for the outbound (send) or inbound (receive) queue.   |
+|   `agent`   |   client id / empty   |   Agent (client) id for principal EventWriter metrics; empty string for the single agent outbound writer counters/gauges.   |

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674
 	github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.3.3
 	github.com/prometheus/client_golang v1.23.2
+	github.com/prometheus/client_model v0.6.2
 	github.com/redis/go-redis/v9 v9.18.0
 	github.com/rs/zerolog v1.35.0
 	github.com/sirupsen/logrus v1.9.4
@@ -148,7 +149,6 @@ require (
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
-	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.66.1 // indirect
 	github.com/prometheus/procfs v0.16.1 // indirect
 	github.com/r3labs/diff/v3 v3.0.2 // indirect

--- a/internal/event/event_writer.go
+++ b/internal/event/event_writer.go
@@ -46,7 +46,22 @@ type EventWriter struct {
 	// agentName is the name of the agent for which this EventWriter is responsible.
 	agentName string
 
+	// onRetryExhausted is called once per resource when an event is dropped after
+	// exceeding maxEventRetries (optional; used for metrics).
+	onRetryExhausted func(resourceID string)
+
 	log *logrus.Entry
+}
+
+// EventWriterOption configures an EventWriter.
+type EventWriterOption func(*EventWriter)
+
+// WithOnRetryExhausted registers a callback invoked when a sent event is removed
+// after exhausting retries. resourceID is the map key (not used as a metric label).
+func WithOnRetryExhausted(fn func(resourceID string)) EventWriterOption {
+	return func(ew *EventWriter) {
+		ew.onRetryExhausted = fn
+	}
 }
 
 type eventMessage struct {
@@ -71,14 +86,18 @@ type eventMessage struct {
 // NewEventWriter creates a new EventWriter for the given target stream.
 // If you create an EventWriter targeting the principal, an empty agentName
 // should be used.
-func NewEventWriter(agentName string, target streamWriter) *EventWriter {
-	return &EventWriter{
+func NewEventWriter(agentName string, target streamWriter, opts ...EventWriterOption) *EventWriter {
+	ew := &EventWriter{
 		unsentEvents: map[string]*eventQueue{},
 		sentEvents:   map[string]*eventMessage{},
 		target:       target,
 		agentName:    agentName,
 		log:          logging.GetDefaultLogger().ModuleLogger("EventWriter").WithField(logfields.ClientAddr, grpcutil.AddressFromContext(target.Context())).WithField(logfields.Agent, agentName),
 	}
+	for _, o := range opts {
+		o(ew)
+	}
+	return ew
 }
 
 func (ew *EventWriter) UpdateTarget(target streamWriter) {
@@ -174,6 +193,28 @@ func (ew *EventWriter) Get(resID string) *eventMessage {
 		return eq.get()
 	}
 	return nil
+}
+
+// ObserveSentResendState calls observer with counts derived from sentEvents:
+// sentPending is len(sentEvents); resendDue is entries whose retryAfter is nil
+// or not after now; resendBackoff is sentPending - resendDue.
+// Lock order: EventWriter.mu RLock, then each eventMessage.mu RLock.
+func (ew *EventWriter) ObserveSentResendState(observer func(sentPending, resendDue, resendBackoff int)) {
+	now := time.Now()
+	ew.mu.RLock()
+	pending := len(ew.sentEvents)
+	due := 0
+	for _, msg := range ew.sentEvents {
+		msg.mu.RLock()
+		ra := msg.retryAfter
+		msg.mu.RUnlock()
+		if ra == nil || !ra.After(now) {
+			due++
+		}
+	}
+	ew.mu.RUnlock()
+	backoff := pending - due
+	observer(pending, due, backoff)
 }
 
 func (ew *EventWriter) Remove(ev *cloudevents.Event) {
@@ -307,9 +348,13 @@ func (ew *EventWriter) retrySentEvent(resID string, sentMsg *eventMessage) {
 		logCtx.Warnf("Event failed after %d retries, giving up to unblock queue", sentMsg.retryCount)
 		sentMsg.mu.Unlock()
 
-		// Remove from sentEvents to unblock the queue
 		ew.mu.Lock()
-		delete(ew.sentEvents, resID)
+		if cur, ok := ew.sentEvents[resID]; ok && cur == sentMsg {
+			if ew.onRetryExhausted != nil {
+				ew.onRetryExhausted(resID)
+			}
+			delete(ew.sentEvents, resID)
+		}
 		ew.mu.Unlock()
 		return
 	}
@@ -464,6 +509,15 @@ func (ewm *EventWritersMap) Remove(agentName string) {
 	defer ewm.mu.Unlock()
 
 	delete(ewm.eventWriters, agentName)
+}
+
+// ObserveWriters calls fn for each agent name and EventWriter while holding a read lock on the map.
+func (ewm *EventWritersMap) ObserveWriters(fn func(agentName string, ew *EventWriter)) {
+	ewm.mu.RLock()
+	defer ewm.mu.RUnlock()
+	for name, w := range ewm.eventWriters {
+		fn(name, w)
+	}
 }
 
 // eventQueue is a queue of eventMessages where the items are coalesced by type.

--- a/internal/event/event_writer_test.go
+++ b/internal/event/event_writer_test.go
@@ -310,6 +310,76 @@ func TestEventWriter(t *testing.T) {
 		require.NotContains(t, evSender.sentEvents, resID)
 	})
 
+	t.Run("ObserveSentResendState counts pending due and backoff", func(t *testing.T) {
+		fs := &fakeStream{}
+		evSender := NewEventWriter("test", fs)
+		evSender.ObserveSentResendState(func(p, d, b int) {
+			require.Equal(t, 0, p)
+			require.Equal(t, 0, d)
+			require.Equal(t, 0, b)
+		})
+
+		ev := es.ApplicationEvent(Create, app1)
+		resID := createResourceID(app1.ObjectMeta)
+		evSender.Add(ev)
+		evSender.sendEvent(resID)
+		evSender.ObserveSentResendState(func(p, d, b int) {
+			require.Equal(t, 1, p)
+			require.Equal(t, 0, d)
+			require.Equal(t, 1, b)
+		})
+
+		sentMsg := evSender.sentEvents[resID]
+		past := time.Now().Add(-time.Second)
+		sentMsg.retryAfter = &past
+		evSender.ObserveSentResendState(func(p, d, b int) {
+			require.Equal(t, 1, p)
+			require.Equal(t, 1, d)
+			require.Equal(t, 0, b)
+		})
+	})
+
+	t.Run("onRetryExhausted called once when retries exhausted", func(t *testing.T) {
+		fs := &fakeStream{}
+		var hookResID string
+		var hookCalls int
+		evSender := NewEventWriter("test", fs, WithOnRetryExhausted(func(rid string) {
+			hookCalls++
+			hookResID = rid
+		}))
+
+		ev := es.ApplicationEvent(Create, app1)
+		resID := createResourceID(app1.ObjectMeta)
+		evSender.Add(ev)
+		evSender.sendEvent(resID)
+		sentMsg := evSender.sentEvents[resID]
+		require.NotNil(t, sentMsg)
+
+		for i := 0; i <= maxEventRetries; i++ {
+			pastTime := time.Now().Add(-1 * time.Second)
+			sentMsg.retryAfter = &pastTime
+			evSender.retrySentEvent(resID, sentMsg)
+		}
+
+		require.NotContains(t, evSender.sentEvents, resID)
+		require.Equal(t, 1, hookCalls)
+		require.Equal(t, resID, hookResID)
+	})
+
+	t.Run("EventWritersMap ObserveWriters visits each writer", func(t *testing.T) {
+		m := NewEventWritersMap()
+		fs1 := &fakeStream{}
+		fs2 := &fakeStream{}
+		m.Add("a1", NewEventWriter("a1", fs1))
+		m.Add("a2", NewEventWriter("a2", fs2))
+		var names []string
+		m.ObserveWriters(func(agent string, ew *EventWriter) {
+			names = append(names, agent)
+			require.NotNil(t, ew)
+		})
+		require.ElementsMatch(t, []string{"a1", "a2"}, names)
+	})
+
 	t.Run("should not send ACK events to sentEvents", func(t *testing.T) {
 		fs := &fakeStream{}
 		evSender := NewEventWriter("test", fs)

--- a/internal/metrics/event_writer.go
+++ b/internal/metrics/event_writer.go
@@ -1,0 +1,210 @@
+// Copyright 2024 The argocd-agent Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metrics
+
+import (
+	"sync"
+
+	"github.com/argoproj-labs/argocd-agent/internal/event"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const eventWriterLabelAgent = "agent"
+
+// EventWriterLookup is implemented by *agent.Agent for scrape-time EventWriter metrics.
+type EventWriterLookup interface {
+	CurrentEventWriter() *event.EventWriter
+}
+
+type principalEventWriterGaugeCollector struct {
+	writers *event.EventWritersMap
+	descPending, descDue, descBackoff *prometheus.Desc
+}
+
+func newPrincipalEventWriterGaugeCollector(writers *event.EventWritersMap) *principalEventWriterGaugeCollector {
+	return &principalEventWriterGaugeCollector{
+		writers: writers,
+		descPending: prometheus.NewDesc(
+			"principal_event_writer_sent_pending",
+			"Number of resources with a CloudEvent sent to the agent and awaiting ACK or resend",
+			[]string{eventWriterLabelAgent},
+			nil,
+		),
+		descDue: prometheus.NewDesc(
+			"principal_event_writer_resend_due",
+			"Subset of sent_pending where the next resend attempt is allowed (retry timer elapsed)",
+			[]string{eventWriterLabelAgent},
+			nil,
+		),
+		descBackoff: prometheus.NewDesc(
+			"principal_event_writer_resend_backoff_wait",
+			"Subset of sent_pending waiting on retry backoff before the next resend attempt",
+			[]string{eventWriterLabelAgent},
+			nil,
+		),
+	}
+}
+
+func (c *principalEventWriterGaugeCollector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- c.descPending
+	ch <- c.descDue
+	ch <- c.descBackoff
+}
+
+func (c *principalEventWriterGaugeCollector) Collect(ch chan<- prometheus.Metric) {
+	c.writers.ObserveWriters(func(agent string, ew *event.EventWriter) {
+		ew.ObserveSentResendState(func(pending, due, backoff int) {
+			ch <- prometheus.MustNewConstMetric(c.descPending, prometheus.GaugeValue, float64(pending), agent)
+			ch <- prometheus.MustNewConstMetric(c.descDue, prometheus.GaugeValue, float64(due), agent)
+			ch <- prometheus.MustNewConstMetric(c.descBackoff, prometheus.GaugeValue, float64(backoff), agent)
+		})
+	})
+}
+
+type agentEventWriterGaugeCollector struct {
+	lookup EventWriterLookup
+	descPending, descDue, descBackoff *prometheus.Desc
+}
+
+func newAgentEventWriterGaugeCollector(lookup EventWriterLookup) *agentEventWriterGaugeCollector {
+	return &agentEventWriterGaugeCollector{
+		lookup: lookup,
+		descPending: prometheus.NewDesc(
+			"agent_event_writer_sent_pending",
+			"Number of resources with a CloudEvent sent to the principal and awaiting ACK or resend",
+			[]string{eventWriterLabelAgent},
+			nil,
+		),
+		descDue: prometheus.NewDesc(
+			"agent_event_writer_resend_due",
+			"Subset of sent_pending where the next resend attempt is allowed (retry timer elapsed)",
+			[]string{eventWriterLabelAgent},
+			nil,
+		),
+		descBackoff: prometheus.NewDesc(
+			"agent_event_writer_resend_backoff_wait",
+			"Subset of sent_pending waiting on retry backoff before the next resend attempt",
+			[]string{eventWriterLabelAgent},
+			nil,
+		),
+	}
+}
+
+func (c *agentEventWriterGaugeCollector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- c.descPending
+	ch <- c.descDue
+	ch <- c.descBackoff
+}
+
+func (c *agentEventWriterGaugeCollector) Collect(ch chan<- prometheus.Metric) {
+	ew := c.lookup.CurrentEventWriter()
+	if ew == nil {
+		return
+	}
+	const agentLabel = ""
+	ew.ObserveSentResendState(func(pending, due, backoff int) {
+		ch <- prometheus.MustNewConstMetric(c.descPending, prometheus.GaugeValue, float64(pending), agentLabel)
+		ch <- prometheus.MustNewConstMetric(c.descDue, prometheus.GaugeValue, float64(due), agentLabel)
+		ch <- prometheus.MustNewConstMetric(c.descBackoff, prometheus.GaugeValue, float64(backoff), agentLabel)
+	})
+}
+
+func registerEventWriterCollector(c prometheus.Collector) {
+	if err := prometheus.DefaultRegisterer.Register(c); err != nil {
+		if _, ok := err.(prometheus.AlreadyRegisteredError); ok {
+			return
+		}
+		panic(err)
+	}
+}
+
+var (
+	principalEventWriterOnce sync.Once
+	agentEventWriterOnce     sync.Once
+
+	principalRetriesExhaustedDrop *prometheus.CounterVec
+	agentRetriesExhaustedDrop     *prometheus.CounterVec
+	dropCountersMu                sync.RWMutex
+)
+
+// RegisterPrincipalEventWriterMetrics registers EventWriter backlog gauges and the
+// retry-exhausted drop counter on the default Prometheus registry (once per process).
+func RegisterPrincipalEventWriterMetrics(writers *event.EventWritersMap) {
+	principalEventWriterOnce.Do(func() {
+		c := prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "principal_event_writer_retries_exhausted_drop_total",
+			Help: "CloudEvents dropped after exhausting send retries (principal to agent stream)",
+		}, []string{eventWriterLabelAgent})
+		if err := prometheus.DefaultRegisterer.Register(c); err != nil {
+			if are, ok := err.(prometheus.AlreadyRegisteredError); ok {
+				if cv, ok := are.ExistingCollector.(*prometheus.CounterVec); ok {
+					c = cv
+				}
+			} else {
+				panic(err)
+			}
+		}
+		dropCountersMu.Lock()
+		principalRetriesExhaustedDrop = c
+		dropCountersMu.Unlock()
+		registerEventWriterCollector(newPrincipalEventWriterGaugeCollector(writers))
+	})
+}
+
+// RegisterAgentEventWriterMetrics registers EventWriter backlog gauges and the
+// retry-exhausted drop counter on the default Prometheus registry (once per process).
+func RegisterAgentEventWriterMetrics(lookup EventWriterLookup) {
+	agentEventWriterOnce.Do(func() {
+		c := prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "agent_event_writer_retries_exhausted_drop_total",
+			Help: "CloudEvents dropped after exhausting send retries (agent to principal stream)",
+		}, []string{eventWriterLabelAgent})
+		if err := prometheus.DefaultRegisterer.Register(c); err != nil {
+			if are, ok := err.(prometheus.AlreadyRegisteredError); ok {
+				if cv, ok := are.ExistingCollector.(*prometheus.CounterVec); ok {
+					c = cv
+				}
+			} else {
+				panic(err)
+			}
+		}
+		dropCountersMu.Lock()
+		agentRetriesExhaustedDrop = c
+		dropCountersMu.Unlock()
+		registerEventWriterCollector(newAgentEventWriterGaugeCollector(lookup))
+	})
+}
+
+// IncPrincipalEventWriterRetriesExhaustedDrop increments the drop counter for an agent stream.
+func IncPrincipalEventWriterRetriesExhaustedDrop(agent string) {
+	dropCountersMu.RLock()
+	c := principalRetriesExhaustedDrop
+	dropCountersMu.RUnlock()
+	if c == nil {
+		return
+	}
+	c.WithLabelValues(agent).Inc()
+}
+
+// IncAgentEventWriterRetriesExhaustedDrop increments the agent-side drop counter.
+func IncAgentEventWriterRetriesExhaustedDrop() {
+	dropCountersMu.RLock()
+	c := agentRetriesExhaustedDrop
+	dropCountersMu.RUnlock()
+	if c == nil {
+		return
+	}
+	c.WithLabelValues("").Inc()
+}

--- a/internal/metrics/event_writer_test.go
+++ b/internal/metrics/event_writer_test.go
@@ -1,0 +1,105 @@
+// Copyright 2024 The argocd-agent Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metrics
+
+import (
+	"context"
+	"testing"
+
+	"github.com/argoproj-labs/argocd-agent/internal/event"
+	"github.com/argoproj-labs/argocd-agent/pkg/api/grpc/eventstreamapi"
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/stretchr/testify/require"
+)
+
+type metricsTestStream struct{}
+
+func (metricsTestStream) Send(*eventstreamapi.Event) error { return nil }
+
+func (metricsTestStream) Context() context.Context { return context.Background() }
+
+type stubLookup struct {
+	ew *event.EventWriter
+}
+
+func (s *stubLookup) CurrentEventWriter() *event.EventWriter {
+	return s.ew
+}
+
+func gaugeValueForAgent(t *testing.T, mfs []*dto.MetricFamily, metricName, agent string) float64 {
+	t.Helper()
+	for _, mf := range mfs {
+		if mf.GetName() != metricName {
+			continue
+		}
+		for _, m := range mf.GetMetric() {
+			var lbl string
+			for _, lp := range m.GetLabel() {
+				if lp.GetName() == eventWriterLabelAgent {
+					lbl = lp.GetValue()
+					break
+				}
+			}
+			if lbl == agent {
+				return m.GetGauge().GetValue()
+			}
+		}
+	}
+	t.Fatalf("metric %s for agent %q not found", metricName, agent)
+	return 0
+}
+
+func TestPrincipalEventWriterGaugeCollector(t *testing.T) {
+	m := event.NewEventWritersMap()
+	reg := prometheus.NewPedanticRegistry()
+	c := newPrincipalEventWriterGaugeCollector(m)
+	require.NoError(t, reg.Register(c))
+
+	mfs, err := reg.Gather()
+	require.NoError(t, err)
+	require.Empty(t, mfs)
+
+	ew := event.NewEventWriter("agent-x", metricsTestStream{})
+	m.Add("agent-x", ew)
+
+	mfs, err = reg.Gather()
+	require.NoError(t, err)
+	require.NotEmpty(t, mfs)
+
+	require.Equal(t, 0.0, gaugeValueForAgent(t, mfs, "principal_event_writer_sent_pending", "agent-x"))
+	require.Equal(t, 0.0, gaugeValueForAgent(t, mfs, "principal_event_writer_resend_due", "agent-x"))
+	require.Equal(t, 0.0, gaugeValueForAgent(t, mfs, "principal_event_writer_resend_backoff_wait", "agent-x"))
+}
+
+func TestAgentEventWriterGaugeCollector_nilWriter(t *testing.T) {
+	reg := prometheus.NewPedanticRegistry()
+	c := newAgentEventWriterGaugeCollector(&stubLookup{ew: nil})
+	require.NoError(t, reg.Register(c))
+	mfs, err := reg.Gather()
+	require.NoError(t, err)
+	require.Empty(t, mfs)
+}
+
+func TestAgentEventWriterGaugeCollector_withWriter(t *testing.T) {
+	reg := prometheus.NewPedanticRegistry()
+	ew := event.NewEventWriter("", metricsTestStream{})
+	c := newAgentEventWriterGaugeCollector(&stubLookup{ew: ew})
+	require.NoError(t, reg.Register(c))
+	mfs, err := reg.Gather()
+	require.NoError(t, err)
+	require.NotEmpty(t, mfs)
+	require.Equal(t, 0.0, gaugeValueForAgent(t, mfs, "agent_event_writer_sent_pending", ""))
+}

--- a/internal/metrics/queue_depth.go
+++ b/internal/metrics/queue_depth.go
@@ -1,0 +1,97 @@
+// Copyright 2024 The argocd-agent Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metrics
+
+import (
+	"sync"
+
+	"github.com/argoproj-labs/argocd-agent/internal/queue"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const (
+	queueDepthLabelQueue     = "queue"
+	queueDepthLabelDirection = "direction"
+)
+
+type eventQueueDepthCollector struct {
+	queues *queue.SendRecvQueues
+	desc   *prometheus.Desc
+}
+
+func newEventQueueDepthCollector(metricName, help string, q *queue.SendRecvQueues) prometheus.Collector {
+	return &eventQueueDepthCollector{
+		queues: q,
+		desc: prometheus.NewDesc(
+			metricName,
+			help,
+			[]string{queueDepthLabelQueue, queueDepthLabelDirection},
+			nil,
+		),
+	}
+}
+
+func (c *eventQueueDepthCollector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- c.desc
+}
+
+func (c *eventQueueDepthCollector) Collect(ch chan<- prometheus.Metric) {
+	c.queues.ObserveDepths(func(name string, sendLen, recvLen int) {
+		ch <- prometheus.MustNewConstMetric(c.desc, prometheus.GaugeValue, float64(sendLen), name, "send")
+		ch <- prometheus.MustNewConstMetric(c.desc, prometheus.GaugeValue, float64(recvLen), name, "recv")
+	})
+}
+
+func registerQueueDepthCollector(c prometheus.Collector) {
+	if err := prometheus.DefaultRegisterer.Register(c); err != nil {
+		if _, ok := err.(prometheus.AlreadyRegisteredError); ok {
+			return
+		}
+		panic(err)
+	}
+}
+
+var (
+	principalQueueDepthRegisterOnce sync.Once
+	agentQueueDepthRegisterOnce    sync.Once
+)
+
+// RegisterPrincipalEventQueueDepthCollector registers a collector for
+// principal_event_queue_depth on the default Prometheus registry. It runs at
+// most once per process; later calls are ignored (see sync.Once).
+func RegisterPrincipalEventQueueDepthCollector(q *queue.SendRecvQueues) {
+	principalQueueDepthRegisterOnce.Do(func() {
+		c := newEventQueueDepthCollector(
+			"principal_event_queue_depth",
+			"Number of CloudEvents waiting in the principal send or receive queue for a queue pair",
+			q,
+		)
+		registerQueueDepthCollector(c)
+	})
+}
+
+// RegisterAgentEventQueueDepthCollector registers a collector for
+// agent_event_queue_depth on the default Prometheus registry. It runs at most
+// once per process; later calls are ignored (see sync.Once).
+func RegisterAgentEventQueueDepthCollector(q *queue.SendRecvQueues) {
+	agentQueueDepthRegisterOnce.Do(func() {
+		c := newEventQueueDepthCollector(
+			"agent_event_queue_depth",
+			"Number of CloudEvents waiting in the agent send or receive queue for a queue pair",
+			q,
+		)
+		registerQueueDepthCollector(c)
+	})
+}

--- a/internal/metrics/queue_depth_test.go
+++ b/internal/metrics/queue_depth_test.go
@@ -1,0 +1,106 @@
+// Copyright 2024 The argocd-agent Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metrics
+
+import (
+	"testing"
+
+	"github.com/argoproj-labs/argocd-agent/internal/queue"
+	"github.com/cloudevents/sdk-go/v2/event"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/stretchr/testify/require"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+func labelValue(labels []*dto.LabelPair, name string) string {
+	for _, lp := range labels {
+		if lp.GetName() == name {
+			return lp.GetValue()
+		}
+	}
+	return ""
+}
+
+func TestEventQueueDepthCollector(t *testing.T) {
+	q := queue.NewSendRecvQueues()
+	require.NoError(t, q.Create("agent-a"))
+	ev := event.New()
+	ev.SetID("1")
+	q.SendQ("agent-a").Add(&ev)
+	ev2 := event.New()
+	ev2.SetID("2")
+	q.RecvQ("agent-a").Add(&ev2)
+	q.RecvQ("agent-a").Add(&ev)
+
+	reg := prometheus.NewPedanticRegistry()
+	c := newEventQueueDepthCollector(
+		"principal_event_queue_depth",
+		"Number of CloudEvents waiting in the principal send or receive queue for a queue pair",
+		q,
+	)
+	require.NoError(t, reg.Register(c))
+
+	mfs, err := reg.Gather()
+	require.NoError(t, err)
+	require.Len(t, mfs, 1)
+	mf := mfs[0]
+	require.Equal(t, "principal_event_queue_depth", mf.GetName())
+	require.Equal(t, dto.MetricType_GAUGE, mf.GetType())
+
+	var sendVal, recvVal float64
+	var seenSend, seenRecv bool
+	for _, m := range mf.GetMetric() {
+		dir := labelValue(m.GetLabel(), queueDepthLabelDirection)
+		switch dir {
+		case "send":
+			seenSend = true
+			require.Equal(t, "agent-a", labelValue(m.GetLabel(), queueDepthLabelQueue))
+			sendVal = m.GetGauge().GetValue()
+		case "recv":
+			seenRecv = true
+			require.Equal(t, "agent-a", labelValue(m.GetLabel(), queueDepthLabelQueue))
+			recvVal = m.GetGauge().GetValue()
+		}
+	}
+	require.True(t, seenSend)
+	require.True(t, seenRecv)
+	require.Equal(t, 1.0, sendVal)
+	require.Equal(t, 2.0, recvVal)
+}
+
+func TestEventQueueDepthCollector_EmptyRegistry(t *testing.T) {
+	q := queue.NewSendRecvQueues()
+	reg := prometheus.NewRegistry()
+	c := newEventQueueDepthCollector("agent_event_queue_depth", "help", q)
+	require.NoError(t, reg.Register(c))
+
+	mfs, err := reg.Gather()
+	require.NoError(t, err)
+	require.Empty(t, mfs, "no queue pairs means no metric series")
+}
+
+func TestEventQueueDepthCollector_Describe(t *testing.T) {
+	q := queue.NewSendRecvQueues()
+	c := newEventQueueDepthCollector("principal_event_queue_depth", "help text", q)
+	ch := make(chan *prometheus.Desc, 1)
+	c.Describe(ch)
+	close(ch)
+	desc := <-ch
+	require.NotNil(t, desc)
+	s := desc.String()
+	require.Contains(t, s, "principal_event_queue_depth")
+	require.Contains(t, s, "help text")
+}

--- a/internal/queue/queue.go
+++ b/internal/queue/queue.go
@@ -122,6 +122,18 @@ func (q *SendRecvQueues) Len() int {
 	return len(q.queues)
 }
 
+// ObserveDepths calls fn once per queue pair while holding a read lock on the
+// queue map. fn receives the pair name and the current send and receive queue
+// lengths from the underlying workqueues. The values are a consistent snapshot
+// for that instant.
+func (q *SendRecvQueues) ObserveDepths(fn func(name string, sendLen, recvLen int)) {
+	q.queuelock.RLock()
+	defer q.queuelock.RUnlock()
+	for name, qp := range q.queues {
+		fn(name, qp.sendq.Len(), qp.recvq.Len())
+	}
+}
+
 // SendQ will return the send queue from the queue pair named name. If no such
 // queue pair exists, returns nil
 func (q *SendRecvQueues) SendQ(name string) workqueue.TypedRateLimitingInterface[*event.Event] {

--- a/internal/queue/queue_test.go
+++ b/internal/queue/queue_test.go
@@ -111,4 +111,39 @@ func Test_Queue(t *testing.T) {
 		assert.Equal(t, "2", front.ID())
 	})
 
+	t.Run("ObserveDepths reflects send and recv lengths", func(t *testing.T) {
+		q := NewSendRecvQueues()
+		assert.NoError(t, q.Create("agent1"))
+		sendQ := q.SendQ("agent1")
+		recvQ := q.RecvQ("agent1")
+		ev1, ev2 := event.New(), event.New()
+		ev1.SetID("a")
+		ev2.SetID("b")
+		sendQ.Add(&ev1)
+		recvQ.Add(&ev2)
+		recvQ.Add(&ev1)
+
+		var gotName string
+		var gotSend, gotRecv int
+		q.ObserveDepths(func(name string, sendLen, recvLen int) {
+			gotName = name
+			gotSend = sendLen
+			gotRecv = recvLen
+		})
+		assert.Equal(t, "agent1", gotName)
+		assert.Equal(t, 1, gotSend)
+		assert.Equal(t, 2, gotRecv)
+
+		item, _ := sendQ.Get()
+		sendQ.Done(item)
+		q.ObserveDepths(func(name string, sendLen, recvLen int) {
+			if name == "agent1" {
+				gotSend = sendLen
+				gotRecv = recvLen
+			}
+		})
+		assert.Equal(t, 0, gotSend)
+		assert.Equal(t, 2, gotRecv)
+	})
+
 }

--- a/principal/apis/eventstream/eventstream.go
+++ b/principal/apis/eventstream/eventstream.go
@@ -387,7 +387,14 @@ func (s *Server) Subscribe(subs eventstreamapi.EventStream_SubscribeServer) erro
 	if eventWriter != nil {
 		eventWriter.UpdateTarget(subs)
 	} else {
-		eventWriter = event.NewEventWriter(c.agentName, subs)
+		var ewOpts []event.EventWriterOption
+		if s.metrics != nil {
+			agentName := c.agentName
+			ewOpts = append(ewOpts, event.WithOnRetryExhausted(func(string) {
+				metrics.IncPrincipalEventWriterRetriesExhaustedDrop(agentName)
+			}))
+		}
+		eventWriter = event.NewEventWriter(c.agentName, subs, ewOpts...)
 		s.eventWriters.Add(c.agentName, eventWriter)
 	}
 

--- a/principal/server.go
+++ b/principal/server.go
@@ -331,6 +331,8 @@ func NewServer(ctx context.Context, kubeClient *kube.KubernetesClient, namespace
 	if s.options.metricsPort > 0 {
 		s.metrics = metrics.NewPrincipalMetrics()
 		metrics.RegisterK8sClientMetrics()
+		metrics.RegisterPrincipalEventQueueDepthCollector(s.queues)
+		metrics.RegisterPrincipalEventWriterMetrics(s.eventWriters)
 
 		appInformerOpts = append(appInformerOpts, informer.WithMetrics[*v1alpha1.Application](prometheus.NewRegistry(), metrics.NewInformerMetrics("applications")))
 		projInformerOpts = append(projInformerOpts, informer.WithMetrics[*v1alpha1.AppProject](prometheus.NewRegistry(), metrics.NewInformerMetrics("appprojects")))


### PR DESCRIPTION
**What does this PR do / why we need it**:

Add metrics for queue depths and events in the event writer

**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:

**Checklist**

* [ ] Documentation update is required by this PR (and has been updated) OR no documentation update is required.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Prometheus metrics for event queue depth monitoring across agent and principal components
  * Introduced event writer state metrics tracking pending events, resend eligibility, and backoff status
  * Added counter for tracking exhausted event retries

* **Documentation**
  * Updated metrics documentation with new metric definitions, including queue depth, event writer state, and retry exhaustion drop counters

<!-- end of auto-generated comment: release notes by coderabbit.ai -->