### PR TITLE
docs: fix typo (occured -> occurred) in CONTRIBUTING

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -33,7 +33,7 @@ logCtx.WithField("resource_id", event.resourceID(ev)).WithField("event_id", even
 ```
 
 Argo CD Agent logs at the following levels (ordered by decreasing severity):
-- **Error**: Logs specific, non-fatal errors that have occured.
+- **Error**: Logs specific, non-fatal errors that have occurred.
 - **Warn**: Logs unexpected behaviour which may be an error in some cases, but might also be innocuous depending on context.
 - **Info**: Logs actions taken by the agent, the reason for the action, and any useful context. May also log general context information related to the operating environment.
 - **Debug**: Logs actions/context that are more verbose than info, and may include information that is only relevant to developers familiar with the code.


### PR DESCRIPTION
**What does this PR do / why we need it**:
Fixes 'occured' -> 'occurred' typo in docs/CONTRIBUTING.md (Error logging level description).

**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:
Documentation-only change, no functional impact.

**Checklist**

* [x] Documentation update is required by this PR (and has been updated) OR no documentation update is required.
