### PR TITLE
feat: adopt existing applications on agent in managed mode

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -164,6 +164,8 @@ type Agent struct {
 	// recreateAction defines the agent's behavior after recreating an app from
 	// an unauthorized deletion. It is only applicable in managed mode.
 	recreateAction manager.RecreateAction
+	// disableAdoption disables existing applications being stamped with source-uid on creation in managed mode
+	disableAdoption bool
 }
 
 const defaultQueueName = "default"

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -165,7 +165,7 @@ type Agent struct {
 	// an unauthorized deletion. It is only applicable in managed mode.
 	recreateAction manager.RecreateAction
 	// disableAdoption disables existing applications being stamped with source-uid on creation in managed mode
-	disableAdoption bool
+	adoptionPolicy string
 }
 
 const defaultQueueName = "default"
@@ -209,6 +209,7 @@ func NewAgent(ctx context.Context, client *kube.KubernetesClient, namespace stri
 	a.namespace = namespace
 	a.mode = types.AgentModeAutonomous
 	a.mismatchPolicy = manager.MismatchPolicyRecreate
+	a.adoptionPolicy = manager.AdoptionPolicyAlways
 	a.recreateAction = manager.RecreateActionIgnore
 	a.redisProxyMsgHandler = &redisProxyMsgHandler{}
 	// Resource proxy is enabled by default.

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -165,7 +165,8 @@ type Agent struct {
 	// an unauthorized deletion. It is only applicable in managed mode.
 	recreateAction manager.RecreateAction
 
-	// disableAdoption disables existing applications being stamped with source-uid on creation in managed mode
+	// adoptionPolicy sets the adoption policy for when an application that's going to be create
+	// already exists in managed mode.
 	adoptionPolicy manager.AdoptionPolicy
 }
 

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -164,8 +164,9 @@ type Agent struct {
 	// recreateAction defines the agent's behavior after recreating an app from
 	// an unauthorized deletion. It is only applicable in managed mode.
 	recreateAction manager.RecreateAction
+
 	// disableAdoption disables existing applications being stamped with source-uid on creation in managed mode
-	adoptionPolicy string
+	adoptionPolicy manager.AdoptionPolicy
 }
 
 const defaultQueueName = "default"

--- a/agent/inbound.go
+++ b/agent/inbound.go
@@ -1378,9 +1378,9 @@ func (a *Agent) ensureNamespaceExists(namespace string) error {
 	return nil
 }
 
-// shouldAdopt checks to see if an application should not be adopted
-// The annotation on the existing application takes priority over the the global setting
-func (a *Agent) effectiveAdoptionPolicy(incoming metav1.Object) string {
+// effectiveAdoptionPolicy gets the adoption policy for the existing appilcation
+// The annotation takes precedence over the global default
+func (a *Agent) effectiveAdoptionPolicy(incoming metav1.Object) manager.AdoptionPolicy {
 	existing, err := a.appManager.Get(a.context, incoming.GetName(), incoming.GetNamespace())
 	if err != nil {
 		log().WithError(err).WithField(logfields.Application, incoming.GetName()).Errorf("Failed to get application to check adoption policy, falling back to default policy")
@@ -1389,7 +1389,11 @@ func (a *Agent) effectiveAdoptionPolicy(incoming metav1.Object) string {
 
 	if annotations := existing.GetAnnotations(); annotations != nil {
 		if policy, ok := annotations[manager.AdoptionPolicyAnnotation]; ok {
-			return policy
+			p := manager.AdoptionPolicy(policy)
+			if p == manager.AdoptionPolicyAlways || p == manager.AdoptionPolicyNever {
+				return p
+			}
+			log().Warnf("unknown adoption policy annotation value %q on %s/%s, defaulting to global option", policy, existing.GetNamespace(), existing.GetName())
 		}
 	}
 	return a.adoptionPolicy

--- a/agent/inbound.go
+++ b/agent/inbound.go
@@ -17,6 +17,7 @@ package agent
 import (
 	"encoding/json"
 	"fmt"
+	"strconv"
 	"time"
 
 	"github.com/argoproj-labs/argocd-agent/internal/auth"
@@ -200,10 +201,6 @@ func (a *Agent) processIncomingApplication(ev *event.Event) error {
 	switch ev.Type() {
 	case event.Create:
 		if a.mode == types.AgentModeManaged {
-			if identity.Exists && identity.ExistingMissingSourceUID {
-				logCtx.Error("Application already exists on agent but is unmanaged.")
-				return fmt.Errorf("application already exists on agent but is unmanaged, please clean it up or switch agent to autonomous mode")
-			}
 			err = a.syncManagedApplication(logCtx, incomingApp, identity, principalUID)
 		} else {
 			_, err = a.createApplication(incomingApp, principalUID)
@@ -333,6 +330,22 @@ func (a *Agent) syncManagedApplication(logCtx *logrus.Entry, incomingApp *v1alph
 			}
 			return nil
 		}
+	case identityActionAdoptExistingApp:
+		logCtx.Info("Application already exists on agent, adopting existing app")
+		dontAdopt, err := a.shouldNotAdopt(incomingApp)
+		if err != nil {
+			logCtx.Warn("failed to check if existing application should be adopted, falling back to global default: %w", err)
+		}
+
+		if dontAdopt {
+			logCtx.Info("Existing application is set to not be adopted")
+			return nil
+		}
+
+		if err := a.updateManagedApplicationIdentity(incomingApp, principalUID); err != nil {
+			return fmt.Errorf("could not adopt app: %w", err)
+		}
+		return nil
 	default:
 		return fmt.Errorf("unknown identity action for app %s", incomingApp.QualifiedName())
 	}
@@ -358,6 +371,10 @@ const (
 	// on the incoming resource (e.g. AppSet controller reconciled and wiped
 	// annotations). Safe to update in-place and re-stamp the source-uid.
 	identityActionUpdateStampUID
+
+	// identityActionAdoptExistingApp: principals targeted app exists on the
+	// agent already. Stamp existing app with source-uid if allowed.
+	identityActionAdoptExistingApp
 )
 
 // effectiveMismatchPolicy returns the mismatch policy for the given incoming resource.
@@ -405,6 +422,11 @@ func identityAction(r *application.IdentityCompareResult) identityActionType {
 	if r.AdoptedPrincipalUID && !r.SourceUIDMatch {
 		return identityActionTransition
 	}
+
+	if r.Exists && r.ExistingMissingSourceUID {
+		return identityActionAdoptExistingApp
+	}
+
 	return identityActionMismatch
 }
 
@@ -1358,4 +1380,24 @@ func (a *Agent) ensureNamespaceExists(namespace string) error {
 
 	log().Infof("Created namespace %s", namespace)
 	return nil
+}
+
+// shouldNotAdopt checks to see if an application should not be adopted
+// The annotation on the existing application takes priority over the the global setting
+func (a *Agent) shouldNotAdopt(incoming metav1.Object) (bool, error) {
+	existing, err := a.appManager.Get(a.context, incoming.GetName(), incoming.GetNamespace())
+	if err != nil {
+		return a.disableAdoption, err
+	}
+
+	if annotations := existing.GetAnnotations(); annotations != nil {
+		if val, ok := annotations[manager.DontAdoptAnnotation]; ok {
+			disabled, err := strconv.ParseBool(val)
+			if err != nil {
+				return a.disableAdoption, err
+			}
+			return disabled, nil
+		}
+	}
+	return a.disableAdoption, nil
 }

--- a/agent/inbound.go
+++ b/agent/inbound.go
@@ -17,7 +17,6 @@ package agent
 import (
 	"encoding/json"
 	"fmt"
-	"strconv"
 	"time"
 
 	"github.com/argoproj-labs/argocd-agent/internal/auth"
@@ -26,6 +25,7 @@ import (
 	"github.com/argoproj-labs/argocd-agent/internal/event"
 	"github.com/argoproj-labs/argocd-agent/internal/event/targets"
 	"github.com/argoproj-labs/argocd-agent/internal/logging"
+	"github.com/argoproj-labs/argocd-agent/internal/logging/logfields"
 	"github.com/argoproj-labs/argocd-agent/internal/manager"
 	"github.com/argoproj-labs/argocd-agent/internal/manager/application"
 	"github.com/argoproj-labs/argocd-agent/internal/metrics"
@@ -331,19 +331,15 @@ func (a *Agent) syncManagedApplication(logCtx *logrus.Entry, incomingApp *v1alph
 			return nil
 		}
 	case identityActionAdoptExistingApp:
-		logCtx.Info("Application already exists on agent, adopting existing app")
-		dontAdopt, err := a.shouldNotAdopt(incomingApp)
-		if err != nil {
-			logCtx.WithError(err).Warn("failed to check if existing application should be adopted, falling back to global default")
-		}
-
-		if dontAdopt {
-			logCtx.Info("Existing application is set to not be adopted")
-			return nil
-		}
-
-		if err := a.updateManagedApplicationIdentity(incomingApp, principalUID); err != nil {
-			return fmt.Errorf("could not adopt app: %w", err)
+		logCtx.WithField(logfields.Application, incomingApp.GetName()).Info("Application already exists on agent, adopting existing app")
+		switch a.effectiveAdoptionPolicy(incomingApp) {
+		case manager.AdoptionPolicyAlways:
+			logCtx.WithField(logfields.Application, incomingApp.GetName()).Info("Adopting existing application")
+			if err := a.updateManagedApplicationIdentity(incomingApp, principalUID); err != nil {
+				return fmt.Errorf("could not adopt app: %w", err)
+			}
+		case manager.AdoptionPolicyNever:
+			logCtx.WithField(logfields.Application, incomingApp.GetName()).Info("Existing application is set to not be adopted")
 		}
 		return nil
 	default:
@@ -1382,22 +1378,19 @@ func (a *Agent) ensureNamespaceExists(namespace string) error {
 	return nil
 }
 
-// shouldNotAdopt checks to see if an application should not be adopted
+// shouldAdopt checks to see if an application should not be adopted
 // The annotation on the existing application takes priority over the the global setting
-func (a *Agent) shouldNotAdopt(incoming metav1.Object) (bool, error) {
+func (a *Agent) effectiveAdoptionPolicy(incoming metav1.Object) string {
 	existing, err := a.appManager.Get(a.context, incoming.GetName(), incoming.GetNamespace())
 	if err != nil {
-		return a.disableAdoption, err
+		log().WithError(err).WithField(logfields.Application, incoming.GetName()).Errorf("Failed to get application to check adoption policy, falling back to default policy")
+		return a.adoptionPolicy
 	}
 
 	if annotations := existing.GetAnnotations(); annotations != nil {
-		if val, ok := annotations[manager.DontAdoptAnnotation]; ok {
-			disabled, err := strconv.ParseBool(val)
-			if err != nil {
-				return a.disableAdoption, err
-			}
-			return disabled, nil
+		if policy, ok := annotations[manager.AdoptionPolicyAnnotation]; ok {
+			return policy
 		}
 	}
-	return a.disableAdoption, nil
+	return a.adoptionPolicy
 }

--- a/agent/inbound.go
+++ b/agent/inbound.go
@@ -334,7 +334,7 @@ func (a *Agent) syncManagedApplication(logCtx *logrus.Entry, incomingApp *v1alph
 		logCtx.Info("Application already exists on agent, adopting existing app")
 		dontAdopt, err := a.shouldNotAdopt(incomingApp)
 		if err != nil {
-			logCtx.Warn("failed to check if existing application should be adopted, falling back to global default: %w", err)
+			logCtx.WithError(err).Warn("failed to check if existing application should be adopted, falling back to global default")
 		}
 
 		if dontAdopt {

--- a/agent/inbound_test.go
+++ b/agent/inbound_test.go
@@ -2678,7 +2678,7 @@ func Test_processIncomingApplication_AdoptsExistingApplications(t *testing.T) {
 		ce := evs.ApplicationEvent(event.Create, incomingApp)
 		event.SetPrincipalUID(ce, expectedPrincipalUID)
 
-		err := a.processIncomingApplication(event.New(ce, event.TargetApplication))
+		err := a.processIncomingApplication(event.New(ce, targets.Application))
 		require.NoError(t, err)
 		require.NotNil(t, updatedApp)
 		require.NotNil(t, updatedApp.Annotations)
@@ -2706,7 +2706,7 @@ func Test_processIncomingApplication_AdoptsExistingApplications(t *testing.T) {
 		ce := evs.ApplicationEvent(event.Create, incomingApp)
 		event.SetPrincipalUID(ce, expectedPrincipalUID)
 
-		err := a.processIncomingApplication(event.New(ce, event.TargetApplication))
+		err := a.processIncomingApplication(event.New(ce, targets.Application))
 		require.NoError(t, err)
 		require.Nil(t, updatedApp)
 	})
@@ -2723,7 +2723,7 @@ func Test_processIncomingApplication_AdoptsExistingApplications(t *testing.T) {
 		ce := evs.ApplicationEvent(event.Create, incomingApp)
 		event.SetPrincipalUID(ce, expectedPrincipalUID)
 
-		err := a.processIncomingApplication(event.New(ce, event.TargetApplication))
+		err := a.processIncomingApplication(event.New(ce, targets.Application))
 		require.NoError(t, err)
 		require.Nil(t, updatedApp)
 	})
@@ -2744,7 +2744,7 @@ func Test_processIncomingApplication_AdoptsExistingApplications(t *testing.T) {
 		ce := evs.ApplicationEvent(event.Create, incomingApp)
 		event.SetPrincipalUID(ce, expectedPrincipalUID)
 
-		err := a.processIncomingApplication(event.New(ce, event.TargetApplication))
+		err := a.processIncomingApplication(event.New(ce, targets.Application))
 		require.NoError(t, err)
 		require.NotNil(t, updatedApp)
 		require.NotNil(t, updatedApp.Annotations)

--- a/agent/inbound_test.go
+++ b/agent/inbound_test.go
@@ -120,7 +120,6 @@ func Test_CreateApplication(t *testing.T) {
 		require.NotEqual(t, a.namespace, newApp.Namespace)
 		require.Equal(t, "principal-namespace", newApp.Namespace, "Namespace should not be modified in destination based mapping")
 	})
-
 }
 
 func Test_ProcessIncomingAppWithUIDMismatch(t *testing.T) {
@@ -291,7 +290,8 @@ func Test_ProcessIncomingAppWithUIDMismatch(t *testing.T) {
 
 		getMock.Unset()
 		notFoundError := kerrors.NewNotFound(schema.GroupResource{
-			Group: "argoproj.io", Resource: "application"}, newApp.Name)
+			Group: "argoproj.io", Resource: "application",
+		}, newApp.Name)
 		getMock = be.On("Get", mock.Anything, mock.Anything, mock.Anything).Return(nil, notFoundError)
 
 		createMock.Unset()
@@ -784,7 +784,8 @@ func Test_ProcessIncomingAppProjectWithUIDMismatch(t *testing.T) {
 
 		getMock.Unset()
 		notFoundError := kerrors.NewNotFound(schema.GroupResource{
-			Group: "argoproj.io", Resource: "appproject"}, newAppProject.Name)
+			Group: "argoproj.io", Resource: "appproject",
+		}, newAppProject.Name)
 		getMock = be.On("Get", mock.Anything, mock.Anything, mock.Anything).Return(nil, notFoundError)
 
 		createMock.Unset()
@@ -1041,7 +1042,8 @@ func Test_UpdateApplication(t *testing.T) {
 					UID:        "uid-1",
 				},
 			},
-		}}
+		},
+	}
 	t.Run("Discard event because version has been seen already", func(t *testing.T) {
 		defer a.appManager.ClearIgnored()
 		a.appManager.IgnoreChange(fmt.Sprintf("%s/test", a.namespace), "12345")
@@ -1142,7 +1144,6 @@ func Test_UpdateApplication(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, napp)
 	})
-
 }
 
 func Test_CreateAppProject(t *testing.T) {
@@ -1205,7 +1206,6 @@ func Test_CreateAppProject(t *testing.T) {
 		require.NotNil(t, napp)
 		require.Empty(t, napp.OwnerReferences, "OwnerReferences should not be applied on managed app project")
 	})
-
 }
 
 func Test_UpdateAppProject(t *testing.T) {
@@ -1231,7 +1231,8 @@ func Test_UpdateAppProject(t *testing.T) {
 		},
 		Spec: v1alpha1.AppProjectSpec{
 			SourceNamespaces: []string{"default", "argocd"},
-		}}
+		},
+	}
 
 	t.Run("Update appproject using patch", func(t *testing.T) {
 		a.mode = types.AgentModeManaged
@@ -1451,7 +1452,6 @@ func Test_UpdateAppProject(t *testing.T) {
 		assert.Equal(t, customAgentNamespace, capturedDeleteNamespace, "Delete should use custom agent namespace")
 		assert.NotEqual(t, "principal-namespace", capturedDeleteNamespace, "Delete should not use principal namespace")
 	})
-
 }
 
 func Test_ProcessIncomingRepositoryWithUIDMismatch(t *testing.T) {
@@ -1623,7 +1623,8 @@ func Test_ProcessIncomingRepositoryWithUIDMismatch(t *testing.T) {
 
 		// Set up mock expectations
 		notFoundError := kerrors.NewNotFound(schema.GroupResource{
-			Group: "", Resource: "secret"}, newRepo.Name)
+			Group: "", Resource: "secret",
+		}, newRepo.Name)
 		getMock := be.On("Get", mock.Anything, mock.Anything, mock.Anything).Return(nil, notFoundError)
 		defer getMock.Unset()
 		createMock := be.On("Create", mock.Anything, mock.Anything).Return(createdRepo, nil)
@@ -2149,7 +2150,8 @@ func Test_ProcessIncomingGPGKey(t *testing.T) {
 		newCM := incomingCM.DeepCopy()
 
 		notFoundError := kerrors.NewNotFound(schema.GroupResource{
-			Group: "", Resource: "configmap"}, newCM.Name)
+			Group: "", Resource: "configmap",
+		}, newCM.Name)
 		getMock := be.On("Get", mock.Anything, mock.Anything, mock.Anything).Return(nil, notFoundError)
 		defer getMock.Unset()
 		createMock := be.On("Create", mock.Anything, mock.Anything).Return(createdCM, nil)
@@ -2614,4 +2616,145 @@ func Test_getTargetNamespaceForApp(t *testing.T) {
 			}
 		})
 	}
