### PR TITLE
fix: detect if unmanaged app exists on agent before principal creates one

### DIFF
--- a/agent/inbound.go
+++ b/agent/inbound.go
@@ -186,6 +186,11 @@ func (a *Agent) processIncomingApplication(ev *event.Event) error {
 		if err != nil {
 			return fmt.Errorf("failed to compare identity of app: %w", err)
 		}
+
+		if identity.ExistingMissingSourceUID && ev.Type() != event.Create {
+			return fmt.Errorf("source UID annotation is not found for app: %s", incomingApp.Name)
+		}
+
 		// In managed mode, Drop ownerReferences from the incoming resource
 		// This can lead to garbage-collection of the resource on the agent cluster, if referenced owner is missing. For example, AppSet
 		incomingApp.OwnerReferences = nil
@@ -194,6 +199,10 @@ func (a *Agent) processIncomingApplication(ev *event.Event) error {
 	switch ev.Type() {
 	case event.Create:
 		if a.mode == types.AgentModeManaged {
+			if identity.Exists && identity.ExistingMissingSourceUID {
+				logCtx.Error("Application already exists on agent but is unmanaged.")
+				return fmt.Errorf("application already exists on agent but is unmanaged, please clean it up or switch agent to autonomous mode")
+			}
 			err = a.syncManagedApplication(logCtx, incomingApp, identity, principalUID)
 		} else {
 			_, err = a.createApplication(incomingApp, principalUID)

--- a/internal/manager/application/application.go
+++ b/internal/manager/application/application.go
@@ -38,8 +38,10 @@ import (
 	ty "k8s.io/apimachinery/pkg/types"
 )
 
-type updateTransformer func(existing, incoming *v1alpha1.Application)
-type patchTransformer func(existing, incoming *v1alpha1.Application) (jsondiff.Patch, error)
+type (
+	updateTransformer func(existing, incoming *v1alpha1.Application)
+	patchTransformer  func(existing, incoming *v1alpha1.Application) (jsondiff.Patch, error)
+)
 
 // LastUpdatedAnnotation is a label put on applications which contains the time
 // when an update was last received for this Application
@@ -147,7 +149,6 @@ func stampLastUpdated(app *v1alpha1.Application) {
 
 // Create creates the application app using the Manager's application backend.
 func (m *ApplicationManager) Create(ctx context.Context, app *v1alpha1.Application) (*v1alpha1.Application, error) {
-
 	// A new Application must neither specify ResourceVersion nor Generation
 	app.ResourceVersion = ""
 	app.Generation = 0
@@ -322,7 +323,6 @@ func (m *ApplicationManager) UpdateManagedApp(ctx context.Context, incoming *v1a
 		if incoming.DeletionTimestamp != nil && existing.DeletionTimestamp == nil {
 			deletionTimestampChanged = true
 		}
-
 	}, func(existing, incoming *v1alpha1.Application) (jsondiff.Patch, error) {
 		applyManagedIdentity(existing, incoming, identity)
 
@@ -385,13 +385,14 @@ func (m *ApplicationManager) UpdateManagedApp(ctx context.Context, incoming *v1a
 // resource and the existing resource on the agent. The agent uses this to
 // decide whether to update, delete/recreate, or transition in-place.
 type IdentityCompareResult struct {
-	Exists              bool
-	SourceUIDMatch      bool
-	PrincipalUIDMatch   bool
-	PrincipalTransition bool // principal-uid changed (failover detected)
-	MissingSourceUID    bool // incoming has no source-uid (AppSet wiped it)
-	MissingPrincipalUID bool // no principal-uid in event (pre-upgrade principal)
-	AdoptedPrincipalUID bool // existing had no principal-uid; incoming's was accepted as-is
+	Exists                   bool
+	SourceUIDMatch           bool
+	PrincipalUIDMatch        bool
+	PrincipalTransition      bool // principal-uid changed (failover detected)
+	MissingSourceUID         bool // incoming has no source-uid (AppSet wiped it)
+	MissingPrincipalUID      bool // no principal-uid in event (pre-upgrade principal)
+	AdoptedPrincipalUID      bool // existing had no principal-uid; incoming's was accepted as-is
+	ExistingMissingSourceUID bool // existing application does not have a source-uid (exists before principal does)
 }
 
 // CompareIdentity checks an existing app against the incoming app and
@@ -418,7 +419,7 @@ func (m *ApplicationManager) CompareIdentity(ctx context.Context, incoming *v1al
 
 	existingSourceUID, hasSourceUID := existing.Annotations[manager.SourceUIDAnnotation]
 	if !hasSourceUID {
-		return result, fmt.Errorf("source UID Annotation is not found for app: %s", incoming.Name)
+		result.ExistingMissingSourceUID = true
 	}
 
 	incomingUID := string(incoming.UID)
@@ -454,6 +455,9 @@ func (m *ApplicationManager) CompareSourceUID(ctx context.Context, incoming *v1a
 	result, err := m.CompareIdentity(ctx, incoming, "")
 	if err != nil {
 		return result != nil && result.Exists, false, err
+	}
+	if result.ExistingMissingSourceUID {
+		return result != nil && result.Exists, false, fmt.Errorf("source UID Annotation is not found for app: test")
 	}
 	return result.Exists, result.SourceUIDMatch, nil
 }

--- a/internal/manager/application/application.go
+++ b/internal/manager/application/application.go
@@ -457,7 +457,7 @@ func (m *ApplicationManager) CompareSourceUID(ctx context.Context, incoming *v1a
 		return result != nil && result.Exists, false, err
 	}
 	if result.ExistingMissingSourceUID {
-		return result != nil && result.Exists, false, fmt.Errorf("source UID Annotation is not found for app: test")
+		return result != nil && result.Exists, false, fmt.Errorf("source UID Annotation is not found for app: %s", incoming.Name)
 	}
 	return result.Exists, result.SourceUIDMatch, nil
 }

--- a/internal/manager/application/application_test.go
+++ b/internal/manager/application/application_test.go
@@ -44,8 +44,10 @@ import (
 	ktypes "k8s.io/apimachinery/pkg/types"
 )
 
-var appExistsError = errors.NewAlreadyExists(schema.GroupResource{Group: "argoproj.io", Resource: "application"}, "existing")
-var appNotFoundError = errors.NewNotFound(schema.GroupResource{Group: "argoproj.io", Resource: "application"}, "existing")
+var (
+	appExistsError   = errors.NewAlreadyExists(schema.GroupResource{Group: "argoproj.io", Resource: "application"}, "existing")
+	appNotFoundError = errors.NewNotFound(schema.GroupResource{Group: "argoproj.io", Resource: "application"}, "existing")
+)
 
 func fakeInformer(t *testing.T, namespace string, objects ...runtime.Object) (*fakeappclient.Clientset, *informer.Informer[*v1alpha1.Application]) {
 	t.Helper()
@@ -350,7 +352,6 @@ func Test_ManagerUpdateManaged(t *testing.T) {
 		require.NotNil(t, updated)
 		require.Empty(t, updated.Finalizers)
 	})
-
 }
 
 func Test_ManagerUpdateStatus(t *testing.T) {


### PR DESCRIPTION
**What does this PR do / why we need it**:

#950 discusses that in managed mode, if an unmanaged application exists on an agent that has the same name and namespace as one a principal app would create on the agent then there will be errors and it is hard to track down. This PR adds in a check to return a proper error if this happens. This check happens when an application is set to be created and the identity comparison shows that it exists but is missing a uid. 

N/A

**How to test changes / Special notes to the reviewer**:
1. Create an app on a managed agent
2. Create an app on the principal that would target the same app you created on the managed agent
3. Check the error logs to see if the new error messages are there

**Checklist**

* [ ] Documentation update is required by this PR (and has been updated) OR no documentation update is required.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Stricter validation in managed mode when an existing agent-side application lacks a source identifier: non-create events now fail to prevent invalid transitions.
  * For create events, if an unmanaged app already exists on the agent, the system logs and returns a clearer error with guidance to clean up or switch to autonomous mode.

* **Tests**
  * Internal test declarations refactored for clarity; no behavioral changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->