### PR TITLE
fix: allow viewing CRD live manifests via resource proxy

### DIFF
--- a/agent/resource.go
+++ b/agent/resource.go
@@ -25,6 +25,12 @@ const ownerLookupRecursionLimit = 5
 
 var ErrUnmanaged = errors.New("resource not managed by app")
 
+// isCRD reports whether the given GroupVersionResource refers to a
+// CustomResourceDefinition.
+func isCRD(gvr schema.GroupVersionResource) bool {
+	return gvr.Group == "apiextensions.k8s.io" && gvr.Resource == "customresourcedefinitions"
+}
+
 // processIncomingResourceRequest processes an incoming event that requests
 // to retrieve information from the Kubernetes API.
 //
@@ -83,6 +89,14 @@ func (a *Agent) processIncomingResourceRequest(ev *event.Event) error {
 				if subresource != "" {
 					logCtx.Debugf("Fetching subresource %s of managed resource %s/%s/%s", subresource, gvr.Group, gvr.Version, gvr.Resource)
 					unres, err = a.getManagedResourceSubresource(ctx, gvr, name, namespace, subresource)
+				} else if isCRD(gvr) {
+					// CRDs never receive Argo CD tracking metadata (argoproj/argo-cd#17400),
+					// so the managed-resource check would always reject them. Allow reading
+					// CRDs without the check so their live manifests are viewable in the UI;
+					// Argo CD's own authorization still gates access to the resource proxy.
+					// See #873.
+					logCtx.Debugf("Fetching CRD %s/%s without managed-resource check", gvr.Version, name)
+					unres, err = a.getResource(ctx, gvr, name, namespace)
 				} else {
 					logCtx.Debugf("Fetching managed resource %s/%s/%s", gvr.Group, gvr.Version, gvr.Resource)
 					unres, err = a.getManagedResource(ctx, gvr, name, namespace)
@@ -315,20 +329,22 @@ func (a *Agent) getManagedResourceSubresource(ctx context.Context, gvr schema.Gr
 	return result, nil
 }
 
+// getResource retrieves a single resource from the cluster and returns it as
+// unstructured data, without performing any Argo CD management check.
+func (a *Agent) getResource(ctx context.Context, gvr schema.GroupVersionResource, name, namespace string) (*unstructured.Unstructured, error) {
+	rif := a.kubeClient.DynamicClient.Resource(gvr)
+
+	if namespace != "" {
+		return rif.Namespace(namespace).Get(ctx, name, v1.GetOptions{})
+	}
+	return rif.Get(ctx, name, v1.GetOptions{})
+}
+
 // getManagedResource retrieves a single resource from the cluster
 // and returns it as unstructured data. The resource to be returned must be
 // managed by Argo CD.
 func (a *Agent) getManagedResource(ctx context.Context, gvr schema.GroupVersionResource, name, namespace string) (*unstructured.Unstructured, error) {
-	var err error
-	var res *unstructured.Unstructured
-
-	rif := a.kubeClient.DynamicClient.Resource(gvr)
-
-	if namespace != "" {
-		res, err = rif.Namespace(namespace).Get(ctx, name, v1.GetOptions{})
-	} else {
-		res, err = rif.Get(ctx, name, v1.GetOptions{})
-	}
+	res, err := a.getResource(ctx, gvr, name, namespace)
 	if err != nil {
 		return nil, err
 	}

--- a/agent/resource_test.go
+++ b/agent/resource_test.go
@@ -723,6 +723,71 @@ func Test_processIncomingResourceRequest(t *testing.T) {
 		assert.Equal(t, 403, resp.Status) // Should return forbidden for unmanaged resources
 	})
 
+	t.Run("Get CRD without tracking metadata succeeds", func(t *testing.T) {
+		// CRDs never receive Argo CD tracking metadata (argoproj/argo-cd#17400),
+		// so the managed-resource check must be skipped for them. See #873.
+		crd := &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": "apiextensions.k8s.io/v1",
+				"kind":       "CustomResourceDefinition",
+				"metadata": map[string]interface{}{
+					"name": "policyexceptions.kyverno.io",
+					// Intentionally no Argo CD tracking label/annotation.
+				},
+			},
+		}
+
+		// Setup test environment with a tracking reader that would otherwise
+		// reject the resource, proving the CRD bypass is what allows access.
+		kubeClient := kube.NewDynamicFakeClient(crd)
+		agent := &Agent{
+			context:             context.Background(),
+			kubeClient:          kubeClient,
+			queues:              queue.NewSendRecvQueues(),
+			emitter:             event.NewEventSource("test-agent"),
+			enableResourceProxy: true,
+			trackingReader:      newTestTrackingReader(v1alpha1.TrackingMethodLabel),
+		}
+		require.NoError(t, agent.queues.Create(defaultQueueName))
+
+		reqUUID := "test-uuid"
+		resourceReq := &event.ResourceRequest{
+			UUID: reqUUID,
+			Name: "policyexceptions.kyverno.io",
+			GroupVersionResource: v1.GroupVersionResource{
+				Group:    "apiextensions.k8s.io",
+				Version:  "v1",
+				Resource: "customresourcedefinitions",
+			},
+			Method: http.MethodGet,
+		}
+
+		ev := cloudevents.NewEvent()
+		ev.SetType(event.GetRequest.String())
+		require.NoError(t, ev.SetData(cloudevents.ApplicationJSON, resourceReq))
+
+		err := agent.processIncomingResourceRequest(event.New(&ev, targets.Resource))
+		require.NoError(t, err)
+
+		q := agent.queues.SendQ(defaultQueueName)
+		require.NotNil(t, q)
+
+		responseEv, shutdown := q.Get()
+		assert.False(t, shutdown)
+		require.NotNil(t, responseEv)
+
+		resp := &event.ResourceResponse{}
+		err = responseEv.DataAs(resp)
+		require.NoError(t, err)
+		assert.Equal(t, reqUUID, resp.UUID)
+		assert.Equal(t, 200, resp.Status) // CRD is returned despite lacking tracking metadata
+
+		var responseResource unstructured.Unstructured
+		err = json.Unmarshal([]byte(resp.Resource), &responseResource)
+		require.NoError(t, err)
+		assert.Equal(t, "policyexceptions.kyverno.io", responseResource.GetName())
+	})
+
 	t.Run("Resource not found returns error", func(t *testing.T) {
 		// Setup test environment with empty client
 		kubeClient := kube.NewDynamicFakeClient()


### PR DESCRIPTION
**What does this PR do / why we need it**:

When viewing an Application's resources through the resource proxy, namespaced
resources (Deployments, Pods, Services, etc.) render correctly, but
cluster-scoped **CustomResourceDefinitions** fail with:

```
customresourcedefinitions.apiextensions.k8s.io "<name>" is forbidden: resource not managed by app
```

The agent's resource proxy gates every fetched resource through an
"is this managed by an Argo CD application?" check, which looks for Argo CD
tracking metadata (label/annotation) on the resource or its owners. **CRDs
never receive that tracking metadata** (see argoproj/argo-cd#17400), so the
check always rejects them — even though the CRD is part of the app's resource
tree.

This PR skips the managed-resource check for **read (GET)** requests targeting
CRDs, so their live manifests become viewable in the UI. This matches
@jannfis's suggestion on the issue ("for the time being, we might want to skip
the 'is managed?' check for CRDs"). Argo CD's own authorization still gates
access to the resource proxy.

Note: this is complementary to argoproj/argo-cd#27907 (opt-in repo-server flag
to add tracking metadata to CRDs) — this agent-side change fixes viewing
regardless of whether that flag is enabled.

**Scope / a question for reviewers**:

The bypass is intentionally limited to **read (GET) of the CRD object**:

- Mutating requests (`PATCH`/`DELETE`) on CRDs remain gated by the
  managed-resource check, since deleting a CRD cascades to all of its custom
  resources.
- A GET of a CRD **subresource** (e.g. `/status`) also remains gated, as the
  reported issue and Argo CD's live-manifest view only fetch the main object.

If maintainers prefer the broader "skip the check for CRDs entirely" reading
(including mutating ops and/or subresource reads), I'm happy to extend it
accordingly — just let me know.

**Which issue(s) this PR fixes**:

Fixes #873

**How to test changes / Special notes to the reviewer**:

- New unit test `Test_processIncomingResourceRequest/Get CRD without tracking
  metadata succeeds` asserts that a CRD lacking tracking metadata returns `200`
  (previously `403`).
- Manual: deploy an Application managing a CRD to an agent (autonomous or
  managed), open the app in the Argo CD UI on the principal, and click the CRD
  in the resource tree — the live manifest now loads.

**Checklist**

* [x] Documentation update is required by this PR (and has been updated) OR no documentation update is required. — _No documentation update required; this restores expected behavior for an existing feature._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * CustomResourceDefinitions (CRDs) can now be retrieved and viewed even when the live CRD manifest is not accompanied by management tracking metadata, improving access to CRD live contents.

* **Tests**
  * Added automated coverage to confirm CRD GET requests succeed when the resource lacks management labels/annotations, asserting an HTTP success response and the expected CRD name.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->