+}
+
+func Test_processIncomingApplication_AdoptsExistingApplications(t *testing.T) {
+	a, _ := newAgent(t)
+	a.mode = types.AgentModeManaged
+	var be *backend_mocks.Application
+	var getMock, updateMock, patchMock *mock.Call
+	var updatedApp *v1alpha1.Application
+
+	incomingApp := &v1alpha1.Application{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "test-app",
+			Namespace: "argocd",
+			UID:       ktypes.UID("new-app"),
+		},
+	}
+
+	existingApp := incomingApp.DeepCopy()
+	existingApp.UID = ktypes.UID("existing-app")
+
+	expectedPrincipalUID := "principal-uid"
+
+	configureManager := func(t *testing.T, app *v1alpha1.Application) {
+		t.Helper()
+		be = backend_mocks.NewApplication(t)
+		var err error
+		a.appManager, err = application.NewApplicationManager(be, "argocd",
+			application.WithAllowUpsert(true),
+			application.WithRole(manager.ManagerRoleAgent),
+			application.WithMode(manager.ManagerModeManaged))
+		require.NoError(t, err)
+
+		getMock = be.On("Get", mock.Anything, "test-app", "argocd").Return(app, nil)
+
+		updateMock = be.On("Update", mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
+			updatedApp = args.Get(1).(*v1alpha1.Application).DeepCopy()
+		}).Return(app, nil)
+
+		patchMock = be.On("SupportsPatch").Return(false)
+	}
+
+	unsetMocks := func(t *testing.T) {
+		t.Helper()
+		getMock.Unset()
+		updateMock.Unset()
+		patchMock.Unset()
+	}
+
+	clearUpdatedApp := func() {
+		updatedApp = nil
+	}
+
+	t.Run("Existing application gets stamped with principal uid when enabled", func(t *testing.T) {
+		defer unsetMocks(t)
+		defer clearUpdatedApp()
+
+		configureManager(t, existingApp.DeepCopy())
+
+		evs := event.NewEventSource("test-app")
+		ce := evs.ApplicationEvent(event.Create, incomingApp)
+		event.SetPrincipalUID(ce, expectedPrincipalUID)
+
+		err := a.processIncomingApplication(event.New(ce, event.TargetApplication))
+		require.NoError(t, err)
+		require.NotNil(t, updatedApp)
+		require.NotNil(t, updatedApp.Annotations)
+
+		sourceUID, exists := updatedApp.Annotations[manager.SourceUIDAnnotation]
+		require.True(t, exists)
+		require.Equal(t, string(incomingApp.UID), sourceUID)
+
+		principalUID, exists := updatedApp.Annotations[manager.PrincipalUIDAnnotation]
+		require.True(t, exists)
+		require.Equal(t, expectedPrincipalUID, principalUID)
+	})
+
+	t.Run("Existing application does not get principal uid when adoption is disabled on existing application", func(t *testing.T) {
+		defer unsetMocks(t)
+		defer clearUpdatedApp()
+
+		existingAppWithAnnotation := existingApp.DeepCopy()
+		existingAppWithAnnotation.SetAnnotations(map[string]string{
+			manager.DontAdoptAnnotation: "true",
+		})
+		configureManager(t, existingAppWithAnnotation)
+
+		evs := event.NewEventSource("test-app")
+		ce := evs.ApplicationEvent(event.Create, incomingApp)
+		event.SetPrincipalUID(ce, expectedPrincipalUID)
+
+		err := a.processIncomingApplication(event.New(ce, event.TargetApplication))
+		require.NoError(t, err)
+		require.Nil(t, updatedApp)
+	})
+
+	t.Run("Existing application does not get principal uid when adoption is disabled globally", func(t *testing.T) {
+		defer unsetMocks(t)
+		defer clearUpdatedApp()
+
+		a.disableAdoption = true
+
+		configureManager(t, existingApp.DeepCopy())
+
+		evs := event.NewEventSource("test-app")
+		ce := evs.ApplicationEvent(event.Create, incomingApp)
+		event.SetPrincipalUID(ce, expectedPrincipalUID)
+
+		err := a.processIncomingApplication(event.New(ce, event.TargetApplication))
+		require.NoError(t, err)
+		require.Nil(t, updatedApp)
+	})
+
+	t.Run("Existing application gets stamped if adoption is globally disabled but enabled on app", func(t *testing.T) {
+		defer unsetMocks(t)
+		defer clearUpdatedApp()
+
+		a.disableAdoption = true
+
+		existingAppWithAnnotation := existingApp.DeepCopy()
+		existingAppWithAnnotation.SetAnnotations(map[string]string{
+			manager.DontAdoptAnnotation: "false",
+		})
+		configureManager(t, existingAppWithAnnotation)
+
+		evs := event.NewEventSource("test-app")
+		ce := evs.ApplicationEvent(event.Create, incomingApp)
+		event.SetPrincipalUID(ce, expectedPrincipalUID)
+
+		err := a.processIncomingApplication(event.New(ce, event.TargetApplication))
+		require.NoError(t, err)
+		require.NotNil(t, updatedApp)
+		require.NotNil(t, updatedApp.Annotations)
+
+		sourceUID, exists := updatedApp.Annotations[manager.SourceUIDAnnotation]
+		require.True(t, exists)
+		require.Equal(t, string(incomingApp.UID), sourceUID)
+
+		principalUID, exists := updatedApp.Annotations[manager.PrincipalUIDAnnotation]
+		require.True(t, exists)
+		require.Equal(t, expectedPrincipalUID, principalUID)
+	})
 }

