### PR TITLE
refactor: use %w instead of %v for error wrapping in fmt.Errorf calls

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -479,7 +479,7 @@ func NewAgent(ctx context.Context, client *kube.KubernetesClient, namespace stri
 
 	clusterCache, err := cluster.NewClusterCacheInstance(a.redisProxyMsgHandler.redisAddress, a.redisProxyMsgHandler.redisPassword, cacheutil.RedisCompressionGZip, clusterCacheTLSConfig)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create cluster cache instance: %v", err)
+		return nil, fmt.Errorf("failed to create cluster cache instance: %w", err)
 	}
 	a.clusterCache = clusterCache
 

--- a/agent/connection.go
+++ b/agent/connection.go
@@ -330,7 +330,7 @@ func (a *Agent) resyncOnStart(logCtx *logrus.Entry) error {
 		// send the checksum to the principal
 		ev, err := a.emitter.RequestSyncedResourceListEvent(checksum)
 		if err != nil {
-			return fmt.Errorf("failed to create synced resource list event: %v", err)
+			return fmt.Errorf("failed to create synced resource list event: %w", err)
 		}
 
 		sendQ.Add(ev)

--- a/agent/inbound_redis.go
+++ b/agent/inbound_redis.go
@@ -159,7 +159,7 @@ func (a *Agent) handleRedisSubscribeMessage(logCtx *logrus.Entry, rreq *event.Re
 		var err error
 		channelName, err = stripNamespaceFromRedisKey(channelName, logCtx)
 		if err != nil {
-			return nil, fmt.Errorf("unable to transform SUBSCRIBE key for agent: %v", err)
+			return nil, fmt.Errorf("unable to transform SUBSCRIBE key for agent: %w", err)
 		}
 	}
 
@@ -273,7 +273,7 @@ func (a *Agent) handleRedisGetMessage(logCtx *logrus.Entry, rreq *event.RedisReq
 		var err error
 		key, err = stripNamespaceFromRedisKey(key, logCtx)
 		if err != nil {
-			return nil, fmt.Errorf("unable to transform GET key for agent: %v", err)
+			return nil, fmt.Errorf("unable to transform GET key for agent: %w", err)
 		}
 	}
 

--- a/cmd/argocd-agent/agent.go
+++ b/cmd/argocd-agent/agent.go
@@ -537,7 +537,7 @@ func redisCreds(credsDirPath string, username string, password string) (outUsern
 		if err != nil {
 			// The file is optional, use an empty username if missing
 			if !os.IsNotExist(err) {
-				return "", "", fmt.Errorf("failed reading username from '%s': %v", usernameFile, err)
+				return "", "", fmt.Errorf("failed reading username from '%s': %w", usernameFile, err)
 			}
 			usernameData = []byte{}
 		}
@@ -546,7 +546,7 @@ func redisCreds(credsDirPath string, username string, password string) (outUsern
 		passwordFile := filepath.Join(credsDirPath, "auth")
 		passwordData, err := os.ReadFile(passwordFile)
 		if err != nil {
-			return "", "", fmt.Errorf("failed reading password from '%s': %v", passwordFile, err)
+			return "", "", fmt.Errorf("failed reading password from '%s': %w", passwordFile, err)
 		}
 		password = strings.TrimSpace(string(passwordData))
 	}

--- a/cmd/cmdutil/kube.go
+++ b/cmd/cmdutil/kube.go
@@ -30,7 +30,7 @@ func GetKubeConfig(ctx context.Context, namespace string, kubeConfig string, kub
 	if kubeConfig != "" {
 		fullKubeConfigPath, err = filepath.Abs(kubeConfig)
 		if err != nil {
-			return nil, fmt.Errorf("cannot expand path %s: %v", kubeConfig, err)
+			return nil, fmt.Errorf("cannot expand path %s: %w", kubeConfig, err)
 		}
 	}
 

--- a/cmd/ctl/agent.go
+++ b/cmd/ctl/agent.go
@@ -92,7 +92,7 @@ func generateAgentClientCert(agentName string, clt *kube.KubernetesClient) (clie
 	// PEM already, but the tls.Certificate contains only RAW byte.
 	caData, err = tlsutil.CertDataToPEM(tlsCert.Certificate[0])
 	if err != nil {
-		err = fmt.Errorf("could not encode CA cert to PEM: %v", err)
+		err = fmt.Errorf("could not encode CA cert to PEM: %w", err)
 		return
 	}
 
@@ -536,7 +536,7 @@ func loadClusterSecret(agentName string) (*v1alpha1.Cluster, error) {
 	}
 	clus, err := db.SecretToCluster(sec)
 	if err != nil {
-		return nil, fmt.Errorf("invalid cluster secret: %v", err)
+		return nil, fmt.Errorf("invalid cluster secret: %w", err)
 	}
 	return clus, nil
 }

--- a/cmd/ctl/ca.go
+++ b/cmd/ctl/ca.go
@@ -592,7 +592,7 @@ func readAndSummarizeCertificate(ctx context.Context, clt *kube.KubernetesClient
 	}
 	parsedCert, err := x509.ParseCertificate(cert.Certificate[0])
 	if err != nil {
-		return certificateSummary{}, fmt.Errorf("could not parse certificate: %v", err)
+		return certificateSummary{}, fmt.Errorf("could not parse certificate: %w", err)
 	}
 
 	warnings := []string{}

--- a/cmd/ctl/validate.go
+++ b/cmd/ctl/validate.go
@@ -591,7 +591,7 @@ func principalNoApplicationCRs(ctx context.Context, kc *kube.KubernetesClient, n
 	gvr := schema.GroupVersionResource{Group: "argoproj.io", Version: "v1alpha1", Resource: "applications"}
 	apps, err := kc.DynamicClient.Resource(gvr).Namespace(ns).List(ctx, metav1.ListOptions{})
 	if err != nil {
-		return fmt.Errorf("failed to list applications in namespace %s: %v", ns, err)
+		return fmt.Errorf("failed to list applications in namespace %s: %w", ns, err)
 	}
 
 	if len(apps.Items) > 0 {

--- a/internal/argocd/cluster/cluster.go
+++ b/internal/argocd/cluster/cluster.go
@@ -169,7 +169,7 @@ func (m *Manager) setClusterInfo(clusterServer, agentName, clusterName string, c
 
 	// Save the given cluster info in cache.
 	if err := m.clusterCache.SetClusterInfo(clusterServer, clusterInfo); err != nil {
-		return fmt.Errorf("failed to refresh connection info in cluster: '%s' mapped with agent: '%s': %v", clusterName, agentName, err)
+		return fmt.Errorf("failed to refresh connection info in cluster: '%s' mapped with agent: '%s': %w", clusterName, agentName, err)
 	}
 	return nil
 }
@@ -205,14 +205,14 @@ func CreateClusterWithBearerToken(ctx context.Context, kubeclient kubernetes.Int
 	// Generate bearer token for this agent
 	bearerToken, err := tokenIssuer.IssueResourceProxyToken(agentName)
 	if err != nil {
-		return fmt.Errorf("could not issue resource proxy token: %v", err)
+		return fmt.Errorf("could not issue resource proxy token: %w", err)
 	}
 	logCtx.Info("Successfully issued resource proxy token")
 
 	// Read shared client certificate for mTLS
 	clientCert, clientKey, caData, err := readClientCertFromSecret(ctx, kubeclient, namespace, clientCertSecretName)
 	if err != nil {
-		return fmt.Errorf("could not read client certificate from secret %s: %v", clientCertSecretName, err)
+		return fmt.Errorf("could not read client certificate from secret %s: %w", clientCertSecretName, err)
 	}
 	logCtx.Info("Successfully read client certificate from secret")
 
@@ -247,7 +247,7 @@ func CreateClusterWithBearerToken(ctx context.Context, kubeclient kubernetes.Int
 		},
 	}
 	if err := ClusterToSecret(cluster, secret); err != nil {
-		return fmt.Errorf("could not convert cluster to secret: %v", err)
+		return fmt.Errorf("could not convert cluster to secret: %w", err)
 	}
 
 	// Create the cluster secret
@@ -256,7 +256,7 @@ func CreateClusterWithBearerToken(ctx context.Context, kubeclient kubernetes.Int
 			logCtx.Info("Cluster secret already exists, skipping creation")
 			return nil
 		}
-		return fmt.Errorf("could not create cluster secret: %v", err)
+		return fmt.Errorf("could not create cluster secret: %w", err)
 	}
 
 	logCtx.Info("Successfully created self-registered cluster secret with shared client cert and bearer token")
@@ -281,24 +281,24 @@ func UpdateClusterBearerTokenFromSecret(ctx context.Context, kubeclient kubernet
 
 	cluster, err := db.SecretToCluster(secret)
 	if err != nil {
-		return fmt.Errorf("could not parse cluster secret: %v", err)
+		return fmt.Errorf("could not parse cluster secret: %w", err)
 	}
 
 	// Generate new bearer token
 	bearerToken, err := tokenIssuer.IssueResourceProxyToken(agentName)
 	if err != nil {
-		return fmt.Errorf("could not issue resource proxy token: %v", err)
+		return fmt.Errorf("could not issue resource proxy token: %w", err)
 	}
 	logCtx.Info("Successfully issued new resource proxy token")
 
 	cluster.Config.BearerToken = bearerToken
 
 	if err := ClusterToSecret(cluster, secret); err != nil {
-		return fmt.Errorf("could not convert cluster to secret: %v", err)
+		return fmt.Errorf("could not convert cluster to secret: %w", err)
 	}
 
 	if _, err = kubeclient.CoreV1().Secrets(namespace).Update(ctx, secret, metav1.UpdateOptions{}); err != nil {
-		return fmt.Errorf("could not update cluster secret: %v", err)
+		return fmt.Errorf("could not update cluster secret: %w", err)
 	}
 
 	logCtx.Info("Successfully updated cluster secret bearer token")

--- a/internal/argocd/cluster/manager.go
+++ b/internal/argocd/cluster/manager.go
@@ -81,7 +81,7 @@ func NewManager(ctx context.Context, namespace, redisAddress, redisPassword stri
 
 	m.clusterCache, err = NewClusterCacheInstance(redisAddress, redisPassword, redisCompressionType, tlsConfig)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create cluster cache instance: %v", err)
+		return nil, fmt.Errorf("failed to create cluster cache instance: %w", err)
 	}
 
 	// We are only interested in secrets that have both, Argo CD's label for

--- a/internal/env/env.go
+++ b/internal/env/env.go
@@ -88,7 +88,7 @@ func Bool(key string) (bool, error) {
 	}
 	bv, err := strconv.ParseBool(ev)
 	if err != nil {
-		return false, fmt.Errorf("error parsing environment '%s': %v", key, err)
+		return false, fmt.Errorf("error parsing environment '%s': %w", key, err)
 	}
 	return bv, nil
 }
@@ -100,7 +100,7 @@ func String(key string, validator func(string) error) (string, error) {
 	}
 	if validator != nil {
 		if err := validator(ev); err != nil {
-			return "", fmt.Errorf("error validating environment '%s': %v", key, err)
+			return "", fmt.Errorf("error validating environment '%s': %w", key, err)
 		}
 	}
 	return ev, nil
@@ -117,7 +117,7 @@ func Num(key string, validator func(num int) error) (int, error) {
 	}
 	if validator != nil {
 		if err := validator(int(nv)); err != nil {
-			return 0, fmt.Errorf("error validating environment '%s': %v", key, err)
+			return 0, fmt.Errorf("error validating environment '%s': %w", key, err)
 		}
 	}
 	return int(nv), nil
@@ -133,7 +133,7 @@ func StringSlice(key string, validator func(string) error) ([]string, error) {
 		s = strings.TrimSpace(s)
 		if validator != nil {
 			if err := validator(s); err != nil {
-				return []string{}, fmt.Errorf("error validating environment '%s': %v", key, err)
+				return []string{}, fmt.Errorf("error validating environment '%s': %w", key, err)
 			}
 		}
 		ret = append(ret, s)
@@ -149,12 +149,12 @@ func Duration(key string, validator func(time.Duration) error) (time.Duration, e
 
 	d, err := time.ParseDuration(ev)
 	if err != nil {
-		return 0, fmt.Errorf("error parsing duration '%s': %v", key, err)
+		return 0, fmt.Errorf("error parsing duration '%s': %w", key, err)
 	}
 
 	if validator != nil {
 		if err := validator(d); err != nil {
-			return 0, fmt.Errorf("error validating environment '%s': %v", key, err)
+			return 0, fmt.Errorf("error validating environment '%s': %w", key, err)
 		}
 	}
 	return d, nil

--- a/internal/resync/resync.go
+++ b/internal/resync/resync.go
@@ -258,7 +258,7 @@ func (r *RequestHandler) sendRequestUpdate(ctx context.Context, resource resourc
 	resClient := r.dynClient.Resource(gvr)
 	res, err := resClient.Namespace(resource.Namespace).Get(ctx, resource.Name, v1.GetOptions{})
 	if err != nil {
-		return fmt.Errorf("failed to get resource: %v", err)
+		return fmt.Errorf("failed to get resource: %w", err)
 	}
 	logCtx := logCtxForResourceKey(r.log, resource)
 	reqUpdate, err := newRequestUpdateFromObject(res, resource.Kind, r.peerNamespace)
@@ -629,7 +629,7 @@ func generateSpecChecksum(resObj *unstructured.Unstructured) ([]byte, error) {
 
 	specBytes, err := json.Marshal(resSpec)
 	if err != nil {
-		return nil, fmt.Errorf("failed to marshal application spec: %v", err)
+		return nil, fmt.Errorf("failed to marshal application spec: %w", err)
 	}
 
 	checksum := sha256.Sum256(specBytes)

--- a/internal/tlsutil/generate.go
+++ b/internal/tlsutil/generate.go
@@ -68,7 +68,7 @@ func GenerateCaCertificate(commonName string) (string, string, error) {
 		Bytes: certBytes,
 	})
 	if err != nil {
-		return "", "", fmt.Errorf("error encoding certificate: %v", err)
+		return "", "", fmt.Errorf("error encoding certificate: %w", err)
 	}
 
 	keyPem := new(bytes.Buffer)
@@ -77,7 +77,7 @@ func GenerateCaCertificate(commonName string) (string, string, error) {
 		Bytes: x509.MarshalPKCS1PrivateKey(key),
 	})
 	if err != nil {
-		return "", "", fmt.Errorf("error encoding key: %v", err)
+		return "", "", fmt.Errorf("error encoding key: %w", err)
 	}
 
 	return certPem.String(), keyPem.String(), nil
@@ -161,7 +161,7 @@ func GenerateCertificate(cert *x509.Certificate, signerCert *x509.Certificate, s
 		Bytes: certBytes,
 	})
 	if err != nil {
-		return "", "", fmt.Errorf("error encoding certificate: %v", err)
+		return "", "", fmt.Errorf("error encoding certificate: %w", err)
 	}
 
 	keyPem := new(bytes.Buffer)
@@ -170,7 +170,7 @@ func GenerateCertificate(cert *x509.Certificate, signerCert *x509.Certificate, s
 		Bytes: x509.MarshalPKCS1PrivateKey(key),
 	})
 	if err != nil {
-		return "", "", fmt.Errorf("error encoding key: %v", err)
+		return "", "", fmt.Errorf("error encoding key: %w", err)
 	}
 
 	return certPem.String(), keyPem.String(), nil

--- a/pkg/client/remote.go
+++ b/pkg/client/remote.go
@@ -167,7 +167,7 @@ func WithTLSClientCertFromFile(certPath, keyPath string) RemoteOption {
 	return func(r *Remote) error {
 		c, err := tlsutil.TLSCertFromFile(certPath, keyPath, true)
 		if err != nil {
-			return fmt.Errorf("unable to read TLS client cert: %v", err)
+			return fmt.Errorf("unable to read TLS client cert: %w", err)
 		}
 		r.tlsConfig.Certificates = append(r.tlsConfig.Certificates, c)
 		return nil
@@ -180,7 +180,7 @@ func WithTLSClientCertFromSecret(kube kubernetes.Interface, namespace, name stri
 	return func(r *Remote) error {
 		c, err := tlsutil.TLSCertFromSecret(context.Background(), kube, namespace, name)
 		if err != nil {
-			return fmt.Errorf("unable to read TLS client from secret: %v", err)
+			return fmt.Errorf("unable to read TLS client from secret: %w", err)
 		}
 		r.tlsConfig.Certificates = append(r.tlsConfig.Certificates, c)
 		return nil

--- a/principal/redisproxy/util.go
+++ b/principal/redisproxy/util.go
@@ -61,7 +61,7 @@ var ErrInvalidRequest = errors.New("invalid request")
 func readRedisArray(rd *bufio.Reader) ([]string, []string, error) {
 	line, err := rd.ReadString('\n')
 	if err != nil {
-		return nil, nil, fmt.Errorf("readArray ReadString error: %v", err)
+		return nil, nil, fmt.Errorf("readArray ReadString error: %w", err)
 	}
 	if len(line) < 3 {
 		return nil, nil, fmt.Errorf("readArray unexpected 'line' length")

--- a/principal/registration/registration.go
+++ b/principal/registration/registration.go
@@ -59,7 +59,7 @@ func (mgr *AgentRegistrationManager) RegisterAgent(ctx context.Context, agentNam
 	// Get cluster secret if it exists
 	existingSecret, err := cluster.GetClusterSecret(ctx, mgr.kubeclient, mgr.namespace, agentName)
 	if err != nil {
-		return fmt.Errorf("could not get cluster secret: %v", err)
+		return fmt.Errorf("could not get cluster secret: %w", err)
 	}
 
 	if existingSecret != nil {
@@ -88,7 +88,7 @@ func (mgr *AgentRegistrationManager) RegisterAgent(ctx context.Context, agentNam
 
 		// Token is invalid, update it
 		if err := cluster.UpdateClusterBearerTokenFromSecret(ctx, mgr.kubeclient, mgr.namespace, agentName, existingSecret, mgr.issuer); err != nil {
-			return fmt.Errorf("failed to refresh cluster bearer token: %v", err)
+			return fmt.Errorf("failed to refresh cluster bearer token: %w", err)
 		}
 
 		logCtx.Info("Cluster bearer token refreshed successfully")

--- a/principal/resource.go
+++ b/principal/resource.go
@@ -403,12 +403,12 @@ func (s *Server) extractAgentFromAuth(r *http.Request) (string, error) {
 		claims, err := s.issuer.ValidateResourceProxyToken(token)
 		if err != nil {
 			logCtx.WithError(err).Info("Bearer token validation failed")
-			return "", fmt.Errorf("invalid bearer token: %v", err)
+			return "", fmt.Errorf("invalid bearer token: %w", err)
 		}
 		subject, err := claims.GetSubject()
 		if err != nil {
 			logCtx.WithError(err).Info("Could not get subject from token")
-			return "", fmt.Errorf("could not get subject from token: %v", err)
+			return "", fmt.Errorf("could not get subject from token: %w", err)
 		}
 		logCtx.WithField("agent", subject).Info("Successfully authenticated via bearer token")
 		return subject, nil

--- a/principal/server.go
+++ b/principal/server.go
@@ -926,7 +926,7 @@ func (s *Server) handleResyncOnConnect(agent types.Agent) error {
 			// So, we send the current state of AppProjects/Repositories to the agent after it reconnects.
 			logCtx.Trace("Sending current state of AppProjects and Repositories to the agent")
 			if err := s.sendCurrentStateToAgent(agent.Name()); err != nil {
-				return fmt.Errorf("failed to send current state to agent: %v", err)
+				return fmt.Errorf("failed to send current state to agent: %w", err)
 			}
 		}
 		logCtx.Trace("Skipping resync messages since the principal has synced with this agent before")
@@ -960,7 +960,7 @@ func (s *Server) handleResyncOnConnect(agent types.Agent) error {
 		// send the checksum to the principal
 		ev, err := s.events.RequestSyncedResourceListEvent(checksum)
 		if err != nil {
-			return fmt.Errorf("failed to create SyncedResourceList event: %v", err)
+			return fmt.Errorf("failed to create SyncedResourceList event: %w", err)
 		}
 
 		span.SetAttributes(tracing.AttrEventType.String(event.SyncedResourceList.String()))
@@ -973,13 +973,13 @@ func (s *Server) handleResyncOnConnect(agent types.Agent) error {
 		// So, we send the current state of AppProjects and Repositories to the agent. This ensures that the agent is in sync with the principal.
 		logCtx.Trace("Sending current state of AppProjects and Repositories to the agent")
 		if err := s.sendCurrentStateToAgent(agent.Name()); err != nil {
-			return fmt.Errorf("failed to send current state to agent: %v", err)
+			return fmt.Errorf("failed to send current state to agent: %w", err)
 		}
 
 		// In managed mode, principal is the source of truth and the it should request resource resync
 		ev, err := s.events.RequestResourceResyncEvent()
 		if err != nil {
-			return fmt.Errorf("failed to create ResourceResync event: %v", err)
+			return fmt.Errorf("failed to create ResourceResync event: %w", err)
 		}
 
 		span.SetAttributes(tracing.AttrEventType.String(event.EventRequestResourceResync.String()))
@@ -1004,7 +1004,7 @@ func (s *Server) sendCurrentStateToAgent(agent string) error {
 	// Send all the AppProjects to the agent
 	appProjects, err := s.projectManager.List(s.ctx, backend.AppProjectSelector{Namespace: s.namespace})
 	if err != nil {
-		return fmt.Errorf("failed to list AppProjects: %v", err)
+		return fmt.Errorf("failed to list AppProjects: %w", err)
 	}
 
 	projectMap := map[string]v1alpha1.AppProject{}
@@ -1042,7 +1042,7 @@ func (s *Server) sendCurrentStateToAgent(agent string) error {
 			},
 		})
 		if err != nil {
-			return fmt.Errorf("failed to list secrets of type %s: %v", secretType, err)
+			return fmt.Errorf("failed to list secrets of type %s: %w", secretType, err)
 		}
 
 		for _, repository := range repositories {

--- a/test/e2e/fixture/argoclient.go
+++ b/test/e2e/fixture/argoclient.go
@@ -444,7 +444,7 @@ func GetInitialAdminSecret(k8sClient KubeClient) (string, error) {
 		types.NamespacedName{Namespace: PrincipalNamespace, Name: "argocd-initial-admin-secret"}, pwdSecret, metav1.GetOptions{})
 
 	if err != nil {
-		return "", fmt.Errorf("unable to get admin secret: %v", err)
+		return "", fmt.Errorf("unable to get admin secret: %w", err)
 	}
 
 	return string(pwdSecret.Data["password"]), nil

--- a/test/e2e/fixture/registration.go
+++ b/test/e2e/fixture/registration.go
@@ -36,7 +36,7 @@ const (
 func EnableSelfAgentRegistration(ctx context.Context, principalClient, agentClient KubeClient) error {
 	// Create the shared client cert secret for self-registration
 	if err := CreateSharedClientCertSecret(ctx, principalClient, agentClient); err != nil {
-		return fmt.Errorf("failed to create shared client cert secret: %v", err)
+		return fmt.Errorf("failed to create shared client cert secret: %w", err)
 	}
 
 	// Set both the enable flag and the client cert secret name environment variables
@@ -100,7 +100,7 @@ func CreateSharedClientCertSecret(ctx context.Context, principalClient, agentCli
 	agentClientCert := &corev1.Secret{}
 	agentClientCertKey := types.NamespacedName{Name: config.SecretNameAgentClientCert, Namespace: ManagedAgentNamespace}
 	if err := agentClient.Get(ctx, agentClientCertKey, agentClientCert, metav1.GetOptions{}); err != nil {
-		return fmt.Errorf("failed to get agent client certificate: %v", err)
+		return fmt.Errorf("failed to get agent client certificate: %w", err)
 	}
 
 	tlsCert, ok := agentClientCert.Data["tls.crt"]
@@ -117,7 +117,7 @@ func CreateSharedClientCertSecret(ctx context.Context, principalClient, agentCli
 	caSecret := &corev1.Secret{}
 	caSecretKey := types.NamespacedName{Name: config.SecretNamePrincipalCA, Namespace: PrincipalNamespace}
 	if err := principalClient.Get(ctx, caSecretKey, caSecret, metav1.GetOptions{}); err != nil {
-		return fmt.Errorf("failed to get CA certificate secret: %v", err)
+		return fmt.Errorf("failed to get CA certificate secret: %w", err)
 	}
 
 	caCert, ok := caSecret.Data["tls.crt"]
@@ -140,7 +140,7 @@ func CreateSharedClientCertSecret(ctx context.Context, principalClient, agentCli
 	}
 
 	if err := principalClient.Create(ctx, sharedSecret, metav1.CreateOptions{}); err != nil {
-		return fmt.Errorf("failed to create shared client cert secret: %v", err)
+		return fmt.Errorf("failed to create shared client cert secret: %w", err)
 	}
 
 	return nil


### PR DESCRIPTION
Just replace `%v` with `%w` in 51 `fmt.Errorf` calls (20 files) where the last argument is an error. 
Using `%v` breaks the error chain - `errors.Is()` and `errors.As()` can't unwrap through it. 
The codebase already uses `%w` in 258 places; these were the remaining inconsistencies

## Test plan
- [x] `go build ./...` passes
- [x] `go test -race -p 1 ./...` passes (excluding E2E tests)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced error handling throughout the application to improve diagnostic capabilities and troubleshooting when failures occur.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->