### PR TITLE
fix: Prevent lingering connections on connect failures

### DIFF
--- a/pkg/client/remote.go
+++ b/pkg/client/remote.go
@@ -586,13 +586,7 @@ func (r *Remote) Connect(ctx context.Context, forceReauth bool) error {
 			opts = append(opts, grpc.WithKeepaliveParams(keepalive.ClientParameters{Time: r.keepAlivePingInterval}))
 		}
 
-		conn, err = grpc.NewClient(r.Addr(), opts...)
-		if err != nil {
-			return err
-		}
 	}
-
-	authC := authapi.NewAuthenticationClient(conn)
 
 	authenticated := false
 	cBackoff := connectBackoff()
@@ -607,6 +601,12 @@ func (r *Remote) Connect(ctx context.Context, forceReauth bool) error {
 		case <-ctx.Done():
 			return status.Error(codes.Canceled, "context canceled")
 		default:
+			conn, err = grpc.NewClient(r.Addr(), opts...)
+			if err != nil {
+				return err
+			}
+			authC := authapi.NewAuthenticationClient(conn)
+
 			resp, ierr := authC.Authenticate(ctx, &authapi.AuthRequest{Method: r.authMethod, Credentials: r.creds, Mode: r.clientMode.String(), Version: r.agentVersion})
 			if ierr != nil {
 				st, ok := status.FromError(ierr)

--- a/pkg/client/remote.go
+++ b/pkg/client/remote.go
@@ -513,6 +513,38 @@ func (r *Remote) Disconnect() {
 	}
 }
 
+func (r *Remote) newClientConn(ctx context.Context, opts ...grpc.DialOption) (*grpc.ClientConn, error) {
+	var conn *grpc.ClientConn
+	var err error
+	if r.enableWebSocket {
+		grpcHTTP1Opts := []grpchttp1client.ConnectOption{
+			grpchttp1client.UseWebSocket(true),
+			grpchttp1client.DialOpts(opts...),
+		}
+
+		// Use nil TLS config for plaintext mode (WebSocket over HTTP)
+		var tlsCfg *tls.Config
+		if !r.insecurePlaintext {
+			tlsCfg = r.tlsConfig
+		}
+		conn, err = grpchttp1client.ConnectViaProxy(ctx, r.Addr(), tlsCfg, grpcHTTP1Opts...)
+	} else {
+		// Use insecure credentials for plaintext mode (e.g., behind Istio)
+		if r.insecurePlaintext {
+			opts = append(opts, grpc.WithTransportCredentials(insecure.NewCredentials()))
+		} else {
+			opts = append(opts, grpc.WithTransportCredentials(credentials.NewTLS(r.tlsConfig)))
+		}
+
+		if r.keepAlivePingInterval != 0 {
+			log().Debugf("Agent ping to principal is enabled, agent will send a ping event after every %s.", r.keepAlivePingInterval)
+			opts = append(opts, grpc.WithKeepaliveParams(keepalive.ClientParameters{Time: r.keepAlivePingInterval}))
+		}
+		conn, err = grpc.NewClient(r.Addr(), opts...)
+	}
+	return conn, err
+}
+
 // Connect connects this Remote to the remote host and performs authentication.
 // If the remote is configured with a retry, Connect will keep trying to
 // establish a connection to the remote host until either the number of maximum
@@ -558,36 +590,6 @@ func (r *Remote) Connect(ctx context.Context, forceReauth bool) error {
 		conn *grpc.ClientConn
 		err  error
 	)
-	if r.enableWebSocket {
-		grpcHTTP1Opts := []grpchttp1client.ConnectOption{
-			grpchttp1client.UseWebSocket(true),
-			grpchttp1client.DialOpts(opts...),
-		}
-
-		// Use nil TLS config for plaintext mode (WebSocket over HTTP)
-		var tlsCfg *tls.Config
-		if !r.insecurePlaintext {
-			tlsCfg = r.tlsConfig
-		}
-		conn, err = grpchttp1client.ConnectViaProxy(ctx, r.Addr(), tlsCfg, grpcHTTP1Opts...)
-		if err != nil {
-			return err
-		}
-	} else {
-		// Use insecure credentials for plaintext mode (e.g., behind Istio)
-		if r.insecurePlaintext {
-			opts = append(opts, grpc.WithTransportCredentials(insecure.NewCredentials()))
-		} else {
-			opts = append(opts, grpc.WithTransportCredentials(credentials.NewTLS(r.tlsConfig)))
-		}
-
-		if r.keepAlivePingInterval != 0 {
-			log().Debugf("Agent ping to principal is enabled, agent will send a ping event after every %s.", r.keepAlivePingInterval)
-			opts = append(opts, grpc.WithKeepaliveParams(keepalive.ClientParameters{Time: r.keepAlivePingInterval}))
-		}
-
-	}
-
 	authenticated := false
 	cBackoff := connectBackoff()
 
@@ -601,13 +603,18 @@ func (r *Remote) Connect(ctx context.Context, forceReauth bool) error {
 		case <-ctx.Done():
 			return status.Error(codes.Canceled, "context canceled")
 		default:
-			conn, err = grpc.NewClient(r.Addr(), opts...)
+			conn, err = r.newClientConn(ctx, opts...)
 			if err != nil {
 				return err
 			}
 			authC := authapi.NewAuthenticationClient(conn)
 
 			resp, ierr := authC.Authenticate(ctx, &authapi.AuthRequest{Method: r.authMethod, Credentials: r.creds, Mode: r.clientMode.String(), Version: r.agentVersion})
+			defer func() {
+				if ierr != nil {
+					conn.Close()
+				}
+			}()
 			if ierr != nil {
 				st, ok := status.FromError(ierr)
 				if ok {
@@ -621,7 +628,6 @@ func (r *Remote) Connect(ctx context.Context, forceReauth bool) error {
 					}
 				}
 				logrus.Warnf("Auth failure: %v (retrying in %v)", ierr, cBackoff.Step())
-				conn.Close()
 				return ierr
 			}
 
@@ -646,7 +652,8 @@ func (r *Remote) Connect(ctx context.Context, forceReauth bool) error {
 		}
 	})
 	if err != nil {
-		conn.Close()
+		// Connection is already closed by the defer func in the retry loop
+		// if the loop exits with an error
 		return err
 	}
 

