### PR TITLE
fix: principal should allow apps from its namespace in the app filter chain

### DIFF
--- a/principal/server.go
+++ b/principal/server.go
@@ -1192,7 +1192,11 @@ func (s *Server) defaultAppFilterChain() *filter.Chain[*v1alpha1.Application] {
 	c := filter.NewFilterChain[*v1alpha1.Application]()
 	// Admit based on namespace of the application
 	c.AppendAdmitFilter(func(res *v1alpha1.Application) bool {
-		return glob.MatchStringInList(s.options.namespaces, res.Namespace, glob.REGEXP)
+		namespaces := s.options.namespaces
+		if s.destinationBasedMapping {
+			namespaces = append([]string{s.namespace}, namespaces...)
+		}
+		return glob.MatchStringInList(namespaces, res.Namespace, glob.REGEXP)
 	})
 	// Ignore applications that have the skip sync label
 	c.AppendAdmitFilter(func(res *v1alpha1.Application) bool {

--- a/principal/server_filter_test.go
+++ b/principal/server_filter_test.go
@@ -258,6 +258,116 @@ func TestServer_DefaultAppFilterChain_EdgeCases(t *testing.T) {
 	}
 }
 
+func TestServer_DefaultAppFilterChain_PrincipalNamespaceWithDestinationMapping(t *testing.T) {
+	t.Run("destination-based: app in principal namespace admitted with empty allowed-namespaces", func(t *testing.T) {
+		server := &Server{
+			namespace:               "principal",
+			destinationBasedMapping: true,
+			options:                 &ServerOptions{namespaces: []string{}},
+		}
+		fc := server.defaultAppFilterChain()
+		app := &v1alpha1.Application{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-app",
+				Namespace: "principal",
+			},
+			Spec: v1alpha1.ApplicationSpec{
+				Destination: v1alpha1.ApplicationDestination{Name: "agent-managed"},
+			},
+		}
+		assert.True(t, fc.Admit(app))
+	})
+
+	t.Run("destination-based: app in other namespace rejected when only principal namespace is implied", func(t *testing.T) {
+		server := &Server{
+			namespace:               "principal",
+			destinationBasedMapping: true,
+			options:                 &ServerOptions{namespaces: []string{}},
+		}
+		fc := server.defaultAppFilterChain()
+		app := &v1alpha1.Application{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-app",
+				Namespace: "other",
+			},
+			Spec: v1alpha1.ApplicationSpec{
+				Destination: v1alpha1.ApplicationDestination{Name: "agent-managed"},
+			},
+		}
+		assert.False(t, fc.Admit(app))
+	})
+
+	t.Run("destination-based: allowed-namespaces works alongside principal namespace", func(t *testing.T) {
+		server := &Server{
+			namespace:               "principal",
+			destinationBasedMapping: true,
+			options:                 &ServerOptions{namespaces: []string{"extra-ns"}},
+		}
+		fc := server.defaultAppFilterChain()
+		app := &v1alpha1.Application{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-app",
+				Namespace: "extra-ns",
+			},
+			Spec: v1alpha1.ApplicationSpec{
+				Destination: v1alpha1.ApplicationDestination{Name: "agent-managed"},
+			},
+		}
+		assert.True(t, fc.Admit(app))
+	})
+
+	t.Run("destination-based: empty principal namespace does not admit everything", func(t *testing.T) {
+		server := &Server{
+			namespace:               "",
+			destinationBasedMapping: true,
+			options:                 &ServerOptions{namespaces: []string{}},
+		}
+		fc := server.defaultAppFilterChain()
+		app := &v1alpha1.Application{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-app",
+				Namespace: "anything",
+			},
+			Spec: v1alpha1.ApplicationSpec{
+				Destination: v1alpha1.ApplicationDestination{Name: "agent-managed"},
+			},
+		}
+		assert.False(t, fc.Admit(app))
+	})
+
+	t.Run("namespace-based: principal namespace NOT auto-included without destination-based mapping", func(t *testing.T) {
+		server := &Server{
+			namespace:               "principal",
+			destinationBasedMapping: false,
+			options:                 &ServerOptions{namespaces: []string{}},
+		}
+		fc := server.defaultAppFilterChain()
+		app := &v1alpha1.Application{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-app",
+				Namespace: "principal",
+			},
+		}
+		assert.False(t, fc.Admit(app))
+	})
+
+	t.Run("namespace-based: explicit allowed-namespaces still works", func(t *testing.T) {
+		server := &Server{
+			namespace:               "principal",
+			destinationBasedMapping: false,
+			options:                 &ServerOptions{namespaces: []string{"agent-managed"}},
+		}
+		fc := server.defaultAppFilterChain()
+		app := &v1alpha1.Application{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-app",
+				Namespace: "agent-managed",
+			},
+		}
+		assert.True(t, fc.Admit(app))
+	})
+}
+
 func TestServer_DefaultAppFilterChain_DestinationBasedMapping(t *testing.T) {
 	withDestName := &v1alpha1.Application{
 		ObjectMeta: metav1.ObjectMeta{Name: "app-with-dest", Namespace: "argocd"},


### PR DESCRIPTION
**What does this PR do / why we need it**:

Currently, the principal doesn't reconcile apps from its own namespace. Users need to include the namespace under the allowed namespace list explicitly. This PR includes the principal's namespace when destination-based mapping is enabled.

**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:


**Checklist**

* [ ] Documentation update is required by this PR (and has been updated) OR no documentation update is required.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced namespace filtering to include a principal's own namespace when using destination-based mapping mode, while maintaining existing behavior for standard filtering configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->