### PR TITLE
feat: agent informer sync timeout configurable

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -63,8 +63,6 @@ import (
 	ty "k8s.io/apimachinery/pkg/types"
 )
 
-const waitForSyncedDuration = 10 * time.Second
-
 // Agent is a controller that synchronizes Application resources
 type Agent struct {
 	context  context.Context
@@ -111,6 +109,7 @@ type Agent struct {
 	enableResourceProxy bool
 
 	cacheRefreshInterval time.Duration
+	informerSyncTimeout  time.Duration
 	clusterCache         *appstatecache.Cache
 
 	inflightMu sync.Mutex
@@ -239,6 +238,10 @@ func NewAgent(ctx context.Context, client *kube.KubernetesClient, namespace stri
 
 	if a.cacheRefreshInterval == 0 {
 		return nil, fmt.Errorf("cache refresh interval not set")
+	}
+
+	if a.informerSyncTimeout <= 0 {
+		return nil, fmt.Errorf("informer sync timeout must be greater than 0")
 	}
 
 	a.kubeClient = client
@@ -524,13 +527,13 @@ func (a *Agent) Start(ctx context.Context) error {
 	}()
 
 	// Wait for the app informer to be synced
-	err := a.appManager.EnsureSynced(waitForSyncedDuration)
+	err := a.appManager.EnsureSynced(a.informerSyncTimeout)
 	if err != nil {
 		return fmt.Errorf("failed to sync applications: %w", err)
 	}
 
 	// Wait for the appProject informer to be synced
-	err = a.projectManager.EnsureSynced(waitForSyncedDuration)
+	err = a.projectManager.EnsureSynced(a.informerSyncTimeout)
 	if err != nil {
 		return fmt.Errorf("failed to sync appProjects: %w", err)
 	}
@@ -544,7 +547,7 @@ func (a *Agent) Start(ctx context.Context) error {
 		}
 	}()
 
-	if err := a.namespaceManager.EnsureSynced(waitForSyncedDuration); err != nil {
+	if err := a.namespaceManager.EnsureSynced(a.informerSyncTimeout); err != nil {
 		return fmt.Errorf("unable to sync Namespace informer: %w", err)
 	}
 	log().Infof("Namespace informer synced and ready")
@@ -567,12 +570,12 @@ func (a *Agent) Start(ctx context.Context) error {
 		}
 	}()
 
-	if err = a.repoManager.EnsureSynced(waitForSyncedDuration); err != nil {
+	if err = a.repoManager.EnsureSynced(a.informerSyncTimeout); err != nil {
 		return fmt.Errorf("unable to sync Repository informer: %w", err)
 	}
 	log().Infof("Repository informer synced and ready")
 
-	if err = a.gpgKeyManager.EnsureSynced(waitForSyncedDuration); err != nil {
+	if err = a.gpgKeyManager.EnsureSynced(a.informerSyncTimeout); err != nil {
 		return fmt.Errorf("unable to sync GPG key informer: %w", err)
 	}
 	log().Infof("GPG key informer synced and ready")

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -35,14 +35,14 @@ func newAgent(t *testing.T, apps ...runtime.Object) (*Agent, *kube.KubernetesCli
 	kubec := fakekube.NewKubernetesFakeClientWithApps("argocd", apps...)
 	remote, err := client.NewRemote("127.0.0.1", 8080)
 	require.NoError(t, err)
-	agent, err := NewAgent(context.TODO(), kubec, "argocd", WithRemote(remote), WithCacheRefreshInterval(10*time.Second))
+	agent, err := NewAgent(context.TODO(), kubec, "argocd", WithRemote(remote), WithCacheRefreshInterval(10*time.Second), WithInformerSyncTimeout(10*time.Second))
 	require.NoError(t, err)
 	return agent, kubec
 }
 
 func Test_NewAgent(t *testing.T) {
 	kubec := fakekube.NewKubernetesFakeClientWithApps("agent")
-	agent, err := NewAgent(context.TODO(), kubec, "agent", WithRemote(&client.Remote{}), WithCacheRefreshInterval(10*time.Second))
+	agent, err := NewAgent(context.TODO(), kubec, "agent", WithRemote(&client.Remote{}), WithCacheRefreshInterval(10*time.Second), WithInformerSyncTimeout(10*time.Second))
 	require.NotNil(t, agent)
 	require.NoError(t, err)
 }

--- a/agent/filters_test.go
+++ b/agent/filters_test.go
@@ -34,7 +34,7 @@ func TestDefaultAppFilterChain_SkipSyncLabel(t *testing.T) {
 	kubec := fakekube.NewKubernetesFakeClientWithApps("argocd")
 	remote, err := client.NewRemote("127.0.0.1", 8080)
 	require.NoError(t, err)
-	agent, err := NewAgent(context.TODO(), kubec, "argocd", WithRemote(remote), WithCacheRefreshInterval(10*time.Second))
+	agent, err := NewAgent(context.TODO(), kubec, "argocd", WithRemote(remote), WithCacheRefreshInterval(10*time.Second), WithInformerSyncTimeout(10*time.Second))
 	require.NoError(t, err)
 
 	filterChain := agent.DefaultAppFilterChain()
@@ -155,7 +155,8 @@ func TestDefaultAppFilterChain_NamespaceAndSkipSyncInteraction(t *testing.T) {
 	agent, err := NewAgent(context.TODO(), kubec, "argocd",
 		WithRemote(remote),
 		WithAllowedNamespaces("argocd", "apps", "staging"),
-		WithCacheRefreshInterval(10*time.Second))
+		WithCacheRefreshInterval(10*time.Second),
+		WithInformerSyncTimeout(10*time.Second))
 	require.NoError(t, err)
 
 	filterChain := agent.DefaultAppFilterChain()
@@ -219,7 +220,7 @@ func TestDefaultAppFilterChain_ProcessChange(t *testing.T) {
 	kubec := fakekube.NewKubernetesFakeClientWithApps("argocd")
 	remote, err := client.NewRemote("127.0.0.1", 8080)
 	require.NoError(t, err)
-	agent, err := NewAgent(context.TODO(), kubec, "argocd", WithRemote(remote), WithCacheRefreshInterval(10*time.Second))
+	agent, err := NewAgent(context.TODO(), kubec, "argocd", WithRemote(remote), WithCacheRefreshInterval(10*time.Second), WithInformerSyncTimeout(10*time.Second))
 	require.NoError(t, err)
 
 	filterChain := agent.DefaultAppFilterChain()
@@ -256,7 +257,7 @@ func TestDefaultAppFilterChain_IgnoreUnmanagedApps(t *testing.T) {
 
 	newAgent := func(t *testing.T, ignore bool) *Agent {
 		t.Helper()
-		opts := []AgentOption{WithRemote(remote), WithCacheRefreshInterval(10 * time.Second)}
+		opts := []AgentOption{WithRemote(remote), WithCacheRefreshInterval(10 * time.Second), WithInformerSyncTimeout(10 * time.Second)}
 		if ignore {
 			opts = append(opts, WithIgnoreUnmanagedApps(true))
 		}

--- a/agent/options.go
+++ b/agent/options.go
@@ -115,6 +115,13 @@ func WithCacheRefreshInterval(interval time.Duration) AgentOption {
 	}
 }
 
+func WithInformerSyncTimeout(timeout time.Duration) AgentOption {
+	return func(o *Agent) error {
+		o.informerSyncTimeout = timeout
+		return nil
+	}
+}
+
 func WithHeartbeatInterval(interval time.Duration) AgentOption {
 	return func(o *Agent) error {
 		o.options.heartbeatInterval = interval

--- a/agent/options_test.go
+++ b/agent/options_test.go
@@ -36,6 +36,7 @@ func Test_WithSourceUIDMismatchPolicy(t *testing.T) {
 		return NewAgent(context.TODO(), kubec, "argocd",
 			WithRemote(remote),
 			WithCacheRefreshInterval(10*time.Second),
+			WithInformerSyncTimeout(10*time.Second),
 			WithSourceUIDMismatchPolicy(policy),
 		)
 	}
@@ -64,6 +65,7 @@ func Test_WithSourceUIDMismatchPolicy(t *testing.T) {
 		a, err := NewAgent(context.TODO(), kubec, "argocd",
 			WithRemote(remote),
 			WithCacheRefreshInterval(10*time.Second),
+			WithInformerSyncTimeout(10*time.Second),
 		)
 		require.NoError(t, err)
 		assert.Equal(t, manager.MismatchPolicyRecreate, a.mismatchPolicy)
@@ -75,7 +77,7 @@ func Test_effectiveMismatchPolicy(t *testing.T) {
 		t.Helper()
 		kubec := fakekube.NewKubernetesFakeClientWithApps("argocd")
 		remote, _ := client.NewRemote("127.0.0.1", 8080)
-		a, err := NewAgent(context.TODO(), kubec, "argocd", WithRemote(remote), WithCacheRefreshInterval(10*time.Second))
+		a, err := NewAgent(context.TODO(), kubec, "argocd", WithRemote(remote), WithCacheRefreshInterval(10*time.Second), WithInformerSyncTimeout(10*time.Second))
 		require.NoError(t, err)
 		a.mismatchPolicy = globalPolicy
 		return a
@@ -105,5 +107,40 @@ func Test_effectiveMismatchPolicy(t *testing.T) {
 			},
 		}
 		assert.Equal(t, manager.MismatchPolicyUpsert, a.effectiveMismatchPolicy(obj))
+	})
+}
+
+func Test_WithInformerSyncTimeout(t *testing.T) {
+	newTestAgent := func(t *testing.T, opts ...AgentOption) (*Agent, error) {
+		t.Helper()
+		kubec := fakekube.NewKubernetesFakeClientWithApps("argocd")
+		remote, err := client.NewRemote("127.0.0.1", 8080)
+		require.NoError(t, err)
+		baseOpts := []AgentOption{WithRemote(remote), WithCacheRefreshInterval(10 * time.Second)}
+		return NewAgent(context.TODO(), kubec, "argocd", append(baseOpts, opts...)...)
+	}
+
+	t.Run("positive value is accepted", func(t *testing.T) {
+		a, err := newTestAgent(t, WithInformerSyncTimeout(30*time.Second))
+		require.NoError(t, err)
+		assert.Equal(t, 30*time.Second, a.informerSyncTimeout)
+	})
+
+	t.Run("zero value returns error", func(t *testing.T) {
+		_, err := newTestAgent(t, WithInformerSyncTimeout(0))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "informer sync timeout must be greater than 0")
+	})
+
+	t.Run("negative value returns error", func(t *testing.T) {
+		_, err := newTestAgent(t, WithInformerSyncTimeout(-1*time.Second))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "informer sync timeout must be greater than 0")
+	})
+
+	t.Run("missing option returns error", func(t *testing.T) {
+		_, err := newTestAgent(t)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "informer sync timeout must be greater than 0")
 	})
 }

--- a/agent/outbound_test.go
+++ b/agent/outbound_test.go
@@ -455,7 +455,7 @@ func Test_addClusterCacheInfoUpdateToQueue(t *testing.T) {
 	remote, err := client.NewRemote("127.0.0.1", 8080)
 	require.NoError(t, err)
 
-	a, err := NewAgent(context.TODO(), kubec, "argocd", WithRemote(remote), WithRedisHost(miniRedis.Addr()), WithCacheRefreshInterval(10*time.Second))
+	a, err := NewAgent(context.TODO(), kubec, "argocd", WithRemote(remote), WithRedisHost(miniRedis.Addr()), WithCacheRefreshInterval(10*time.Second), WithInformerSyncTimeout(10*time.Second))
 	require.NoError(t, err)
 
 	a.remote.SetClientID("agent")

--- a/cmd/argocd-agent/agent.go
+++ b/cmd/argocd-agent/agent.go
@@ -80,6 +80,9 @@ func NewAgentRunCommand() *cobra.Command {
 		// Time interval for agent to refresh cluster cache info in principal
 		cacheRefreshInterval time.Duration
 
+		// Timeout for the initial informer sync at startup
+		informerSyncTimeout time.Duration
+
 		// Time interval for application-level heartbeats over the Subscribe stream.
 		// This is used to keep the connection alive through service meshes like Istio.
 		heartbeatInterval time.Duration
@@ -294,6 +297,7 @@ func NewAgentRunCommand() *cobra.Command {
 
 			agentOpts = append(agentOpts, agent.WithEnableResourceProxy(enableResourceProxy))
 			agentOpts = append(agentOpts, agent.WithCacheRefreshInterval(cacheRefreshInterval))
+			agentOpts = append(agentOpts, agent.WithInformerSyncTimeout(informerSyncTimeout))
 			agentOpts = append(agentOpts, agent.WithHeartbeatInterval(heartbeatInterval))
 			agentOpts = append(agentOpts, agent.WithCreateNamespace(createNamespace))
 			agentOpts = append(agentOpts, agent.WithDestinationBasedMapping(destinationBasedMapping))
@@ -423,6 +427,9 @@ func NewAgentRunCommand() *cobra.Command {
 	command.Flags().DurationVar(&cacheRefreshInterval, "cache-refresh-interval",
 		env.DurationWithDefault("ARGOCD_AGENT_CACHE_REFRESH_INTERVAL", nil, 10*time.Second),
 		"Interval to refresh cluster cache info in principal")
+	command.Flags().DurationVar(&informerSyncTimeout, "informer-sync-timeout",
+		env.DurationWithDefault("ARGOCD_AGENT_INFORMER_SYNC_TIMEOUT", nil, 10*time.Second),
+		"Timeout to wait for Application/AppProject/Repository/GPG/Namespace informers to sync at startup")
 	command.Flags().DurationVar(&heartbeatInterval, "heartbeat-interval",
 		env.DurationWithDefault("ARGOCD_AGENT_HEARTBEAT_INTERVAL", nil, 0),
 		"Interval for application-level heartbeats over the Subscribe stream (e.g., 30s). "+

--- a/docs/configuration/reference/agent.md
+++ b/docs/configuration/reference/agent.md
@@ -270,6 +270,24 @@ Port the metrics server will listen on.
 
 Port the health check server will listen on.
 
+## Startup Behavior
+
+### Informer Sync Timeout
+
+| | |
+|---|---|
+| **CLI Flag** | `--informer-sync-timeout` |
+| **Environment Variable** | `ARGOCD_AGENT_INFORMER_SYNC_TIMEOUT` |
+| **ConfigMap Entry** | `agent.informer-sync-timeout` |
+| **Type** | Duration |
+| **Default** | `10s` |
+
+How long the agent waits for its informers (Application, AppProject, Repository, GPG, Namespace) to complete the initial cache sync at startup. If the informers do not sync within this window, the agent fails to start.
+
+Increase this value on large clusters or clusters under high API server load where the initial list-and-watch round-trips take longer than the default.
+
+**Example:** `30s`
+
 ## Network and Performance
 
 ### Enable WebSocket

--- a/install/helm-repo/argocd-agent-agent/Chart.yaml
+++ b/install/helm-repo/argocd-agent-agent/Chart.yaml
@@ -5,7 +5,7 @@ description: Argo CD Agent for connecting managed clusters to a Principal
 type: application
 
 # chart version
-version: 0.2.0
+version: 0.2.1
 
 # application version, ArgoCD Agent version
 appVersion: v0.8.1

--- a/install/helm-repo/argocd-agent-agent/README.md
+++ b/install/helm-repo/argocd-agent-agent/README.md
@@ -31,6 +31,7 @@ Kubernetes: `>=1.24.0-0`
 | argoCdRedisSecretName | string | `"argocd-redis"` | ArgoCD Redis password secret name. |
 | auth | string | `"mtls:any"` | Authentication mode for connecting to the principal. |
 | cacheRefreshInterval | string | `"10s"` | Cache refresh interval. |
+| informerSyncTimeout | string | `"10s"` | Timeout for the initial informer sync at agent startup. Increase on large clusters or when the API server is under heavy load. |
 | createNamespace | bool | `false` | Whether to create target namespaces automatically when they don't exist. Used with destination-based mapping. |
 | destinationBasedMapping | bool | `false` | Whether to enable destination-based mapping. When enabled, the agent creates applications in their original namespace (preserving the namespace from the principal) instead of the agent's own namespace. |
 | dnsConfig | object | `{}` | DNS config for the Pod. Only honored when `dnsPolicy` is "None". |

--- a/install/helm-repo/argocd-agent-agent/README.md
+++ b/install/helm-repo/argocd-agent-agent/README.md
@@ -1,6 +1,6 @@
 # argocd-agent-agent
 
-![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.8.1](https://img.shields.io/badge/AppVersion-v0.8.1-informational?style=flat-square)
+![Version: 0.2.1](https://img.shields.io/badge/Version-0.2.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.8.1](https://img.shields.io/badge/AppVersion-v0.8.1-informational?style=flat-square)
 
 Argo CD Agent for connecting managed clusters to a Principal
 
@@ -31,7 +31,6 @@ Kubernetes: `>=1.24.0-0`
 | argoCdRedisSecretName | string | `"argocd-redis"` | ArgoCD Redis password secret name. |
 | auth | string | `"mtls:any"` | Authentication mode for connecting to the principal. |
 | cacheRefreshInterval | string | `"10s"` | Cache refresh interval. |
-| informerSyncTimeout | string | `"10s"` | Timeout for the initial informer sync at agent startup. Increase on large clusters or when the API server is under heavy load. |
 | createNamespace | bool | `false` | Whether to create target namespaces automatically when they don't exist. Used with destination-based mapping. |
 | destinationBasedMapping | bool | `false` | Whether to enable destination-based mapping. When enabled, the agent creates applications in their original namespace (preserving the namespace from the principal) instead of the agent's own namespace. |
 | dnsConfig | object | `{}` | DNS config for the Pod. Only honored when `dnsPolicy` is "None". |
@@ -46,6 +45,7 @@ Kubernetes: `>=1.24.0-0`
 | image.repository | string | `"ghcr.io/argoproj-labs/argocd-agent/argocd-agent"` | Container image repository for the agent. |
 | image.tag | string | `""` | Overrides the image tag whose default is the chart appVersion. |
 | imagePullSecrets | list | `[]` | Image pull secrets for private registries. |
+| informerSyncTimeout | string | `"10s"` | Timeout for the initial informer sync at agent startup. Increase on large clusters or when the API server is under heavy load. |
 | keepAliveInterval | string | `"50s"` | Keep-alive interval for connections. |
 | labelSelector | string | `""` | Kubernetes label selector to restrict which resources the agent watches. Only matching resources will be listed, watched, and processed. |
 | logFormat | string | `"text"` | Log format for the agent (text or json). |

--- a/install/helm-repo/argocd-agent-agent/templates/agent-deployment.yaml
+++ b/install/helm-repo/argocd-agent-agent/templates/agent-deployment.yaml
@@ -237,6 +237,12 @@ spec:
                 name: {{ include "argocd-agent-agent.paramsConfigMapName" . }}
                 key: agent.cache.refresh-interval
                 optional: true
+          - name: ARGOCD_AGENT_INFORMER_SYNC_TIMEOUT
+            valueFrom:
+              configMapKeyRef:
+                name: {{ include "argocd-agent-agent.paramsConfigMapName" . }}
+                key: agent.informer-sync-timeout
+                optional: true
           - name: ARGOCD_AGENT_DESTINATION_BASED_MAPPING
             valueFrom:
               configMapKeyRef:

--- a/install/helm-repo/argocd-agent-agent/templates/agent-params-cm.yaml
+++ b/install/helm-repo/argocd-agent-agent/templates/agent-params-cm.yaml
@@ -100,6 +100,9 @@ data:
   # agent.cache.refresh-interval: Cache refresh interval.
   # Default: "10s"
   agent.cache.refresh-interval: {{ .Values.cacheRefreshInterval | quote }}
+  # agent.informer-sync-timeout: Timeout for the initial informer sync at startup.
+  # Default: "10s"
+  agent.informer-sync-timeout: {{ .Values.informerSyncTimeout | quote }}
   # agent.destination-based-mapping: Whether to enable destination-based mapping.
   # When enabled, the agent creates applications in their original namespace
   # (preserving the namespace from the principal) instead of the agent's own namespace.

--- a/install/helm-repo/argocd-agent-agent/values.schema.json
+++ b/install/helm-repo/argocd-agent-agent/values.schema.json
@@ -51,6 +51,12 @@
       "title": "cacheRefreshInterval",
       "type": "string"
     },
+    "informerSyncTimeout": {
+      "default": "10s",
+      "description": "Timeout for the initial informer sync at agent startup. Increase on large clusters or when the API server is under heavy load.",
+      "title": "informerSyncTimeout",
+      "type": "string"
+    },
     "createNamespace": {
       "default": false,
       "description": "Whether to create target namespaces automatically when they don't exist.\nUsed with destination-based mapping.",
@@ -1052,6 +1058,7 @@
     "pprofPort",
     "enableResourceProxy",
     "cacheRefreshInterval",
+    "informerSyncTimeout",
     "keepAliveInterval",
     "tlsClientKeyPath",
     "tlsClientCertPath",

--- a/install/helm-repo/argocd-agent-agent/values.yaml
+++ b/install/helm-repo/argocd-agent-agent/values.yaml
@@ -193,6 +193,9 @@ pprofPort: "0"
 enableResourceProxy: true
 # -- Cache refresh interval.
 cacheRefreshInterval: "10s"
+# -- Timeout for the initial informer sync at agent startup. Increase on
+# large clusters or when the API server is under heavy load.
+informerSyncTimeout: "10s"
 # -- Keep-alive interval for connections.
 keepAliveInterval: "50s"
 # -- Path to the TLS client key.

--- a/install/kubernetes/agent/agent-deployment.yaml
+++ b/install/kubernetes/agent/agent-deployment.yaml
@@ -218,6 +218,12 @@ spec:
                 name: argocd-agent-params
                 key: agent.tls.insecure-plaintext
                 optional: true
+          - name: ARGOCD_AGENT_INFORMER_SYNC_TIMEOUT
+            valueFrom:
+              configMapKeyRef:
+                name: argocd-agent-params
+                key: agent.informer-sync-timeout
+                optional: true
           image: argocd-agent
           imagePullPolicy: Always
           name: argocd-agent-agent

--- a/install/kubernetes/agent/agent-params-cm.yaml
+++ b/install/kubernetes/agent/agent-params-cm.yaml
@@ -132,3 +132,8 @@ data:
   # agent.redis.tls.insecure: INSECURE: Do not verify Redis TLS certificate.
   # Default: false
   agent.redis.tls.insecure: "false"
+  # agent.informer-sync-timeout: How long the agent waits for its informers
+  # (Application, AppProject, Repository, GPG, Namespace) to complete the
+  # initial sync at startup. Increase on large or high-API-load clusters.
+  # Default: "10s"
+  agent.informer-sync-timeout: "10s"


### PR DESCRIPTION
## What does this PR do / why do we need it?

On large clusters where the API server is under load, the initial agent LIST calls to populate informer cache may take longer than usual. There is currently a hard coded 10 second constant call `waitForSyncedDuration`. For such large clusters, we would get the following error on agent startup

```
time="2026-05-20T11:04:04Z" level=info msg="Loading root CA certificate from file /app/config/ca/ca.crt"
time="2026-05-20T11:04:04Z" level=info msg="Loading client TLS certificate from secret argocd/argocd-agent-client-tls"
time="2026-05-20T11:04:04Z" level=info msg="Loaded 30 cert(s) into the root CA pool" module=Connector
time="2026-05-20T11:04:04Z" level=info msg="Starting argocd-agent (agent) v99.9.9-unreleased (ns=argocd, allowed_namespaces=[], mode=managed, auth=mtls)" module=Agent
time="2026-05-20T11:04:04Z" level=info msg="Destination-based mapping is enabled" module=Agent
time="2026-05-20T11:04:04Z" level=info msg="Recreating application spec cache from existing resources on cluster" module=Agent
time="2026-05-20T11:04:14Z" level=info msg="Recreating appProject spec cache from existing resources on cluster" module=Agent
time="2026-05-20T11:04:14Z" level=info msg="Recreating repository spec cache from existing resources on cluster" module=Agent
time="2026-05-20T11:04:15Z" level=info msg="Recreating GPG key spec cache from existing resources on cluster" module=Agent
time="2026-05-20T11:04:15Z" level=info msg="Source cache populated successfully" module=Agent
time="2026-05-20T11:04:15Z" level=info msg="Starting metrics server on http://0.0.0.0:8181/metrics"
time="2026-05-20T11:04:15Z" level=debug msg="Starting informer" module=Informer type="*v1alpha1.AppProject"
time="2026-05-20T11:04:15Z" level=debug msg="Starting informer" module=Informer type="*v1alpha1.Application"
time="2026-05-20T11:04:15Z" level=info msg="Starting watcher" module=Informer type="*v1alpha1.AppProject"
time="2026-05-20T11:04:15Z" level=debug msg="New appProject event" appProject=XXXX event=NewAppProject module=GrpcEvent sendq_name=default
time="2026-05-20T11:04:15Z" level=debug msg="New appProject event" appProject=default event=NewAppProject module=GrpcEvent sendq_name=default
[FATAL]: Could not start agent: failed to sync applications: context deadline exceeded
```

This PR makes the agent's `waitForSyncedDuration` configurable through both CLI flag and ENV var. The  value can be set through helm accordingly

## Which issue(s) this PR fixes

N/A

## How to test changes / Special notes to the reviewer

- `make test` passes locally (covers `WithInformerSyncTimeout` validation plus existing agent/filter/outbound suites)
- `make lint` passes locally
- Helm: install with `--set informerSyncTimeout=30s` and confirm the Deployment env contains `ARGOCD_AGENT_INFORMER_SYNC_TIMEOUT=30s`
- Omit the value and confirm the default `10s` is applied (backward compatible)
- manual helm rendering
```
# default and non default values in configmap
❯ helm template test-release install/helm-repo/argocd-agent-agent \
  --show-only templates/agent-params-cm.yaml | grep informer-sync-timeout
  # agent.informer-sync-timeout: Timeout for the initial informer sync at startup.
  agent.informer-sync-timeout: "10s"
❯ helm template test-release install/helm-repo/argocd-agent-agent \
  --set informerSyncTimeout=30s \
  --show-only templates/agent-params-cm.yaml | grep informer-sync-timeout
  # agent.informer-sync-timeout: Timeout for the initial informer sync at startup.
  agent.informer-sync-timeout: "30s"

# env var set when value is set
❯ helm template test-release install/helm-repo/argocd-agent-agent \
  --set informerSyncTimeout=30s | grep -A5 'ARGOCD_AGENT_INFORMER_SYNC_TIMEOUT'
          - name: ARGOCD_AGENT_INFORMER_SYNC_TIMEOUT
            valueFrom:
              configMapKeyRef:
                name: test-release-agent-helm-params
                key: agent.informer-sync-timeout
                optional: true

# env var is also set when value is not set
❯ helm template test-release install/helm-repo/argocd-agent-agent  | grep -A5 'ARGOCD_AGENT_INFORMER_SYNC_TIMEOUT'
          - name: ARGOCD_AGENT_INFORMER_SYNC_TIMEOUT
            valueFrom:
              configMapKeyRef:
                name: test-release-agent-helm-params
                key: agent.informer-sync-timeout
                optional: true
```

## Checklist

* [x] Tests updated
* [x] Documentation updated (Helm chart README)
* [x] Title of the PR follows Conventional Commits

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Agent startup now supports a configurable informer sync timeout (default: 10s); value must be > 0. Exposed via CLI flag and ARGOCD_AGENT_INFORMER_SYNC_TIMEOUT env var.

* **Documentation**
  * Docs, chart README and values/schema updated; deployment and ConfigMap templates expose and document the informerSyncTimeout. Chart version bumped to 0.2.1.

* **Tests**
  * Tests updated to set and validate the informer sync timeout option.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/argoproj-labs/argocd-agent/pull/955?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->