### PR TITLE
ci: harden Helm chart validation pipeline

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -277,12 +277,27 @@ jobs:
         with:
           persist-credentials: false
       
-      - name: Install required packages
+      - name: Install yq
+        env:
+          YQ_VERSION: v4.53.2
+          # SHA-256 of yq_linux_amd64 from
+          # https://github.com/mikefarah/yq/releases/download/v4.53.2/checksums
+          YQ_SHA256: d56bf5c6819e8e696340c312bd70f849dc1678a7cda9c2ad63eebd906371d56b
         run: |
-          # Install yq
-          YQ_VERSION="v4.44.3"
-          sudo wget -qO /usr/local/bin/yq "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64"
-          sudo chmod +x /usr/local/bin/yq
+          set -euo pipefail
+          curl --fail --silent --show-error --location --retry 3 \
+            --output /tmp/yq \
+            "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64"
+          echo "${YQ_SHA256}  /tmp/yq" | sha256sum --check --status
+          sudo install -m 0755 /tmp/yq /usr/local/bin/yq
+          rm -f /tmp/yq
+          yq --version
+
+      - name: Install Helm
+        uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
+        with:
+          version: v3.20.2
+
       - name: Validate schema
         working-directory: ${{ github.workspace }}
         run: |

--- a/hack/validate-values-schema.sh
+++ b/hack/validate-values-schema.sh
@@ -14,6 +14,10 @@
 # limitations under the License.
 
 set -euo pipefail
+# Propagate failures from command substitutions (e.g., $(yq ...)) into the
+# parent shell. Without this, a broken yq pipeline could exit non-zero while
+# the caller silently continues with an empty value.
+shopt -s inherit_errexit 2>/dev/null || true
 
 # Script directory
 SCRIPT_DIR="$( cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
@@ -23,7 +27,7 @@ VALUES_YAML="${REPO_ROOT}/install/helm-repo/argocd-agent-agent/values.yaml"
 SCHEMA_JSON="${REPO_ROOT}/install/helm-repo/argocd-agent-agent/values.schema.json"
 
 # Check required binaries
-required_binaries="yq jq"
+required_binaries="yq jq helm"
 for bin in $required_binaries; do
 	if ! command -v "$bin" >/dev/null 2>&1; then
 		echo "Error: Required binary '$bin' not found in \$PATH" >&2
@@ -32,10 +36,23 @@ for bin in $required_binaries; do
 			echo "  yq: https://github.com/mikefarah/yq#install" >&2
 		elif [ "$bin" = "jq" ]; then
 			echo "  jq: https://stedolan.github.io/jq/download/" >&2
+		elif [ "$bin" = "helm" ]; then
+			echo "  helm: https://helm.sh/docs/intro/install/" >&2
 		fi
 		exit 1
 	fi
 done
+
+# The script uses Mike Farah's Go yq (`yq eval -o=json`). Other yq
+# implementations — notably kislyuk's Python yq, which is a thin jq wrapper —
+# use incompatible syntax and will emit garbage output while the script
+# believes it succeeded. Detect and reject anything else up front.
+if ! yq --version 2>&1 | grep -qi 'mikefarah'; then
+	echo "Error: incompatible yq detected. This script requires Mike Farah's yq." >&2
+	echo "  Detected: $(yq --version 2>&1 | head -n1)" >&2
+	echo "  Install:  https://github.com/mikefarah/yq#install" >&2
+	exit 1
+fi
 
 # Check if files exist
 if [ ! -f "$VALUES_YAML" ]; then
@@ -48,6 +65,18 @@ if [ ! -f "$SCHEMA_JSON" ]; then
 	exit 1
 fi
 
