### PR TITLE
fix: principal send deadlock fix

### DIFF
--- a/agent/connection.go
+++ b/agent/connection.go
@@ -177,12 +177,13 @@ func (a *Agent) handleStreamEvents() error {
 	streamCtx, streamCancel := context.WithCancel(a.context)
 	defer streamCancel()
 
+	var lease event.TargetLease
 	if a.eventWriter == nil {
-		a.eventWriter = event.NewEventWriter("", stream)
+		a.eventWriter, lease = event.NewEventWriter("", stream)
 	} else {
-		a.eventWriter.UpdateTarget(stream)
+		lease = a.eventWriter.UpdateTarget(stream)
 	}
-	go a.eventWriter.SendWaitingEvents(streamCtx)
+	go a.eventWriter.SendWaitingEvents(streamCtx, lease)
 
 	logCtx := log().WithFields(logrus.Fields{
 		logfields.Module:     "StreamEvent",

--- a/internal/event/event_writer.go
+++ b/internal/event/event_writer.go
@@ -2,6 +2,7 @@ package event
 
 import (
 	"context"
+	"errors"
 	"sync"
 	"time"
 
@@ -25,6 +26,28 @@ type streamWriter interface {
 	Context() context.Context
 }
 
+// SendErrorReason classifies an error returned from streamWriter.Send so
+// callers (and metrics) can distinguish a dead transport from a transient
+// failure.
+type SendErrorReason string
+
+const (
+	SendErrorTransportClosing SendErrorReason = "transport-closing"
+	SendErrorContextCanceled  SendErrorReason = "context-canceled"
+	SendErrorOther            SendErrorReason = "other"
+)
+
+// SendErrorObserver is invoked synchronously after every Send() failure on
+// the underlying stream. The Subscribe handler installs one of these to
+// detect a permanently dead target and trigger a reconnect.
+type SendErrorObserver func(reason SendErrorReason, err error)
+
+// TargetLease is an opaque token returned by NewEventWriter and UpdateTarget.
+// Pass it to SendWaitingEvents to bind the send loop to exactly that stream;
+// the loop exits when a subsequent UpdateTarget advances the internal
+// generation and this lease becomes stale.
+type TargetLease struct{ gen uint64 }
+
 // EventWriter keeps track of the latest event for resources and sends them on a given gRPC stream.
 // It resends the event with exponential backoff until the event is ACK'd and removed from its list.
 type EventWriter struct {
@@ -43,8 +66,24 @@ type EventWriter struct {
 	// target refers to the specified gRPC stream.
 	target streamWriter
 
+	// targetGen is bumped every time UpdateTarget swaps the stream. A
+	// pending Send goroutine that captured an older generation must NOT
+	// surface its error to the current observer — that error belongs to
+	// a stream the current Subscribe owner does not control.
+	// - acquire 'mu' (read or write) before accessing
+	targetGen uint64
+
 	// agentName is the name of the agent for which this EventWriter is responsible.
 	agentName string
+
+	// onSendError is invoked after every Send() failure. May be nil.
+	// - acquire 'mu' (read or write) before accessing
+	onSendError SendErrorObserver
+
+	// testHookAfterUnlock is called in sendUnsentEvent after ew.mu is released
+	// and before snapshotTargetForGen. Nil in production; set in tests to
+	// inject a synchronization point that exercises the post-pop gen-advance race.
+	testHookAfterUnlock func()
 
 	log *logrus.Entry
 }
@@ -70,25 +109,37 @@ type eventMessage struct {
 
 // NewEventWriter creates a new EventWriter for the given target stream.
 // If you create an EventWriter targeting the principal, an empty agentName
-// should be used.
-func NewEventWriter(agentName string, target streamWriter) *EventWriter {
-	return &EventWriter{
+// should be used. The returned TargetLease must be passed to SendWaitingEvents
+// to bind that loop to this specific stream.
+func NewEventWriter(agentName string, target streamWriter) (*EventWriter, TargetLease) {
+	const initialGen uint64 = 1
+	ew := &EventWriter{
 		unsentEvents: map[string]*eventQueue{},
 		sentEvents:   map[string]*eventMessage{},
 		target:       target,
+		targetGen:    initialGen,
 		agentName:    agentName,
 		log:          logging.GetDefaultLogger().ModuleLogger("EventWriter").WithField(logfields.ClientAddr, grpcutil.AddressFromContext(target.Context())).WithField(logfields.Agent, agentName),
 	}
+	return ew, TargetLease{initialGen}
 }
 
-func (ew *EventWriter) UpdateTarget(target streamWriter) {
+// UpdateTarget swaps in a new stream. Returns a TargetLease the caller must
+// pass to SendWaitingEvents to bind that loop to this stream; the loop exits
+// once a later UpdateTarget supersedes it.
+//
+// Clears the send-error observer — the new owner must call
+// SetSendErrorObserver after UpdateTarget. Resets retry timers so queued
+// events are resent immediately on the fresh stream.
+func (ew *EventWriter) UpdateTarget(target streamWriter) TargetLease {
 	ew.mu.Lock()
 	defer ew.mu.Unlock()
 	ew.target = target
+	ew.targetGen++
 	ew.log = logging.GetDefaultLogger().ModuleLogger("EventWriter").
 		WithField(logfields.ClientAddr, grpcutil.AddressFromContext(target.Context())).
 		WithField(logfields.Agent, ew.agentName)
-
+	ew.onSendError = nil
 	// Reset retry timers so events in sentEvents are retried immediately on the new connection.
 	// This is important for reconnection scenarios where the old connection died
 	// and ACKs will never arrive, so we want to give events a fresh chance on the new stream.
@@ -98,6 +149,79 @@ func (ew *EventWriter) UpdateTarget(target streamWriter) {
 		msg.retryAfter = &now
 		msg.mu.Unlock()
 	}
+	return TargetLease{ew.targetGen}
+}
+
+// snapshotTargetForGen returns the current target if its generation still
+// matches the lease. Returns ok=false when a newer UpdateTarget has taken
+// over; callers must not Send in that case.
+func (ew *EventWriter) snapshotTargetForGen(lease TargetLease) (streamWriter, bool) {
+	ew.mu.RLock()
+	defer ew.mu.RUnlock()
+	if ew.targetGen != lease.gen {
+		return nil, false
+	}
+	return ew.target, true
+}
+
+// SetSendErrorObserver installs a callback fired after every Send() failure.
+// Pass nil to clear. Intended for the Subscribe handler to detect a dead
+// target and tear down the stream.
+func (ew *EventWriter) SetSendErrorObserver(fn SendErrorObserver) {
+	ew.mu.Lock()
+	defer ew.mu.Unlock()
+	ew.onSendError = fn
+}
+
+// Depth returns the total number of events currently held in the writer
+// (sent waiting for ACK + unsent queued). Cheap enough to call from a
+// metrics scrape loop.
+func (ew *EventWriter) Depth() int {
+	ew.mu.RLock()
+	defer ew.mu.RUnlock()
+
+	depth := len(ew.sentEvents)
+	for _, eq := range ew.unsentEvents {
+		eq.mu.RLock()
+		depth += len(eq.items)
+		eq.mu.RUnlock()
+	}
+	return depth
+}
+
+// classifySendError maps a Send() error to a SendErrorReason for metrics
+// labels and observer dispatch.
+func classifySendError(err error) SendErrorReason {
+	if err == nil {
+		return SendErrorOther
+	}
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return SendErrorContextCanceled
+	}
+	if grpcutil.NeedReconnectOnError(err) {
+		// NeedReconnectOnError covers Unavailable / Canceled / EOF / RST_STREAM —
+		// all of which mean the underlying transport is gone for this stream.
+		return SendErrorTransportClosing
+	}
+	return SendErrorOther
+}
+
+// notifySendError fires the registered observer (if any). Must be called
+// without ew.mu held to avoid re-entrant deadlocks if the observer touches
+// the EventWriter. Drops the notification when the lease is stale so a slow
+// Send goroutine from a replaced stream cannot tear down the current owner.
+func (ew *EventWriter) notifySendError(lease TargetLease, err error) {
+	ew.mu.RLock()
+	if ew.targetGen != lease.gen {
+		ew.mu.RUnlock()
+		return
+	}
+	fn := ew.onSendError
+	ew.mu.RUnlock()
+	if fn == nil {
+		return
+	}
+	fn(classifySendError(err), err)
 }
 
 func (ew *EventWriter) Add(ev *cloudevents.Event) {
@@ -222,7 +346,10 @@ func (ew *EventWriter) Remove(ev *cloudevents.Event) {
 // SendWaitingEvents will periodically send the events waiting in the EventWriter.
 // Note: This function will never return unless the context is done, and therefore
 // should be started in a separate goroutine.
-func (ew *EventWriter) SendWaitingEvents(ctx context.Context) {
+//
+// The lease binds this loop to a specific stream generation. When UpdateTarget
+// is called the generation advances and the loop exits.
+func (ew *EventWriter) SendWaitingEvents(ctx context.Context, lease TargetLease) {
 	ew.mu.RLock()
 	logCtx := ew.log
 	ew.mu.RUnlock()
@@ -235,6 +362,11 @@ func (ew *EventWriter) SendWaitingEvents(ctx context.Context) {
 			return
 		default:
 			ew.mu.RLock()
+			if ew.targetGen != lease.gen {
+				ew.mu.RUnlock()
+				logCtx.Info("Target generation advanced; stopping event writer")
+				return
+			}
 			// Collect all resource IDs that have either unsent or sent events
 			resourceIDs := make([]string, 0, len(ew.unsentEvents)+len(ew.sentEvents))
 			for resID := range ew.unsentEvents {
@@ -249,7 +381,7 @@ func (ew *EventWriter) SendWaitingEvents(ctx context.Context) {
 			ew.mu.RUnlock()
 
 			for _, resourceID := range resourceIDs {
-				ew.sendEvent(resourceID)
+				ew.sendEvent(resourceID, lease)
 			}
 		}
 		time.Sleep(100 * time.Millisecond)
@@ -257,33 +389,42 @@ func (ew *EventWriter) SendWaitingEvents(ctx context.Context) {
 }
 
 // sendEvent determines whether to retry a sent event or send a new unsent event
-func (ew *EventWriter) sendEvent(resID string) {
+func (ew *EventWriter) sendEvent(resID string, lease TargetLease) {
 	// Check if there's a sent event awaiting retry
 	ew.mu.RLock()
 	sentMsg, hasSent := ew.sentEvents[resID]
 	ew.mu.RUnlock()
 
 	if hasSent {
-		ew.retrySentEvent(resID, sentMsg)
+		ew.retrySentEvent(resID, sentMsg, lease)
 	} else {
-		ew.sendUnsentEvent(resID)
+		ew.sendUnsentEvent(resID, lease)
 	}
 }
 
-// retrySentEvent handles retrying an event that was already sent but not yet acknowledged
-func (ew *EventWriter) retrySentEvent(resID string, sentMsg *eventMessage) {
+// retrySentEvent handles retrying an event that was already sent but not yet acknowledged.
+//
+// Lock order invariant: ew.mu must be acquired before sentMsg.mu, never the
+// reverse — UpdateTarget holds ew.mu while ranging over sentEvents and
+// locking each msg.mu. Snapshot (stream, gen) under ew.mu.RLock before
+// touching sentMsg.mu to preserve that order.
+func (ew *EventWriter) retrySentEvent(resID string, sentMsg *eventMessage, lease TargetLease) {
 	ew.mu.RLock()
 	logCtx := ew.log.WithFields(logrus.Fields{
 		"method":      "retrySentEvent",
 		"resource_id": resID,
 	})
-
 	// Re-verify the event is still in sentEvents
 	currentSent, stillExists := ew.sentEvents[resID]
+	stream := ew.target
+	currentGen := ew.targetGen
 	ew.mu.RUnlock()
 
 	// If event was ACK'd between check and use, skip retry
 	if !stillExists || currentSent != sentMsg {
+		return
+	}
+	if currentGen != lease.gen {
 		return
 	}
 
@@ -306,8 +447,8 @@ func (ew *EventWriter) retrySentEvent(resID string, sentMsg *eventMessage) {
 	if sentMsg.retryCount >= maxEventRetries {
 		logCtx.Warnf("Event failed after %d retries, giving up to unblock queue", sentMsg.retryCount)
 		sentMsg.mu.Unlock()
-
-		// Remove from sentEvents to unblock the queue
+		// Remove from sentEvents to unblock the queue. ew.mu is taken
+		// AFTER sentMsg.mu was released, preserving lock order.
 		ew.mu.Lock()
 		delete(ew.sentEvents, resID)
 		ew.mu.Unlock()
@@ -317,24 +458,24 @@ func (ew *EventWriter) retrySentEvent(resID string, sentMsg *eventMessage) {
 	logCtx.Trace("resending an event")
 
 	// Increment retry count and schedule next retry BEFORE attempting send
-	// This ensures proper backoff even when the send fails
+	// This ensures proper backoff even when the send fails.
 	sentMsg.retryCount++
 	retryAfter := time.Now().Add(sentMsg.backoff.Step())
 	sentMsg.retryAfter = &retryAfter
 
 	// Resend the event
 	pev, err := format.ToProto(sentMsg.event)
-	if err != nil {
-		logCtx.Errorf("Could not wire event: %v\n", err)
-		sentMsg.mu.Unlock()
-		return
-	}
-
-	err = ew.target.Send(&eventstreamapi.Event{Event: pev})
 	sentMsg.mu.Unlock()
 
 	if err != nil {
+		logCtx.Errorf("Could not wire event: %v\n", err)
+		return
+	}
+
+	err = stream.Send(&eventstreamapi.Event{Event: pev})
+	if err != nil {
 		logCtx.Errorf("Error while sending: %v\n", err)
+		ew.notifySendError(lease, err)
 		return
 	}
 
@@ -350,12 +491,17 @@ func (ew *EventWriter) scheduleRetry(eventMsg *eventMessage) {
 }
 
 // sendUnsentEvent pops an event from the unsent queue and sends it for the first time
-func (ew *EventWriter) sendUnsentEvent(resID string) {
+func (ew *EventWriter) sendUnsentEvent(resID string, lease TargetLease) {
 	ew.mu.Lock()
 	logCtx := ew.log.WithFields(logrus.Fields{
 		"method":      "sendUnsentEvent",
 		"resource_id": resID,
 	})
+
+	if ew.targetGen != lease.gen {
+		ew.mu.Unlock()
+		return
+	}
 
 	// Pop event from unsent queue and atomically move to sent tracker
 	eq, exists := ew.unsentEvents[resID]
@@ -374,8 +520,8 @@ func (ew *EventWriter) sendUnsentEvent(resID string) {
 		return
 	}
 
-	target := Target(eventMsg.event)
-	isFireAndForget := target == TargetEventAck || target == TargetHeartbeat
+	isFireAndForget := Target(eventMsg.event) == TargetEventAck || Target(eventMsg.event) == TargetHeartbeat
+
 	if !isFireAndForget {
 		// IMPORTANT: Set retryAfter *before* publishing into sentEvents.
 		// We can have concurrent SendWaitingEvents loops (e.g. brief overlap during reconnect),
@@ -389,6 +535,10 @@ func (ew *EventWriter) sendUnsentEvent(resID string) {
 		ew.sentEvents[resID] = eventMsg
 	}
 	ew.mu.Unlock()
+
+	if ew.testHookAfterUnlock != nil {
+		ew.testHookAfterUnlock()
+	}
 
 	// Send the event
 	eventMsg.mu.Lock()
@@ -410,10 +560,29 @@ func (ew *EventWriter) sendUnsentEvent(resID string) {
 		return
 	}
 
-	// A Send() on the stream is actually not blocking.
-	err = ew.target.Send(&eventstreamapi.Event{Event: pev})
+	// A Send() on the stream is actually not blocking. If a successor took
+	// over the stream while we were preparing this event, snapshotTargetForGen
+	// returns false and we re-enqueue fire-and-forget events rather than drop them.
+	stream, ok := ew.snapshotTargetForGen(lease)
+	if !ok {
+		// Gen advanced between pop and here. Non-fire-and-forget events are
+		// safe: they landed in sentEvents above and the new owner retries them.
+		// Fire-and-forget events (ACKs, heartbeats) have no such safety net;
+		// push back to the front of the unsent queue for the new owner.
+		if isFireAndForget {
+			ew.mu.Lock()
+			if ew.unsentEvents[resID] == nil {
+				ew.unsentEvents[resID] = newEventQueue()
+			}
+			ew.unsentEvents[resID].pushFront(eventMsg)
+			ew.mu.Unlock()
+		}
+		return
+	}
+	err = stream.Send(&eventstreamapi.Event{Event: pev})
 	if err != nil {
 		logCtx.Errorf("Error while sending: %v\n", err)
+		ew.notifySendError(lease, err)
 		return
 	}
 
@@ -529,4 +698,12 @@ func (eq *eventQueue) isEmpty() bool {
 	eq.mu.RLock()
 	defer eq.mu.RUnlock()
 	return len(eq.items) == 0
+}
+
+// pushFront prepends an item to the front of the queue without dedup.
+// Used to restore a popped fire-and-forget event when the target gen changed.
+func (eq *eventQueue) pushFront(ev *eventMessage) {
+	eq.mu.Lock()
+	defer eq.mu.Unlock()
+	eq.items = append([]*eventMessage{ev}, eq.items...)
 }

--- a/internal/event/event_writer_test.go
+++ b/internal/event/event_writer_test.go
@@ -26,6 +26,8 @@ import (
 	"github.com/argoproj-labs/argocd-agent/pkg/api/grpc/eventstreamapi"
 	"github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 )
@@ -53,7 +55,8 @@ func TestEventWriter(t *testing.T) {
 
 	t.Run("should add/update/remove events from the queue", func(t *testing.T) {
 		fs := &fakeStream{}
-		evSender := NewEventWriter("test", fs)
+		evSender, gen := NewEventWriter("test", fs)
+		_ = gen
 
 		ev := es.ApplicationEvent(Create, app1)
 		evSender.Add(ev)
@@ -94,7 +97,8 @@ func TestEventWriter(t *testing.T) {
 
 	t.Run("should handle events from multiple resources", func(t *testing.T) {
 		fs := &fakeStream{}
-		evSender := NewEventWriter("test", fs)
+		evSender, gen := NewEventWriter("test", fs)
+		_ = gen
 
 		app1Events := []EventType{Create, SpecUpdate, Delete}
 		app2Events := []EventType{Create, SpecUpdate, SpecUpdate, Delete}
@@ -121,14 +125,15 @@ func TestEventWriter(t *testing.T) {
 
 	t.Run("should send waiting events to the stream", func(t *testing.T) {
 		fs := &fakeStream{}
-		evSender := NewEventWriter("test", fs)
+		evSender, gen := NewEventWriter("test", fs)
+		_ = gen
 
 		ev := es.ApplicationEvent(Create, app1)
 		resID := createResourceID(app1.ObjectMeta)
 		evSender.Add(ev)
 
 		// shouldn't send an event that is not being tracked
-		evSender.sendEvent("random-id")
+		evSender.sendEvent("random-id", gen)
 		require.Len(t, fs.events, 0)
 
 		// shouldn't send an event that isn't past the retryAfter time.
@@ -137,20 +142,21 @@ func TestEventWriter(t *testing.T) {
 		retryAfter := time.Now().Add(1 * time.Hour)
 		latestEvent.retryAfter = &retryAfter
 
-		evSender.retrySentEvent(resID, latestEvent)
+		evSender.retrySentEvent(resID, latestEvent, gen)
 		require.Len(t, fs.events, 0)
 
 		// should send a valid event to the stream
 		retryAfter = time.Now().Add(-10 * time.Second)
 		latestEvent.retryAfter = &retryAfter
-		evSender.sendEvent(resID)
+		evSender.sendEvent(resID, gen)
 		require.Len(t, fs.events, 1)
 		require.Equal(t, []string{createEventID(app1.ObjectMeta)}, fs.events[resID])
 	})
 
 	t.Run("should prioritize DELETE events and clear queue", func(t *testing.T) {
 		fs := &fakeStream{}
-		evSender := NewEventWriter("test", fs)
+		evSender, gen := NewEventWriter("test", fs)
+		_ = gen
 
 		// Add Create and SpecUpdate events
 		ev1 := es.ApplicationEvent(Create, app1)
@@ -181,7 +187,8 @@ func TestEventWriter(t *testing.T) {
 
 	t.Run("should handle concurrent adds and removes", func(t *testing.T) {
 		fs := &fakeStream{}
-		evSender := NewEventWriter("test", fs)
+		evSender, gen := NewEventWriter("test", fs)
+		_ = gen
 
 		var wg sync.WaitGroup
 		numGoroutines := 10
@@ -236,7 +243,8 @@ func TestEventWriter(t *testing.T) {
 
 	t.Run("should move events from unsent to sent on first send", func(t *testing.T) {
 		fs := &fakeStream{}
-		evSender := NewEventWriter("test", fs)
+		evSender, gen := NewEventWriter("test", fs)
+		_ = gen
 
 		ev := es.ApplicationEvent(Create, app1)
 		resID := createResourceID(app1.ObjectMeta)
@@ -247,7 +255,7 @@ func TestEventWriter(t *testing.T) {
 		require.NotContains(t, evSender.sentEvents, resID)
 
 		// Send the event
-		evSender.sendEvent(resID)
+		evSender.sendEvent(resID, gen)
 
 		// Event should now be in sent map and removed from unsent
 		require.NotContains(t, evSender.unsentEvents, resID)
@@ -256,14 +264,15 @@ func TestEventWriter(t *testing.T) {
 
 	t.Run("should retry sent events with exponential backoff", func(t *testing.T) {
 		fs := &fakeStream{}
-		evSender := NewEventWriter("test", fs)
+		evSender, gen := NewEventWriter("test", fs)
+		_ = gen
 
 		ev := es.ApplicationEvent(Create, app1)
 		resID := createResourceID(app1.ObjectMeta)
 		evSender.Add(ev)
 
 		// Send the event once
-		evSender.sendEvent(resID)
+		evSender.sendEvent(resID, gen)
 		require.Len(t, fs.events[resID], 1)
 
 		// Get the sent event
@@ -273,7 +282,7 @@ func TestEventWriter(t *testing.T) {
 		require.Equal(t, 0, sentMsg.retryCount)
 
 		// Try to retry immediately - should not send
-		evSender.retrySentEvent(resID, sentMsg)
+		evSender.retrySentEvent(resID, sentMsg, gen)
 		require.Len(t, fs.events[resID], 1)
 
 		// Set retryAfter to past time
@@ -281,21 +290,22 @@ func TestEventWriter(t *testing.T) {
 		sentMsg.retryAfter = &pastTime
 
 		// Now retry should work
-		evSender.retrySentEvent(resID, sentMsg)
+		evSender.retrySentEvent(resID, sentMsg, gen)
 		require.Len(t, fs.events[resID], 2)
 		require.Equal(t, 1, sentMsg.retryCount)
 	})
 
 	t.Run("should give up after max retries", func(t *testing.T) {
 		fs := &fakeStream{}
-		evSender := NewEventWriter("test", fs)
+		evSender, gen := NewEventWriter("test", fs)
+		_ = gen
 
 		ev := es.ApplicationEvent(Create, app1)
 		resID := createResourceID(app1.ObjectMeta)
 		evSender.Add(ev)
 
 		// Send the event
-		evSender.sendEvent(resID)
+		evSender.sendEvent(resID, gen)
 		sentMsg := evSender.sentEvents[resID]
 		require.NotNil(t, sentMsg)
 
@@ -303,7 +313,7 @@ func TestEventWriter(t *testing.T) {
 		for i := 0; i <= maxEventRetries; i++ {
 			pastTime := time.Now().Add(-1 * time.Second)
 			sentMsg.retryAfter = &pastTime
-			evSender.retrySentEvent(resID, sentMsg)
+			evSender.retrySentEvent(resID, sentMsg, gen)
 		}
 
 		// After max retries, event should be removed from sentEvents
@@ -312,7 +322,8 @@ func TestEventWriter(t *testing.T) {
 
 	t.Run("should not send ACK events to sentEvents", func(t *testing.T) {
 		fs := &fakeStream{}
-		evSender := NewEventWriter("test", fs)
+		evSender, gen := NewEventWriter("test", fs)
+		_ = gen
 
 		// Create an ACK event
 		cev := cloudevents.NewEvent()
@@ -326,7 +337,7 @@ func TestEventWriter(t *testing.T) {
 		resID := "test-resource"
 
 		// Send the ACK event
-		evSender.sendEvent(resID)
+		evSender.sendEvent(resID, gen)
 
 		// ACK should not be in sentEvents (doesn't need ACK confirmation)
 		require.NotContains(t, evSender.sentEvents, resID)
@@ -335,7 +346,8 @@ func TestEventWriter(t *testing.T) {
 
 	t.Run("should not send heartbeat events to sentEvents (fire-and-forget)", func(t *testing.T) {
 		fs := &fakeStream{}
-		evSender := NewEventWriter("test", fs)
+		evSender, gen := NewEventWriter("test", fs)
+		_ = gen
 
 		// Create a heartbeat event using EventSource helper
 		heartbeatEv := es.HeartbeatEvent(Ping)
@@ -344,7 +356,7 @@ func TestEventWriter(t *testing.T) {
 		evSender.Add(heartbeatEv)
 
 		// Send the heartbeat event
-		evSender.sendEvent(resID)
+		evSender.sendEvent(resID, gen)
 
 		// Heartbeat should not be in sentEvents (fire-and-forget, no ACK tracking)
 		require.NotContains(t, evSender.sentEvents, resID)
@@ -354,14 +366,15 @@ func TestEventWriter(t *testing.T) {
 
 	t.Run("heartbeat events should not accumulate in sentEvents over time", func(t *testing.T) {
 		fs := &fakeStream{}
-		evSender := NewEventWriter("test", fs)
+		evSender, gen := NewEventWriter("test", fs)
+		_ = gen
 
 		// Simulate multiple heartbeats being sent (like a real heartbeat interval)
 		for i := 0; i < 10; i++ {
 			heartbeatEv := es.HeartbeatEvent(Ping)
 			resID := ResourceID(heartbeatEv)
 			evSender.Add(heartbeatEv)
-			evSender.sendEvent(resID)
+			evSender.sendEvent(resID, gen)
 		}
 
 		// sentEvents should be empty - no heartbeats should accumulate
@@ -370,7 +383,8 @@ func TestEventWriter(t *testing.T) {
 
 	t.Run("should handle empty resource ID gracefully", func(t *testing.T) {
 		fs := &fakeStream{}
-		evSender := NewEventWriter("test", fs)
+		evSender, gen := NewEventWriter("test", fs)
+		_ = gen
 
 		// Create an event manually with empty resourceID extension
 		cev := cloudevents.NewEvent()
@@ -389,7 +403,8 @@ func TestEventWriter(t *testing.T) {
 
 	t.Run("should handle Get for non-existent resource", func(t *testing.T) {
 		fs := &fakeStream{}
-		evSender := NewEventWriter("test", fs)
+		evSender, gen := NewEventWriter("test", fs)
+		_ = gen
 
 		result := evSender.Get("non-existent-resource-id")
 		require.Nil(t, result)
@@ -397,7 +412,8 @@ func TestEventWriter(t *testing.T) {
 
 	t.Run("should return sent event before checking unsent queue in Get", func(t *testing.T) {
 		fs := &fakeStream{}
-		evSender := NewEventWriter("test", fs)
+		evSender, gen := NewEventWriter("test", fs)
+		_ = gen
 
 		// Reset app1 to version 1
 		app1.ResourceVersion = "1"
@@ -406,7 +422,7 @@ func TestEventWriter(t *testing.T) {
 		evSender.Add(ev)
 
 		// Send the event (moves to sentEvents)
-		evSender.sendEvent(resID)
+		evSender.sendEvent(resID, gen)
 
 		// Verify the sent event has version 1
 		sentEventID := EventID(ev)
@@ -427,7 +443,8 @@ func TestEventWriter(t *testing.T) {
 
 	t.Run("should handle SendWaitingEvents with context cancellation", func(t *testing.T) {
 		fs := &fakeStream{}
-		evSender := NewEventWriter("test", fs)
+		evSender, gen := NewEventWriter("test", fs)
+		_ = gen
 
 		ev := es.ApplicationEvent(Create, app1)
 		evSender.Add(ev)
@@ -437,7 +454,7 @@ func TestEventWriter(t *testing.T) {
 		// Start sending in background
 		done := make(chan bool)
 		go func() {
-			evSender.SendWaitingEvents(ctx)
+			evSender.SendWaitingEvents(ctx, gen)
 			done <- true
 		}()
 
@@ -458,7 +475,8 @@ func TestEventWriter(t *testing.T) {
 
 	t.Run("should coalesce multiple updates for same resource", func(t *testing.T) {
 		fs := &fakeStream{}
-		evSender := NewEventWriter("test", fs)
+		evSender, gen := NewEventWriter("test", fs)
+		_ = gen
 
 		resID := createResourceID(app1.ObjectMeta)
 
@@ -480,11 +498,17 @@ func TestEventWriter(t *testing.T) {
 type fakeStream struct {
 	mu     sync.RWMutex
 	events map[string][]string
+	// sendErr, if set, is returned from every Send() call instead of
+	// recording the event. Useful for simulating a dead transport.
+	sendErr error
 }
 
 func (fs *fakeStream) Send(event *eventstreamapi.Event) error {
 	fs.mu.Lock()
 	defer fs.mu.Unlock()
+	if fs.sendErr != nil {
+		return fs.sendErr
+	}
 	ev, err := FromWire(event.Event)
 	if err != nil {
 		return err
@@ -500,4 +524,280 @@ func (fs *fakeStream) Send(event *eventstreamapi.Event) error {
 
 func (fs *fakeStream) Context() context.Context {
 	return context.Background()
+}
+
+func TestEventWriter_Depth(t *testing.T) {
+	es := NewEventSource("test")
+	app1 := &v1alpha1.Application{
+		ObjectMeta: metav1.ObjectMeta{Name: "app1", Namespace: "test", UID: types.UID("u1")},
+	}
+	app2 := &v1alpha1.Application{
+		ObjectMeta: metav1.ObjectMeta{Name: "app2", Namespace: "test", UID: types.UID("u2")},
+	}
+
+	t.Run("counts unsent + sent events", func(t *testing.T) {
+		fs := &fakeStream{}
+		ew, gen := NewEventWriter("test", fs)
+		_ = gen
+		require.Equal(t, 0, ew.Depth())
+
+		ew.Add(es.ApplicationEvent(Create, app1))
+		ew.Add(es.ApplicationEvent(Create, app2))
+		require.Equal(t, 2, ew.Depth())
+
+		// Send moves one app's event from unsent → sent (still counted).
+		ew.sendEvent(ResourceID(es.ApplicationEvent(Create, app1)), gen)
+		require.Equal(t, 2, ew.Depth())
+	})
+}
+
+func TestEventWriter_SendErrorObserver(t *testing.T) {
+	es := NewEventSource("test")
+	app1 := &v1alpha1.Application{
+		ObjectMeta: metav1.ObjectMeta{Name: "app1", Namespace: "test", UID: types.UID("u1")},
+	}
+
+	t.Run("invokes observer with classified reason on transport-closing", func(t *testing.T) {
+		fs := &fakeStream{
+			sendErr: status.Error(codes.Unavailable, "transport is closing"),
+		}
+		ew, gen := NewEventWriter("test", fs)
+		_ = gen
+
+		var got SendErrorReason
+		var calls int
+		ew.SetSendErrorObserver(func(reason SendErrorReason, err error) {
+			got = reason
+			calls++
+		})
+
+		ev := es.ApplicationEvent(Create, app1)
+		ew.Add(ev)
+		ew.sendEvent(ResourceID(ev), gen)
+
+		require.Equal(t, 1, calls)
+		require.Equal(t, SendErrorTransportClosing, got)
+	})
+
+	t.Run("UpdateTarget clears observer", func(t *testing.T) {
+		fs := &fakeStream{
+			sendErr: status.Error(codes.Unavailable, "transport is closing"),
+		}
+		ew, _ := NewEventWriter("test", fs)
+
+		var calls int
+		ew.SetSendErrorObserver(func(reason SendErrorReason, err error) {
+			calls++
+		})
+
+		// Swap target — observer must be cleared so it doesn't fire for the
+		// new owner's stream. Use the new gen so Send actually executes.
+		newGen := ew.UpdateTarget(&fakeStream{sendErr: status.Error(codes.Unavailable, "transport is closing")})
+
+		ev := es.ApplicationEvent(Create, app1)
+		ew.Add(ev)
+		ew.sendEvent(ResourceID(ev), newGen)
+
+		require.Equal(t, 0, calls)
+	})
+
+	t.Run("classifies context.Canceled separately", func(t *testing.T) {
+		fs := &fakeStream{sendErr: context.Canceled}
+		ew, gen := NewEventWriter("test", fs)
+		_ = gen
+
+		var got SendErrorReason
+		ew.SetSendErrorObserver(func(reason SendErrorReason, _ error) {
+			got = reason
+		})
+
+		ev := es.ApplicationEvent(Create, app1)
+		ew.Add(ev)
+		ew.sendEvent(ResourceID(ev), gen)
+		require.Equal(t, SendErrorContextCanceled, got)
+	})
+
+	t.Run("does not notify observer if target was replaced after Send started", func(t *testing.T) {
+		// Simulate the duplicate-Subscribe race: an old goroutine Sends
+		// against the prior target, then UpdateTarget swaps in a new
+		// stream + observer before the Send error reaches notifySendError.
+		// The new observer must NOT be invoked for the old stream's failure.
+		ew, oldGen := NewEventWriter("test", &fakeStream{})
+
+		// The new owner (after reconnect) installs an observer.
+		newGen := ew.UpdateTarget(&fakeStream{})
+		require.NotEqual(t, oldGen, newGen)
+
+		var calls int
+		ew.SetSendErrorObserver(func(SendErrorReason, error) {
+			calls++
+		})
+
+		// A slow Send goroutine that fired against the prior target tries
+		// to surface its error, but oldGen is no longer current.
+		ew.notifySendError(oldGen, status.Error(codes.Unavailable, "transport is closing"))
+		require.Equal(t, 0, calls,
+			"observer must not fire for a Send that targeted a replaced stream")
+
+		// Sanity: notifySendError with the current gen does fire.
+		ew.notifySendError(newGen, status.Error(codes.Unavailable, "transport is closing"))
+		require.Equal(t, 1, calls)
+	})
+
+	t.Run("retrySentEvent skips retry-state mutation when gen is stale", func(t *testing.T) {
+		// A stale send loop must NOT advance retryCount or push retryAfter
+		// into the future after UpdateTarget moved the gen — that would
+		// undo the immediate-retry timer reset UpdateTarget did for the
+		// new owner.
+		fs := &fakeStream{}
+		ew, oldGen := NewEventWriter("test", fs)
+
+		ev := es.ApplicationEvent(Create, app1)
+		resID := ResourceID(ev)
+		ew.Add(ev)
+		ew.sendEvent(resID, oldGen)
+		require.Contains(t, ew.sentEvents, resID)
+		sentMsg := ew.sentEvents[resID]
+		preCount := sentMsg.retryCount
+
+		// New owner takes over: bumps gen and resets retryAfter to "now"
+		// for immediate resend.
+		_ = ew.UpdateTarget(&fakeStream{})
+		// Make the entry due so a non-stale loop would actually retry.
+		past := time.Now().Add(-time.Second)
+		sentMsg.retryAfter = &past
+
+		// Old loop tries to retry against its (now stale) gen.
+		ew.retrySentEvent(resID, sentMsg, oldGen)
+
+		require.Equal(t, preCount, sentMsg.retryCount,
+			"stale loop must not advance retryCount")
+		// retryAfter should still be the "now" we set above (old loop must
+		// not push it forward).
+		require.Equal(t, past, *sentMsg.retryAfter,
+			"stale loop must not extend retryAfter into backoff")
+	})
+
+	t.Run("SendWaitingEvents stops once a successor takes over", func(t *testing.T) {
+		// An old SendWaitingEvents loop must exit once UpdateTarget moves
+		// the gen — otherwise it would race with the new owner's loop.
+		fs := &fakeStream{}
+		ew, oldGen := NewEventWriter("test", fs)
+
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+
+		done := make(chan struct{})
+		go func() {
+			ew.SendWaitingEvents(ctx, oldGen)
+			close(done)
+		}()
+
+		// Successor swaps in a new stream.
+		_ = ew.UpdateTarget(&fakeStream{})
+
+		select {
+		case <-done:
+		case <-time.After(time.Second):
+			t.Fatal("SendWaitingEvents did not exit after UpdateTarget bumped gen")
+		}
+	})
+
+	t.Run("ACK re-enqueued when gen advances before pop", func(t *testing.T) {
+		// Gen advances before sendUnsentEvent enters: opening gen check fires
+		// and the ACK stays in the unsent queue untouched.
+		ew, oldGen := NewEventWriter("test", &fakeStream{})
+
+		cev := cloudevents.NewEvent()
+		cev.SetSource("test")
+		cev.SetType(EventProcessed.String())
+		cev.SetDataSchema(TargetEventAck.String())
+		cev.SetExtension(eventID, "ack-1")
+		cev.SetExtension(resourceID, "ack-resource")
+		ew.Add(&cev)
+
+		_ = ew.UpdateTarget(&fakeStream{})
+		ew.sendUnsentEvent("ack-resource", oldGen)
+
+		ew.mu.RLock()
+		q, exists := ew.unsentEvents["ack-resource"]
+		ew.mu.RUnlock()
+		require.True(t, exists)
+		require.False(t, q.isEmpty(), "ACK must remain for new owner")
+	})
+
+	t.Run("ACK re-enqueued when gen advances after pop but before Send", func(t *testing.T) {
+		// The dangerous window: gen is current when the ACK is popped, but
+		// UpdateTarget races between ew.mu.Unlock() and snapshotTargetForGen.
+		// snapshotTargetForGen then returns false — the ACK must be re-enqueued
+		// rather than silently dropped.
+		//
+		// testHookAfterUnlock fires after ew.mu is released and before
+		// snapshotTargetForGen, giving us a deterministic synchronization point.
+
+		hookReached := make(chan struct{})
+		genAdvanced := make(chan struct{})
+
+		ew, lease := NewEventWriter("test", &fakeStream{})
+		ew.testHookAfterUnlock = func() {
+			close(hookReached) // signal: pop done, lock released
+			<-genAdvanced      // wait: UpdateTarget has advanced the gen
+		}
+
+		cev := cloudevents.NewEvent()
+		cev.SetSource("test")
+		cev.SetType(EventProcessed.String())
+		cev.SetDataSchema(TargetEventAck.String())
+		cev.SetExtension(eventID, "ack-2")
+		cev.SetExtension(resourceID, "ack-resource2")
+		ew.Add(&cev)
+
+		done := make(chan struct{})
+		go func() {
+			ew.sendUnsentEvent("ack-resource2", lease)
+			close(done)
+		}()
+
+		<-hookReached
+		_ = ew.UpdateTarget(&fakeStream{}) // advances gen; snapshotTargetForGen will return false
+		close(genAdvanced)
+		<-done
+
+		ew.mu.RLock()
+		q, exists := ew.unsentEvents["ack-resource2"]
+		ew.mu.RUnlock()
+		require.True(t, exists, "ACK queue must exist after re-enqueue")
+		require.False(t, q.isEmpty(), "ACK must be re-enqueued after post-pop gen advance")
+	})
+
+	t.Run("retrySentEvent also notifies observer", func(t *testing.T) {
+		// First Send succeeds, then flip to failure to test the retry path.
+		fs := &fakeStream{}
+		ew, gen := NewEventWriter("test", fs)
+		_ = gen
+
+		ev := es.ApplicationEvent(Create, app1)
+		resID := ResourceID(ev)
+		ew.Add(ev)
+		ew.sendEvent(resID, gen)
+		require.Contains(t, ew.sentEvents, resID)
+
+		// Now switch to failure mode and force a retry.
+		fs.mu.Lock()
+		fs.sendErr = status.Error(codes.Unavailable, "transport is closing")
+		fs.mu.Unlock()
+
+		var calls int
+		ew.SetSendErrorObserver(func(reason SendErrorReason, _ error) {
+			require.Equal(t, SendErrorTransportClosing, reason)
+			calls++
+		})
+
+		sentMsg := ew.sentEvents[resID]
+		past := time.Now().Add(-time.Second)
+		sentMsg.retryAfter = &past
+		ew.retrySentEvent(resID, sentMsg, gen)
+
+		require.Equal(t, 1, calls)
+	})
 }

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -66,6 +66,17 @@ type PrincipalMetrics struct {
 	EventProcessingTime *prometheus.HistogramVec
 
 	PrincipalErrors *prometheus.CounterVec
+
+	// EventWriterQueueDepth is the per-agent count of events held in the
+	// EventWriter (sent + unsent). A high or growing value indicates the
+	// agent's send half-stream is broken while the EventWriter still holds
+	// the same target.
+	EventWriterQueueDepth *prometheus.GaugeVec
+
+	// EventWriterSendErrors counts EventWriter Send() failures per agent and
+	// reason ("transport-closing", "context-canceled", "other"). A sustained
+	// rate signals a dead target the Subscribe handler hasn't noticed.
+	EventWriterSendErrors *prometheus.CounterVec
 }
 
 // AgentMetrics holds metrics of agent
@@ -172,6 +183,16 @@ func NewPrincipalMetrics() *PrincipalMetrics {
 			Name: "principal_errors",
 			Help: "The total number of errors occurred in principal",
 		}, []string{"resource_type"}),
+
+		EventWriterQueueDepth: promauto.NewGaugeVec(prometheus.GaugeOpts{
+			Name: "principal_event_writer_queue_depth",
+			Help: "Number of events held in the per-agent EventWriter (sent + unsent). Persistently >0 indicates a broken send half-stream.",
+		}, []string{"agent_name"}),
+
+		EventWriterSendErrors: promauto.NewCounterVec(prometheus.CounterOpts{
+			Name: "principal_event_writer_send_errors_total",
+			Help: "EventWriter Send() failures per agent. Reason is one of: transport-closing, context-canceled, other.",
+		}, []string{"agent_name", "reason"}),
 	}
 }
 

--- a/principal/apis/eventstream/eventstream.go
+++ b/principal/apis/eventstream/eventstream.go
@@ -349,6 +349,40 @@ func (s *Server) sendFunc(c *client, subs eventstreamapi.EventStream_SubscribeSe
 	return nil
 }
 
+// swapActiveClient atomically registers c as the active client for its agent,
+// cancels any prior client, updates (or creates) the agent's EventWriter to
+// target the new stream, and installs observer as the send-error callback.
+//
+// Lock order: activeClientsMu is held for the entire swap so that
+// (activeClients entry, EventWriter target, send-error observer) change as a
+// unit. eventWriters.Get/Add and ew.mu do not acquire activeClientsMu, so
+// there is no lock inversion.
+//
+// Returns the EventWriter, the TargetLease for the new stream, and whether a
+// prior client existed (used to decide whether to increment AgentConnected).
+func (s *Server) swapActiveClient(c *client, subs eventstreamapi.EventStream_SubscribeServer, observer event.SendErrorObserver) (*event.EventWriter, event.TargetLease, bool) {
+	s.activeClientsMu.Lock()
+	defer s.activeClientsMu.Unlock()
+
+	prior, hadPrior := s.activeClients[c.agentName]
+	if hadPrior && prior != c {
+		c.logCtx.Info("Preempting existing Subscribe for this agent")
+		prior.cancelFn()
+	}
+	s.activeClients[c.agentName] = c
+
+	ew := s.eventWriters.Get(c.agentName)
+	var lease event.TargetLease
+	if ew != nil {
+		lease = ew.UpdateTarget(subs)
+	} else {
+		ew, lease = event.NewEventWriter(c.agentName, subs)
+		s.eventWriters.Add(c.agentName, ew)
+	}
+	ew.SetSendErrorObserver(observer)
+	return ew, lease, hadPrior
+}
+
 // Subscribe implements a bi-directional stream to exchange application updates
 // between the agent and the server.
 //
@@ -369,29 +403,32 @@ func (s *Server) Subscribe(subs eventstreamapi.EventStream_SubscribeServer) erro
 		}
 	}
 
-	s.activeClientsMu.Lock()
-	s.activeClients[c.agentName] = c
-	s.activeClientsMu.Unlock()
+	eventWriter, lease, hadPrior := s.swapActiveClient(c, subs, func(reason event.SendErrorReason, sendErr error) {
+		if s.metrics != nil && s.metrics.EventWriterSendErrors != nil {
+			s.metrics.EventWriterSendErrors.WithLabelValues(c.agentName, string(reason)).Inc()
+		}
+		switch reason {
+		case event.SendErrorTransportClosing, event.SendErrorContextCanceled:
+			c.logCtx.WithError(sendErr).Warnf("EventWriter Send failed (%s); cancelling Subscribe", reason)
+			c.cancelFn()
+		}
+	})
 
 	s.clusterMgr.SetAgentConnectionStatus(c.agentName, v1alpha1.ConnectionStatusSuccessful, c.start)
 
 	if s.metrics != nil {
-		// increase counter when an agent is connected with principal
-		s.metrics.AgentConnected.Inc()
-
-		// store connection time to find average connection time of all agents
+		if !hadPrior {
+			s.metrics.AgentConnected.Inc()
+		}
 		metrics.SetAgentConnectionTime(c.agentName, c.start)
 	}
 
-	eventWriter := s.eventWriters.Get(c.agentName)
-	if eventWriter != nil {
-		eventWriter.UpdateTarget(subs)
-	} else {
-		eventWriter = event.NewEventWriter(c.agentName, subs)
-		s.eventWriters.Add(c.agentName, eventWriter)
-	}
+	go eventWriter.SendWaitingEvents(c.ctx, lease)
 
-	go eventWriter.SendWaitingEvents(c.ctx)
+	// Queue-depth publisher exits when the Subscribe context is cancelled.
+	if s.metrics != nil && s.metrics.EventWriterQueueDepth != nil {
+		go s.publishQueueDepth(c, eventWriter)
+	}
 
 	// Notify to run handlers for the newly connected agent
 	if s.options.notifyOnConnect != nil {
@@ -455,21 +492,56 @@ func (s *Server) Subscribe(subs eventstreamapi.EventStream_SubscribeServer) erro
 	c.wg.Wait()
 	c.logCtx.Info("Closing EventStream")
 
+	// Only the *current* active client should perform global cleanup — a
+	// preempted prior Subscribe whose goroutines just unwound must NOT
+	// decrement metrics or delete state for the live successor.
 	s.activeClientsMu.Lock()
-	if s.activeClients[c.agentName] == c {
+	wasActive := s.activeClients[c.agentName] == c
+	if wasActive {
 		delete(s.activeClients, c.agentName)
 	}
 	s.activeClientsMu.Unlock()
 
-	if s.metrics != nil {
+	if wasActive && s.metrics != nil {
 		// decrease counter when an agent is disconnected with principal
 		s.metrics.AgentConnected.Dec()
 
 		// remove connection time of agent
 		metrics.DeleteAgentConnectionTime(c.agentName)
+
+		// Drop this agent's queue-depth gauge series so a permanently
+		// disconnected agent doesn't leave a stale value behind.
+		if s.metrics.EventWriterQueueDepth != nil {
+			s.metrics.EventWriterQueueDepth.DeleteLabelValues(c.agentName)
+		}
 	}
 
 	return nil
+}
+
+// publishQueueDepth periodically samples the EventWriter and publishes the
+// per-agent queue depth as a gauge. Returns when c.ctx is canceled.
+//
+// Note: the EventWriter outlives any single Subscribe (it's keyed by agent
+// in eventWriters), so on reconnect the new Subscribe takes over publishing.
+func (s *Server) publishQueueDepth(c *client, ew *event.EventWriter) {
+	const interval = 10 * time.Second
+	gauge := s.metrics.EventWriterQueueDepth.WithLabelValues(c.agentName)
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-c.ctx.Done():
+			return
+		case <-ticker.C:
+		}
+		// Re-check: if both Done and ticker fired simultaneously Go may have
+		// chosen ticker, and gauge.Set would recreate the deleted label series.
+		if c.ctx.Err() != nil {
+			return
+		}
+		gauge.Set(float64(ew.Depth()))
+	}
 }
 
 // ConnectedAgentCount returns the number of currently connected agents.

--- a/principal/apis/eventstream/eventstream_test.go
+++ b/principal/apis/eventstream/eventstream_test.go
@@ -285,17 +285,14 @@ func TestSubscribe_SendErrorCancelsSubscribeCtx(t *testing.T) {
 		<-recvGate
 		return io.EOF
 	})
-	// Every Send returns Unavailable — simulates a dead send half-stream.
+	// sendGate holds off the first Send until the test has captured the client.
+	// Without it the observer can cancel c.ctx before the test polls activeClients,
+	// causing recv to exit via ctx.Done() and cleanup to remove the entry.
+	sendGate := make(chan struct{})
 	st.AddSendHook(func(_ *mock.MockEventServer, _ *eventstreamapi.Event) error {
+		<-sendGate
 		return status.Error(codes.Unavailable, "transport is closing")
 	})
-
-	// Queue an event so SendWaitingEvents will attempt a Send.
-	emitter := event.NewEventSource("test")
-	qs.SendQ("agent-y").Add(emitter.ApplicationEvent(
-		event.Create,
-		&v1alpha1.Application{ObjectMeta: v1.ObjectMeta{Name: "app", Namespace: "ns"}},
-	))
 
 	subscribeReturned := make(chan struct{})
 	go func() {
@@ -303,7 +300,8 @@ func TestSubscribe_SendErrorCancelsSubscribeCtx(t *testing.T) {
 		close(subscribeReturned)
 	}()
 
-	// Capture the client once Subscribe registers it.
+	// Capture the client once Subscribe registers it, then queue the event and
+	// release sendGate so the Send-error path can proceed.
 	var captured *client
 	require.Eventually(t, func() bool {
 		s.activeClientsMu.Lock()
@@ -311,6 +309,13 @@ func TestSubscribe_SendErrorCancelsSubscribeCtx(t *testing.T) {
 		s.activeClientsMu.Unlock()
 		return captured != nil
 	}, time.Second, 10*time.Millisecond, "Subscribe didn't register active client")
+
+	emitter := event.NewEventSource("test")
+	qs.SendQ("agent-y").Add(emitter.ApplicationEvent(
+		event.Create,
+		&v1alpha1.Application{ObjectMeta: v1.ObjectMeta{Name: "app", Namespace: "ns"}},
+	))
+	close(sendGate)
 
 	// The Send-error observer must cancel c.ctx. recv is parked, so
 	// Subscribe is still running and activeClients still holds c — no

--- a/principal/apis/eventstream/eventstream_test.go
+++ b/principal/apis/eventstream/eventstream_test.go
@@ -25,10 +25,13 @@ import (
 	"github.com/argoproj-labs/argocd-agent/internal/event"
 	"github.com/argoproj-labs/argocd-agent/internal/metrics"
 	"github.com/argoproj-labs/argocd-agent/internal/queue"
+	"github.com/argoproj-labs/argocd-agent/pkg/api/grpc/eventstreamapi"
 	"github.com/argoproj-labs/argocd-agent/pkg/types"
 	"github.com/argoproj-labs/argocd-agent/principal/apis/eventstream/mock"
 	"github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
 	"github.com/sirupsen/logrus"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/stretchr/testify/assert"
@@ -63,8 +66,13 @@ func (f *fakeStatusUpdater) statusesFor(name string) []v1alpha1.ConnectionStatus
 	return out
 }
 
+// sharedMetrics is process-wide because metrics.NewPrincipalMetrics uses
+// promauto's default registry — calling it a second time panics on
+// duplicate registration.
+var sharedMetrics = metrics.NewPrincipalMetrics()
+
 func Test_Subscribe(t *testing.T) {
-	metric := metrics.NewPrincipalMetrics()
+	metric := sharedMetrics
 	cluster := &cluster.Manager{}
 
 	t.Run("Test send to subcription stream", func(t *testing.T) {
@@ -186,6 +194,136 @@ func Test_Subscribe(t *testing.T) {
 		assert.Equal(t, 0, int(st.NumRecv.Load()))
 		assert.Equal(t, 1, int(st.NumSent.Load()))
 	})
+}
+
+// Two near-simultaneous Subscribes for the same agent must not leave the
+// EventWriter pointing at a dead stream. The newer call must cancel the
+// older one's context (which the recv goroutine observes once the recv
+// hook unblocks) and own the EventWriter target afterwards.
+func TestSubscribe_PreemptsDuplicateForSameAgent(t *testing.T) {
+	clusterMgr := &cluster.Manager{}
+	qs := queue.NewSendRecvQueues()
+	qs.Create("agent-x")
+	ewm := event.NewEventWritersMap()
+	s := NewServer(qs, ewm, nil, clusterMgr)
+
+	// Older Subscribe — recv blocks until released so the stream stays alive.
+	olderGate := make(chan struct{})
+	older := &mock.MockEventServer{AgentName: "agent-x"}
+	older.AddRecvHook(func(_ *mock.MockEventServer) error {
+		<-olderGate
+		return io.EOF
+	})
+	olderDone := make(chan struct{})
+	go func() {
+		_ = s.Subscribe(older)
+		close(olderDone)
+	}()
+	require.Eventually(t, func() bool { return s.IsAgentConnected("agent-x") },
+		time.Second, 10*time.Millisecond)
+
+	// Capture the older client so we can verify it was preempted by checking
+	// its context was canceled.
+	s.activeClientsMu.Lock()
+	olderClient := s.activeClients["agent-x"]
+	s.activeClientsMu.Unlock()
+	require.NotNil(t, olderClient)
+
+	// Newer Subscribe — should preempt by cancelling the older client's ctx.
+	newerGate := make(chan struct{})
+	newer := &mock.MockEventServer{AgentName: "agent-x"}
+	newer.AddRecvHook(func(_ *mock.MockEventServer) error {
+		<-newerGate
+		return io.EOF
+	})
+	newerDone := make(chan struct{})
+	go func() {
+		_ = s.Subscribe(newer)
+		close(newerDone)
+	}()
+
+	// Verify the older client's context got canceled by the preemption.
+	require.Eventually(t, func() bool {
+		return olderClient.ctx.Err() != nil
+	}, time.Second, 10*time.Millisecond, "older client's ctx should be canceled by preemption")
+
+	// Release both gates so recv hooks return EOF and the goroutines unwind.
+	close(olderGate)
+	close(newerGate)
+	<-olderDone
+	<-newerDone
+	require.False(t, s.IsAgentConnected("agent-x"))
+}
+
+// A Send() error reporting a dead transport must cancel the Subscribe so
+// the agent reconnects, instead of EventWriter retrying forever against a
+// broken target.
+//
+// Witness: the Subscribe handler's per-client context. We capture it via
+// the activeClients map while the recv hook is parked (which keeps
+// c.wg.Wait blocked, which keeps Subscribe's cleanup from running). We
+// then poll until the ctx is Done, which only happens if the Send-error
+// observer called c.cancelFn(). If a regression removes that call, the
+// ctx never cancels and the test times out — the metric counter alone
+// would still increment, so we assert on the cancel directly.
+func TestSubscribe_SendErrorCancelsSubscribeCtx(t *testing.T) {
+	clusterMgr := &cluster.Manager{}
+	qs := queue.NewSendRecvQueues()
+	qs.Create("agent-y")
+	ewm := event.NewEventWritersMap()
+	s := NewServer(qs, ewm, sharedMetrics, clusterMgr)
+
+	st := &mock.MockEventServer{
+		AgentName: "agent-y",
+		AgentMode: string(types.AgentModeManaged),
+	}
+	// recv parks; while parked, c.wg.Wait blocks, which means Subscribe's
+	// cleanup of activeClients[name] cannot run, so c is stable for us
+	// to read until the test releases recvGate.
+	recvGate := make(chan struct{})
+	st.AddRecvHook(func(_ *mock.MockEventServer) error {
+		<-recvGate
+		return io.EOF
+	})
+	// Every Send returns Unavailable — simulates a dead send half-stream.
+	st.AddSendHook(func(_ *mock.MockEventServer, _ *eventstreamapi.Event) error {
+		return status.Error(codes.Unavailable, "transport is closing")
+	})
+
+	// Queue an event so SendWaitingEvents will attempt a Send.
+	emitter := event.NewEventSource("test")
+	qs.SendQ("agent-y").Add(emitter.ApplicationEvent(
+		event.Create,
+		&v1alpha1.Application{ObjectMeta: v1.ObjectMeta{Name: "app", Namespace: "ns"}},
+	))
+
+	subscribeReturned := make(chan struct{})
+	go func() {
+		_ = s.Subscribe(st)
+		close(subscribeReturned)
+	}()
+
+	// Capture the client once Subscribe registers it.
+	var captured *client
+	require.Eventually(t, func() bool {
+		s.activeClientsMu.Lock()
+		captured = s.activeClients["agent-y"]
+		s.activeClientsMu.Unlock()
+		return captured != nil
+	}, time.Second, 10*time.Millisecond, "Subscribe didn't register active client")
+
+	// The Send-error observer must cancel c.ctx. recv is parked, so
+	// Subscribe is still running and activeClients still holds c — no
+	// race with cleanup.
+	select {
+	case <-captured.ctx.Done():
+	case <-time.After(3 * time.Second):
+		close(recvGate)
+		t.Fatal("Send error did not cancel Subscribe ctx within 3s")
+	}
+
+	close(recvGate)
+	<-subscribeReturned
 }
 
 func TestDisconnectAll(t *testing.T) {


### PR DESCRIPTION
**What does this PR do / why we need it**:

We observed argocd-agent principal with repeated error logs with "transport is closing" Send errors against a single agent. 

```
time="2026-05-05T20:49:32Z" level=error msg="Error while sending: rpc error: code = Unavailable desc = transport is 
closing\n" clientAddr="100.101.10.228:52936" event_id=m-p-yun-headlamp-production_ad4d09d4-146b-4b38-8b72-00c3ba5c0d1b_93364803 event_target=application event_type=io.argoproj.argocd-agent.event.spec-update
method=retrySentEvent module=EventWriter resource_id=m-p-yun-headlamp-production_ad4d09d4-146b-4b38-8b72-00c3ba5c0d1b retry_count=5
```

Root cause: when an agent reconnected before the old TCP connection fully closed, two concurrent Subscribe calls raced on activeClients and EventWriter.UpdateTarget. The loser left EventWriter pointed at the dead send half-stream while the winner held the live recv — so every retry hit the broken transport with no path to recovery.

Commit 1: Subscribe preemption + Send-error teardown
- Hold activeClientsMu across UpdateTarget so (activeClient, target, observer) swap atomically; cancel the prior client's context first.
- Install a SendErrorObserver that calls cancelFn on fatal errors (transport-closing, context-canceled) so the Subscribe goroutines exit and force a clean reconnect.
- Add EventWriterSendErrors counter (by agent + reason) and EventWriterQueueDepth gauge; guard all disconnect cleanup on activeClients[name] == c so a preempted connection's late close can't corrupt metrics for its live successor.

Commit 2: Bind SendWaitingEvents to its target generation
- NewEventWriter and UpdateTarget return a targetGen. SendWaitingEvents carries that gen through every Send; snapshotTargetForGen returns ok=false once the gen moves, preventing two loops from writing to the same gRPC stream concurrently.
- notifySendError drops notifications when targetGen has advanced, so a stale loop's Send error can't cancel a healthy new Subscribe.
- sendUnsentEvent skips the queue pop on gen mismatch so events aren't consumed from a stream that won't deliver them.

Commit 3: Fix lock-order inversion in retrySentEvent
- The prior shape acquired sentMsg.mu while holding ew.mu.RLock, while a concurrent path acquired them in the opposite order via notifySendError → ew.mu.RLock. Restructured to snapshot (stream, targetGen) under ew.mu.RLock, release it, check gen before touching retry state, release sentMsg.mu before Send(), and call notifySendError only after all locks are dropped.

**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:


**Checklist**

* [ ] Documentation update is required by this PR (and has been updated) OR no documentation update is required.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes & Improvements**
  * Lease-aware event writing, improved concurrent subscription preemption, guarded cleanup to avoid races, and send-error handling that cancels faulty subscribers.

* **Monitoring & Observability**
  * Added per-agent queue-depth gauge and send-error counters; periodic publishing of queue depth.

* **Tests**
  * Expanded coverage for preemption, send-error cancellation, depth tracking, transport-error simulation, and concurrent scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->