### PR TITLE
fix: destination mapping shouldn't require agent name in AppProject sourceNamespaces

### DIFF
--- a/docs/user-guide/appprojects.md
+++ b/docs/user-guide/appprojects.md
@@ -22,14 +22,25 @@ In managed mode, AppProjects must be created on the **principal cluster** (contr
 
 ### Distribution Logic
 
-The principal distributes an AppProject to a managed agent when **both** conditions are met:
+The principal distributes an AppProject to a managed agent based on the active mapping mode.
+Glob pattern matching is used throughout, so wildcards like `agent-*` are supported.
 
-1. The agent name matches one of the patterns in `.spec.destinations[].name`
-2. The agent name matches one of the patterns in `.spec.sourceNamespaces`
+**Namespace-based mapping** (default): the agent name must match **both**:
 
-This uses glob pattern matching, so wildcards like `agent-*` are supported.
+1. A pattern in `.spec.destinations[].name` (or via server URL `?agentName=` param)
+2. A pattern in `.spec.sourceNamespaces`
+
+**Destination-based mapping**: the agent name must match:
+
+1. A pattern in `.spec.destinations[].name` (or via server URL `?agentName=` param)
+
+`.spec.sourceNamespaces` is not consulted for routing in this mode — it is preserved on the AppProject sent to the agent and controls where Applications may live on the workload cluster.
+
+In both modes, a destination deny pattern (`!name`) matching the agent causes the AppProject to be withheld from that agent.
 
 ### Example: Creating an AppProject for Managed Agents
+
+**Namespace-based mapping** (both fields required for routing):
 
 ```yaml
 apiVersion: argoproj.io/v1alpha1
@@ -40,11 +51,30 @@ metadata:
 spec:
   # This project will be distributed to agents matching "agent-*" pattern
   sourceNamespaces:
-  - agent-*
+  - agent-*          # agent name must match here (routing)
   destinations:
-  - name: agent-*
+  - name: agent-*    # and here
     namespace: "guestbook"
     server: "*"
+  sourceRepos:
+  - "*"
+```
+
+**Destination-based mapping** (only destinations required for routing):
+
+```yaml
+apiVersion: argoproj.io/v1alpha1
+kind: AppProject
+metadata:
+  name: my-project
+  namespace: argocd
+spec:
+  destinations:
+  - name: agent-*    # agent name must match here
+    namespace: "guestbook"
+    server: "*"
+  sourceNamespaces:
+  - "*"              # controls app namespaces on the workload cluster, not routing
   sourceRepos:
   - "*"
 ```
@@ -63,8 +93,9 @@ When an AppProject is sent to an agent, it undergoes transformation to make it a
      namespace: "guestbook"  # Preserves original namespace restrictions
 ```
 
-2. **Source Namespaces**: Removed completely since they're only used on the control plane for routing
-    - The `sourceNamespaces` field is used on the control plane to determine which agents should receive the AppProject. Once the AppProject arrives at the agent cluster, this field is removed as it's no longer needed.
+2. **Source Namespaces**:
+    - **Namespace-based mapping**: removed from the AppProject sent to the agent, since it was only used on the principal for routing.
+    - **Destination-based mapping**: preserved on the AppProject sent to the agent, where it controls which namespaces Applications may be created in on the workload cluster.
 
 3. **Roles**: Removed since they're not relevant on the workload cluster
 
@@ -164,9 +195,9 @@ The transformation logic differs significantly between managed and autonomous ag
 
 ### Managed Agents (Principal → Agent)
 - **Direction**: AppProject flows from principal to agent
-- **Selection**: Uses glob pattern matching on `sourceNamespaces` and `destinations` to determine which agents receive the project
+- **Selection**: Glob pattern matching on `destinations` (always) and `sourceNamespaces` (namespace-based mapping only)
 - **Destinations**: Filtered to only include destinations matching the agent, then transformed to `in-cluster`
-- **Source Namespaces**: Removed completely since they're only used on the control plane for routing
+- **Source Namespaces**: Removed in namespace-based mapping (used only for routing on the principal); preserved in destination-based mapping (controls app namespaces on the workload cluster)
 - **Name**: Remains unchanged
 
 ### Autonomous Agents (Agent → Principal)
@@ -187,14 +218,19 @@ The transformation logic differs significantly between managed and autonomous ag
 
 ### For Managed Agents
 
-1. **Use Descriptive Patterns**: Use clear glob patterns in `sourceNamespaces` and `destinations` to target the right agents:
+1. **Use Descriptive Patterns**: Use clear glob patterns to target the right agents. In namespace-based mapping both `sourceNamespaces` and `destinations` must match; in destination-based mapping only `destinations` is used for routing:
 ```yaml
+   # namespace-based mapping
    sourceNamespaces:
    - "production-*"
-   - "staging-*"
    destinations:
    - name: "production-*"
-   - name: "staging-*"
+
+   # destination-based mapping (sourceNamespaces controls app placement, not routing)
+   destinations:
+   - name: "production-*"
+   sourceNamespaces:
+   - "*"
 ```
 
 2. **Test Connectivity**: Ensure agents are connected before creating AppProjects, or they'll receive them upon next connection
@@ -214,7 +250,7 @@ The transformation logic differs significantly between managed and autonomous ag
 ### AppProject Not Appearing on Agent
 
 1. **Check Agent Mode**: Ensure the agent is in managed mode
-2. **Verify Patterns**: Confirm the agent name matches patterns in `sourceNamespaces` and `destinations`
+2. **Verify Patterns**: Confirm the agent name matches patterns in `destinations`. In namespace-based mapping it must also match `sourceNamespaces`
 3. **Check Connectivity**: Verify the agent is connected to the principal
 4. **Review Logs**: Check principal and agent logs for synchronization errors
 

--- a/internal/manager/appproject/appproject.go
+++ b/internal/manager/appproject/appproject.go
@@ -456,11 +456,12 @@ func (m *AppProjectManager) RevertAppProjectChanges(ctx context.Context, project
 
 // DoesAgentMatchWithProject checks if the agent name matches the given AppProject.
 // We match the agent to an AppProject if:
-// 1. The agent name matches any one of the destination names OR
-// 2. The agent name is empty but the agent name is present in the server URL parameter AND
-// 3. The agent name is not denied by any of the destination names
+// 1. The agent name is not denied by any of the destination names.
+// 2. The agent name matches one of the AppProject's destination names and source namespaces in the case of namespace-based mapping.
+// 3. The agent name matches one of the AppProject's destination names in the case of destination-based mapping.
+// It matches the agent name with the server URL parameter if the destination name is empty and the server URL is present.
 // Ref: https://github.com/argoproj/argo-cd/blob/master/pkg/apis/application/v1alpha1/app_project_types.go#L477
-func DoesAgentMatchWithProject(agentName string, appProject v1alpha1.AppProject) bool {
+func DoesAgentMatchWithProject(agentName string, appProject v1alpha1.AppProject, dstMapping bool) bool {
 	destinationMatched := false
 
 	for _, dst := range appProject.Spec.Destinations {
@@ -498,9 +499,14 @@ func DoesAgentMatchWithProject(agentName string, appProject v1alpha1.AppProject)
 		}
 	}
 
-	// Must match both destination and source namespace requirements
-	return destinationMatched &&
-		glob.MatchStringInList(appProject.Spec.SourceNamespaces, agentName, glob.REGEXP)
+	// Must match both destination and source namespace requirements for namespace-based mapping
+	if !dstMapping {
+		return destinationMatched &&
+			glob.MatchStringInList(appProject.Spec.SourceNamespaces, agentName, glob.REGEXP)
+	}
+
+	// For destination-based mapping, only match the destination name
+	return destinationMatched
 }
 
 func isDenyPattern(pattern string) bool {

--- a/internal/manager/appproject/appproject_test.go
+++ b/internal/manager/appproject/appproject_test.go
@@ -351,6 +351,7 @@ func TestDoesAgentMatchWithProject(t *testing.T) {
 		agentName  string
 		appProject v1alpha1.AppProject
 		want       bool
+		dstMapping bool
 	}{
 		{
 			name:      "agent matches destination name",
@@ -499,11 +500,51 @@ func TestDoesAgentMatchWithProject(t *testing.T) {
 			},
 			want: false, // Agent name doesn't match extracted query parameter
 		},
+		{
+			name:      "destination-based mapping - agent only matches destination name",
+			agentName: "agent-prod",
+			appProject: v1alpha1.AppProject{
+				Spec: v1alpha1.AppProjectSpec{
+					Destinations: []v1alpha1.ApplicationDestination{
+						{Name: "agent-prod", Namespace: "default"},
+					},
+					SourceNamespaces: []string{"test"},
+				},
+			},
+			want:       true,
+			dstMapping: true,
+		},
+		{
+			name:      "destination-based mapping - nil sourceNamespaces with matching destination",
+			agentName: "agent-prod",
+			appProject: v1alpha1.AppProject{
+				Spec: v1alpha1.AppProjectSpec{
+					Destinations: []v1alpha1.ApplicationDestination{
+						{Name: "agent-prod", Namespace: "default"},
+					},
+				},
+			},
+			want:       true,
+			dstMapping: true,
+		},
+		{
+			name:      "destination-based mapping - destination does not match",
+			agentName: "agent-prod",
+			appProject: v1alpha1.AppProject{
+				Spec: v1alpha1.AppProjectSpec{
+					Destinations: []v1alpha1.ApplicationDestination{
+						{Name: "other-agent", Namespace: "default"},
+					},
+				},
+			},
+			want:       false,
+			dstMapping: true,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := DoesAgentMatchWithProject(tt.agentName, tt.appProject)
+			got := DoesAgentMatchWithProject(tt.agentName, tt.appProject, tt.dstMapping)
 			assert.Equal(t, tt.want, got)
 		})
 	}

--- a/internal/resync/resync.go
+++ b/internal/resync/resync.go
@@ -429,7 +429,7 @@ func (r *RequestHandler) isAppProjectRelevant(ctx context.Context, logCtx *logru
 			return err, false
 		}
 
-		if appproject.DoesAgentMatchWithProject(agentName, *appProject) {
+		if appproject.DoesAgentMatchWithProject(agentName, *appProject, r.destinationBasedMapping) {
 			// The AppProject is still relevant to the agent
 			logCtx.Trace("AppProject is still relevant to the agent")
 			return nil, true
@@ -476,7 +476,7 @@ func (r *RequestHandler) isAppProjectRelevant(ctx context.Context, logCtx *logru
 			return err, false
 		}
 
-		if appproject.DoesAgentMatchWithProject(agentName, *appProject) {
+		if appproject.DoesAgentMatchWithProject(agentName, *appProject, r.destinationBasedMapping) {
 			// The AppProject is still relevant to the agent
 			logCtx.Trace("AppProject is still relevant to the agent. Checking the repository for updates")
 			return nil, true

--- a/principal/callbacks.go
+++ b/principal/callbacks.go
@@ -770,10 +770,7 @@ func (s *Server) deleteNamespaceCallback(outbound *corev1.Namespace) {
 	logCtx.Tracef("Deleted the queue pair since the agent namespace is deleted")
 }
 
-// mapAppProjectToAgents maps an AppProject to the list of managed agents that should receive it.
-// We sync an AppProject from the principal to an agent if:
-// 1. It is a managed agent (not autonomous)
-// 2. The agent name matches one of the AppProject's destinations and source namespaces
+// mapAppProjectToAgents returns the set of managed agents that should receive this AppProject.
 func (s *Server) mapAppProjectToAgents(appProject v1alpha1.AppProject) map[string]bool {
 	agents := map[string]bool{}
 	s.clientLock.RLock()
@@ -783,7 +780,7 @@ func (s *Server) mapAppProjectToAgents(appProject v1alpha1.AppProject) map[strin
 			continue
 		}
 
-		if appproject.DoesAgentMatchWithProject(agentName, appProject) {
+		if appproject.DoesAgentMatchWithProject(agentName, appProject, s.destinationBasedMapping) {
 			agents[agentName] = true
 		}
 	}

--- a/principal/callbacks_test.go
+++ b/principal/callbacks_test.go
@@ -54,6 +54,7 @@ func TestMapAppProjectToAgents(t *testing.T) {
 		appProject v1alpha1.AppProject
 		agents     map[string]types.AgentMode
 		want       map[string]bool
+		dstMapping bool
 	}{
 		{
 			name: "matches single agent",
@@ -124,11 +125,32 @@ func TestMapAppProjectToAgents(t *testing.T) {
 			},
 			want: map[string]bool{},
 		},
+		{
+			name: "destination-based mapping - agent only matches destination name",
+			appProject: v1alpha1.AppProject{
+				Spec: v1alpha1.AppProjectSpec{
+					Destinations: []v1alpha1.ApplicationDestination{
+						{Name: "cluster-1"},
+					},
+				},
+			},
+			agents: map[string]types.AgentMode{
+				"cluster-1": types.AgentModeManaged,
+				"cluster-2": types.AgentModeManaged,
+			},
+			want: map[string]bool{
+				"cluster-1": true,
+			},
+			dstMapping: true,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			s := &Server{namespaceMap: tt.agents}
+			s := &Server{
+				namespaceMap:            tt.agents,
+				destinationBasedMapping: tt.dstMapping,
+			}
 			got := s.mapAppProjectToAgents(tt.appProject)
 			assert.Equal(t, tt.want, got)
 		})

--- a/principal/server.go
+++ b/principal/server.go
@@ -1015,7 +1015,7 @@ func (s *Server) sendCurrentStateToAgent(agent string) error {
 			}
 		}
 
-		if !appproject.DoesAgentMatchWithProject(agent, appProject) {
+		if !appproject.DoesAgentMatchWithProject(agent, appProject, s.destinationBasedMapping) {
 			continue
 		}
 
@@ -1061,7 +1061,7 @@ func (s *Server) sendCurrentStateToAgent(agent string) error {
 				continue
 			}
 
-			if !appproject.DoesAgentMatchWithProject(agent, project) {
+			if !appproject.DoesAgentMatchWithProject(agent, project, s.destinationBasedMapping) {
 				continue
 			}
 

--- a/test/e2e/dest_mapping_test.go
+++ b/test/e2e/dest_mapping_test.go
@@ -361,6 +361,57 @@ func (suite *DestinationMappingTestSuite) TestAppCreatedInOriginalNamespace() {
 	requires.True(foundDeployment, "Status should include the kustomize-guestbook-ui Deployment")
 }
 
+func (suite *DestinationMappingTestSuite) TestAppProjectSync() {
+	requires := suite.Require()
+	t := suite.T()
+
+	t.Log("Create an appProject on the principal without source namespaces")
+	appProjectName := "destmap-appproject-test"
+	appProject := &argoapp.AppProject{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      appProjectName,
+			Namespace: fixture.PrincipalNamespace,
+		},
+		Spec: argoapp.AppProjectSpec{
+			Destinations: []argoapp.ApplicationDestination{
+				{Name: destMapAgentName},
+			},
+		},
+	}
+
+	err := suite.PrincipalClient.Create(suite.Ctx, appProject, metav1.CreateOptions{})
+	requires.NoError(err)
+
+	defer func() {
+		err = fixture.EnsureDeletion(suite.Ctx, suite.PrincipalClient, appProject)
+		requires.NoError(err)
+	}()
+
+	t.Log("Verify the appProject is synced to the agent")
+	requires.Eventually(func() bool {
+		appProject := &argoapp.AppProject{}
+		err := suite.ManagedAgentClient.Get(suite.Ctx, types.NamespacedName{
+			Name:      appProjectName,
+			Namespace: fixture.ManagedAgentNamespace,
+		}, appProject, metav1.GetOptions{})
+		return err == nil
+	}, 30*time.Second, 1*time.Second)
+
+	t.Log("Delete the appProject from the principal")
+	err = suite.PrincipalClient.Delete(suite.Ctx, appProject, metav1.DeleteOptions{})
+	requires.NoError(err)
+
+	t.Log("Verify the appProject is deleted from the agent")
+	requires.Eventually(func() bool {
+		appProject := &argoapp.AppProject{}
+		err := suite.ManagedAgentClient.Get(suite.Ctx, types.NamespacedName{
+			Name:      appProjectName,
+			Namespace: fixture.ManagedAgentNamespace,
+		}, appProject, metav1.GetOptions{})
+		return errors.IsNotFound(err)
+	}, 30*time.Second, 1*time.Second)
+}
+
 // TestRefreshPropagation verifies that refresh requests from the
 // principal are correctly propagated to the agent.
 func (suite *DestinationMappingTestSuite) TestRefreshPropagation() {


### PR DESCRIPTION
**What does this PR do / why we need it**:

Currently, with destination-based mapping, the principal expects the agent name pattern to match both the destination names and the source namespaces. This PR updates the routing logic to align with the apps, where only the destination name is checked, and the agent name is not required in the sourceNamespaces. The namespace-based mapping still requires the agent name to match both the destination and the sourceNamespace.


**Which issue(s) this PR fixes**:

Fixes https://github.com/argoproj-labs/argocd-agent/issues/921

**How to test changes / Special notes to the reviewer**:

1. Start the principal and the managed agent with destination-based mapping
2. Create an AppProject that has the agent name only in the destination and not the sourceNamespace.
3. The AppProject must be synced to the managed agent.


**Checklist**

* [👍 ] Documentation update is required by this PR (and has been updated) OR no documentation update is required.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added destination-based mapping mode for AppProject synchronization, changing how agents are selected and how AppProjects are routed to managed clusters.

* **Documentation**
  * Expanded AppProject sync guide with clarified behavior for namespace- vs destination-based mapping, updated examples, best practices, and troubleshooting.

* **Tests**
  * Added end-to-end tests covering destination-based AppProject synchronization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->