+CHART_DIR="$(dirname "$VALUES_YAML")"
+
+# Validate values.yaml against the schema using helm lint. This enforces
+# `required`, types, and enum constraints that path-based membership cannot
+# detect (e.g., deleting a required top-level block from values.yaml).
+echo "==> Validating values.yaml against values.schema.json (helm lint)"
+if ! lint_output=$(helm lint --quiet "$CHART_DIR" 2>&1); then
+	echo "Error: helm lint failed; values.yaml does not satisfy values.schema.json:" >&2
+	echo "$lint_output" >&2
+	exit 1
+fi
+
 # Function to extract all paths from YAML (recursive)
 extract_yaml_paths() {
 	local data="$1"
@@ -57,12 +86,16 @@ extract_yaml_paths() {
 	local json_data
 	json_data=$(echo "$data" | yq eval -o=json -)
 	
-	# Extract all keys recursively
+	# Emit every path (to scalars, objects, and arrays) as a dot-joined
+	# string. Numeric array indices are dropped so paths align with schema
+	# property paths (which describe `items`, not indexes). Using `paths`
+	# instead of `paths(scalars)` ensures empty objects/arrays (e.g.
+	# `tolerations: []`, `dnsConfig: {}`) are still compared to the schema.
 	echo "$json_data" | jq -r '
-		def paths_to_strings:
-			paths(scalars) as $p | 
-			$p | map(tostring) | join(".");
-		paths_to_strings
+		paths
+		| map(select(type == "string"))
+		| select(length > 0)
+		| join(".")
 	'
 }
 


### PR DESCRIPTION
**What does this PR do / why we need it**:

The Helm chart validation in CI had three gaps that let real bugs slip
through and one supply-chain weakness:

1. `required`, type, and enum constraints in `values.schema.json` were never enforced.
 `hack/validate-values-schema.sh` only walks paths in `values.yaml` and checks each one exists in the schema. That direction catches *unknown* keys, but completely misses:
   - a required top-level block being deleted from `values.yaml`,
   - a value with the wrong type (e.g. `replicaCount: "1"` instead of `1`),
   - a value violating an `enum`.
   These would surface only at chart install time, not in CI.

2. Empty containers in `values.yaml` were skipped. The path extractor used `jq … paths(scalars)`, so `tolerations: []`  produced no path at all and could not be compared against the schema.

3. `yq` was downloaded with `wget` and no integrity check. A compromised release asset would be installed silently. The script also accepted *any* `yq` on PATH, including the Python `yq` (kislyuk/yq), which uses different syntax and produces wrong output without erroring — so a developer running the script locally with the wrong `yq` got a green pass on broken values.

4. `set -e` doesn't propagate failures from `$(…)` substitutions in bash. A broken `yq` pipeline could exit non-zero while the caller silently continued with empty output.

## What changed

### `hack/validate-values-schema.sh`
- Add a `helm lint` invocation against the chart, which evaluates `values.yaml` against `values.schema.json` and enforces `required`, `type`, and `enum`. This is complementary to the existing path walker (which still catches unknown-key drift in the other direction).
- Add `helm` to `required_binaries`.
- Detect and reject non-mikefarah `yq` implementations up front, with a clear error message pointing at the right install.
- Enable `shopt -s inherit_errexit` so command-substitution failures propagate.
- Switch the YAML path extractor from `paths(scalars)` to `paths` (filtering numeric array indices), so empty arrays/objects in `values.yaml` still produce a path that gets compared to the schema.

### `.github/workflows/ci.yaml` (`validate-helm-charts` job)
- Replace `wget` + chmod with `curl --fail --retry` + `sha256sum -c` to verify the yq binary against a pinned SHA-256.
- Pin `YQ_VERSION` and `YQ_SHA256` as step env vars.
- Add an `Install Helm` step using `azure/setup-helm` pinned to a SHA (`v5.0.0`), with `helm` pinned to `v3.20.2`.

**Which issue(s) this PR fixes**:

N/A

**How to test changes / Special notes to the reviewer**:

Ran `hack/validate-values-schema.sh` locally against the chart in this repo and exercised three cases:

| Scenario                                          | Expected | Result   |
| ------------------------------------------------- | -------- | -------- |
| Unmodified `values.yaml`                          | pass     | ✓ pass   |
| Required `image` block deleted from `values.yaml` | fail (helm lint) | ✓ fail with `missing property 'image'` |
| Unknown key `unknownField` added to `values.yaml` | fail (path walker) | ✓ fail with `unknownField missing in schema` |
| Python `yq` on PATH instead of mikefarah `yq`     | early exit with guidance | ✓ exits 1 with install link |

No changes to runtime code or chart contents.

**Checklist**

* [X] Documentation update is required by this PR (and has been updated) OR no documentation update is required.

