### PR TITLE
test: resolve go vet warnings in test files

### DIFF
--- a/cmd/cmdutil/text_test.go
+++ b/cmd/cmdutil/text_test.go
@@ -14,7 +14,7 @@ import (
 func Test_MarshalStruct(t *testing.T) {
 	type good struct {
 		Visible   string `json:"visible" yaml:"visible" text:"Visible"`
-		invisible string `json:"invisible" yaml:"invisible" text:"Invisible"`
+		invisible string
 	}
 	t.Run("Marshal to JSON", func(t *testing.T) {
 		s := &good{"visible", "invisible"}

--- a/internal/manager/application/application_test.go
+++ b/internal/manager/application/application_test.go
@@ -65,9 +65,9 @@ func fakeInformer(t *testing.T, namespace string, objects ...runtime.Object) (*f
 	require.NoError(t, err)
 
 	go func() {
-		err = informer.Start(context.Background())
-		if err != nil {
-			t.Errorf("failed to start informer: %v", err)
+		startErr := informer.Start(context.Background())
+		if startErr != nil {
+			t.Errorf("failed to start informer: %v", startErr)
 		}
 	}()
 

--- a/internal/manager/application/application_test.go
+++ b/internal/manager/application/application_test.go
@@ -67,7 +67,7 @@ func fakeInformer(t *testing.T, namespace string, objects ...runtime.Object) (*f
 	go func() {
 		err = informer.Start(context.Background())
 		if err != nil {
-			t.Fatalf("failed to start informer: %v", err)
+			t.Errorf("failed to start informer: %v", err)
 		}
 	}()
 


### PR DESCRIPTION
**What does this PR do / why we need it**:

Fixes two `go vet` warnings in test files:

1. `cmd/cmdutil/text_test.go:17` - unexported field `invisible` had json/yaml/text tags; all marshalers skip unexported fields so the tags do nothing. The json tag triggers a vet warning. Removed all tags from that field.

2. `internal/manager/application/application_test.go:70` - `t.Fatalf` called from a goroutine. Go docs say Fatal/FailNow must only be called from the test goroutine; from a spawned goroutine it exits that goroutine silently, masking real failures. Changed to `t.Errorf`.

**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:

Reproduce with `go vet ./...` before/after:

```
cmd/cmdutil/text_test.go:17:3: struct field invisible has json tag but is not exported
internal/manager/application/application_test.go:70:4: call to (*testing.T).Fatalf from a non-test goroutine
```

**Checklist**

* [x] Documentation update is required by this PR (and has been updated) OR no documentation update is required.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Adjusted marshaling tests to verify visible text rendering while excluding internal metadata and ensuring unexported fields remain unchanged after round-trip.
  * Changed test error reporting to surface informer startup failures without aborting the whole test, improving diagnostics and test stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->