### PR TITLE
fix(principal): reconnect Subscribe on EventWriter send failures

### DIFF
--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -63,7 +63,8 @@ type PrincipalMetrics struct {
 	EventReceived prometheus.Counter
 	EventSent     prometheus.Counter
 
-	EventProcessingTime *prometheus.HistogramVec
+	EventProcessingTime   *prometheus.HistogramVec
+	EventWriterSendErrors *prometheus.CounterVec
 
 	PrincipalErrors *prometheus.CounterVec
 }
@@ -167,6 +168,11 @@ func NewPrincipalMetrics() *PrincipalMetrics {
 			Name: "principal_event_processing_time",
 			Help: "Histogram of time taken to process events (in seconds)",
 		}, []string{"status", "agent_name", "resource_type"}),
+
+		EventWriterSendErrors: promauto.NewCounterVec(prometheus.CounterOpts{
+			Name: "principal_event_writer_send_errors_total",
+			Help: "The total number of EventWriter send errors observed by principal",
+		}, []string{"agent_name", "reason"}),
 
 		PrincipalErrors: promauto.NewCounterVec(prometheus.CounterOpts{
 			Name: "principal_errors",

--- a/principal/apis/eventstream/eventstream.go
+++ b/principal/apis/eventstream/eventstream.go
@@ -16,12 +16,14 @@ package eventstream
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"sync"
 	"time"
 
 	"github.com/argoproj-labs/argocd-agent/internal/event"
+	"github.com/argoproj-labs/argocd-agent/internal/grpcutil"
 	"github.com/argoproj-labs/argocd-agent/internal/logging"
 	"github.com/argoproj-labs/argocd-agent/internal/logging/logfields"
 	"github.com/argoproj-labs/argocd-agent/internal/metrics"
@@ -71,6 +73,25 @@ type Server struct {
 // AcceptCheck is called at the start of Subscribe to decide whether to accept
 // the agent connection. Return a non-nil error to reject with that status.
 type AcceptCheck func(agentName string) error
+
+const (
+	eventWriterSendErrorReasonContextCanceled  = "context-canceled"
+	eventWriterSendErrorReasonTransportClosing = "transport-closing"
+	eventWriterSendErrorReasonOther            = "other"
+)
+
+type sendErrorObservingSubscribeServer struct {
+	eventstreamapi.EventStream_SubscribeServer
+	onSendError func(error)
+}
+
+func (s *sendErrorObservingSubscribeServer) Send(ev *eventstreamapi.Event) error {
+	err := s.EventStream_SubscribeServer.Send(ev)
+	if err != nil && s.onSendError != nil {
+		s.onSendError(err)
+	}
+	return err
+}
 
 type ServerOptions struct {
 	MaxStreamDuration time.Duration
@@ -169,6 +190,32 @@ func (s *Server) newClientConnection(ctx context.Context, timeout time.Duration)
 
 	c.logCtx.Info("An agent connected to the subscription stream")
 	return c, nil
+}
+
+func classifyEventWriterSendError(err error) string {
+	if errors.Is(err, context.Canceled) || status.Code(err) == codes.Canceled {
+		return eventWriterSendErrorReasonContextCanceled
+	}
+	if grpcutil.NeedReconnectOnError(err) {
+		return eventWriterSendErrorReasonTransportClosing
+	}
+	return eventWriterSendErrorReasonOther
+}
+
+func (s *Server) observeSubscribeSendErrors(c *client, subs eventstreamapi.EventStream_SubscribeServer) eventstreamapi.EventStream_SubscribeServer {
+	return &sendErrorObservingSubscribeServer{
+		EventStream_SubscribeServer: subs,
+		onSendError: func(err error) {
+			reason := classifyEventWriterSendError(err)
+			if s.metrics != nil {
+				s.metrics.EventWriterSendErrors.WithLabelValues(c.agentName, reason).Inc()
+			}
+			if reason == eventWriterSendErrorReasonContextCanceled || reason == eventWriterSendErrorReasonTransportClosing {
+				c.logCtx.WithError(err).WithField("reason", reason).Info("Event writer send error requires reconnect")
+				c.cancelFn()
+			}
+		},
+	}
 }
 
 // onDisconnect must be called whenever client c disconnects from the stream
@@ -383,11 +430,12 @@ func (s *Server) Subscribe(subs eventstreamapi.EventStream_SubscribeServer) erro
 		metrics.SetAgentConnectionTime(c.agentName, c.start)
 	}
 
+	target := s.observeSubscribeSendErrors(c, subs)
 	eventWriter := s.eventWriters.Get(c.agentName)
 	if eventWriter != nil {
-		eventWriter.UpdateTarget(subs)
+		eventWriter.UpdateTarget(target)
 	} else {
-		eventWriter = event.NewEventWriter(c.agentName, subs)
+		eventWriter = event.NewEventWriter(c.agentName, target)
 		s.eventWriters.Add(c.agentName, eventWriter)
 	}
 

--- a/principal/apis/eventstream/eventstream_test.go
+++ b/principal/apis/eventstream/eventstream_test.go
@@ -25,10 +25,13 @@ import (
 	"github.com/argoproj-labs/argocd-agent/internal/event"
 	"github.com/argoproj-labs/argocd-agent/internal/metrics"
 	"github.com/argoproj-labs/argocd-agent/internal/queue"
+	"github.com/argoproj-labs/argocd-agent/pkg/api/grpc/eventstreamapi"
 	"github.com/argoproj-labs/argocd-agent/pkg/types"
 	"github.com/argoproj-labs/argocd-agent/principal/apis/eventstream/mock"
 	"github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
 	"github.com/sirupsen/logrus"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/stretchr/testify/assert"
@@ -186,6 +189,61 @@ func Test_Subscribe(t *testing.T) {
 		assert.Equal(t, 0, int(st.NumRecv.Load()))
 		assert.Equal(t, 1, int(st.NumSent.Load()))
 	})
+}
+
+func TestSubscribe_SendErrorCancelsSubscribeCtx(t *testing.T) {
+	clusterMgr := &cluster.Manager{}
+	qs := queue.NewSendRecvQueues()
+	qs.Create("agent-y")
+	s := NewServer(qs, event.NewEventWritersMap(), nil, clusterMgr)
+
+	st := &mock.MockEventServer{
+		AgentName: "agent-y",
+		AgentMode: string(types.AgentModeManaged),
+	}
+
+	recvGate := make(chan struct{})
+	st.AddRecvHook(func(_ *mock.MockEventServer) error {
+		<-recvGate
+		return io.EOF
+	})
+
+	sendGate := make(chan struct{})
+	st.AddSendHook(func(_ *mock.MockEventServer, _ *eventstreamapi.Event) error {
+		<-sendGate
+		return status.Error(codes.Unavailable, "transport is closing")
+	})
+
+	subscribeReturned := make(chan struct{})
+	go func() {
+		_ = s.Subscribe(st)
+		close(subscribeReturned)
+	}()
+
+	var captured *client
+	require.Eventually(t, func() bool {
+		s.activeClientsMu.Lock()
+		defer s.activeClientsMu.Unlock()
+		captured = s.activeClients["agent-y"]
+		return captured != nil
+	}, time.Second, 10*time.Millisecond)
+
+	emitter := event.NewEventSource("test")
+	qs.SendQ("agent-y").Add(emitter.ApplicationEvent(
+		event.Create,
+		&v1alpha1.Application{ObjectMeta: v1.ObjectMeta{Name: "app", Namespace: "ns"}},
+	))
+	close(sendGate)
+
+	select {
+	case <-captured.ctx.Done():
+	case <-time.After(3 * time.Second):
+		close(recvGate)
+		t.Fatal("Send error did not cancel Subscribe ctx within 3s")
+	}
+
+	close(recvGate)
+	<-subscribeReturned
 }
 
 func TestDisconnectAll(t *testing.T) {


### PR DESCRIPTION
Supersedes #941 

Add principal-side detection for EventWriter stream Send failures by wrapping the Subscribe stream before passing it to EventWriter. When Send returns a reconnectable transport error, cancel the owning Subscribe context so the connection tears down and the agent can reconnect cleanly.

This keeps EventWriter itself unchanged and avoids adding ownership tracking, stream leases, target generations, queue-depth metrics, or retry semantic changes. EventWriter continues to manage retry state as before; the principal only observes send failures at the stream boundary where they occur.

Add a new principal metric:

  principal_event_writer_send_errors_total{agent_name,reason}

The reason label classifies failures as:

  - context-canceled
  - transport-closing
  - other

Only context-canceled and reconnectable transport-closing errors cancel the Subscribe context. Other send errors are counted for observability but do not force reconnect behavior.

Add a focused Subscribe test that forces the mocked stream Send method to return codes.Unavailable and verifies the active Subscribe context is canceled.

**What does this PR do / why we need it**:

**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:


**Checklist**

* [ ] Documentation update is required by this PR (and has been updated) OR no documentation update is required.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced monitoring and observability for event streaming operations with new error-tracking metrics for writer send failures.
  * Improved error classification and handling for event stream transport issues, with better categorization of error types.
  * Added error observability layer to track and respond to send failures on the event streaming path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->