### PR TITLE
fix: check if resource being patched is managed

### DIFF
--- a/agent/resource.go
+++ b/agent/resource.go
@@ -162,6 +162,12 @@ func (a *Agent) processIncomingPostResourceRequest(ctx context.Context, req *eve
 }
 
 func (a *Agent) processIncomingPatchResourceRequest(ctx context.Context, req *event.ResourceRequest, gvr schema.GroupVersionResource) (*unstructured.Unstructured, error) {
+	// Check to see if resource is managed by an Argo CD application.
+	_, err := a.getManagedResource(ctx, gvr, req.Name, req.Namespace)
+	if err != nil {
+		return nil, err
+	}
+
 	patchOpts := v1.PatchOptions{}
 	if params, ok := req.Params["dryRun"]; ok {
 		patchOpts.DryRun = []string{params}

--- a/agent/resource_test.go
+++ b/agent/resource_test.go
@@ -1057,6 +1057,7 @@ func Test_processIncomingPatchResourceRequest(t *testing.T) {
 		expectErr     bool
 		expectPatched bool
 		forceValue    string
+		managedByApp  bool
 	}
 
 	originalObj := &corev1.Pod{
@@ -1081,6 +1082,7 @@ func Test_processIncomingPatchResourceRequest(t *testing.T) {
 			setupReactor:  func(fakeDyn *fake.FakeDynamicClient) {},
 			expectErr:     false,
 			expectPatched: true,
+			managedByApp:  true,
 		},
 		{
 			name:      "Patch returns error",
@@ -1094,6 +1096,7 @@ func Test_processIncomingPatchResourceRequest(t *testing.T) {
 			},
 			expectErr:     true,
 			expectPatched: false,
+			managedByApp:  true,
 		},
 		{
 			name:          "Invalid force param returns error",
@@ -1103,6 +1106,7 @@ func Test_processIncomingPatchResourceRequest(t *testing.T) {
 			setupReactor:  func(fakeDyn *fake.FakeDynamicClient) {},
 			expectErr:     true,
 			expectPatched: false,
+			managedByApp:  true,
 		},
 		{
 			name:          "Passes PatchOptions params",
@@ -1112,21 +1116,40 @@ func Test_processIncomingPatchResourceRequest(t *testing.T) {
 			setupReactor:  func(fakeDyn *fake.FakeDynamicClient) {},
 			expectErr:     false,
 			expectPatched: true,
+			managedByApp:  true,
+		},
+		{
+			name:          "Returns error on unmanaged resource",
+			params:        map[string]string{},
+			namespace:     "default",
+			patchBody:     patch,
+			setupReactor:  func(fakeDyn *fake.FakeDynamicClient) {},
+			expectErr:     true,
+			expectPatched: false,
+			managedByApp:  false,
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			kubeClient := kube.NewDynamicFakeClient(originalObj)
+			obj := originalObj.DeepCopy()
+			if tc.managedByApp {
+				obj.ObjectMeta.Labels = map[string]string{
+					"app.kubernetes.io/instance": "test-app",
+				}
+			}
+
+			kubeClient := kube.NewDynamicFakeClient(obj)
 			scheme := runtime.NewScheme()
 			_ = corev1.AddToScheme(scheme)
-			fakeDyn := fake.NewSimpleDynamicClient(scheme, originalObj)
+			fakeDyn := fake.NewSimpleDynamicClient(scheme, obj)
 			tc.setupReactor(fakeDyn)
 			kubeClient.DynamicClient = fakeDyn
 
 			agent := &Agent{
-				context:    context.Background(),
-				kubeClient: kubeClient,
+				context:        context.Background(),
+				kubeClient:     kubeClient,
+				trackingReader: newTestTrackingReader(v1alpha1.TrackingMethodLabel),
 			}
 
 			gvr := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "pods"}


### PR DESCRIPTION
While reading through the code for the agent resource operations when working on the CRD related `GET` bug. I noticed that the `PATCH` operation for non sub-resources did not contain a call to `getManagedResource` which returns an error denying the request with forbidden if the resource is not managed by Argo CD. This PR adds that check to the operation to deny an attacker from being able to update all resources on the agent cluster if the principal was compromised. 

**What does this PR do / why we need it**:

**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:


**Checklist**

* [ ] Documentation update is required by this PR (and has been updated) OR no documentation update is required.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Patch requests now verify a resource is managed by the application before applying changes, preventing patches to unmanaged resources.
* **Tests**
  * Tests updated to cover managed vs. unmanaged resource patch behavior, ensuring correct success and error outcomes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/argoproj-labs/argocd-agent/pull/957?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->