### PR TITLE
feat: Add metrics for worker queues

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -178,6 +178,8 @@ type AgentOptions struct {
 // It takes a pointer to an Agent and returns an error if the configuration fails.
 type AgentOption func(*Agent) error
 
+var metricsRegistered sync.Once
+
 // NewAgent creates a new agent instance, using the given client interfaces and
 // options.
 func NewAgent(ctx context.Context, client *kube.KubernetesClient, namespace string, opts ...AgentOption) (*Agent, error) {
@@ -200,6 +202,15 @@ func NewAgent(ctx context.Context, client *kube.KubernetesClient, namespace stri
 		if err != nil {
 			return nil, err
 		}
+	}
+
+	// Register metrics early
+	if a.options.metricsPort > 0 {
+		a.metrics = metrics.NewAgentMetrics()
+		metricsRegistered.Do(func() {
+			metrics.RegisterK8sClientMetrics()
+			metrics.RegisterQueueMetrics("argocd_agent")
+		})
 	}
 
 	if a.resourceProxyLogger == nil {
@@ -288,11 +299,6 @@ func NewAgent(ctx context.Context, client *kube.KubernetesClient, namespace stri
 		application.WithMode(managerMode),
 		application.WithDeletionTracker(a.deletions),
 		application.WithDestinationBasedMapping(a.destinationBasedMapping),
-	}
-
-	if a.options.metricsPort > 0 {
-		a.metrics = metrics.NewAgentMetrics()
-		metrics.RegisterK8sClientMetrics()
 	}
 
 	appInformer, err := informer.NewInformer(ctx, appInformerOptions...)

--- a/internal/metrics/queue.go
+++ b/internal/metrics/queue.go
@@ -1,0 +1,144 @@
+// Copyright 2026 The argocd-agent Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"k8s.io/client-go/util/workqueue"
+)
+
+var _ workqueue.MetricsProvider = &QueueMetrics{}
+
+// QueueMetrics implements the workqueue.MetricsProvider interface,
+// providing metrics for our send/recv queues.
+type QueueMetrics struct {
+	depth                   *prometheus.GaugeVec
+	adds                    *prometheus.CounterVec
+	latency                 *prometheus.HistogramVec
+	workDuration            *prometheus.HistogramVec
+	unfinishedWorkSeconds   *prometheus.GaugeVec
+	longestRunningProcessor *prometheus.GaugeVec
+	retries                 *prometheus.CounterVec
+}
+
+type gauge struct{ prometheus.Gauge }
+type counter struct{ prometheus.Counter }
+type histogram struct{ prometheus.Observer }
+
+func (g gauge) Inc()          { g.Gauge.Inc() }
+func (g gauge) Dec()          { g.Gauge.Dec() }
+func (g gauge) Set(v float64) { g.Gauge.Set(v) }
+
+func (c counter) Inc()          { c.Counter.Inc() }
+func (c counter) Add(v float64) { c.Counter.Add(v) }
+
+func (h histogram) Observe(v float64) { h.Observer.Observe(v) }
+
+func (p *QueueMetrics) NewDepthMetric(name string) workqueue.GaugeMetric {
+	return gauge{p.depth.WithLabelValues(name)}
+}
+
+func (p *QueueMetrics) NewAddsMetric(name string) workqueue.CounterMetric {
+	return counter{p.adds.WithLabelValues(name)}
+}
+
+func (p *QueueMetrics) NewLatencyMetric(name string) workqueue.HistogramMetric {
+	return histogram{p.latency.WithLabelValues(name)}
+}
+
+func (p *QueueMetrics) NewWorkDurationMetric(name string) workqueue.HistogramMetric {
+	return histogram{p.workDuration.WithLabelValues(name)}
+}
+
+func (p *QueueMetrics) NewUnfinishedWorkSecondsMetric(name string) workqueue.SettableGaugeMetric {
+	return gauge{p.unfinishedWorkSeconds.WithLabelValues(name)}
+}
+
+func (p *QueueMetrics) NewLongestRunningProcessorSecondsMetric(name string) workqueue.SettableGaugeMetric {
+	return gauge{p.longestRunningProcessor.WithLabelValues(name)}
+}
+
+func (p *QueueMetrics) NewRetriesMetric(name string) workqueue.CounterMetric {
+	return counter{p.retries.WithLabelValues(name)}
+}
+
+// RegisterQueueMetrics registers the queue metrics with the given prefix.
+// The prefix should be the component's name.
+// This function must only be called once per process, otherwise it will panic.
+func RegisterQueueMetrics(prefix string) {
+	provider := &QueueMetrics{
+		depth: prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Name: prefix + "_workqueue_depth",
+				Help: "Current depth of workqueue",
+			},
+			[]string{"queue"},
+		),
+		adds: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Name: prefix + "_workqueue_adds_total",
+				Help: "Total number of adds to the workqueue",
+			},
+			[]string{"queue"},
+		),
+		latency: prometheus.NewHistogramVec(
+			prometheus.HistogramOpts{
+				Name:    prefix + "_workqueue_queue_duration_seconds",
+				Help:    "How long items stay in queue before being processed",
+				Buckets: prometheus.DefBuckets,
+			},
+			[]string{"queue"},
+		),
+		workDuration: prometheus.NewHistogramVec(
+			prometheus.HistogramOpts{
+				Name:    prefix + "_workqueue_work_duration_seconds",
+				Help:    "How long processing an item takes",
+				Buckets: prometheus.DefBuckets,
+			},
+			[]string{"queue"},
+		),
+		unfinishedWorkSeconds: prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Name: prefix + "_workqueue_unfinished_work_seconds",
+				Help: "Total time of unfinished work",
+			},
+			[]string{"queue"},
+		),
+		longestRunningProcessor: prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Name: prefix + "_workqueue_longest_running_processor_seconds",
+				Help: "Longest running processor duration",
+			},
+			[]string{"queue"},
+		),
+		retries: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Name: prefix + "_workqueue_retries_total",
+				Help: "Total number of retries",
+			},
+			[]string{"queue"},
+		),
+	}
+	prometheus.DefaultRegisterer.MustRegister(
+		provider.depth,
+		provider.adds,
+		provider.latency,
+		provider.workDuration,
+		provider.unfinishedWorkSeconds,
+		provider.longestRunningProcessor,
+		provider.retries,
+	)
+	workqueue.SetProvider(provider)
+}