--- a/pkg/client/remote.go
+++ b/pkg/client/remote.go
@@ -536,10 +536,6 @@ func (r *Remote) newClientConn(ctx context.Context, opts ...grpc.DialOption) (*g
 			opts = append(opts, grpc.WithTransportCredentials(credentials.NewTLS(r.tlsConfig)))
 		}
 
-		if r.keepAlivePingInterval != 0 {
-			log().Debugf("Agent ping to principal is enabled, agent will send a ping event after every %s.", r.keepAlivePingInterval)
-			opts = append(opts, grpc.WithKeepaliveParams(keepalive.ClientParameters{Time: r.keepAlivePingInterval}))
-		}
 		conn, err = grpc.NewClient(r.Addr(), opts...)
 	}
 	return conn, err
@@ -584,6 +580,11 @@ func (r *Remote) Connect(ctx context.Context, forceReauth bool) error {
 	if r.enableCompression {
 		log().Debug("gRPC compression is enabled.")
 		opts = append(opts, grpc.WithDefaultCallOptions(grpc.UseCompressor(gzip.Name)))
+	}
+
+	if r.keepAlivePingInterval != 0 {
+		log().Debugf("Agent ping to principal is enabled, agent will send a ping event after every %s.", r.keepAlivePingInterval)
+		opts = append(opts, grpc.WithKeepaliveParams(keepalive.ClientParameters{Time: r.keepAlivePingInterval}))
 	}
 
 	var (

--- a/pkg/client/remote.go
+++ b/pkg/client/remote.go
@@ -621,6 +621,7 @@ func (r *Remote) Connect(ctx context.Context, forceReauth bool) error {
 					}
 				}
 				logrus.Warnf("Auth failure: %v (retrying in %v)", ierr, cBackoff.Step())
+				conn.Close()
 				return ierr
 			}
 

--- a/pkg/client/remote_test.go
+++ b/pkg/client/remote_test.go
@@ -21,19 +21,28 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"math/big"
+	"net"
 	"path"
+	"strconv"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/argoproj-labs/argocd-agent/internal/auth"
 	"github.com/argoproj-labs/argocd-agent/internal/auth/userpass"
 	"github.com/argoproj-labs/argocd-agent/internal/issuer"
+	"github.com/argoproj-labs/argocd-agent/pkg/api/grpc/authapi"
+	"github.com/argoproj-labs/argocd-agent/pkg/api/grpc/versionapi"
 	"github.com/argoproj-labs/argocd-agent/pkg/types"
 	"github.com/argoproj-labs/argocd-agent/principal"
 	"github.com/argoproj-labs/argocd-agent/test/fake/kube"
 	"github.com/argoproj-labs/argocd-agent/test/fake/testcerts"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/stats"
+	"google.golang.org/grpc/status"
 )
 
 func Test_Connect(t *testing.T) {
@@ -99,6 +108,108 @@ func Test_Connect(t *testing.T) {
 		assert.Nil(t, r.conn)
 	})
 
