### PR TITLE
fix: optional Redis TLS secret mounts on vcluster

### DIFF
--- a/install/kubernetes/principal/principal-deployment.yaml
+++ b/install/kubernetes/principal/principal-deployment.yaml
@@ -371,11 +371,11 @@ spec:
             path: tls.crt
           - key: tls.key
             path: tls.key
-          optional: false
+          optional: true
       - name: redis-tls-ca
         secret:
           secretName: argocd-redis-tls
           items:
           - key: ca.crt
             path: ca.crt
-          optional: false
+          optional: true


### PR DESCRIPTION
**What does this PR do / why we need it**:
This PR updates the principal Deployment so the Argo CD Redis TLS volumes (argocd-redis-tls and redis-tls-ca) are optional instead of required. After [#664 ](https://github.com/argoproj-labs/argocd-agent/pull/664), those secrets are always mounted with optional: false, but principal.redis.tls.enabled still defaults to false so the principal does not need those files at startup. On vcluster pods run in the host namespace where the kubelet looks for synced secret names ( argocd-redis-tls-x-argocd-x-vcluster-control-plane) that are not present so argocd-agent-principal stays in ContainerCreating and rollouts hit the progress deadline.
Making the mounts optional matches the default configuration where principal.redis.tls.enabled=false allowing the principal to start successfully without these secrets present. This restores ARGOCD_AGENT_IN_CLUSTER=true make setup-e2e functionality on vcluster.
This regression occurred because #664 did not include the integration changes needed to make the Redis TLS secrets available when TLS is disabled, but still required the secret mounts unconditionally.

**Which issue(s) this PR fixes**:
Fixes #876 
JIRA - https://redhat.atlassian.net/browse/GITOPS-9265

**How to test changes / Special notes to the reviewer**:
run - ARGOCD_AGENT_IN_CLUSTER=true make setup-e2e
you should see it run successfully
<img width="1728" height="447" alt="Screenshot 2026-04-29 at 6 11 39 PM" src="https://github.com/user-attachments/assets/e77f6df3-d304-4ee2-bcee-6711c16b1611" />
<img width="1728" height="249" alt="Screenshot 2026-04-29 at 6 17 33 PM" src="https://github.com/user-attachments/assets/f226dfa7-ff38-4786-ba33-f1f947329791" />


**Checklist**

* [ ] Documentation update is required by this PR (and has been updated) OR no documentation update is required.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Made specific TLS secret entries optional so deployments can start even when certain Redis TLS secret keys are missing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->