### PR TITLE
feat: track dropped EventWriter events in metrics

### DIFF
--- a/agent/connection.go
+++ b/agent/connection.go
@@ -181,6 +181,12 @@ func (a *Agent) handleStreamEvents() error {
 
 	if a.eventWriter == nil {
 		a.eventWriter = event.NewEventWriter("", stream)
+		if a.metrics != nil {
+			// set function to call when an event is discarded
+			a.eventWriter.SetOnDiscard(func(eventType, resourceType string) {
+				a.metrics.EventWriterEventsDiscarded.WithLabelValues(eventType, resourceType).Inc()
+			})
+		}
 	} else {
 		a.eventWriter.UpdateTarget(stream)
 	}

--- a/docs/operations/metrics.md
+++ b/docs/operations/metrics.md
@@ -23,6 +23,7 @@ Here is the list of available metrics:
 |   `principal_events_received` |	counter |   The total number of events sent by principal.   |
 |   `principal_events_sent` |   counter |   The total number of events sent by principal.   |
 |   `principal_event_processing_time`   |   histogramVec    |   Histogram of time taken to process events (in seconds). |
+|   `argocd_principal_event_writer_events_discarded_total`  |	counterVec  |   The total number of events discarded by the EventWriter after exhausting retries.   |
 |   `principal_errors`  |	counterVec  |   The total number of errors occurred in principal.   |
 
 ### Agent Metrics
@@ -31,6 +32,7 @@ Here is the list of available metrics:
 |   `agent_events_received` |   counter |   The total number of events received by agent.   |
 |   `agent_events_sent` |   counter |   The total number of events sent by agent.   |
 |   `agent_event_processing_time`   |	histogramVec    | Histogram of time taken to process events (in seconds).   |
+|   `argocd_agent_event_writer_events_discarded_total`  |	counterVec  |   The total number of events discarded by the EventWriter after exhausting retries.   |
 |   `agent_errors`  |   counterVec	| The total number of errors occurred in agent. |
 
 Here is the list of available labels:
@@ -41,3 +43,4 @@ Here is the list of available labels:
 |   `call_status` | success   |   Status of event processing. Possible values are: success, failure, discarded, not-allowed.  |
 |   `agent_name`  |   agent-managed   |   Name of Agent. Possible values are: agent-managed, agent-autonomous.    |
 |   `resource_type`   |   application |   Type of resource. Possible values are: application, app project, resource, resourceResync.   |
+|   `event_type`   |   create |   Type of event. Possible values are: create, delete, spec-update, status-update, etc.   |

--- a/internal/event/event_writer.go
+++ b/internal/event/event_writer.go
@@ -2,6 +2,7 @@ package event
 
 import (
 	"context"
+	"strings"
 	"sync"
 	"time"
 
@@ -45,6 +46,9 @@ type EventWriter struct {
 
 	// agentName is the name of the agent for which this EventWriter is responsible.
 	agentName string
+
+	// onDiscard is called when an event is discarded after exhausting retries.
+	onDiscard func(eventType, resourceType string)
 
 	log *logrus.Entry
 }
@@ -98,6 +102,12 @@ func (ew *EventWriter) UpdateTarget(target streamWriter) {
 		msg.retryAfter = &now
 		msg.mu.Unlock()
 	}
+}
+
+func (ew *EventWriter) SetOnDiscard(fn func(eventType, resourceType string)) {
+	ew.mu.Lock()
+	defer ew.mu.Unlock()
+	ew.onDiscard = fn
 }
 
 func (ew *EventWriter) Add(ev *cloudevents.Event) {
@@ -305,12 +315,20 @@ func (ew *EventWriter) retrySentEvent(resID string, sentMsg *eventMessage) {
 	// Check if we've exhausted retries
 	if sentMsg.retryCount >= maxEventRetries {
 		logCtx.Warnf("Event failed after %d retries, giving up to unblock queue", sentMsg.retryCount)
+		evType := strings.TrimPrefix(sentMsg.event.Type(), TypePrefix+".")
+		resType := sentMsg.event.DataSchema()
 		sentMsg.mu.Unlock()
 
 		// Remove from sentEvents to unblock the queue
 		ew.mu.Lock()
+		onDiscard := ew.onDiscard
 		delete(ew.sentEvents, resID)
 		ew.mu.Unlock()
+
+		// call function provided by caller to handle the discarded event
+		if onDiscard != nil {
+			onDiscard(evType, resType)
+		}
 		return
 	}
 

--- a/internal/event/event_writer_test.go
+++ b/internal/event/event_writer_test.go
@@ -290,6 +290,14 @@ func TestEventWriter(t *testing.T) {
 		fs := &fakeStream{}
 		evSender := NewEventWriter("test", fs)
 
+		discardCalled := false
+		var discardedEventType, discardedResourceType string
+		evSender.SetOnDiscard(func(eventType, resourceType string) {
+			discardCalled = true
+			discardedEventType = eventType
+			discardedResourceType = resourceType
+		})
+
 		ev := es.ApplicationEvent(Create, app1)
 		resID := createResourceID(app1.ObjectMeta)
 		evSender.Add(ev)
@@ -308,6 +316,11 @@ func TestEventWriter(t *testing.T) {
 
 		// After max retries, event should be removed from sentEvents
 		require.NotContains(t, evSender.sentEvents, resID)
+
+		// Verify onDiscard callback was called with correct values
+		require.True(t, discardCalled)
+		require.Equal(t, "create", discardedEventType)
+		require.Equal(t, TargetApplication.String(), discardedResourceType)
 	})
 
 	t.Run("should not send ACK events to sentEvents", func(t *testing.T) {

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -177,7 +177,7 @@ func NewPrincipalMetrics() *PrincipalMetrics {
 		}, []string{"agent_name", "reason"}),
 
 		EventWriterEventsDiscarded: promauto.NewCounterVec(prometheus.CounterOpts{
-			Name: "principal_event_writer_events_discarded_total",
+			Name: "argocd_principal_event_writer_events_discarded_total",
 			Help: "The total number of events discarded by the EventWriter after exhausting retries",
 		}, []string{"agent_name", "event_type", "resource_type"}),
 
@@ -211,7 +211,7 @@ func NewAgentMetrics() *AgentMetrics {
 		}, []string{"resource_type"}),
 
 		EventWriterEventsDiscarded: promauto.NewCounterVec(prometheus.CounterOpts{
-			Name: "agent_event_writer_events_discarded_total",
+			Name: "argocd_agent_event_writer_events_discarded_total",
 			Help: "The total number of events discarded by the EventWriter after exhausting retries",
 		}, []string{"event_type", "resource_type"}),
 

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -63,19 +63,21 @@ type PrincipalMetrics struct {
 	EventReceived prometheus.Counter
 	EventSent     prometheus.Counter
 
-	EventProcessingTime   *prometheus.HistogramVec
-	EventWriterSendErrors *prometheus.CounterVec
+	EventProcessingTime        *prometheus.HistogramVec
+	EventWriterSendErrors      *prometheus.CounterVec
+	EventWriterEventsDiscarded *prometheus.CounterVec
 
 	PrincipalErrors *prometheus.CounterVec
 }
 
 // AgentMetrics holds metrics of agent
 type AgentMetrics struct {
-	EventReceived       prometheus.Counter
-	EventSent           prometheus.Counter
-	EventProcessingTime *prometheus.HistogramVec
-	PropagationLatency  *prometheus.HistogramVec
-	AgentErrors         *prometheus.CounterVec
+	EventReceived              prometheus.Counter
+	EventSent                  prometheus.Counter
+	EventProcessingTime        *prometheus.HistogramVec
+	PropagationLatency         *prometheus.HistogramVec
+	EventWriterEventsDiscarded *prometheus.CounterVec
+	AgentErrors                *prometheus.CounterVec
 }
 
 func NewInformerMetrics(label string) *InformerMetrics {
@@ -174,6 +176,11 @@ func NewPrincipalMetrics() *PrincipalMetrics {
 			Help: "The total number of EventWriter send errors observed by principal",
 		}, []string{"agent_name", "reason"}),
 
+		EventWriterEventsDiscarded: promauto.NewCounterVec(prometheus.CounterOpts{
+			Name: "principal_event_writer_events_discarded_total",
+			Help: "The total number of events discarded by the EventWriter after exhausting retries",
+		}, []string{"agent_name", "event_type", "resource_type"}),
+
 		PrincipalErrors: promauto.NewCounterVec(prometheus.CounterOpts{
 			Name: "principal_errors",
 			Help: "The total number of errors occurred in principal",
@@ -202,6 +209,11 @@ func NewAgentMetrics() *AgentMetrics {
 			Help:    "Histogram of time from principal send to agent processing (in seconds)",
 			Buckets: prometheus.DefBuckets,
 		}, []string{"resource_type"}),
+
+		EventWriterEventsDiscarded: promauto.NewCounterVec(prometheus.CounterOpts{
+			Name: "agent_event_writer_events_discarded_total",
+			Help: "The total number of events discarded by the EventWriter after exhausting retries",
+		}, []string{"event_type", "resource_type"}),
 
 		AgentErrors: promauto.NewCounterVec(prometheus.CounterOpts{
 			Name: "agent_errors",

--- a/principal/apis/eventstream/eventstream.go
+++ b/principal/apis/eventstream/eventstream.go
@@ -435,6 +435,12 @@ func (s *Server) Subscribe(subs eventstreamapi.EventStream_SubscribeServer) erro
 		eventWriter.UpdateTarget(target)
 	} else {
 		eventWriter = event.NewEventWriter(c.agentName, target)
+		if s.metrics != nil {
+			// set function to call when an event is discarded
+			eventWriter.SetOnDiscard(func(eventType, resourceType string) {
+				s.metrics.EventWriterEventsDiscarded.WithLabelValues(c.agentName, eventType, resourceType).Inc()
+			})
+		}
 		s.eventWriters.Add(c.agentName, eventWriter)
 	}
 


### PR DESCRIPTION
This PR is to add metrics for event that are discarded by the event writer for both agent and principal.

Fixes: https://github.com/argoproj-labs/argocd-agent/issues/902

Assisted by: Cursor


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Metrics added to track events discarded after exhausting retry attempts, labeled by event and resource type for better observability.

* **Behavior**
  * Event writers now invoke a discard handler when events are dropped, causing the new discarded-event metrics to be incremented.

* **Tests**
  * Tests updated to assert discarded-event reporting is triggered when retries are exhausted.

* **Documentation**
  * Metrics docs updated to document the new discarded-events metrics and labels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->