### PR TITLE
feat: deduplicate unsent event writer events for spec/statusupdate

### DIFF
--- a/internal/event/event_writer.go
+++ b/internal/event/event_writer.go
@@ -2,6 +2,8 @@ package event
 
 import (
 	"context"
+	"math"
+	"math/rand/v2"
 	"strings"
 	"sync"
 	"time"
@@ -19,7 +21,7 @@ import (
 
 const (
 	// maxEventRetries is the maximum number of times an event will be retried before giving up.
-	maxEventRetries = 12
+	maxEventRetries = math.MaxInt
 )
 
 type streamWriter interface {
@@ -124,9 +126,10 @@ func (ew *EventWriter) Add(ev *cloudevents.Event) {
 
 	defaultBackoff := wait.Backoff{
 		Steps:    maxEventRetries,
-		Duration: 1 * time.Second,
-		Factor:   1.5,
-		Jitter:   0.1,
+		Duration: 5 * time.Second,
+		Factor:   4,
+		Jitter:   1,
+		Cap:      2 * time.Minute, // never wait longer than 2 minutes
 	}
 
 	if resID == "" {
@@ -182,7 +185,7 @@ func (ew *EventWriter) Get(resID string) *eventMessage {
 
 	// Then check unsent queue
 	if eq, exists := ew.unsentEvents[resID]; exists {
-		return eq.get()
+		return eq.peek()
 	}
 	return nil
 }
@@ -207,13 +210,18 @@ func (ew *EventWriter) Remove(ev *cloudevents.Event) {
 		}
 	}
 
+	// JGW-TODO:
+	// - A) Should Remove remove from both sentEvents/unsentEvents? (I mean, it seems likely it will be in one or the other, but we could check both?)
+	// and
+	// - B) In the unsent case, why does remove only remove from the front of the queue?
+
 	// If not in sent events, check unsent queue
 	eq, exists := ew.unsentEvents[resourceID]
 	if !exists {
 		return
 	}
 
-	front := eq.get()
+	front := eq.peek()
 	if front == nil {
 		return
 	}
@@ -258,6 +266,11 @@ func (ew *EventWriter) SendWaitingEvents(ctx context.Context) {
 				}
 			}
 			ew.mu.RUnlock()
+
+			// Shuffle so no resource is systematically starved
+			rand.Shuffle(len(resourceIDs), func(i, j int) {
+				resourceIDs[i], resourceIDs[j] = resourceIDs[j], resourceIDs[i]
+			})
 
 			for _, resourceID := range resourceIDs {
 				ew.sendEvent(resourceID)
@@ -503,26 +516,63 @@ func (eq *eventQueue) add(ev *eventMessage) {
 	eq.mu.Lock()
 	defer eq.mu.Unlock()
 
-	if len(eq.items) > 0 {
-		tail := eq.items[len(eq.items)-1]
-		tail.mu.Lock()
-
-		// Replace an older event with a newer one of the same type
-		if ev.event.Type() == tail.event.Type() {
-			tail.event = ev.event
-			tail.backoff = ev.backoff
-			tail.retryAfter = ev.retryAfter
-			tail.mu.Unlock()
-			return
-		}
-		tail.mu.Unlock()
-	}
-
 	eq.items = append(eq.items, ev)
+
+	deduplicateEventMessageItems(&eq.items)
+
+	// if len(eq.items) > 0 {
+	// 	tail := eq.items[len(eq.items)-1]
+	// 	tail.mu.Lock()
+
+	// 	// Replace an older event with a newer one of the same type
+	// 	if ev.event.Type() == tail.event.Type() {
+	// 		tail.event = ev.event
+	// 		tail.backoff = ev.backoff
+	// 		tail.retryAfter = ev.retryAfter
+	// 		tail.mu.Unlock()
+	// 		return
+	// 	}
+	// 	tail.mu.Unlock()
+	// }
+
+	// eq.items = append(eq.items, ev)
 }
 
-// get the first item from the queue.
-func (eq *eventQueue) get() *eventMessage {
+// deduplicateEventMessageItems
+// - Ensure you own the lock on the items parameter (e.g. via eq.mu.Lock()) before calling this function
+func deduplicateEventMessageItems(items *[]*eventMessage) {
+
+	// key: Type() of event
+	// value: (not used)
+	haveWeSeenMsgWithType := make(map[string]bool, 0)
+
+	// Work backwards through the list:
+	// - Items at the end of the list are 'fresher', items are the beginning of the list are more stale
+	// - We thus remove items early in the list in favour of those that are later in the list
+	for idx := len(*items) - 1; idx >= 0; idx-- {
+		item := (*items)[idx]
+
+		myType := item.event.Type()
+
+		// No de-duplication of events we can't guarantee are safe to de-duplicate
+		if myType != StatusUpdate.String() && myType != SpecUpdate.String() {
+			continue
+		}
+
+		// De-duplicate statusupdate and specupdate, as we know they are safe to de-duplicate
+		if _, typePreviouslySeen := haveWeSeenMsgWithType[myType]; typePreviouslySeen {
+			// Stale duplicate: a fresher same-type entry was retained when scanning from the tail.
+			*items = append((*items)[:idx], (*items)[idx+1:]...)
+		} else {
+			// This is the first type we have seen the type, so add it to the map and continue without removal
+			haveWeSeenMsgWithType[myType] = true
+		}
+	}
+
+}
+
+// peek the first item from the queue.
+func (eq *eventQueue) peek() *eventMessage {
 	eq.mu.RLock()
 	defer eq.mu.RUnlock()
 	if len(eq.items) == 0 {

--- a/internal/event/event_writer.go
+++ b/internal/event/event_writer.go
@@ -210,11 +210,6 @@ func (ew *EventWriter) Remove(ev *cloudevents.Event) {
 		}
 	}
 
-	// JGW-TODO:
-	// - A) Should Remove remove from both sentEvents/unsentEvents? (I mean, it seems likely it will be in one or the other, but we could check both?)
-	// and
-	// - B) In the unsent case, why does remove only remove from the front of the queue?
-
 	// If not in sent events, check unsent queue
 	eq, exists := ew.unsentEvents[resourceID]
 	if !exists {
@@ -304,6 +299,8 @@ func (ew *EventWriter) retrySentEvent(resID string, sentMsg *eventMessage) {
 
 	// Re-verify the event is still in sentEvents
 	currentSent, stillExists := ew.sentEvents[resID]
+	// Create thread local copy of target under lock to avoid a data race with UpdateTarget.
+	target := ew.target
 	ew.mu.RUnlock()
 
 	// If event was ACK'd between check and use, skip retry
@@ -362,7 +359,7 @@ func (ew *EventWriter) retrySentEvent(resID string, sentMsg *eventMessage) {
 		return
 	}
 
-	err = ew.target.Send(&eventstreamapi.Event{Event: pev})
+	err = target.Send(&eventstreamapi.Event{Event: pev})
 	sentMsg.mu.Unlock()
 
 	if err != nil {
@@ -420,6 +417,8 @@ func (ew *EventWriter) sendUnsentEvent(resID string) {
 		ew.scheduleRetry(eventMsg)
 		ew.sentEvents[resID] = eventMsg
 	}
+	// Create thread local copy of target under lock to avoid a data race with UpdateTarget.
+	sendTarget := ew.target
 	ew.mu.Unlock()
 
 	// Send the event
@@ -443,7 +442,7 @@ func (ew *EventWriter) sendUnsentEvent(resID string) {
 	}
 
 	// A Send() on the stream is actually not blocking.
-	err = ew.target.Send(&eventstreamapi.Event{Event: pev})
+	err = sendTarget.Send(&eventstreamapi.Event{Event: pev})
 	if err != nil {
 		logCtx.Errorf("Error while sending: %v\n", err)
 		return
@@ -520,22 +519,6 @@ func (eq *eventQueue) add(ev *eventMessage) {
 
 	deduplicateEventMessageItems(&eq.items)
 
-	// if len(eq.items) > 0 {
-	// 	tail := eq.items[len(eq.items)-1]
-	// 	tail.mu.Lock()
-
-	// 	// Replace an older event with a newer one of the same type
-	// 	if ev.event.Type() == tail.event.Type() {
-	// 		tail.event = ev.event
-	// 		tail.backoff = ev.backoff
-	// 		tail.retryAfter = ev.retryAfter
-	// 		tail.mu.Unlock()
-	// 		return
-	// 	}
-	// 	tail.mu.Unlock()
-	// }
-
-	// eq.items = append(eq.items, ev)
 }
 
 // deduplicateEventMessageItems
@@ -547,7 +530,7 @@ func deduplicateEventMessageItems(items *[]*eventMessage) {
 	haveWeSeenMsgWithType := make(map[string]bool, 0)
 
 	// Work backwards through the list:
-	// - Items at the end of the list are 'fresher', items are the beginning of the list are more stale
+	// - Items at the end of the list are 'fresher', items at the beginning of the list are more stale
 	// - We thus remove items early in the list in favour of those that are later in the list
 	for idx := len(*items) - 1; idx >= 0; idx-- {
 		item := (*items)[idx]

--- a/internal/event/event_writer_test.go
+++ b/internal/event/event_writer_test.go
@@ -288,42 +288,42 @@ func TestEventWriter(t *testing.T) {
 		require.Equal(t, 1, sentMsg.retryCount)
 	})
 
-	t.Run("should give up after max retries", func(t *testing.T) {
-		fs := &fakeStream{}
-		evSender := NewEventWriter("test", fs)
+	// t.Run("should give up after max retries", func(t *testing.T) {
+	// 	fs := &fakeStream{}
+	// 	evSender := NewEventWriter("test", fs)
 
-		discardCalled := false
-		var discardedEventType, discardedResourceType string
-		evSender.SetOnDiscard(func(eventType, resourceType string) {
-			discardCalled = true
-			discardedEventType = eventType
-			discardedResourceType = resourceType
-		})
+	// discardCalled := false
+	// var discardedEventType, discardedResourceType string
+	// evSender.SetOnDiscard(func(eventType, resourceType string) {
+	// 	discardCalled = true
+	// 	discardedEventType = eventType
+	// 	discardedResourceType = resourceType
+	// })
 
-		ev := es.ApplicationEvent(Create, app1)
-		resID := createResourceID(app1.ObjectMeta)
-		evSender.Add(ev)
+	// ev := es.ApplicationEvent(Create, app1)
+	// resID := createResourceID(app1.ObjectMeta)
+	// evSender.Add(ev)
 
-		// Send the event
-		evSender.sendEvent(resID)
-		sentMsg := evSender.sentEvents[resID]
-		require.NotNil(t, sentMsg)
+	// 	// Send the event
+	// 	evSender.sendEvent(resID)
+	// 	sentMsg := evSender.sentEvents[resID]
+	// 	require.NotNil(t, sentMsg)
 
-		// Exhaust retries
-		for i := 0; i <= maxEventRetries; i++ {
-			pastTime := time.Now().Add(-1 * time.Second)
-			sentMsg.retryAfter = &pastTime
-			evSender.retrySentEvent(resID, sentMsg)
-		}
+	// 	// Exhaust retries
+	// 	for i := 0; i <= maxEventRetries; i++ {
+	// 		pastTime := time.Now().Add(-1 * time.Second)
+	// 		sentMsg.retryAfter = &pastTime
+	// 		evSender.retrySentEvent(resID, sentMsg)
+	// 	}
 
-		// After max retries, event should be removed from sentEvents
-		require.NotContains(t, evSender.sentEvents, resID)
+	// 	// After max retries, event should be removed from sentEvents
+	// 	require.NotContains(t, evSender.sentEvents, resID)
 
-		// Verify onDiscard callback was called with correct values
-		require.True(t, discardCalled)
-		require.Equal(t, "create", discardedEventType)
-		require.Equal(t, targets.Application.String(), discardedResourceType)
-	})
+	// 	// Verify onDiscard callback was called with correct values
+	// 	require.True(t, discardCalled)
+	// 	require.Equal(t, "create", discardedEventType)
+	// 	require.Equal(t, targets.Application.String(), discardedResourceType)
+	// })
 
 	t.Run("should not send ACK events to sentEvents", func(t *testing.T) {
 		fs := &fakeStream{}
@@ -489,6 +489,107 @@ func TestEventWriter(t *testing.T) {
 		require.NotNil(t, latestEvent)
 		eventID := EventID(latestEvent.event)
 		require.Contains(t, eventID, "_5") // Should be version 5
+	})
+}
+
+func TestDeduplicateEventMessageItems(t *testing.T) {
+	es := NewEventSource("dedupe-test")
+	app := &v1alpha1.Application{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "app",
+			Namespace: "ns",
+			UID:       "uid-a",
+		},
+	}
+
+	eventMsg := func(evType EventType, resourceVersion string) *eventMessage {
+		app.ResourceVersion = resourceVersion
+		return &eventMessage{event: es.ApplicationEvent(evType, app)}
+	}
+
+	t.Run("empty slice", func(t *testing.T) {
+		items := []*eventMessage{}
+		deduplicateEventMessageItems(&items)
+		require.Empty(t, items)
+	})
+
+	t.Run("single spec update unchanged", func(t *testing.T) {
+		ev := eventMsg(SpecUpdate, "1")
+		items := []*eventMessage{ev}
+		deduplicateEventMessageItems(&items)
+		require.Len(t, items, 1)
+		require.Equal(t, EventID(ev.event), EventID(items[0].event))
+	})
+
+	t.Run("multiple spec updates keep only freshest", func(t *testing.T) {
+		items := []*eventMessage{
+			eventMsg(SpecUpdate, "1"),
+			eventMsg(SpecUpdate, "2"),
+			eventMsg(SpecUpdate, "3"),
+		}
+		deduplicateEventMessageItems(&items)
+		require.Len(t, items, 1)
+		require.Contains(t, EventID(items[0].event), "_3")
+	})
+
+	t.Run("multiple status updates keep only freshest", func(t *testing.T) {
+		items := []*eventMessage{
+			eventMsg(StatusUpdate, "10"),
+			eventMsg(StatusUpdate, "20"),
+		}
+		deduplicateEventMessageItems(&items)
+		require.Len(t, items, 1)
+		require.Contains(t, EventID(items[0].event), "_20")
+	})
+
+	t.Run("spec and status updates both retained", func(t *testing.T) {
+		items := []*eventMessage{
+			eventMsg(SpecUpdate, "1"),
+			eventMsg(StatusUpdate, "2"),
+		}
+		deduplicateEventMessageItems(&items)
+		require.Len(t, items, 2)
+		require.Equal(t, SpecUpdate.String(), items[0].event.Type())
+		require.Equal(t, StatusUpdate.String(), items[1].event.Type())
+	})
+
+	t.Run("interleaved create leaves creates alone but dedupes spec updates", func(t *testing.T) {
+		items := []*eventMessage{
+			eventMsg(SpecUpdate, "1"),
+			eventMsg(Create, "2"),
+			eventMsg(SpecUpdate, "3"),
+		}
+		deduplicateEventMessageItems(&items)
+		require.Len(t, items, 2)
+		require.Equal(t, Create.String(), items[0].event.Type())
+		require.Equal(t, SpecUpdate.String(), items[1].event.Type())
+		require.Contains(t, EventID(items[1].event), "_3")
+	})
+
+	t.Run("does not dedupe event types other than spec or status update", func(t *testing.T) {
+		items := []*eventMessage{
+			eventMsg(Create, "1"),
+			eventMsg(Create, "2"),
+		}
+		deduplicateEventMessageItems(&items)
+		require.Len(t, items, 2)
+		require.Contains(t, EventID(items[0].event), "_1")
+		require.Contains(t, EventID(items[1].event), "_2")
+	})
+
+	t.Run("keeps latest of each deduped type when interleaved", func(t *testing.T) {
+		items := []*eventMessage{
+			eventMsg(SpecUpdate, "1"),
+			eventMsg(SpecUpdate, "2"),
+			eventMsg(StatusUpdate, "3"),
+			eventMsg(SpecUpdate, "4"),
+		}
+		deduplicateEventMessageItems(&items)
+		require.Len(t, items, 2)
+		require.Equal(t, StatusUpdate.String(), items[0].event.Type())
+		require.Contains(t, EventID(items[0].event), "_3")
+		require.Equal(t, SpecUpdate.String(), items[1].event.Type())
+		require.Contains(t, EventID(items[1].event), "_4")
 	})
 }
 

--- a/internal/event/event_writer_test.go
+++ b/internal/event/event_writer_test.go
@@ -288,43 +288,6 @@ func TestEventWriter(t *testing.T) {
 		require.Equal(t, 1, sentMsg.retryCount)
 	})
 
-	// t.Run("should give up after max retries", func(t *testing.T) {
-	// 	fs := &fakeStream{}
-	// 	evSender := NewEventWriter("test", fs)
-
-	// discardCalled := false
-	// var discardedEventType, discardedResourceType string
-	// evSender.SetOnDiscard(func(eventType, resourceType string) {
-	// 	discardCalled = true
-	// 	discardedEventType = eventType
-	// 	discardedResourceType = resourceType
-	// })
-
-	// ev := es.ApplicationEvent(Create, app1)
-	// resID := createResourceID(app1.ObjectMeta)
-	// evSender.Add(ev)
-
-	// 	// Send the event
-	// 	evSender.sendEvent(resID)
-	// 	sentMsg := evSender.sentEvents[resID]
-	// 	require.NotNil(t, sentMsg)
-
-	// 	// Exhaust retries
-	// 	for i := 0; i <= maxEventRetries; i++ {
-	// 		pastTime := time.Now().Add(-1 * time.Second)
-	// 		sentMsg.retryAfter = &pastTime
-	// 		evSender.retrySentEvent(resID, sentMsg)
-	// 	}
-
-	// 	// After max retries, event should be removed from sentEvents
-	// 	require.NotContains(t, evSender.sentEvents, resID)
-
-	// 	// Verify onDiscard callback was called with correct values
-	// 	require.True(t, discardCalled)
-	// 	require.Equal(t, "create", discardedEventType)
-	// 	require.Equal(t, targets.Application.String(), discardedResourceType)
-	// })
-
 	t.Run("should not send ACK events to sentEvents", func(t *testing.T) {
 		fs := &fakeStream{}
 		evSender := NewEventWriter("test", fs)


### PR DESCRIPTION
**What does this PR do / why we need it**:
- The event writer is responsible for ensuring that outbound messages are written (and acked) from principal to agent.
- This PR observes that in at least a couple cases (spec update and status update), it is straightforward to remove stale events from the queue, in order to avoid spending bandwidth/cpu/memory on transmitting events that are already known to be stale at the source.
    - This PR only de-duplicates unsent events; we never throw away a previously sent event (even though it will potentially be more stale then some events in the unsent queue)
- This PR also increases the exponential backoff to more aggressively ramp up, tuning it to avoid a large number of messages in the worst case scenario (initial cluster+application initialization)
    - In a previous PR I made the backoff much more gradual, but in retrospect I think that is now incorrect give the possible failure case we will see.
- This PR also increases the max number of retries to infinite, such that we never give up on sending a non-stale message (or at least until agent OS process restart)
    - This is done for correctness: we really shouldn't be dropping message, as there is no mechanism to get that data after the fact (e.g. without an agent/principal process restart)
    - In the future/a separate PR, we should instead implement a 'max ttl' for messages which is configurable by users, based on the max length of time they expect agents to be reasonably disconnected from principal.
    - We can also more quickly drop messages that are known to be ephemeral, like redis/request proxy responses.
- Adds a randomize to avoid disproportionately favouring somes keys in the map over others

**Which issue(s) this PR fixes**:

Fixes N/A

**Checklist**

* [X] Documentation update is required by this PR (and has been updated) OR no documentation update is required.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved event retry/backoff behavior for more reliable delivery.
  * Fixed unsent-event queue handling to safely inspect and remove the correct next item.
  * Enhanced deduplication of repeated status/spec updates to reduce redundant processing.
  * Randomized the order of waiting resources processed each cycle to help prevent starvation.

* **Tests**
  * Added focused test coverage for deduplicating event message items across multiple scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->