### PR TITLE
fix(e2e): flaky GPG key and self-registration e2e tests

### DIFF
--- a/test/e2e/fixture/fixture.go
+++ b/test/e2e/fixture/fixture.go
@@ -423,13 +423,25 @@ func CleanUp(ctx context.Context, principalClient KubeClient, managedAgentClient
 		}
 	}
 
-	// Delete GPG keys ConfigMap from all clusters
-	for _, client := range []KubeClient{principalClient, managedAgentClient, autonomousAgentClient} {
-		gpgKeysCM := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: common.ArgoCDGPGKeysConfigMapName, Namespace: "argocd"}}
-		err = client.Delete(ctx, gpgKeysCM, metav1.DeleteOptions{})
-		if err != nil && !errors.IsNotFound(err) {
-			return err
-		}
+	// Delete GPG keys ConfigMap from the principal
+	gpgKeysCM := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: common.ArgoCDGPGKeysConfigMapName, Namespace: "argocd"}}
+	err = EnsureDeletion(ctx, principalClient, gpgKeysCM)
+	if err != nil {
+		return err
+	}
+
+	// Wait for the GPG keys ConfigMap to be deleted from the managed agent
+	gpgKeysCM = &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: common.ArgoCDGPGKeysConfigMapName, Namespace: "argocd"}}
+	err = WaitForDeletion(ctx, managedAgentClient, gpgKeysCM, "managed agent")
+	if err != nil {
+		return err
+	}
+
+	// Delete GPG keys ConfigMap from the autonomous agent
+	gpgKeysCM = &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: common.ArgoCDGPGKeysConfigMapName, Namespace: "argocd"}}
+	err = EnsureDeletion(ctx, autonomousAgentClient, gpgKeysCM)
+	if err != nil {
+		return err
 	}
 
 	// Remove known finalizer-containing resources from guestbook ns (before we delete the NS in the next step)

--- a/test/e2e/gpgkey_test.go
+++ b/test/e2e/gpgkey_test.go
@@ -323,8 +323,22 @@ func (suite *GPGKeyTestSuite) Test_GPGKey_UseAndUpdatePreExistingConfigMap() {
 
 	// Delete ConfigMap manually created on the managed agent
 	defer func() {
-		cm := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: common.ArgoCDGPGKeysConfigMapName, Namespace: "argocd"}}
-		_ = suite.ManagedAgentClient.Delete(suite.Ctx, cm, metav1.DeleteOptions{})
+		cm := &corev1.ConfigMap{}
+		err := suite.ManagedAgentClient.Get(suite.Ctx,
+			types.NamespacedName{Name: common.ArgoCDGPGKeysConfigMapName, Namespace: "argocd"}, cm, metav1.GetOptions{})
+		if err != nil {
+			if errors.IsNotFound(err) {
+				return
+			}
+			requires.NoError(err)
+			return
+		}
+
+		// Only delete if CM is still an orphan (no source-uid)
+		// once adopted, TearDownTest handles it via principal deletion.
+		if _, adopted := cm.Annotations[manager.SourceUIDAnnotation]; !adopted {
+			requires.NoError(suite.ManagedAgentClient.Delete(suite.Ctx, cm, metav1.DeleteOptions{}))
+		}
 	}()
 
 	// Verify the orphan ConfigMap has no source-uid annotation

--- a/test/e2e/gpgkey_test.go
+++ b/test/e2e/gpgkey_test.go
@@ -321,6 +321,12 @@ func (suite *GPGKeyTestSuite) Test_GPGKey_UseAndUpdatePreExistingConfigMap() {
 	err := suite.ManagedAgentClient.Create(suite.Ctx, &orphanCM, metav1.CreateOptions{})
 	requires.NoError(err)
 
+	// Delete ConfigMap manually created on the managed agent
+	defer func() {
+		cm := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: common.ArgoCDGPGKeysConfigMapName, Namespace: "argocd"}}
+		_ = suite.ManagedAgentClient.Delete(suite.Ctx, cm, metav1.DeleteOptions{})
+	}()
+
 	// Verify the orphan ConfigMap has no source-uid annotation
 	agentCM := corev1.ConfigMap{}
 	err = suite.ManagedAgentClient.Get(suite.Ctx, key, &agentCM, metav1.GetOptions{})

--- a/test/e2e/self_agent_registration_test.go
+++ b/test/e2e/self_agent_registration_test.go
@@ -249,6 +249,14 @@ func (suite *SelfAgentRegistrationTestSuite) Test_SelfRegistrationCreatesSecret(
 	fixture.RestartAgent(suite.T(), fixture.PrincipalName)
 	fixture.CheckReadiness(suite.T(), fixture.PrincipalName)
 
+	// After restarting the principal, wait for redis cache to be updated
+	requires.Eventually(func() bool {
+		return fixture.HasConnectionStatus(fixture.AgentManagedName, appv1.ConnectionState{
+			Status:  appv1.ConnectionStatusSuccessful,
+			Message: fmt.Sprintf("Agent: '%s' is %s with principal", fixture.AgentManagedName, "connected"),
+		}, suite.ClusterDetails)
+	}, 60*time.Second, 1*time.Second)
+
 	// Stop the agent
 	err := fixture.StopProcess(fixture.AgentManagedName)
 	requires.NoError(err)


### PR DESCRIPTION
This PR is to fix a race condition in E2E test cleanup of gpg keys. Existing cleanup is directly deleting gpg key configmap  from all clusters.  On managed agent sometimes it gets into race condition where cleanup function first deletes the CM from principal and the it directly deletes the CM on managed agent, but agent considers it as "unauthorized deletion" and recreates the CM. But in that short window between unauthorized deletion and recreate, if agent receives delete event sent by principal, it will return as CM is not there. 

Along with gpg key e2e, fixed self-registration tests as well. This occurs when principal is restarted and agent reconnects, but redis cache is not updated yet and we stop agent causing conflict between previous and current refresh operations.  

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Ensured GPG keys cleanup runs in a cluster-aware sequence and stops on deletion errors to avoid inconsistent states.
  * Added a safe teardown to remove orphaned ConfigMaps only when not adopted, preventing interference with normal cleanup.
  * Added a synchronization gate in self-registration tests to wait for agent connection status before proceeding with teardown assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->