### PR TITLE
fix(dev-env): align in-cluster dev env namespaces with deployed components

### DIFF
--- a/hack/dev-env/deploy.sh
+++ b/hack/dev-env/deploy.sh
@@ -59,6 +59,7 @@ deploy_principal() {
 			kustomize edit set image argocd-agent=${IMAGE_NAME}
 		)
 		sed -i'' \
+			-e "s/  principal.namespace:.*/  principal.namespace: \"${ARGOCD_PRINCIPAL_NAMESPACE}\"/" \
 			-e "s/  principal.allowed-namespaces:.*/  principal.allowed-namespaces: \"agent-*\"/" \
 			principal-params-cm.yaml
 		kustomize build . | kubectl --context ${ARGOCD_AGENT_PRINCIPAL_CONTEXT} -n ${ARGOCD_PRINCIPAL_NAMESPACE} apply -f -
@@ -74,7 +75,8 @@ deploy_agent_managed() {
 			kustomize edit set image argocd-agent=${IMAGE_NAME}
 		)
 		sed -i'' \
-		        -e "s/  agent.mode:.*/  agent.mode: \"managed\"/" \
+			-e "s/  agent.namespace:.*/  agent.namespace: \"${ARGOCD_MANAGED_NAMESPACE}\"/" \
+			-e "s/  agent.mode:.*/  agent.mode: \"managed\"/" \
 			-e "s/  agent.creds:.*/  agent.creds: \"mtls:any\"/" \
 			-e "s/  agent.server.address:.*/  agent.server.address: \"$principal_addr\"/" \
 			agent-params-cm.yaml
@@ -90,7 +92,8 @@ deploy_agent_autonomous() {
 			kustomize edit set image argocd-agent=${IMAGE_NAME}
 		)
 		sed -i'' \
-		        -e "s/  agent.mode:.*/  agent.mode: \"autonomous\"/" \
+			-e "s/  agent.namespace:.*/  agent.namespace: \"${ARGOCD_AUTONOMOUS_NAMESPACE}\"/" \
+			-e "s/  agent.mode:.*/  agent.mode: \"autonomous\"/" \
 			-e "s/  agent.creds:.*/  agent.creds: \"mtls:any\"/" \
 			-e "s/  agent.server.address:.*/  agent.server.address: \"$principal_addr\"/" \
 			agent-params-cm.yaml
@@ -135,4 +138,3 @@ case "$1" in
 	echo "[image] is optional and defaults to ${DEFAULT_IMAGE_NAME}" >&2
 	exit 1
 esac
-


### PR DESCRIPTION
Fixes #963

Looks like the namespace split from #939 updated the manifest namespaces, but not the runtime config in `hack/dev-env/deploy.sh`.

When `ARGOCD_AGENT_IN_CLUSTER=true make setup-e2e` runs, the in-cluster principal and agents still get `principal.namespace` or `agent.namespace` set to `argocd`. Then they try to read secrets from `argocd`, not from `argocd-principal`, `argocd-managed`, or `argocd-autonomous`. Kinda a small footgun, and yep it stalls rollout.

This patch keeps those ConfigMap keys in sync with the namespace rewrite for principal, managed agent, and autonomous agent.

Repro:
1. Run `ARGOCD_AGENT_IN_CLUSTER=true make setup-e2e`
2. Wait for `argocd-agent-principal` rollout to hang
3. Check the principal pod logs
4. See secret reads against `argocd/...`, for example `argocd/argocd-agent-resource-proxy-tls`

Checks:
- `bash -n hack/dev-env/deploy.sh`
- simulated deploy rewrite now renders:
  - `principal.namespace: "argocd-principal"`
  - `agent.namespace: "argocd-managed"`
  - `agent.namespace: "argocd-autonomous"`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed namespace configuration in deployment ConfigMaps for principal services and both managed and autonomous agent deployments to ensure they receive the correct namespace values in their service configurations.

* **Improvements**
  * Enhanced command-line error handling and user feedback with improved error messages and usage guidance when deployment scripts are invoked with unsupported or invalid commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->