+}
+
+// grpcConnTracker counts transport connections opened and closed on a gRPC server.
+// Used to assert the agent closes the ClientConn after a failed Authenticate attempt.
+type grpcConnTracker struct {
+	begins atomic.Int32
+	ends   atomic.Int32
+}
+
+func (t *grpcConnTracker) TagRPC(ctx context.Context, info *stats.RPCTagInfo) context.Context {
+	return ctx
+}
+
+func (t *grpcConnTracker) HandleRPC(context.Context, stats.RPCStats) {}
+
+func (t *grpcConnTracker) TagConn(ctx context.Context, info *stats.ConnTagInfo) context.Context {
+	return ctx
+}
+
+func (t *grpcConnTracker) HandleConn(_ context.Context, s stats.ConnStats) {
+	switch s.(type) {
+	case *stats.ConnBegin:
+		t.begins.Add(1)
+	case *stats.ConnEnd:
+		t.ends.Add(1)
+	}
+}
+
+type flakyAuthenticateServer struct {
+	authapi.UnimplementedAuthenticationServer
+	issuer issuer.Issuer
+	calls  atomic.Int32
+}
+
+func (s *flakyAuthenticateServer) Authenticate(context.Context, *authapi.AuthRequest) (*authapi.AuthResponse, error) {
+	if s.calls.Add(1) == 1 {
+		return nil, status.Errorf(codes.Unauthenticated, "forced first-attempt auth failure for test")
+	}
+	sub := `{"clientID":"retry-client","mode":"managed"}`
+	access, err := s.issuer.IssueAccessToken(sub, time.Hour)
+	if err != nil {
+		return nil, err
+	}
+	refresh, err := s.issuer.IssueRefreshToken(sub, 24*time.Hour)
+	if err != nil {
+		return nil, err
+	}
+	return &authapi.AuthResponse{AccessToken: access, RefreshToken: refresh}, nil
+}
+
+type stubVersionServer struct {
+	versionapi.UnimplementedVersionServer
+}
+
+func (stubVersionServer) Version(context.Context, *versionapi.VersionRequest) (*versionapi.VersionResponse, error) {
+	return &versionapi.VersionResponse{Version: "test-version"}, nil
+}
+
+// Regression: Connect must close the gRPC ClientConn when Authenticate fails so retries do not leak transports.
+func Test_Connect_closesConnOnFailedAuthAttempt_beforeRetry(t *testing.T) {
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	iss, err := issuer.NewIssuer("test", issuer.WithRSAPrivateKey(key))
+	require.NoError(t, err)
+
+	tracker := &grpcConnTracker{}
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	srv := grpc.NewServer(grpc.StatsHandler(tracker))
+	authapi.RegisterAuthenticationServer(srv, &flakyAuthenticateServer{issuer: iss})
+	versionapi.RegisterVersionServer(srv, stubVersionServer{})
+
+	go func() { _ = srv.Serve(lis) }()
+	t.Cleanup(func() {
+		srv.Stop()
+	})
+
+	host, portStr, err := net.SplitHostPort(lis.Addr().String())
+	require.NoError(t, err)
+	port, err := strconv.Atoi(portStr)
+	require.NoError(t, err)
+
+	r, err := NewRemote(host, port,
+		WithInsecurePlaintext(),
+		WithAuth("noop", auth.Credentials{}),
+		WithClientMode(types.AgentModeManaged),
+	)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	require.NoError(t, r.Connect(ctx, false))
+
+	require.Eventually(t, func() bool {
+		return tracker.begins.Load() >= 2 && tracker.ends.Load() >= 1
+	}, 2*time.Second, 5*time.Millisecond,
+		"expected first failed auth attempt to close its connection before the retry succeeds")
+
+	assert.Equal(t, int32(2), tracker.begins.Load(), "two dial attempts should open two connections")
+	assert.Equal(t, int32(1), tracker.ends.Load(), "only the failed attempt's conn should be closed before Connect returns")
+	require.NotNil(t, r.Conn())
 }
 
 func Test_WithMinimumTLSVersion(t *testing.T) {


### PR DESCRIPTION
**What does this PR do / why we need it**:

We forgot to close the underlying connection used by gRPC after authentication failures. Because the agent tries endlessly to connect to the principal on error, waiting for it to get back up, this lead to a lot of lingering connections.

This PR correctly closes the underlying connection on failure.

**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:


**Checklist**

* [ ] Documentation update is required by this PR (and has been updated) OR no documentation update is required.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensures per-attempt connection teardown during authentication retries to prevent lingering transports.
  * Removes duplicate connection-close on error path and clarifies keepalive handling to reduce leak risk.

* **Tests**
  * Added regression test verifying connections are closed after a failed authenticate attempt and that retries do not leak transports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->