--- a/internal/queue/queue.go
+++ b/internal/queue/queue.go
@@ -51,16 +51,18 @@ type queuepair struct {
 type boundedQueue struct {
 	workqueue.TypedRateLimitingInterface[*event.Event]
 	maxSize int
-
-	notify chan struct{}
+	notify  chan struct{}
+	name    string
 }
 
-func newBoundedQueue(maxSize int) *boundedQueue {
+func newBoundedQueue(maxSize int, name string) *boundedQueue {
 	rateLimiter := workqueue.DefaultTypedControllerRateLimiter[*event.Event]()
 	return &boundedQueue{
-		TypedRateLimitingInterface: workqueue.NewTypedRateLimitingQueue(rateLimiter),
-		maxSize:                    maxSize,
-		notify:                     make(chan struct{}, 10),
+		TypedRateLimitingInterface: workqueue.NewTypedRateLimitingQueueWithConfig(rateLimiter,
+			workqueue.TypedRateLimitingQueueConfig[*event.Event]{Name: name}),
+		maxSize: maxSize,
+		notify:  make(chan struct{}, 10),
+		name:    name,
 	}
 }
 
@@ -70,7 +72,6 @@ func (bq *boundedQueue) Add(item *event.Event) {
 		old, _ := bq.Get()
 		bq.Done(old)
 	}
-
 	bq.TypedRateLimitingInterface.Add(item)
 
 	// Notify any waiting goroutines that an item has been added to the queue.
@@ -169,9 +170,9 @@ func (q *SendRecvQueues) Create(name string) error {
 		return nil
 	}, defaultMaxQueueSize)
 	qp := &queuepair{}
-	// Send queue is non-blocking, to keep up with the informer
-	qp.sendq = newBoundedQueue(sendQueueSize)
-	qp.recvq = newBoundedQueue(recvQueueSize)
+
+	qp.sendq = newBoundedQueue(sendQueueSize, name+"-send")
+	qp.recvq = newBoundedQueue(recvQueueSize, name+"-recv")
 	q.queues[name] = qp
 
 	return nil

--- a/principal/server.go
+++ b/principal/server.go
@@ -214,6 +214,8 @@ var noAuthEndpoints = map[string]bool{
 	"/authapi.Authentication/RefreshToken": true,
 }
 
+var metricsRegistered sync.Once
+
 const waitForSyncedDuration = 60 * time.Second
 
 // defaultResourceProxyListenerAddr is the default listener address for the
@@ -248,6 +250,14 @@ func NewServer(ctx context.Context, kubeClient *kube.KubernetesClient, namespace
 		if err != nil {
 			return nil, err
 		}
+	}
+
+	if s.options.metricsPort > 0 {
+		s.metrics = metrics.NewPrincipalMetrics()
+		metricsRegistered.Do(func() {
+			metrics.RegisterK8sClientMetrics()
+			metrics.RegisterQueueMetrics("argocd_principal")
+		})
 	}
 
 	if s.options.resourceProxyLogger == nil {
@@ -330,10 +340,7 @@ func NewServer(ctx context.Context, kubeClient *kube.KubernetesClient, namespace
 		appproject.WithRole(manager.ManagerRolePrincipal),
 	}
 
-	if s.options.metricsPort > 0 {
-		s.metrics = metrics.NewPrincipalMetrics()
-		metrics.RegisterK8sClientMetrics()
-
+	if s.metrics != nil {
 		appInformerOpts = append(appInformerOpts, informer.WithMetrics[*v1alpha1.Application](prometheus.NewRegistry(), metrics.NewInformerMetrics("applications")))
 		projInformerOpts = append(projInformerOpts, informer.WithMetrics[*v1alpha1.AppProject](prometheus.NewRegistry(), metrics.NewInformerMetrics("appprojects")))
 	}


### PR DESCRIPTION
**What does this PR do / why we need it**:

Add workqueue metrics to both, principal and agents. This uses client-go's workqueue metrics, instead of rolling our own observers and supersedes parts of https://github.com/argoproj-labs/argocd-agent/pull/922

**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:

1. Start either principal or agent
2. Curl to metrics endpoint
3. On principal, you should see new metrics prefixed with `argocd_principal_workqueue`
4. On agent, you should see new metrics prefixed with `argocd_agent_workqueue`

**Checklist**

* [ ] Documentation update is required by this PR (and has been updated) OR no documentation update is required.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate metric registration when initializing multiple agent instances using synchronization guards.
  * Fixed principal server metrics initialization to ensure consistent behavior across instances.

* **New Features**
  * Added comprehensive queue metrics monitoring including depth, latency, duration, and retry tracking for improved operational visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->