### PR TITLE
fix: UI navigation to child apps fails in autonomous app-of-apps

### DIFF
--- a/principal/event.go
+++ b/principal/event.go
@@ -217,6 +217,14 @@ func (s *Server) processApplicationEvent(ctx context.Context, agentName string, 
 		}
 		incoming.Spec.Destination.Name = cluster.Name
 		incoming.Spec.Destination.Server = ""
+
+		// Rewrite namespace for child Application entries in status.resources
+		// so the UI navigates to child apps using the principal-side namespace
+		for i, res := range incoming.Status.Resources {
+			if res.Group == "argoproj.io" && res.Kind == "Application" {
+				incoming.Status.Resources[i].Namespace = agentName
+			}
+		}
 	}
 
 	// When destination-based mapping is active, the agent may send apps under

--- a/principal/event_test.go
+++ b/principal/event_test.go
@@ -263,6 +263,67 @@ func Test_CreateEvents(t *testing.T) {
 		assert.NoError(t, err)
 		assert.NotNil(t, ns)
 	})
+	t.Run("Create application in autonomous mode rewrites child app namespaces in status.resources", func(t *testing.T) {
+		app := &v1alpha1.Application{
+			ObjectMeta: v1.ObjectMeta{
+				Name:      "parent-app",
+				Namespace: "argocd",
+			},
+			Spec: v1alpha1.ApplicationSpec{
+				Project: "default",
+				Source: &v1alpha1.ApplicationSource{
+					RepoURL:        "https://github.com/example/apps",
+					Path:           ".",
+					TargetRevision: "HEAD",
+				},
+			},
+			Status: v1alpha1.ApplicationStatus{
+				Sync: v1alpha1.SyncStatus{Status: v1alpha1.SyncStatusCodeSynced},
+				Resources: []v1alpha1.ResourceStatus{
+					{
+						Group:     "argoproj.io",
+						Kind:      "Application",
+						Name:      "child-app",
+						Namespace: "argocd",
+						Version:   "v1alpha1",
+						Status:    v1alpha1.SyncStatusCodeSynced,
+					},
+					{
+						Group:     "apps",
+						Kind:      "Deployment",
+						Name:      "my-deploy",
+						Namespace: "default",
+						Version:   "v1",
+						Status:    v1alpha1.SyncStatusCodeSynced,
+					},
+				},
+			},
+		}
+		fac := kube.NewKubernetesFakeClientWithApps("argocd", app)
+		ev := cloudevents.NewEvent()
+		ev.SetDataSchema("application")
+		ev.SetType(event.Create.String())
+		ev.SetData(cloudevents.ApplicationJSON, app)
+		wq := wqmock.NewTypedRateLimitingInterface[*cloudevents.Event](t)
+		wq.On("Get").Return(&ev, false)
+		wq.On("Done", &ev)
+		s, err := NewServer(context.Background(), fac, "argocd", WithGeneratedTokenSigningKey(), WithAutoNamespaceCreate(true, "", nil), WithRedisProxyDisabled())
+		require.NoError(t, err)
+		s.clusterMgr.MapCluster("agent-staging", &v1alpha1.Cluster{Name: "agent-staging", Server: "https://staging.com"})
+		s.setAgentMode("agent-staging", types.AgentModeAutonomous)
+		_, err = s.processRecvQueue(context.Background(), "agent-staging", wq)
+		assert.NoError(t, err)
+		napp, err := fac.ApplicationsClientset.ArgoprojV1alpha1().Applications("agent-staging").Get(context.TODO(), "parent-app", v1.GetOptions{})
+		require.NoError(t, err)
+		require.NotNil(t, napp)
+		require.Len(t, napp.Status.Resources, 2)
+		// Child Application namespace should be rewritten to the agent name (principal-side namespace)
+		assert.Equal(t, "agent-staging", napp.Status.Resources[0].Namespace)
+		assert.Equal(t, "Application", napp.Status.Resources[0].Kind)
+		// Non-Application resources should retain their original namespace
+		assert.Equal(t, "default", napp.Status.Resources[1].Namespace)
+		assert.Equal(t, "Deployment", napp.Status.Resources[1].Kind)
+	})
 	t.Run("Create pre-existing application in autonomous mode", func(t *testing.T) {
 		app := &v1alpha1.Application{
 			ObjectMeta: v1.ObjectMeta{
@@ -723,6 +784,83 @@ func Test_UpdateEvents(t *testing.T) {
 		assert.Equal(t, v1alpha1.SyncStatusCodeSynced, napp.Status.Sync.Status)
 	})
 
+	t.Run("SpecUpdate in autonomous mode rewrites child app namespaces in status.resources", func(t *testing.T) {
+		upApp := &v1alpha1.Application{
+			ObjectMeta: v1.ObjectMeta{
+				Name:      "parent-app",
+				Namespace: "argocd",
+			},
+			Spec: v1alpha1.ApplicationSpec{
+				Project: "default",
+				Source: &v1alpha1.ApplicationSource{
+					RepoURL:        "https://github.com/example/apps",
+					Path:           ".",
+					TargetRevision: "HEAD",
+				},
+			},
+			Status: v1alpha1.ApplicationStatus{
+				Sync: v1alpha1.SyncStatus{Status: v1alpha1.SyncStatusCodeSynced},
+				Resources: []v1alpha1.ResourceStatus{
+					{
+						Group:     "argoproj.io",
+						Kind:      "Application",
+						Name:      "child-app",
+						Namespace: "argocd",
+						Version:   "v1alpha1",
+						Status:    v1alpha1.SyncStatusCodeSynced,
+					},
+					{
+						Group:     "apps",
+						Kind:      "Deployment",
+						Name:      "my-deploy",
+						Namespace: "default",
+						Version:   "v1",
+						Status:    v1alpha1.SyncStatusCodeSynced,
+					},
+				},
+			},
+		}
+		exApp := upApp.DeepCopy()
+		exApp.Namespace = "agent-staging"
+		fac := kube.NewKubernetesFakeClientWithApps("argocd", exApp)
+		ev := cloudevents.NewEvent()
+		ev.SetDataSchema("application")
+		ev.SetType(event.SpecUpdate.String())
+		ev.SetData(cloudevents.ApplicationJSON, upApp)
+		wq := wqmock.NewTypedRateLimitingInterface[*cloudevents.Event](t)
+		wq.On("Get").Return(&ev, false)
+		wq.On("Done", &ev)
+
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+
+		s, err := NewServer(ctx, fac, "argocd",
+			WithGeneratedTokenSigningKey(),
+			WithAutoNamespaceCreate(true, "", nil),
+			WithRedisProxyDisabled(),
+		)
+		require.NoError(t, err)
+
+		defer func() {
+			_ = s.Shutdown()
+		}()
+
+		err = s.Start(ctx, make(chan error))
+		require.NoError(t, err)
+
+		s.clusterMgr.MapCluster("agent-staging", &v1alpha1.Cluster{Name: "agent-staging", Server: "https://staging.com"})
+		s.setAgentMode("agent-staging", types.AgentModeAutonomous)
+		_, err = s.processRecvQueue(ctx, "agent-staging", wq)
+		assert.NoError(t, err)
+		napp, err := fac.ApplicationsClientset.ArgoprojV1alpha1().Applications("agent-staging").Get(ctx, "parent-app", v1.GetOptions{})
+		require.NoError(t, err)
+		require.NotNil(t, napp)
+		require.Len(t, napp.Status.Resources, 2)
+		assert.Equal(t, "agent-staging", napp.Status.Resources[0].Namespace)
+		assert.Equal(t, "Application", napp.Status.Resources[0].Kind)
+		assert.Equal(t, "default", napp.Status.Resources[1].Namespace)
+		assert.Equal(t, "Deployment", napp.Status.Resources[1].Kind)
+	})
 	t.Run("Spec update for managed mode fails", func(t *testing.T) {
 		upApp := &v1alpha1.Application{
 			ObjectMeta: v1.ObjectMeta{


### PR DESCRIPTION
This PR is to fix https://github.com/argoproj-labs/argocd-agent/issues/949

Issue is caused because in app-of-apps scenario in autonomous agents, parent application `status.resources` has the agent instance namespace (argocd-autonomous) for child application entries and due to this the link generated by UI is not correct as principal does not have that namespace. In principal, resources are stored in namespace same as agent name (agent-autonomous).

Assisted by: Cursor



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed UI navigation for child applications in autonomous agent mode. Namespace references are now correctly rewritten to use the principal-side namespace for both create and update operations.

* **Tests**
  * Added test coverage validating namespace handling in autonomous-mode application processing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/argoproj-labs/argocd-agent/pull/962?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->