--- a/agent/inbound_test.go
+++ b/agent/inbound_test.go
@@ -2698,7 +2698,7 @@ func Test_processIncomingApplication_AdoptsExistingApplications(t *testing.T) {
 
 		existingAppWithAnnotation := existingApp.DeepCopy()
 		existingAppWithAnnotation.SetAnnotations(map[string]string{
-			manager.AdoptionPolicyAnnotation: manager.AdoptionPolicyNever,
+			manager.AdoptionPolicyAnnotation: string(manager.AdoptionPolicyNever),
 		})
 		configureManager(t, existingAppWithAnnotation)
 
@@ -2736,7 +2736,7 @@ func Test_processIncomingApplication_AdoptsExistingApplications(t *testing.T) {
 
 		existingAppWithAnnotation := existingApp.DeepCopy()
 		existingAppWithAnnotation.SetAnnotations(map[string]string{
-			manager.AdoptionPolicyAnnotation: manager.AdoptionPolicyAlways,
+			manager.AdoptionPolicyAnnotation: string(manager.AdoptionPolicyAlways),
 		})
 		configureManager(t, existingAppWithAnnotation)
 

--- a/agent/inbound_test.go
+++ b/agent/inbound_test.go
@@ -2698,7 +2698,7 @@ func Test_processIncomingApplication_AdoptsExistingApplications(t *testing.T) {
 
 		existingAppWithAnnotation := existingApp.DeepCopy()
 		existingAppWithAnnotation.SetAnnotations(map[string]string{
-			manager.DontAdoptAnnotation: "true",
+			manager.AdoptionPolicyAnnotation: manager.AdoptionPolicyNever,
 		})
 		configureManager(t, existingAppWithAnnotation)
 
@@ -2715,7 +2715,7 @@ func Test_processIncomingApplication_AdoptsExistingApplications(t *testing.T) {
 		defer unsetMocks(t)
 		defer clearUpdatedApp()
 
-		a.disableAdoption = true
+		a.adoptionPolicy = manager.AdoptionPolicyNever
 
 		configureManager(t, existingApp.DeepCopy())
 
@@ -2732,11 +2732,11 @@ func Test_processIncomingApplication_AdoptsExistingApplications(t *testing.T) {
 		defer unsetMocks(t)
 		defer clearUpdatedApp()
 
-		a.disableAdoption = true
+		a.adoptionPolicy = manager.AdoptionPolicyNever
 
 		existingAppWithAnnotation := existingApp.DeepCopy()
 		existingAppWithAnnotation.SetAnnotations(map[string]string{
-			manager.DontAdoptAnnotation: "false",
+			manager.AdoptionPolicyAnnotation: manager.AdoptionPolicyAlways,
 		})
 		configureManager(t, existingAppWithAnnotation)
 

--- a/agent/options.go
+++ b/agent/options.go
@@ -253,9 +253,9 @@ func WithRecreateAction(action string) AgentOption {
 	}
 }
 
-func WithDisableAdoption(adopt bool) AgentOption {
+func WithAdoptionPolicy(policy string) AgentOption {
 	return func(a *Agent) error {
-		a.disableAdoption = adopt
+		a.adoptionPolicy = policy
 		return nil
 	}
 }

--- a/agent/options.go
+++ b/agent/options.go
@@ -252,3 +252,10 @@ func WithRecreateAction(action string) AgentOption {
 		}
 	}
 }
+
+func WithDisableAdoption(adopt bool) AgentOption {
+	return func(a *Agent) error {
+		a.disableAdoption = adopt
+		return nil
+	}
+}

--- a/agent/options.go
+++ b/agent/options.go
@@ -255,7 +255,7 @@ func WithRecreateAction(action string) AgentOption {
 
 func WithAdoptionPolicy(policy string) AgentOption {
 	return func(a *Agent) error {
-		a.adoptionPolicy = policy
+		a.adoptionPolicy = manager.AdoptionPolicy(policy)
 		return nil
 	}
 }

--- a/cmd/argocd-agent/agent.go
+++ b/cmd/argocd-agent/agent.go
@@ -113,7 +113,7 @@ func NewAgentRunCommand() *cobra.Command {
 		redisTLSInsecure     bool
 
 		// Adoption options
-		disableAdoption bool
+		adoptionPolicy string
 	)
 	command := &cobra.Command{
 		Use:   "agent",
@@ -315,7 +315,7 @@ func NewAgentRunCommand() *cobra.Command {
 			agentOpts = append(agentOpts, agent.WithRecreateAction(onApplicationRecreate))
 			agentOpts = append(agentOpts, agent.WithAllowedNamespaces(allowedNamespaces...))
 			agentOpts = append(agentOpts, agent.WithLabelSelector(labelSelector))
-			agentOpts = append(agentOpts, agent.WithDisableAdoption(disableAdoption))
+			agentOpts = append(agentOpts, agent.WithAdoptionPolicy(adoptionPolicy))
 
 			if metricsPort > 0 {
 				agentOpts = append(agentOpts, agent.WithMetricsPort(metricsPort))
@@ -483,9 +483,9 @@ func NewAgentRunCommand() *cobra.Command {
 		env.StringWithDefault("ARGOCD_AGENT_LABEL_SELECTOR", nil, ""),
 		"Kubernetes label selector to restrict which resources the agent watches")
 
-	command.Flags().BoolVar(&disableAdoption, "disable-application-adoption",
-		env.BoolWithDefault("ARGOCD_AGENT_DISABLE_APPLICATION_ADOPTION", false),
-		"Disable adoption of existing applications in managed mode")
+	command.Flags().StringVar(&adoptionPolicy, "adoption-policy",
+		env.StringWithDefault("ARGOCD_AGENT_ADOPTION_POLICY", nil, "always"),
+		"Set the adoption policy for applications that already exist on a managed agent (always or never)")
 
 	command.Flags().StringVar(&kubeConfig, "kubeconfig", "", "Path to a kubeconfig file to use")
 	command.Flags().StringVar(&kubeContext, "kubecontext", "", "Override the default kube context")

--- a/cmd/argocd-agent/agent.go
+++ b/cmd/argocd-agent/agent.go
@@ -111,6 +111,9 @@ func NewAgentRunCommand() *cobra.Command {
 		redisTLSCAPath       string
 		redisTLSCASecretName string
 		redisTLSInsecure     bool
+
+		// Adoption options
+		disableAdoption bool
 	)
 	command := &cobra.Command{
 		Use:   "agent",
@@ -312,6 +315,7 @@ func NewAgentRunCommand() *cobra.Command {
 			agentOpts = append(agentOpts, agent.WithRecreateAction(onApplicationRecreate))
 			agentOpts = append(agentOpts, agent.WithAllowedNamespaces(allowedNamespaces...))
 			agentOpts = append(agentOpts, agent.WithLabelSelector(labelSelector))
+			agentOpts = append(agentOpts, agent.WithDisableAdoption(disableAdoption))
 
 			if metricsPort > 0 {
 				agentOpts = append(agentOpts, agent.WithMetricsPort(metricsPort))
@@ -478,6 +482,10 @@ func NewAgentRunCommand() *cobra.Command {
 	command.Flags().StringVar(&labelSelector, "label-selector",
 		env.StringWithDefault("ARGOCD_AGENT_LABEL_SELECTOR", nil, ""),
 		"Kubernetes label selector to restrict which resources the agent watches")
+
+	command.Flags().BoolVar(&disableAdoption, "disable-application-adoption",
+		env.BoolWithDefault("ARGOCD_AGENT_DISABLE_APPLICATION_ADOPTION", false),
+		"Disable adoption of existing applications in managed mode")
 
 	command.Flags().StringVar(&kubeConfig, "kubeconfig", "", "Path to a kubeconfig file to use")
 	command.Flags().StringVar(&kubeContext, "kubecontext", "", "Override the default kube context")

--- a/docs/configuration/reference/agent.md
+++ b/docs/configuration/reference/agent.md
@@ -571,18 +571,20 @@ ARGOCD_AGENT_ON_APPLICATION_RECREATE=clear-status
 
 | | |
 |---|---|
-| **CLI Flag** | `--disable-application-adoption` |
-| **Environment Variable** | `ARGOCD_AGENT_DISABLE_APPLICATION_ADOPTION` |
+| **CLI Flag** | `--adoption-policy` |
+| **Environment Variable** | `ARGOCD_AGENT_ADOPTION_POLICY` |
 | **ConfigMap Entry** | N/A |
-| **Type** | Boolean |
-| **Default** | `false` |
+| **Type** | String |
+| **Default** | `always` |
+| **Valid Values** | `always`, `never` |
 
-This flag will disable adoption of applications in managed mode. The agent will not stamp the principal's UID on the application on the create action.
+This flag sets the adoption policy for existing applications in managed mode. Adoption occurs when the application that the principal is trying to create already exists on the agent.
 
-Adoption occurs when the application that the principal is trying to create already exists on the agent. It stamps the UID on the application
-similar to the `upsert` mismatch policy.
+**Policies:**
 
-This setting can also be set on the application level by including the annotation `argocd.argoproj.io/dont-adopt` to the value of `true` or
-`false`. The annotation takes priority over the global flag.
+- `always`: always adopt existing applications
+- `never`: never adopt existing applications
+
+This setting can also be set on the application level by including the annotation `argocd.argoproj.io/adoption-policy` to the value of a valid policy.
 
 **Use Case:** The main use case for this would be to transfer applications from a multi-instance Argo CD set up to using the agent set up.

--- a/docs/configuration/reference/agent.md
+++ b/docs/configuration/reference/agent.md
@@ -568,6 +568,7 @@ ARGOCD_AGENT_ON_APPLICATION_RECREATE=clear-status
 ```
 
 ### Application Adoption
+
 | | |
 |---|---|
 | **CLI Flag** | `--disable-application-adoption` |
@@ -576,7 +577,7 @@ ARGOCD_AGENT_ON_APPLICATION_RECREATE=clear-status
 | **Type** | Boolean |
 | **Default** | `false` |
 
-This flag will disable the principal from adopting applications in managed mode if it is present.
+This flag will disable adoption of applications in managed mode. The agent will not stamp the principal's UID on the application on the create action.
 
 Adoption occurs when the application that the principal is trying to create already exists on the agent. It stamps the UID on the application
 similar to the `upsert` mismatch policy.

--- a/docs/configuration/reference/agent.md
+++ b/docs/configuration/reference/agent.md
@@ -566,3 +566,22 @@ Or via environment variable:
 ```bash
 ARGOCD_AGENT_ON_APPLICATION_RECREATE=clear-status
 ```
+
+### Application Adoption
+| | |
+|---|---|
+| **CLI Flag** | `--disable-application-adoption` |
+| **Environment Variable** | `ARGOCD_AGENT_DISABLE_APPLICATION_ADOPTION` |
+| **ConfigMap Entry** | N/A |
+| **Type** | Boolean |
+| **Default** | `false` |
+
+This flag will disable the principal from adopting applications in managed mode if it is present.
+
+Adoption occurs when the application that the principal is trying to create already exists on the agent. It stamps the UID on the application
+similar to the `upsert` mismatch policy.
+
+This setting can also be set on the application level by including the annotation `argocd.argoproj.io/dont-adopt` to the value of `true` or
+`false`. The annotation takes priority over the global flag.
+
+**Use Case:** The main use case for this would be to transfer applications from a multi-instance Argo CD set up to using the agent set up.

--- a/internal/manager/application/application.go
+++ b/internal/manager/application/application.go
@@ -420,6 +420,7 @@ func (m *ApplicationManager) CompareIdentity(ctx context.Context, incoming *v1al
 	existingSourceUID, hasSourceUID := existing.Annotations[manager.SourceUIDAnnotation]
 	if !hasSourceUID {
 		result.ExistingMissingSourceUID = true
+		return result, nil
 	}
 
 	incomingUID := string(incoming.UID)

--- a/internal/manager/manager.go
+++ b/internal/manager/manager.go
@@ -72,15 +72,6 @@ const (
 	// MismatchPolicyAnnotation is the annotation operators set on a resource to override
 	// the global mismatch policy for that specific resource.
 	MismatchPolicyAnnotation = "argocd.argoproj.io/source-uid-mismatch-policy"
-
-	// AdoptionPolicyAlways adopts an application by stamping the principal-uid onto the application
-	AdoptionPolicyAlways = "always"
-
-	// AdoptionPolicyNever does not adoption the application and leaves it as is
-	AdoptionPolicyNever = "never"
-
-	// DontAdoptAnnotation is an annotation for setting whether an app should not be adopted
-	AdoptionPolicyAnnotation = "argocd.argoproj.io/adoption-policy"
 )
 
 // RecreateAction defines the agent's behavior after recreating an Application
@@ -94,6 +85,21 @@ const (
 	RecreateActionClearStatus RecreateAction = "clear-status"
 	// RecreateActionResync sets a sync operation to force immediate re-sync.
 	RecreateActionResync RecreateAction = "resync"
+)
+
+// AdoptionPolicy defines a managed mode agent's behavior when dealing with a create event where
+// the application to be created already exists
+type AdoptionPolicy string
+
+const (
+	// AdoptionPolicyAlways adopts an application by stamping the principal-uid onto the application
+	AdoptionPolicyAlways AdoptionPolicy = "always"
+
+	// AdoptionPolicyNever does not adoption the application and leaves it as is
+	AdoptionPolicyNever AdoptionPolicy = "never"
+
+	// DontAdoptAnnotation is an annotation for setting whether an app should not be adopted
+	AdoptionPolicyAnnotation = "argocd.argoproj.io/adoption-policy"
 )
 
 type Manager interface {

--- a/internal/manager/manager.go
+++ b/internal/manager/manager.go
@@ -73,8 +73,14 @@ const (
 	// the global mismatch policy for that specific resource.
 	MismatchPolicyAnnotation = "argocd.argoproj.io/source-uid-mismatch-policy"
 
+	// AdoptionPolicyAlways adopts an application by stamping the principal-uid onto the application
+	AdoptionPolicyAlways = "always"
+
+	// AdoptionPolicyNever does not adoption the application and leaves it as is
+	AdoptionPolicyNever = "never"
+
 	// DontAdoptAnnotation is an annotation for setting whether an app should not be adopted
-	DontAdoptAnnotation = "argocd.argoproj.io/dont-adopt"
+	AdoptionPolicyAnnotation = "argocd.argoproj.io/adoption-policy"
 )
 
 // RecreateAction defines the agent's behavior after recreating an Application
@@ -255,7 +261,6 @@ func RevertUserInitiatedDeletion[R kubeResource](ctx context.Context,
 	mgr resourceManager[R],
 	logCtx *logrus.Entry,
 ) (bool, error) {
-
 	logCtx = logCtx.WithFields(logrus.Fields{
 		"resource": outbound.GetName(),
 		"kind":     outbound.GetObjectKind().GroupVersionKind().Kind,

--- a/internal/manager/manager.go
+++ b/internal/manager/manager.go
@@ -72,6 +72,9 @@ const (
 	// MismatchPolicyAnnotation is the annotation operators set on a resource to override
 	// the global mismatch policy for that specific resource.
 	MismatchPolicyAnnotation = "argocd.argoproj.io/source-uid-mismatch-policy"
+
+	// DontAdoptAnnotation is an annotation for setting whether an app should not be adopted
+	DontAdoptAnnotation = "argocd.argoproj.io/dont-adopt"
 )
 
 // RecreateAction defines the agent's behavior after recreating an Application

--- a/test/e2e/adoption_test.go
+++ b/test/e2e/adoption_test.go
@@ -1,0 +1,234 @@
+// Copyright 2024 The argocd-agent Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package e2e
+
+import (
+	"testing"
+	"time"
+
+	"github.com/argoproj-labs/argocd-agent/internal/manager"
+	"github.com/argoproj-labs/argocd-agent/test/e2e/fixture"
+	argoapp "github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
+	"github.com/stretchr/testify/suite"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8stypes "k8s.io/apimachinery/pkg/types"
+)
+
+type AdoptionTestSuite struct {
+	fixture.BaseSuite
+}
+
+func TestAdoptionTestSuite(t *testing.T) {
+	suite.Run(t, new(AdoptionTestSuite))
+}
+
+func (suite *AdoptionTestSuite) SetupTest() {
+	suite.BaseSuite.SetupTest()
+
+	// Ensure principal and managed agent are running
+	if !fixture.IsProcessRunning(fixture.PrincipalName) {
+		suite.Require().NoError(fixture.StartProcess(fixture.PrincipalName))
+		fixture.CheckReadiness(suite.T(), fixture.PrincipalName)
+	} else {
+		fixture.CheckReadiness(suite.T(), fixture.PrincipalName)
+	}
+
+	if !fixture.IsProcessRunning(fixture.AgentManagedName) {
+		suite.Require().NoError(fixture.StartProcess(fixture.AgentManagedName))
+		fixture.CheckReadiness(suite.T(), fixture.AgentManagedName)
+	} else {
+		fixture.CheckReadiness(suite.T(), fixture.AgentManagedName)
+	}
+}
+
+func (suite *AdoptionTestSuite) Test_ApplicationIsAdoptedIfExists() {
+	requires := suite.Require()
+
+	// Create application on managed agent
+	app := argoapp.Application{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "guestbook-adopt",
+			Namespace: fixture.ManagedAgentNamespace,
+		},
+		Spec: argoapp.ApplicationSpec{
+			Project: "default",
+			Source: &argoapp.ApplicationSource{
+				RepoURL:        "https://github.com/argoproj/argocd-example-apps",
+				TargetRevision: "HEAD",
+				Path:           "kustomize-guestbook",
+			},
+			Destination: argoapp.ApplicationDestination{
+				Server:    "https://kubernetes.default.svc",
+				Namespace: "adoption-test",
+			},
+			SyncPolicy: &argoapp.SyncPolicy{
+				SyncOptions: argoapp.SyncOptions{
+					"CreateNamespace=true",
+				},
+			},
+		},
+	}
+
+	err := suite.ManagedAgentClient.Create(suite.Ctx, &app, metav1.CreateOptions{})
+	requires.NoError(err)
+
+	// Make sure app exists on managed agent
+	agentKey := fixture.ToNamespacedName(&app)
+	managedApp := argoapp.Application{}
+	requires.Eventually(func() bool {
+		err := suite.ManagedAgentClient.Get(suite.Ctx, agentKey, &managedApp, metav1.GetOptions{})
+		return err == nil
+	}, 30*time.Second, 1*time.Second)
+
+	// Create application that would create the already existing app on the managed agent
+	app2 := argoapp.Application{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "guestbook-adopt",
+			Namespace: "agent-managed",
+		},
+		Spec: argoapp.ApplicationSpec{
+			Project: "default",
+			Source: &argoapp.ApplicationSource{
+				RepoURL:        "https://github.com/argoproj/argocd-example-apps",
+				TargetRevision: "HEAD",
+				Path:           "kustomize-guestbook",
+			},
+			Destination: argoapp.ApplicationDestination{
+				Name:      "agent-managed",
+				Namespace: "adoption-test",
+			},
+		},
+	}
+
+	err = suite.PrincipalClient.Create(suite.Ctx, &app2, metav1.CreateOptions{})
+	requires.NoError(err)
+
+	// Make sure app exists on principal and get the application
+	principalKey := fixture.ToNamespacedName(&app2)
+	principalApp := argoapp.Application{}
+	requires.Eventually(func() bool {
+		err := suite.PrincipalClient.Get(suite.Ctx, principalKey, &principalApp, metav1.GetOptions{})
+		return err == nil
+	}, 30*time.Second, 1*time.Second)
+
+	// Recapture the managed appliction and check if it has been adopted by the principal
+	requires.Eventually(func() bool {
+		err := suite.ManagedAgentClient.Get(suite.Ctx, agentKey, &managedApp, metav1.GetOptions{})
+		if err != nil {
+			return false
+		}
+
+		annotations := managedApp.GetAnnotations()
+		if annotations == nil {
+			return false
+		}
+
+		sourceUID, exists := annotations[manager.SourceUIDAnnotation]
+		return exists && k8stypes.UID(sourceUID) == principalApp.UID
+	}, 30*time.Second, 1*time.Second)
+}
+
+func (suite *AdoptionTestSuite) Test_ApplicationIsNotAdoptedIfAnnotationIsPresent() {
+	requires := suite.Require()
+
+	// Create application on managed agent with ignore annotation
+	app := argoapp.Application{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "guestbook-dontadopt",
+			Namespace: fixture.ManagedAgentNamespace,
+			Annotations: map[string]string{
+				manager.DontAdoptAnnotation: "true",
+			},
+		},
+		Spec: argoapp.ApplicationSpec{
+			Project: "default",
+			Source: &argoapp.ApplicationSource{
+				RepoURL:        "https://github.com/argoproj/argocd-example-apps",
+				TargetRevision: "HEAD",
+				Path:           "kustomize-guestbook",
+			},
+			Destination: argoapp.ApplicationDestination{
+				Server:    "https://kubernetes.default.svc",
+				Namespace: "adoption-test",
+			},
+			SyncPolicy: &argoapp.SyncPolicy{
+				SyncOptions: argoapp.SyncOptions{
+					"CreateNamespace=true",
+				},
+			},
+		},
+	}
+
+	err := suite.ManagedAgentClient.Create(suite.Ctx, &app, metav1.CreateOptions{})
+	requires.NoError(err)
+
+	// Make sure app exists on managed agent
+	agentKey := fixture.ToNamespacedName(&app)
+	managedApp := argoapp.Application{}
+	requires.Eventually(func() bool {
+		err := suite.ManagedAgentClient.Get(suite.Ctx, agentKey, &managedApp, metav1.GetOptions{})
+		return err == nil
+	}, 30*time.Second, 1*time.Second)
+
+	// Create application that would create the already existing app on the managed agent
+	app2 := argoapp.Application{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "guestbook-dontadopt",
+			Namespace: "agent-managed",
+		},
+		Spec: argoapp.ApplicationSpec{
+			Project: "default",
+			Source: &argoapp.ApplicationSource{
+				RepoURL:        "https://github.com/argoproj/argocd-example-apps",
+				TargetRevision: "HEAD",
+				Path:           "kustomize-guestbook",
+			},
+			Destination: argoapp.ApplicationDestination{
+				Name:      "agent-managed",
+				Namespace: "adoption-test",
+			},
+		},
+	}
+
+	err = suite.PrincipalClient.Create(suite.Ctx, &app2, metav1.CreateOptions{})
+	requires.NoError(err)
+
+	// Make sure app exists on principal and get the application
+	principalKey := fixture.ToNamespacedName(&app2)
+	principalApp := argoapp.Application{}
+	requires.Eventually(func() bool {
+		err := suite.PrincipalClient.Get(suite.Ctx, principalKey, &principalApp, metav1.GetOptions{})
+		return err == nil
+	}, 30*time.Second, 1*time.Second)
+
+	// Wait a short time for principal to sync
+	time.Sleep(3 * time.Second)
+
+	// Recapture the managed appliction and check if it has not been adopted by the principal
+	requires.Eventually(func() bool {
+		err := suite.ManagedAgentClient.Get(suite.Ctx, agentKey, &managedApp, metav1.GetOptions{})
+		if err != nil {
+			return false
+		}
+
+		annotations := managedApp.GetAnnotations()
+		if annotations == nil {
+			return false
+		}
+
+		_, exists := annotations[manager.SourceUIDAnnotation]
+		return !exists
+	}, 30*time.Second, 1*time.Second)
+}

--- a/test/e2e/adoption_test.go
+++ b/test/e2e/adoption_test.go
@@ -149,7 +149,7 @@ func (suite *AdoptionTestSuite) Test_ApplicationIsNotAdoptedIfAnnotationIsPresen
 			Name:      "guestbook-dontadopt",
 			Namespace: fixture.ManagedAgentNamespace,
 			Annotations: map[string]string{
-				manager.AdoptionPolicyAnnotation: manager.AdoptionPolicyNever,
+				manager.AdoptionPolicyAnnotation: string(manager.AdoptionPolicyNever),
 			},
 		},
 		Spec: argoapp.ApplicationSpec{

--- a/test/e2e/adoption_test.go
+++ b/test/e2e/adoption_test.go
@@ -213,11 +213,8 @@ func (suite *AdoptionTestSuite) Test_ApplicationIsNotAdoptedIfAnnotationIsPresen
 		return err == nil
 	}, 30*time.Second, 1*time.Second)
 
-	// Wait a short time for principal to sync
-	time.Sleep(3 * time.Second)
-
-	// Recapture the managed appliction and check if it has not been adopted by the principal
-	requires.Eventually(func() bool {
+	// Recapture the managed appliction and check for thirty seconds if the annotation never appears
+	requires.Never(func() bool {
 		err := suite.ManagedAgentClient.Get(suite.Ctx, agentKey, &managedApp, metav1.GetOptions{})
 		if err != nil {
 			return false
@@ -229,7 +226,7 @@ func (suite *AdoptionTestSuite) Test_ApplicationIsNotAdoptedIfAnnotationIsPresen
 		}
 
 		_, exists := annotations[manager.SourceUIDAnnotation]
-		return !exists
+		return exists
 	}, 30*time.Second, 1*time.Second)
 
 	// Manually clean up managed agent application

--- a/test/e2e/adoption_test.go
+++ b/test/e2e/adoption_test.go
@@ -149,7 +149,7 @@ func (suite *AdoptionTestSuite) Test_ApplicationIsNotAdoptedIfAnnotationIsPresen
 			Name:      "guestbook-dontadopt",
 			Namespace: fixture.ManagedAgentNamespace,
 			Annotations: map[string]string{
-				manager.DontAdoptAnnotation: "true",
+				manager.AdoptionPolicyAnnotation: manager.AdoptionPolicyNever,
 			},
 		},
 		Spec: argoapp.ApplicationSpec{

--- a/test/e2e/adoption_test.go
+++ b/test/e2e/adoption_test.go
@@ -231,4 +231,8 @@ func (suite *AdoptionTestSuite) Test_ApplicationIsNotAdoptedIfAnnotationIsPresen
 		_, exists := annotations[manager.SourceUIDAnnotation]
 		return !exists
 	}, 30*time.Second, 1*time.Second)
+
+	// Manually clean up managed agent application
+	err = suite.ManagedAgentClient.Delete(suite.Ctx, &app, metav1.DeleteOptions{})
+	requires.NoError(err)
 }


### PR DESCRIPTION
**What does this PR do / why we need it**:

At the current moment in managed mode, if an application is created on the agent before the principal and then the principal app targets that app it will appear in an unknown state. This PR fixes that issue by having the principal stamp the application if it detects it exists. This PR also adds a new annotation that can be put on agent apps and a global flag to not adopt applications if the user does not want this to be the default behavior. 

**Which issue(s) this PR fixes**:

Fixes #950 

**How to test changes / Special notes to the reviewer**:

1. Set up an agent in managed mode
2. Create an application on the managed agent
3. Create an application on the principal that would create that same application on the agent you just created
4. See if the principal adopted the application on the agent by checking source UID annotations or if principal app shows up as healthy when before it would show up as unknown


**Checklist**

* [X] Documentation update is required by this PR (and has been updated) OR no documentation update is required.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Agents can adopt and stamp pre-existing applications that lack a source UID.
  * New CLI/env flag to globally disable application adoption.
  * Per-application annotation to opt out or opt back in to adoption.

* **Tests**
  * Added unit and end-to-end tests covering adoption, the global disable flag, and the per-application annotation.

* **Documentation**
  * Added docs describing adoption behavior, the flag, and the per-application opt-out.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->