### PR TITLE
fix: noisy warning logs for gitfiles redis key

### DIFF
--- a/agent/inbound_redis.go
+++ b/agent/inbound_redis.go
@@ -314,8 +314,8 @@ func (a *Agent) handleRedisGetMessage(logCtx *logrus.Entry, rreq *event.RedisReq
 // "app|resources-tree|my-app|1.8.3.gz
 func stripNamespaceFromRedisKey(key string, logCtx *logrus.Entry) (string, error) {
 
-	// git-refs and gitdirs keys don't contain namespace information; return as-is
-	if strings.HasPrefix(key, "git-refs|") || strings.HasPrefix(key, "gitdirs|") {
+	// git-refs, gitdirs, and gitfiles keys don't contain namespace information; return as-is
+	if strings.HasPrefix(key, "git-refs|") || strings.HasPrefix(key, "gitdirs|") || strings.HasPrefix(key, "gitfiles|") {
 		return key, nil
 	}
 

--- a/agent/inbound_redis_test.go
+++ b/agent/inbound_redis_test.go
@@ -81,6 +81,12 @@ func Test_stripNamespaceFromKeyForAutonomousAgent(t *testing.T) {
 			expectedValue: "gitdirs|https://github.com/gnunn-gitops/cluster-config-v2%7C232c92db490001cb7f239ba70a2a14ff42b7e2d0%7C1.8.3.gz",
 			errorExpected: false,
 		},
+		{
+			name:          "gitfiles key is returned unchanged",
+			key:           "gitfiles|https://github.com/argoproj/argocd-example-apps|d9dec7aed84f20b6b25905fe24ab0844bfa38a8e|apps/config.yaml|1.8.3.gz",
+			expectedValue: "gitfiles|https://github.com/argoproj/argocd-example-apps|d9dec7aed84f20b6b25905fe24ab0844bfa38a8e|apps/config.yaml|1.8.3.gz",
+			errorExpected: false,
+		},
 	}
 
 	for _, testEntry := range testEntries {

--- a/principal/redisproxy/redisproxy.go
+++ b/principal/redisproxy/redisproxy.go
@@ -963,14 +963,15 @@ func (rp *RedisProxy) extractAgentNameFromRedisCommandKey(redisKey string, logCt
 			return "", nil
 		}
 
-		if strings.HasPrefix(redisKey, "git-refs|") || strings.HasPrefix(redisKey, "gitdirs|") {
+		if strings.HasPrefix(redisKey, "git-refs|") || strings.HasPrefix(redisKey, "gitdirs|") || strings.HasPrefix(redisKey, "gitfiles|") {
 			// 'git-refs' redis prefix: a cache of git references (branches, tags, etc) (used in a number of places, including exposed via '/api/v1/repositories/{repo}/refs' api)
 			// 'gitdirs' redis prefix: a cache of all directories contained within a git repo (e.g. a dir list, but excluding files. Seemingly only used by appset, presumably by git directory generator)
+			// 'gitfiles' redis prefix: a cache of file contents within a git repo (used by appset git file generator)
 			logCtx.Debug("redirecting git redis key to principal redis")
 			return "", nil
 		}
 
-		logCtx.Warningf("Unexpected redis key seen: '%s'. Redirecting to principal by default.", redisKey)
+		logCtx.Debugf("Unexpected redis key seen: '%s'. Redirecting to principal by default.", redisKey)
 
 		return "", nil
 	}

--- a/principal/redisproxy/redisproxy_test.go
+++ b/principal/redisproxy/redisproxy_test.go
@@ -100,6 +100,12 @@ func Test_extractAgentNameFromRedisCommandKey(t *testing.T) {
 			errorExpected: false,
 		},
 		{
+			name:          "gitfiles| key",
+			key:           "gitfiles|https://github.com/argoproj/argocd-example-apps|d9dec7aed84f20b6b25905fe24ab0844bfa38a8e|apps/config.yaml|1.8.3.gz",
+			value:         "",
+			errorExpected: false,
+		},
+		{
 			name:          "unexpected key should just return empty value, so it will be forwarded to principal",
 			key:           "some other unexpected key",
 			value:         "",


### PR DESCRIPTION
This PR is to fix https://github.com/argoproj-labs/argocd-agent/issues/984, by changing warning message to debug and add `gitfiles` to known redis key prefixes.

Assisted by: Cursor



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Redis cache routing for git files to be handled consistently with other git repository cache types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->