### PR TITLE
fix(ctl): support ca output in agent print-tls

### DIFF
--- a/cmd/ctl/agent.go
+++ b/cmd/ctl/agent.go
@@ -375,7 +375,7 @@ func NewAgentInspectCommand() *cobra.Command {
 func NewAgentPrintTLSCommand() *cobra.Command {
 	var printWhat string
 	command := &cobra.Command{
-		Short:   "Print the TLS client certificate of an agent to stdout",
+		Short:   "Print a TLS asset of an agent to stdout",
 		Use:     "print-tls",
 		Aliases: []string{"dump-tls"},
 		Run: func(cmd *cobra.Command, args []string) {
@@ -391,19 +391,30 @@ func NewAgentPrintTLSCommand() *cobra.Command {
 				cmd.Printf("Agent '%s' is not configured.\n", agentName)
 				os.Exit(1)
 			}
-			switch printWhat {
-			case "cert":
-				fmt.Print(string(clus.Config.CertData))
-			case "key":
-				fmt.Print(string(clus.Config.KeyData))
-			case "ca:":
-				fmt.Print(string(clus.Config.CAData))
+
+			assetData, err := clusterTLSAsset(clus, printWhat)
+			if err != nil {
+				cmdutil.Fatal("%v", err)
 			}
+			fmt.Print(string(assetData))
 		},
 	}
 
-	command.Flags().StringVarP(&printWhat, "type", "t", "cert", "Type of asset to print (cert or key)")
+	command.Flags().StringVarP(&printWhat, "type", "t", "cert", "Type of asset to print (cert, key, or ca)")
 	return command
+}
+
+func clusterTLSAsset(clus *v1alpha1.Cluster, assetType string) ([]byte, error) {
+	switch strings.ToLower(assetType) {
+	case "cert":
+		return clus.Config.CertData, nil
+	case "key":
+		return clus.Config.KeyData, nil
+	case "ca":
+		return clus.Config.CAData, nil
+	default:
+		return nil, fmt.Errorf("unknown TLS asset type %q; expected one of cert, key, or ca", assetType)
+	}
 }
 
 func NewAgentReconfigureCommand() *cobra.Command {

--- a/cmd/ctl/agent_test.go
+++ b/cmd/ctl/agent_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/argoproj-labs/argocd-agent/internal/kube"
 	"github.com/argoproj-labs/argocd-agent/test/testutil"
+	"github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/core/v1"
@@ -246,6 +247,49 @@ func Test_serverURL(t *testing.T) {
 			}
 		})
 	}
+}
+
+func Test_clusterTLSAsset(t *testing.T) {
+	cluster := &v1alpha1.Cluster{
+		Config: v1alpha1.ClusterConfig{
+			TLSClientConfig: v1alpha1.TLSClientConfig{
+				CertData: []byte("cert-data"),
+				KeyData:  []byte("key-data"),
+				CAData:   []byte("ca-data"),
+			},
+		},
+	}
+
+	t.Run("returns cert data", func(t *testing.T) {
+		data, err := clusterTLSAsset(cluster, "cert")
+		require.NoError(t, err)
+		assert.Equal(t, []byte("cert-data"), data)
+	})
+
+	t.Run("returns key data", func(t *testing.T) {
+		data, err := clusterTLSAsset(cluster, "key")
+		require.NoError(t, err)
+		assert.Equal(t, []byte("key-data"), data)
+	})
+
+	t.Run("returns ca data", func(t *testing.T) {
+		data, err := clusterTLSAsset(cluster, "ca")
+		require.NoError(t, err)
+		assert.Equal(t, []byte("ca-data"), data)
+	})
+
+	t.Run("accepts uppercase input", func(t *testing.T) {
+		data, err := clusterTLSAsset(cluster, "CA")
+		require.NoError(t, err)
+		assert.Equal(t, []byte("ca-data"), data)
+	})
+
+	t.Run("rejects invalid asset type", func(t *testing.T) {
+		data, err := clusterTLSAsset(cluster, "foo")
+		require.Error(t, err)
+		assert.Nil(t, data)
+		assert.Contains(t, err.Error(), `unknown TLS asset type "foo"`)
+	})
 }
 
 func Test_parseSecretRef(t *testing.T) {

--- a/docs/configuration/ctl.md
+++ b/docs/configuration/ctl.md
@@ -97,7 +97,7 @@ Inspect and manage agent configuration
 
 `list` - List configured agents
 
-`print-tls` - Print the TLS client certificate of an agent to stdout
+`print-tls` - Print a TLS asset of an agent to stdout (`cert`, `key`, or `ca`)
 
 `reconfigure` - Reconfigures an agent's properties
 
@@ -159,4 +159,3 @@ OR TO PROTECT ANY KIND OF DATA.
 `issue` - NON-PROD!! Issue TLS certificates signed by the PKI's CA
 
 `propagate` - NON-PROD!! Propagate the PKI to the agent
-


### PR DESCRIPTION
**What does this PR do / why we need it**:

`argocd-agentctl agent print-tls <agent> --type ca` was a no-op. The command checked `ca:` instead of `ca`, so it printed nothing and exited 0. Kinda a sneaky footgun.

This patch makes `ca` work, keeps `cert` and `key` working, and errors on bad `--type` values.

**Which issue(s) this PR fixes**:

No linked issue. I did not find an open one for this bug.

**How to test changes / Special notes to the reviewer**:

1. Configure any agent. Normal flows already store `CAData` in the cluster secret via `agent create` and `agent reconfigure --reissue-client-cert`.
2. Before this patch, run `argocd-agentctl agent print-tls <agent> --type ca`.
3. It exits 0 and prints nothing, which is pretty weird.
4. With this patch, the same command prints the CA PEM.
5. Run `go test ./cmd/ctl`.

**Checklist**

* [x] Documentation update is required by this PR (and has been updated) OR no documentation update is required.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * print-tls now lets you choose which TLS asset to output: cert, key, or ca; unknown types return an error.

* **Documentation**
  * Updated agent command docs to reflect selectable TLS asset printing and clarified flag descriptions.

* **Tests**
  * Added unit test coverage for cert/key/ca selection, case-insensitive input, and unknown-type error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->