### PR TITLE
fix: Respect managed app finalizer updates

### DIFF
--- a/internal/manager/application/application.go
+++ b/internal/manager/application/application.go
@@ -340,6 +340,7 @@ func (m *ApplicationManager) UpdateManagedApp(ctx context.Context, incoming *v1a
 			ObjectMeta: v1.ObjectMeta{
 				Annotations: existing.Annotations,
 				Labels:      existing.Labels,
+				Finalizers:  existing.Finalizers,
 			},
 			Spec:      existing.Spec,
 			Operation: existing.Operation,

--- a/internal/manager/application/application_test.go
+++ b/internal/manager/application/application_test.go
@@ -321,6 +321,36 @@ func Test_ManagerUpdateManaged(t *testing.T) {
 		require.Equal(t, "principal-B", updated.Annotations[manager.PrincipalUIDAnnotation])
 	})
 
+	t.Run("Remove finalizers with patch backend", func(t *testing.T) {
+		incoming := &v1alpha1.Application{
+			ObjectMeta: v1.ObjectMeta{
+				Name:      "foobar",
+				Namespace: "argocd",
+			},
+		}
+		existing := &v1alpha1.Application{
+			ObjectMeta: v1.ObjectMeta{
+				Name:       "foobar",
+				Namespace:  "argocd",
+				Finalizers: []string{"resources-finalizer.argocd.argoproj.io"},
+				Annotations: map[string]string{
+					manager.SourceUIDAnnotation: "source-uid",
+				},
+			},
+		}
+
+		appC, ai := fakeInformer(t, "", existing)
+		be := application.NewKubernetesBackend(appC, "", ai, true)
+		mgr, err := NewApplicationManager(be, "argocd", WithMode(manager.ManagerModeManaged), WithRole(manager.ManagerRoleAgent))
+		require.NoError(t, err)
+
+		updated, err := mgr.UpdateManagedApp(context.Background(), incoming, ManagedIdentity{})
+
+		require.NoError(t, err)
+		require.NotNil(t, updated)
+		require.Empty(t, updated.Finalizers)
+	})
+
 }
 
 func Test_ManagerUpdateStatus(t *testing.T) {


### PR DESCRIPTION
Managed agent updates use JSON patch when the backend supports it. The patch target included incoming finalizers, but the source omitted existing finalizers, so removing a finalizer on the principal produced no diff and left the agent-side finalizer intact.

Include existing finalizers in the patch source comparison so additions and removals are emitted, and add a regression test for removing finalizers with a patch-backed managed update.

**What does this PR do / why we need it**:

**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:


**Checklist**

* [ ] Documentation update is required by this PR (and has been updated) OR no documentation update is required.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved how the system handles application finalizers during updates to ensure proper state consideration.

* **Tests**
  * Added validation test for finalizer removal during application update operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->