### PR TITLE
feat(cli): Allow users to set certificate lifetime

### DIFF
--- a/cmd/ctl/agent.go
+++ b/cmd/ctl/agent.go
@@ -64,7 +64,7 @@ func NewAgentCommand() *cobra.Command {
 	return command
 }
 
-func generateAgentClientCert(agentName string, clt *kube.KubernetesClient) (clientCert string, clientKey string, caData string, err error) {
+func generateAgentClientCert(agentName string, clt *kube.KubernetesClient, validityDays int) (clientCert string, clientKey string, caData string, err error) {
 	ctx := context.Background()
 
 	// Our CA certificate is stored in a secret
@@ -80,8 +80,13 @@ func generateAgentClientCert(agentName string, clt *kube.KubernetesClient) (clie
 		return
 	}
 
+	if err = tlsutil.ValidateLeafValidityDays(signerCert, validityDays); err != nil {
+		err = fmt.Errorf("invalid certificate validity: %w", err)
+		return
+	}
+
 	// Generate a client cert and sign it using the CA's cert and key
-	clientCert, clientKey, err = tlsutil.GenerateClientCertificate(agentName, signerCert, tlsCert.PrivateKey)
+	clientCert, clientKey, err = tlsutil.GenerateClientCertificate(agentName, signerCert, tlsCert.PrivateKey, validityDays)
 	if err != nil {
 		err = fmt.Errorf("could not create client cert: %w", err)
 		return
@@ -172,6 +177,7 @@ func NewAgentCreateCommand() *cobra.Command {
 		addLabels     []string
 		tlsFromSecret string
 		caFromSecret  string
+		days          int
 	)
 	command := &cobra.Command{
 		Short: "Create a new agent configuration",
@@ -230,7 +236,7 @@ func NewAgentCreateCommand() *cobra.Command {
 				}
 			} else {
 				// Generate certificates from the PKI
-				clientCert, clientKey, caData, err = generateAgentClientCert(agentName, clt)
+				clientCert, clientKey, caData, err = generateAgentClientCert(agentName, clt, days)
 				if err != nil {
 					cmdutil.Fatal("%v", err)
 				}
@@ -277,6 +283,7 @@ func NewAgentCreateCommand() *cobra.Command {
 	command.Flags().StringSliceVarP(&addLabels, "label", "l", []string{}, "Additional labels for the agent")
 	command.Flags().StringVar(&tlsFromSecret, "tls-from-secret", "", "Name of an existing secret containing TLS certificate and key (keys: tls.crt, tls.key). Format: [namespace/]name")
 	command.Flags().StringVar(&caFromSecret, "ca-from-secret", "", "Name of an existing secret containing CA certificate (key: ca.crt). Format: [namespace/]name")
+	command.Flags().IntVar(&days, "days", tlsutil.DefaultLeafCertValidityDays, "Number of days the client certificate is valid for (only used when generating from PKI)")
 	return command
 }
 
@@ -423,6 +430,7 @@ func NewAgentReconfigureCommand() *cobra.Command {
 		rpUsername        string
 		rpPassword        string
 		reissueClientCert bool
+		days              int
 	)
 	command := &cobra.Command{
 		Short: "Reconfigures an agent's properties",
@@ -462,7 +470,7 @@ func NewAgentReconfigureCommand() *cobra.Command {
 				if err != nil {
 					cmdutil.Fatal("Could not create Kubernetes client: %v", err)
 				}
-				clientCert, clientKey, caData, err := generateAgentClientCert(agentName, clt)
+				clientCert, clientKey, caData, err := generateAgentClientCert(agentName, clt, days)
 				if err != nil {
 					cmdutil.Fatal("%v", err)
 				}
@@ -486,6 +494,7 @@ func NewAgentReconfigureCommand() *cobra.Command {
 	command.Flags().StringVar(&rpUsername, "resource-proxy-username", "", "The username for the resource-proxy")
 	command.Flags().StringVar(&rpPassword, "resource-proxy-password", "", "The password for the resource-proxy")
 	command.Flags().BoolVar(&reissueClientCert, "reissue-client-cert", false, "Reissue the agent's client cert")
+	command.Flags().IntVar(&days, "days", tlsutil.DefaultLeafCertValidityDays, "Number of days the client certificate is valid for (only used with --reissue-client-cert)")
 	return command
 }
 

--- a/cmd/ctl/ca.go
+++ b/cmd/ctl/ca.go
@@ -88,7 +88,10 @@ OR TO PROTECT ANY KIND OF DATA.
 }
 
 func NewPKIInitCommand() *cobra.Command {
-	var force bool
+	var (
+		force bool
+		days  int
+	)
 	command := &cobra.Command{
 		Short: "NON-PROD!! Initialize the PKI for use with argocd-agent",
 		Use:   "init",
@@ -109,7 +112,7 @@ func NewPKIInitCommand() *cobra.Command {
 				exists = true
 			}
 			fmt.Println("Generating CA and storing it in secret")
-			cert, key, err := tlsutil.GenerateCaCertificate(config.SecretNamePrincipalCA)
+			cert, key, err := tlsutil.GenerateCaCertificate(config.SecretNamePrincipalCA, days)
 			if err != nil {
 				cmdutil.Fatal("Could not generate certificate: %v", err)
 			}
@@ -139,6 +142,7 @@ func NewPKIInitCommand() *cobra.Command {
 	}
 
 	command.Flags().BoolVarP(&force, "force", "f", false, "Force regeneration of PKI if it exists")
+	command.Flags().IntVar(&days, "days", tlsutil.DefaultCACertValidityDays, "Number of days the certificate is valid for")
 	return command
 }
 
@@ -381,19 +385,21 @@ func NewPKIIssuePrincipalCommand() *cobra.Command {
 		ips    []string
 		dns    []string
 		upsert bool
+		days   int
 	)
 	command := &cobra.Command{
 		Short: "Issue a TLS certificate for the principal",
 		Use:   "principal",
 		Run: func(cmd *cobra.Command, args []string) {
-			issueAndSaveSecret(principalCfg.KubeContext, "argocd-agent-principal-tls", principalCfg.Namespace, upsert, func(c *x509.Certificate, pk crypto.PrivateKey) (string, string, error) {
-				return tlsutil.GenerateServerCertificate("argocd-agent-principal", c, pk, ips, dns)
+			issueAndSaveSecret(principalCfg.KubeContext, "argocd-agent-principal-tls", principalCfg.Namespace, upsert, days, func(c *x509.Certificate, pk crypto.PrivateKey) (string, string, error) {
+				return tlsutil.GenerateServerCertificate("argocd-agent-principal", c, pk, ips, dns, days)
 			})
 		},
 	}
 	command.Flags().StringSliceVar(&ips, "ip", []string{"127.0.0.1"}, "The IP addresses this certificate is valid for")
 	command.Flags().StringSliceVar(&dns, "dns", []string{"localhost"}, "The DNS names this certificate is valid for")
 	command.Flags().BoolVarP(&upsert, "upsert", "u", false, "Whether to update an existing certificate if it exists")
+	command.Flags().IntVar(&days, "days", tlsutil.DefaultLeafCertValidityDays, "Number of days the certificate is valid for")
 	return command
 }
 
@@ -403,17 +409,18 @@ func NewPKIIssueResourceProxyCommand() *cobra.Command {
 		dns    []string
 		upsert bool
 		noSAN  bool
+		days   int
 	)
 	command := &cobra.Command{
 		Short: "Issue a TLS certificate for the resource proxy",
 		Use:   "resource-proxy",
 		Run: func(cmd *cobra.Command, args []string) {
-			if len(ips) == 0 && len(dns) == 0 {
-				fmt.Println("Please pass at least one of --ips or --dns options or use --no-san to create certificate without SAN")
+			if len(ips) == 0 && len(dns) == 0 && !noSAN {
+				fmt.Println("Please pass at least one of --ip or --dns options or use --no-san to create certificate without SAN")
 				os.Exit(1)
 			}
-			issueAndSaveSecret(principalCfg.KubeContext, "argocd-agent-resource-proxy-tls", principalCfg.Namespace, upsert, func(c *x509.Certificate, pk crypto.PrivateKey) (string, string, error) {
-				return tlsutil.GenerateServerCertificate("argocd-agent-resource-proxy", c, pk, ips, dns)
+			issueAndSaveSecret(principalCfg.KubeContext, "argocd-agent-resource-proxy-tls", principalCfg.Namespace, upsert, days, func(c *x509.Certificate, pk crypto.PrivateKey) (string, string, error) {
+				return tlsutil.GenerateServerCertificate("argocd-agent-resource-proxy", c, pk, ips, dns, days)
 			})
 		},
 	}
@@ -421,6 +428,7 @@ func NewPKIIssueResourceProxyCommand() *cobra.Command {
 	command.Flags().StringSliceVar(&dns, "dns", []string{}, "The DNS names this certificate is valid for")
 	command.Flags().BoolVarP(&upsert, "upsert", "u", false, "Whether to update an existing certificate if it exists")
 	command.Flags().BoolVar(&noSAN, "no-san", false, "Do not add SAN information to the certificate")
+	command.Flags().IntVar(&days, "days", tlsutil.DefaultLeafCertValidityDays, "Number of days the certificate is valid for")
 	return command
 }
 
@@ -429,6 +437,7 @@ func NewPKIIssueAgentClientCert() *cobra.Command {
 		upsert         bool
 		sameContext    bool
 		agentNamespace string
+		days           int
 	)
 	command := &cobra.Command{
 		Use:   "agent <name>",
@@ -447,8 +456,8 @@ func NewPKIIssueAgentClientCert() *cobra.Command {
 			if principalCfg.KubeContext == agentCfg.KubeContext && !sameContext {
 				cmdutil.Fatal("PKI and agent usually do not reside within the same context. Use --same-context if you really mean it.")
 			}
-			issueAndSaveSecret(agentCfg.KubeContext, config.SecretNameAgentClientCert, agentNamespace, upsert, func(c *x509.Certificate, pk crypto.PrivateKey) (string, string, error) {
-				return tlsutil.GenerateClientCertificate(agentName, c, pk)
+			issueAndSaveSecret(agentCfg.KubeContext, config.SecretNameAgentClientCert, agentNamespace, upsert, days, func(c *x509.Certificate, pk crypto.PrivateKey) (string, string, error) {
+				return tlsutil.GenerateClientCertificate(agentName, c, pk, days)
 			})
 			ctx := context.TODO()
 
@@ -503,6 +512,7 @@ func NewPKIIssueAgentClientCert() *cobra.Command {
 	command.Flags().BoolVarP(&upsert, "upsert", "u", false, "Whether to update an existing certificate if it exists")
 	command.Flags().BoolVar(&sameContext, "same-context", false, "Use when the PKI and agent use the same context")
 	command.Flags().StringVar(&agentNamespace, "agent-namespace", "argocd", "The namespace the agent is installed to")
+	command.Flags().IntVar(&days, "days", tlsutil.DefaultLeafCertValidityDays, "Number of days the certificate is valid for")
 	return command
 }
 
@@ -512,7 +522,7 @@ func NewPKIIssueAgentClientCert() *cobra.Command {
 // secret's certificate and private key as PEM encoded string. The resulting
 // certificate will be saved to a secret referred to by outContext, outName and
 // outNamespace.
-func issueAndSaveSecret(outContext, outName, outNamespace string, upsert bool, issue func(*x509.Certificate, crypto.PrivateKey) (string, string, error)) {
+func issueAndSaveSecret(outContext, outName, outNamespace string, upsert bool, validityDays int, issue func(*x509.Certificate, crypto.PrivateKey) (string, string, error)) {
 	ctx := context.TODO()
 
 	// Client for principal's kube context - it has the CA
@@ -546,6 +556,10 @@ func issueAndSaveSecret(outContext, outName, outNamespace string, upsert bool, i
 	signerCert, err := x509.ParseCertificate(caCert.Certificate[0])
 	if err != nil {
 		cmdutil.Fatal("Could not parse CA certificate: %v", err)
+	}
+
+	if err := tlsutil.ValidateLeafValidityDays(signerCert, validityDays); err != nil {
+		cmdutil.Fatal("%v", err)
 	}
 
 	// Generate a new TLS keypair from the cert and private key

--- a/cmd/ctl/validate_test.go
+++ b/cmd/ctl/validate_test.go
@@ -98,7 +98,7 @@ func createExpiredCertificate(t *testing.T, name string, signerCert *x509.Certif
 func createCertSignedByDifferentCA(t *testing.T, name string, ips []string, dns []string) (string, string) {
 	t.Helper()
 	// Create a different CA
-	differentCAPEM, differentCAKeyPEM, err := tlsutil.GenerateCaCertificate("different-ca")
+	differentCAPEM, differentCAKeyPEM, err := tlsutil.GenerateCaCertificate("different-ca", tlsutil.DefaultCACertValidityDays)
 	require.NoError(t, err, "generate different CA")
 
 	// Create a fake client to parse the CA
@@ -334,7 +334,7 @@ func TestCheckConfigPrincipal(t *testing.T) {
 		}
 
 		// CA
-		caCertPEM, caKeyPEM, err := tlsutil.GenerateCaCertificate(config.SecretNamePrincipalCA)
+		caCertPEM, caKeyPEM, err := tlsutil.GenerateCaCertificate(config.SecretNamePrincipalCA, tlsutil.DefaultCACertValidityDays)
 		require.NoError(t, err, "generate CA")
 
 		// Principal TLS
@@ -345,12 +345,12 @@ func TestCheckConfigPrincipal(t *testing.T) {
 		require.NoError(t, err, "read CA")
 		signer, err := x509.ParseCertificate(caCert.Certificate[0])
 		require.NoError(t, err, "parse CA")
-		pCertPEM, pKeyPEM, err := tlsutil.GenerateServerCertificate("principal", signer, caCert.PrivateKey, []string{"127.0.0.1"}, []string{"localhost"})
+		pCertPEM, pKeyPEM, err := tlsutil.GenerateServerCertificate("principal", signer, caCert.PrivateKey, []string{"127.0.0.1"}, []string{"localhost"}, tlsutil.DefaultLeafCertValidityDays)
 		require.NoError(t, err, "gen principal cert")
 		mustCreateTLSSecret(t, cl, principalNS, config.SecretNamePrincipalTLS, pCertPEM, pKeyPEM)
 
 		// Resource proxy TLS
-		rpCertPEM, rpKeyPEM, err := tlsutil.GenerateServerCertificate("resource-proxy", signer, caCert.PrivateKey, []string{"127.0.0.1"}, []string{"localhost"})
+		rpCertPEM, rpKeyPEM, err := tlsutil.GenerateServerCertificate("resource-proxy", signer, caCert.PrivateKey, []string{"127.0.0.1"}, []string{"localhost"}, tlsutil.DefaultLeafCertValidityDays)
 		require.NoError(t, err, "gen rp cert")
 		mustCreateTLSSecret(t, cl, principalNS, config.SecretNameProxyTLS, rpCertPEM, rpKeyPEM)
 
@@ -452,7 +452,7 @@ func TestCheckConfigPrincipal(t *testing.T) {
 		require.NoError(t, err, "create namespace")
 
 		// Create CA only
-		caCertPEM, caKeyPEM, err := tlsutil.GenerateCaCertificate(config.SecretNamePrincipalCA)
+		caCertPEM, caKeyPEM, err := tlsutil.GenerateCaCertificate(config.SecretNamePrincipalCA, tlsutil.DefaultCACertValidityDays)
 		require.NoError(t, err, "generate CA")
 		mustCreateTLSSecret(t, cl, principalNS, config.SecretNamePrincipalCA, caCertPEM, caKeyPEM)
 
@@ -498,7 +498,7 @@ func TestCheckConfigPrincipal(t *testing.T) {
 		require.NoError(t, err, "create namespace")
 
 		// Create CA and Principal TLS
-		caCertPEM, caKeyPEM, err := tlsutil.GenerateCaCertificate(config.SecretNamePrincipalCA)
+		caCertPEM, caKeyPEM, err := tlsutil.GenerateCaCertificate(config.SecretNamePrincipalCA, tlsutil.DefaultCACertValidityDays)
 		require.NoError(t, err, "generate CA")
 		mustCreateTLSSecret(t, cl, principalNS, config.SecretNamePrincipalCA, caCertPEM, caKeyPEM)
 
@@ -506,7 +506,7 @@ func TestCheckConfigPrincipal(t *testing.T) {
 		require.NoError(t, err, "read CA")
 		signer, err := x509.ParseCertificate(caCert.Certificate[0])
 		require.NoError(t, err, "parse CA")
-		pCertPEM, pKeyPEM, err := tlsutil.GenerateServerCertificate("principal", signer, caCert.PrivateKey, []string{"127.0.0.1"}, []string{"localhost"})
+		pCertPEM, pKeyPEM, err := tlsutil.GenerateServerCertificate("principal", signer, caCert.PrivateKey, []string{"127.0.0.1"}, []string{"localhost"}, tlsutil.DefaultLeafCertValidityDays)
 		require.NoError(t, err, "gen principal cert")
 		mustCreateTLSSecret(t, cl, principalNS, config.SecretNamePrincipalTLS, pCertPEM, pKeyPEM)
 
@@ -552,7 +552,7 @@ func TestCheckConfigPrincipal(t *testing.T) {
 		require.NoError(t, err, "create namespace")
 
 		// Create CA and TLS secrets
-		caCertPEM, caKeyPEM, err := tlsutil.GenerateCaCertificate(config.SecretNamePrincipalCA)
+		caCertPEM, caKeyPEM, err := tlsutil.GenerateCaCertificate(config.SecretNamePrincipalCA, tlsutil.DefaultCACertValidityDays)
 		require.NoError(t, err, "generate CA")
 		mustCreateTLSSecret(t, cl, principalNS, config.SecretNamePrincipalCA, caCertPEM, caKeyPEM)
 
@@ -560,11 +560,11 @@ func TestCheckConfigPrincipal(t *testing.T) {
 		require.NoError(t, err, "read CA")
 		signer, err := x509.ParseCertificate(caCert.Certificate[0])
 		require.NoError(t, err, "parse CA")
-		pCertPEM, pKeyPEM, err := tlsutil.GenerateServerCertificate("principal", signer, caCert.PrivateKey, []string{"127.0.0.1"}, []string{"localhost"})
+		pCertPEM, pKeyPEM, err := tlsutil.GenerateServerCertificate("principal", signer, caCert.PrivateKey, []string{"127.0.0.1"}, []string{"localhost"}, tlsutil.DefaultLeafCertValidityDays)
 		require.NoError(t, err, "gen principal cert")
 		mustCreateTLSSecret(t, cl, principalNS, config.SecretNamePrincipalTLS, pCertPEM, pKeyPEM)
 
-		rpCertPEM, rpKeyPEM, err := tlsutil.GenerateServerCertificate("resource-proxy", signer, caCert.PrivateKey, []string{"127.0.0.1"}, []string{"localhost"})
+		rpCertPEM, rpKeyPEM, err := tlsutil.GenerateServerCertificate("resource-proxy", signer, caCert.PrivateKey, []string{"127.0.0.1"}, []string{"localhost"}, tlsutil.DefaultLeafCertValidityDays)
 		require.NoError(t, err, "gen rp cert")
 		mustCreateTLSSecret(t, cl, principalNS, config.SecretNameProxyTLS, rpCertPEM, rpKeyPEM)
 
@@ -610,7 +610,7 @@ func TestCheckConfigPrincipal(t *testing.T) {
 		require.NoError(t, err, "create namespace")
 
 		// Create CA
-		caCertPEM, caKeyPEM, err := tlsutil.GenerateCaCertificate(config.SecretNamePrincipalCA)
+		caCertPEM, caKeyPEM, err := tlsutil.GenerateCaCertificate(config.SecretNamePrincipalCA, tlsutil.DefaultCACertValidityDays)
 		require.NoError(t, err, "generate CA")
 		mustCreateTLSSecret(t, cl, principalNS, config.SecretNamePrincipalCA, caCertPEM, caKeyPEM)
 
@@ -664,7 +664,7 @@ func TestCheckConfigPrincipal(t *testing.T) {
 		require.NoError(t, err, "create namespace")
 
 		// Create CA
-		caCertPEM, caKeyPEM, err := tlsutil.GenerateCaCertificate(config.SecretNamePrincipalCA)
+		caCertPEM, caKeyPEM, err := tlsutil.GenerateCaCertificate(config.SecretNamePrincipalCA, tlsutil.DefaultCACertValidityDays)
 		require.NoError(t, err, "generate CA")
 		mustCreateTLSSecret(t, cl, principalNS, config.SecretNamePrincipalCA, caCertPEM, caKeyPEM)
 
@@ -674,7 +674,7 @@ func TestCheckConfigPrincipal(t *testing.T) {
 		require.NoError(t, err, "parse CA")
 
 		// Create valid Principal TLS
-		pCertPEM, pKeyPEM, err := tlsutil.GenerateServerCertificate("principal", signer, caCert.PrivateKey, []string{"127.0.0.1"}, []string{"localhost"})
+		pCertPEM, pKeyPEM, err := tlsutil.GenerateServerCertificate("principal", signer, caCert.PrivateKey, []string{"127.0.0.1"}, []string{"localhost"}, tlsutil.DefaultLeafCertValidityDays)
 		require.NoError(t, err, "gen principal cert")
 		mustCreateTLSSecret(t, cl, principalNS, config.SecretNamePrincipalTLS, pCertPEM, pKeyPEM)
 
@@ -765,7 +765,7 @@ func TestCheckConfigPrincipal(t *testing.T) {
 		require.NoError(t, err, "create namespace")
 
 		// Create CA and TLS secrets
-		caCertPEM, caKeyPEM, err := tlsutil.GenerateCaCertificate(config.SecretNamePrincipalCA)
+		caCertPEM, caKeyPEM, err := tlsutil.GenerateCaCertificate(config.SecretNamePrincipalCA, tlsutil.DefaultCACertValidityDays)
 		require.NoError(t, err, "generate CA")
 		mustCreateTLSSecret(t, cl, principalNS, config.SecretNamePrincipalCA, caCertPEM, caKeyPEM)
 
@@ -773,11 +773,11 @@ func TestCheckConfigPrincipal(t *testing.T) {
 		require.NoError(t, err, "read CA")
 		signer, err := x509.ParseCertificate(caCert.Certificate[0])
 		require.NoError(t, err, "parse CA")
-		pCertPEM, pKeyPEM, err := tlsutil.GenerateServerCertificate("principal", signer, caCert.PrivateKey, []string{"127.0.0.1"}, []string{"localhost"})
+		pCertPEM, pKeyPEM, err := tlsutil.GenerateServerCertificate("principal", signer, caCert.PrivateKey, []string{"127.0.0.1"}, []string{"localhost"}, tlsutil.DefaultLeafCertValidityDays)
 		require.NoError(t, err, "gen principal cert")
 		mustCreateTLSSecret(t, cl, principalNS, config.SecretNamePrincipalTLS, pCertPEM, pKeyPEM)
 
-		rpCertPEM, rpKeyPEM, err := tlsutil.GenerateServerCertificate("resource-proxy", signer, caCert.PrivateKey, []string{"127.0.0.1"}, []string{"localhost"})
+		rpCertPEM, rpKeyPEM, err := tlsutil.GenerateServerCertificate("resource-proxy", signer, caCert.PrivateKey, []string{"127.0.0.1"}, []string{"localhost"}, tlsutil.DefaultLeafCertValidityDays)
 		require.NoError(t, err, "gen rp cert")
 		mustCreateTLSSecret(t, cl, principalNS, config.SecretNameProxyTLS, rpCertPEM, rpKeyPEM)
 
@@ -839,7 +839,7 @@ func TestCheckConfigPrincipal(t *testing.T) {
 		require.NoError(t, err, "create namespace")
 
 		// Create CA and TLS secrets
-		caCertPEM, caKeyPEM, err := tlsutil.GenerateCaCertificate(config.SecretNamePrincipalCA)
+		caCertPEM, caKeyPEM, err := tlsutil.GenerateCaCertificate(config.SecretNamePrincipalCA, tlsutil.DefaultCACertValidityDays)
 		require.NoError(t, err, "generate CA")
 		mustCreateTLSSecret(t, cl, principalNS, config.SecretNamePrincipalCA, caCertPEM, caKeyPEM)
 
@@ -848,11 +848,11 @@ func TestCheckConfigPrincipal(t *testing.T) {
 		signer, err := x509.ParseCertificate(caCert.Certificate[0])
 		require.NoError(t, err, "parse CA")
 		// Certificate with DNS: localhost, but route will have different host
-		pCertPEM, pKeyPEM, err := tlsutil.GenerateServerCertificate("principal", signer, caCert.PrivateKey, []string{"127.0.0.1"}, []string{"localhost"})
+		pCertPEM, pKeyPEM, err := tlsutil.GenerateServerCertificate("principal", signer, caCert.PrivateKey, []string{"127.0.0.1"}, []string{"localhost"}, tlsutil.DefaultLeafCertValidityDays)
 		require.NoError(t, err, "gen principal cert")
 		mustCreateTLSSecret(t, cl, principalNS, config.SecretNamePrincipalTLS, pCertPEM, pKeyPEM)
 
-		rpCertPEM, rpKeyPEM, err := tlsutil.GenerateServerCertificate("resource-proxy", signer, caCert.PrivateKey, []string{"127.0.0.1"}, []string{"localhost"})
+		rpCertPEM, rpKeyPEM, err := tlsutil.GenerateServerCertificate("resource-proxy", signer, caCert.PrivateKey, []string{"127.0.0.1"}, []string{"localhost"}, tlsutil.DefaultLeafCertValidityDays)
 		require.NoError(t, err, "gen rp cert")
 		mustCreateTLSSecret(t, cl, principalNS, config.SecretNameProxyTLS, rpCertPEM, rpKeyPEM)
 
@@ -1107,7 +1107,7 @@ func TestCheckConfigAgent(t *testing.T) {
 		}
 
 		// Create principal CA
-		caCertPEM, caKeyPEM, err := tlsutil.GenerateCaCertificate(config.SecretNamePrincipalCA)
+		caCertPEM, caKeyPEM, err := tlsutil.GenerateCaCertificate(config.SecretNamePrincipalCA, tlsutil.DefaultCACertValidityDays)
 		require.NoError(t, err, "generate CA")
 		mustCreateTLSSecret(t, principalCl, principalNS, config.SecretNamePrincipalCA, caCertPEM, caKeyPEM)
 
@@ -1127,7 +1127,7 @@ func TestCheckConfigAgent(t *testing.T) {
 		signer, err := x509.ParseCertificate(caCert.Certificate[0])
 		require.NoError(t, err, "parse CA")
 		agentName := "test-cluster"
-		cCert, cKey, err := tlsutil.GenerateClientCertificate(agentName, signer, caCert.PrivateKey)
+		cCert, cKey, err := tlsutil.GenerateClientCertificate(agentName, signer, caCert.PrivateKey, tlsutil.DefaultLeafCertValidityDays)
 		require.NoError(t, err, "gen client cert")
 		mustCreateTLSSecret(t, agentCl, agentNS, config.SecretNameAgentClientCert, cCert, cKey)
 
@@ -1169,7 +1169,7 @@ func TestCheckConfigAgent(t *testing.T) {
 		}
 
 		// Create principal CA (required for principal checks)
-		caCertPEM, caKeyPEM, err := tlsutil.GenerateCaCertificate(config.SecretNamePrincipalCA)
+		caCertPEM, caKeyPEM, err := tlsutil.GenerateCaCertificate(config.SecretNamePrincipalCA, tlsutil.DefaultCACertValidityDays)
 		require.NoError(t, err, "generate CA")
 		mustCreateTLSSecret(t, principalCl, principalNS, config.SecretNamePrincipalCA, caCertPEM, caKeyPEM)
 
@@ -1213,7 +1213,7 @@ func TestCheckConfigAgent(t *testing.T) {
 		}
 
 		// Create principal CA
-		caCertPEM, caKeyPEM, err := tlsutil.GenerateCaCertificate(config.SecretNamePrincipalCA)
+		caCertPEM, caKeyPEM, err := tlsutil.GenerateCaCertificate(config.SecretNamePrincipalCA, tlsutil.DefaultCACertValidityDays)
 		require.NoError(t, err, "generate CA")
 		mustCreateTLSSecret(t, principalCl, principalNS, config.SecretNamePrincipalCA, caCertPEM, caKeyPEM)
 
@@ -1233,7 +1233,7 @@ func TestCheckConfigAgent(t *testing.T) {
 		signer, err := x509.ParseCertificate(caCert.Certificate[0])
 		require.NoError(t, err, "parse CA")
 		agentName := "non-existent-namespace"
-		cCert, cKey, err := tlsutil.GenerateClientCertificate(agentName, signer, caCert.PrivateKey)
+		cCert, cKey, err := tlsutil.GenerateClientCertificate(agentName, signer, caCert.PrivateKey, tlsutil.DefaultLeafCertValidityDays)
 		require.NoError(t, err, "gen client cert")
 		mustCreateTLSSecret(t, agentCl, agentNS, config.SecretNameAgentClientCert, cCert, cKey)
 
@@ -1277,7 +1277,7 @@ func TestCheckConfigAgent(t *testing.T) {
 		}
 
 		// Create principal CA
-		caCertPEM, caKeyPEM, err := tlsutil.GenerateCaCertificate(config.SecretNamePrincipalCA)
+		caCertPEM, caKeyPEM, err := tlsutil.GenerateCaCertificate(config.SecretNamePrincipalCA, tlsutil.DefaultCACertValidityDays)
 		require.NoError(t, err, "generate CA")
 		mustCreateTLSSecret(t, principalCl, principalNS, config.SecretNamePrincipalCA, caCertPEM, caKeyPEM)
 
@@ -1331,7 +1331,7 @@ func TestCheckConfigAgent(t *testing.T) {
 		}
 
 		// Create principal CA
-		caCertPEM, caKeyPEM, err := tlsutil.GenerateCaCertificate(config.SecretNamePrincipalCA)
+		caCertPEM, caKeyPEM, err := tlsutil.GenerateCaCertificate(config.SecretNamePrincipalCA, tlsutil.DefaultCACertValidityDays)
 		require.NoError(t, err, "generate CA")
 		mustCreateTLSSecret(t, principalCl, principalNS, config.SecretNamePrincipalCA, caCertPEM, caKeyPEM)
 
@@ -1393,7 +1393,7 @@ func TestCheckConfigAgent(t *testing.T) {
 		}
 
 		// Create principal CA
-		caCertPEM, caKeyPEM, err := tlsutil.GenerateCaCertificate(config.SecretNamePrincipalCA)
+		caCertPEM, caKeyPEM, err := tlsutil.GenerateCaCertificate(config.SecretNamePrincipalCA, tlsutil.DefaultCACertValidityDays)
 		require.NoError(t, err, "generate CA")
 		mustCreateTLSSecret(t, principalCl, principalNS, config.SecretNamePrincipalCA, caCertPEM, caKeyPEM)
 
@@ -1455,7 +1455,7 @@ func TestCheckConfigAgent(t *testing.T) {
 		}
 
 		// Create principal CA
-		caCertPEM, caKeyPEM, err := tlsutil.GenerateCaCertificate(config.SecretNamePrincipalCA)
+		caCertPEM, caKeyPEM, err := tlsutil.GenerateCaCertificate(config.SecretNamePrincipalCA, tlsutil.DefaultCACertValidityDays)
 		require.NoError(t, err, "generate CA")
 		mustCreateTLSSecret(t, principalCl, principalNS, config.SecretNamePrincipalCA, caCertPEM, caKeyPEM)
 
@@ -1673,7 +1673,7 @@ func TestX509FromTLSSecret(t *testing.T) {
 	ctx := context.TODO()
 
 	// Generate a root CA
-	rootCACertPEM, rootCAKeyPEM, err := tlsutil.GenerateCaCertificate("root-ca")
+	rootCACertPEM, rootCAKeyPEM, err := tlsutil.GenerateCaCertificate("root-ca", tlsutil.DefaultCACertValidityDays)
 	require.NoError(t, err)
 	cl := fake.NewSimpleClientset()
 	mustCreateTLSSecret(t, cl, "default", "root-ca", rootCACertPEM, rootCAKeyPEM)
@@ -1683,7 +1683,7 @@ func TestX509FromTLSSecret(t *testing.T) {
 	require.NoError(t, err)
 
 	// Generate an intermediate CA signed by root CA
-	intermCACertPEM, intermCAKeyPEM, err := tlsutil.GenerateCaCertificate("intermediate-ca")
+	intermCACertPEM, intermCAKeyPEM, err := tlsutil.GenerateCaCertificate("intermediate-ca", tlsutil.DefaultCACertValidityDays)
 	require.NoError(t, err)
 	mustCreateTLSSecret(t, cl, "default", "interm-ca", intermCACertPEM, intermCAKeyPEM)
 	intermCACert, err := tlsutil.TLSCertFromSecret(ctx, cl, "default", "interm-ca")
@@ -1693,7 +1693,7 @@ func TestX509FromTLSSecret(t *testing.T) {
 	_ = rootCASigner
 
 	// Generate a leaf certificate signed by the intermediate CA
-	leafCertPEM, leafKeyPEM, err := tlsutil.GenerateServerCertificate("leaf", intermCASigner, intermCACert.PrivateKey, []string{"127.0.0.1"}, []string{"localhost"})
+	leafCertPEM, leafKeyPEM, err := tlsutil.GenerateServerCertificate("leaf", intermCASigner, intermCACert.PrivateKey, []string{"127.0.0.1"}, []string{"localhost"}, tlsutil.DefaultLeafCertValidityDays)
 	require.NoError(t, err)
 
 	// Parse the expected leaf cert DER for strict identity checks

--- a/docs/configuration/ctl.md
+++ b/docs/configuration/ctl.md
@@ -93,6 +93,8 @@ Inspect and manage agent configuration
 
 `create` - Create a new agent configuration
 
+  - `--days`: Client certificate validity in days when generating from PKI (default: 180). Ignored when using `--tls-from-secret` / `--ca-from-secret`. Must not exceed the signing CA's remaining validity.
+
 `inspect` - Inspect agent configuration
 
 `list` - List configured agents
@@ -100,6 +102,8 @@ Inspect and manage agent configuration
 `print-tls` - Print a TLS asset of an agent to stdout (`cert`, `key`, or `ca`)
 
 `reconfigure` - Reconfigures an agent's properties
+
+  - `--days`: Client certificate validity in days when using `--reissue-client-cert` (default: 180). Must not exceed the signing CA's remaining validity.
 
 ## `check-config` Command
 
@@ -154,8 +158,14 @@ OR TO PROTECT ANY KIND OF DATA.
 
 `init` - NON-PROD!! Initialize the PKI for use with argocd-agent
 
+  - `--days`: Certificate validity in days (default: 3650, ~10 years)
+
 `inspect` - NON-PROD!! Inspect the configured PKI
 
 `issue` - NON-PROD!! Issue TLS certificates signed by the PKI's CA
+
+  Subcommands: `principal`, `resource-proxy`, `agent <name>`
+
+  - `--days`: Certificate validity in days (default: 180, ~6 months). For leaf certificates, must not exceed the signing CA's remaining validity.
 
 `propagate` - NON-PROD!! Propagate the PKI to the agent

--- a/docs/configuration/tls-certificates.md
+++ b/docs/configuration/tls-certificates.md
@@ -74,6 +74,7 @@ This creates the `argocd-agent-ca` secret containing the CA certificate and priv
 **Options:**
 
 - `--force, -f`: Overwrite existing CA if it already exists
+- `--days`: Number of days the CA certificate is valid for (default: 3650, ~10 years)
 
 ### Step 2: Issue Principal Server Certificate
 
@@ -93,6 +94,7 @@ argocd-agentctl pki issue principal \
 - `--ip`: Comma-separated list of IP addresses for the principal service
 - `--dns`: Comma-separated list of DNS names for the principal service
 - `--upsert, -u`: Update existing certificate if it already exists
+- `--days`: Number of days the certificate is valid for (default: 180, ~6 months). Must not exceed the signing CA's remaining validity.
 
 **Example for Kubernetes:**
 
@@ -113,6 +115,8 @@ argocd-agentctl pki issue resource-proxy \
   --dns "localhost,argocd-agent-resource-proxy.argocd.svc.cluster.local" \
   --upsert
 ```
+
+Supports the same `--days` flag as `pki issue principal` (default: 180).
 
 ### Step 4: Create JWT Signing Key
 
@@ -138,6 +142,8 @@ argocd-agentctl pki issue agent <agent-name> \
 This command creates both:
 - `argocd-agent-client-tls` secret (client certificate) in the agent cluster
 - `argocd-agent-ca` secret (CA certificate) in the agent cluster
+
+Supports `--days` (default: 180). The requested lifetime must not exceed the signing CA's remaining validity.
 
 **Note**: If you need to propagate the CA certificate separately (e.g., for existing agents), you can still use:
 

--- a/internal/tlsutil/generate.go
+++ b/internal/tlsutil/generate.go
@@ -165,7 +165,7 @@ func ValidateLeafValidityDays(signerCert *x509.Certificate, validityDays int) er
 	}
 	requestedNotAfter := time.Now().AddDate(0, 0, validityDays)
 	if requestedNotAfter.After(signerCert.NotAfter) {
-		maxDays := int(signerCert.NotAfter.Sub(time.Now()).Hours() / 24)
+		maxDays := int(time.Until(signerCert.NotAfter).Hours() / 24)
 		return fmt.Errorf(
 			"requested validity of %d days exceeds CA expiry (%s); maximum is approximately %d days",
 			validityDays, signerCert.NotAfter.Format(time.RFC1123Z), maxDays,

--- a/internal/tlsutil/generate.go
+++ b/internal/tlsutil/generate.go
@@ -29,17 +29,27 @@ import (
 	"time"
 )
 
+const (
+	// DefaultLeafCertValidityDays is the default validity period for leaf certificates (~6 months).
+	DefaultLeafCertValidityDays = 180
+	// DefaultCACertValidityDays is the default validity period for CA certificates (~10 years).
+	DefaultCACertValidityDays = 3650
+)
+
 // GenerateCaCertificate generates a certificate and private key that will be
 // configured to be usable as a Certificate Authority (CA). It returns both,
 // the public certificate and the private key in PEM format.
 //
-// The certificate will be valid for 10 days.
+// The certificate will be valid for validityDays days.
 //
 // DO NOT USE THE RESULTING CERTIFICATE OR KEY OR ANY CERTIFICATES SIGNED BY
 // THIS CA FOR PRODUCTION PURPOSES. NEVER. YOU HAVE BEEN WARNED.
 //
 // And sorry for shouting.
-func GenerateCaCertificate(commonName string) (string, string, error) {
+func GenerateCaCertificate(commonName string, validityDays int) (string, string, error) {
+	if err := validateValidityDays(validityDays); err != nil {
+		return "", "", err
+	}
 	cert := &x509.Certificate{
 		SerialNumber: big.NewInt(1),
 		Subject: pkix.Name{
@@ -47,7 +57,7 @@ func GenerateCaCertificate(commonName string) (string, string, error) {
 			Organization: []string{"DO NOT USE IN PRODUCTION"},
 		},
 		NotBefore:             time.Now(),
-		NotAfter:              time.Now().AddDate(10, 0, 0),
+		NotAfter:              time.Now().AddDate(0, 0, validityDays),
 		IsCA:                  true,
 		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
 		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
@@ -88,7 +98,10 @@ func GenerateCaCertificate(commonName string) (string, string, error) {
 // authentication.
 //
 // It will return the certificate and its private key as PEM encoded strings.
-func GenerateClientCertificate(name string, signerCert *x509.Certificate, signerKey crypto.PrivateKey) (string, string, error) {
+func GenerateClientCertificate(name string, signerCert *x509.Certificate, signerKey crypto.PrivateKey, validityDays int) (string, string, error) {
+	if err := validateValidityDays(validityDays); err != nil {
+		return "", "", err
+	}
 	cert := &x509.Certificate{
 		SerialNumber: big.NewInt(1),
 		Subject: pkix.Name{
@@ -96,7 +109,7 @@ func GenerateClientCertificate(name string, signerCert *x509.Certificate, signer
 			Organization: []string{"DO NOT USE IN PRODUCTION"},
 		},
 		NotBefore:             time.Now(),
-		NotAfter:              time.Now().AddDate(0, 6, 0),
+		NotAfter:              time.Now().AddDate(0, 0, validityDays),
 		IsCA:                  false,
 		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
 		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
@@ -111,7 +124,10 @@ func GenerateClientCertificate(name string, signerCert *x509.Certificate, signer
 // authentication.
 //
 // It will return the certificate and its private key as PEM encoded strings.
-func GenerateServerCertificate(name string, signerCert *x509.Certificate, signerKey crypto.PrivateKey, ips []string, dns []string) (string, string, error) {
+func GenerateServerCertificate(name string, signerCert *x509.Certificate, signerKey crypto.PrivateKey, ips []string, dns []string, validityDays int) (string, string, error) {
+	if err := validateValidityDays(validityDays); err != nil {
+		return "", "", err
+	}
 	dnsNames := dns
 	ipAddresses := []net.IP{}
 	for _, ip := range ips {
@@ -129,7 +145,7 @@ func GenerateServerCertificate(name string, signerCert *x509.Certificate, signer
 			Organization: []string{"DO NOT USE IN PRODUCTION"},
 		},
 		NotBefore:             time.Now(),
-		NotAfter:              time.Now().AddDate(0, 6, 0),
+		NotAfter:              time.Now().AddDate(0, 0, validityDays),
 		IsCA:                  false,
 		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
 		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
@@ -139,6 +155,30 @@ func GenerateServerCertificate(name string, signerCert *x509.Certificate, signer
 	}
 
 	return GenerateCertificate(cert, signerCert, signerKey)
+}
+
+// ValidateLeafValidityDays returns an error if a leaf cert issued today for
+// validityDays would expire after signerCert.NotAfter.
+func ValidateLeafValidityDays(signerCert *x509.Certificate, validityDays int) error {
+	if err := validateValidityDays(validityDays); err != nil {
+		return err
+	}
+	requestedNotAfter := time.Now().AddDate(0, 0, validityDays)
+	if requestedNotAfter.After(signerCert.NotAfter) {
+		maxDays := int(signerCert.NotAfter.Sub(time.Now()).Hours() / 24)
+		return fmt.Errorf(
+			"requested validity of %d days exceeds CA expiry (%s); maximum is approximately %d days",
+			validityDays, signerCert.NotAfter.Format(time.RFC1123Z), maxDays,
+		)
+	}
+	return nil
+}
+
+func validateValidityDays(validityDays int) error {
+	if validityDays <= 0 {
+		return fmt.Errorf("validity days must be greater than 0, got %d", validityDays)
+	}
+	return nil
 }
 
 // GenerateCertificate generates a certificate from template cert and signs it

--- a/internal/tlsutil/generate_test.go
+++ b/internal/tlsutil/generate_test.go
@@ -19,6 +19,7 @@ import (
 	"crypto/x509"
 	"net"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -26,7 +27,7 @@ import (
 
 func Test_GenerateCaCertificate(t *testing.T) {
 	// We'll require the CA cert for the tests to come
-	certData, keyData, err := GenerateCaCertificate("test")
+	certData, keyData, err := GenerateCaCertificate("test", DefaultCACertValidityDays)
 	require.NoError(t, err)
 	cert, err := tls.X509KeyPair([]byte(certData), []byte(keyData))
 	require.NoError(t, err)
@@ -37,7 +38,7 @@ func Test_GenerateCaCertificate(t *testing.T) {
 
 	t.Run("Generate client certificate", func(t *testing.T) {
 		certSubj := "abcdefg"
-		certData, keyData, err := GenerateClientCertificate(certSubj, cert.Leaf, cert.PrivateKey)
+		certData, keyData, err := GenerateClientCertificate(certSubj, cert.Leaf, cert.PrivateKey, DefaultLeafCertValidityDays)
 		require.NoError(t, err)
 		ccert, err := tls.X509KeyPair([]byte(certData), []byte(keyData))
 		require.NoError(t, err)
@@ -47,9 +48,10 @@ func Test_GenerateCaCertificate(t *testing.T) {
 		assert.Equal(t, certSubj, ccert.Leaf.Subject.CommonName)
 		assert.Equal(t, "test", ccert.Leaf.Issuer.CommonName)
 	})
+
 	t.Run("Generate server certificate", func(t *testing.T) {
 		certSubj := "abcdefg"
-		certData, keyData, err := GenerateServerCertificate(certSubj, cert.Leaf, cert.PrivateKey, []string{"127.0.0.1"}, []string{"localhost"})
+		certData, keyData, err := GenerateServerCertificate(certSubj, cert.Leaf, cert.PrivateKey, []string{"127.0.0.1"}, []string{"localhost"}, DefaultLeafCertValidityDays)
 		require.NoError(t, err)
 		ccert, err := tls.X509KeyPair([]byte(certData), []byte(keyData))
 		require.NoError(t, err)
@@ -63,4 +65,51 @@ func Test_GenerateCaCertificate(t *testing.T) {
 		assert.Contains(t, ccert.Leaf.DNSNames, "localhost")
 	})
 
+	t.Run("custom validity days", func(t *testing.T) {
+		const customDays = 42
+		before := time.Now()
+		certData, keyData, err := GenerateClientCertificate("custom-days", cert.Leaf, cert.PrivateKey, customDays)
+		require.NoError(t, err)
+		ccert, err := tls.X509KeyPair([]byte(certData), []byte(keyData))
+		require.NoError(t, err)
+
+		expectedNotAfter := before.AddDate(0, 0, customDays)
+		assert.WithinDuration(t, expectedNotAfter, ccert.Leaf.NotAfter, 2*time.Second)
+	})
+
+	t.Run("reject invalid validity days", func(t *testing.T) {
+		_, _, err := GenerateClientCertificate("bad-days", cert.Leaf, cert.PrivateKey, 0)
+		require.Error(t, err)
+		_, _, err = GenerateCaCertificate("bad-days", -1)
+		require.Error(t, err)
+	})
+}
+
+func Test_ValidateLeafValidityDays(t *testing.T) {
+	caCert := &x509.Certificate{
+		NotBefore: time.Now().Add(-time.Hour),
+		NotAfter:  time.Now().AddDate(0, 0, 365),
+	}
+
+	t.Run("accept within CA window", func(t *testing.T) {
+		err := ValidateLeafValidityDays(caCert, 30)
+		require.NoError(t, err)
+	})
+
+	t.Run("accept up to CA expiry", func(t *testing.T) {
+		maxDays := int(caCert.NotAfter.Sub(time.Now()).Hours() / 24)
+		err := ValidateLeafValidityDays(caCert, maxDays)
+		require.NoError(t, err)
+	})
+
+	t.Run("reject when exceeding CA expiry", func(t *testing.T) {
+		err := ValidateLeafValidityDays(caCert, 9999)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "exceeds CA expiry")
+	})
+
+	t.Run("reject invalid validity days", func(t *testing.T) {
+		err := ValidateLeafValidityDays(caCert, 0)
+		require.Error(t, err)
+	})
 }

--- a/principal/registration/registration_test.go
+++ b/principal/registration/registration_test.go
@@ -45,7 +45,7 @@ func createTestClientCertSecret(t *testing.T, kubeclient kubernetes.Interface) s
 	t.Helper()
 
 	// Generate CA certificate
-	caCertPEM, caKeyPEM, err := tlsutil.GenerateCaCertificate(config.SecretNamePrincipalCA)
+	caCertPEM, caKeyPEM, err := tlsutil.GenerateCaCertificate(config.SecretNamePrincipalCA, tlsutil.DefaultCACertValidityDays)
 	require.NoError(t, err, "generate CA certificate")
 
 	// Parse CA cert PEM for signing
@@ -60,7 +60,7 @@ func createTestClientCertSecret(t *testing.T, kubeclient kubernetes.Interface) s
 	require.NoError(t, err, "parse CA private key")
 
 	// Generate client certificate signed by CA
-	clientCertPEM, clientKeyPEM, err := tlsutil.GenerateClientCertificate("shared-client", caCert, caKey)
+	clientCertPEM, clientKeyPEM, err := tlsutil.GenerateClientCertificate("shared-client", caCert, caKey, tlsutil.DefaultLeafCertValidityDays)
 	require.NoError(t, err, "generate client certificate")
 
 	// Create secret with tls.crt, tls.key, and ca.crt

--- a/test/e2e/rp_test.go
+++ b/test/e2e/rp_test.go
@@ -65,7 +65,7 @@ func (suite *ResourceProxyTestSuite) getRpClient(agentName string) *http.Client 
 	certPool.AddCert(caCert.Leaf)
 
 	// Generate client certificate
-	ccert, ckey, err := tlsutil.GenerateClientCertificate(agentName, caCert.Leaf, caCert.PrivateKey)
+	ccert, ckey, err := tlsutil.GenerateClientCertificate(agentName, caCert.Leaf, caCert.PrivateKey, tlsutil.DefaultLeafCertValidityDays)
 	requires.NoError(err)
 	tlsCert, err := tls.X509KeyPair([]byte(ccert), []byte(ckey))
 	requires.NoError(err)


### PR DESCRIPTION
Assisted-by: Cursor

**What does this PR do / why we need it**:

Allow users to specify the lifetime of the CA and certs as issued by `argocd-agentctl pki` by number of days.

**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:


**Checklist**

* [ ] Documentation update is required by this PR (and has been updated) OR no documentation update is required.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `--days` flag to PKI and agent certificate commands to set certificate validity periods (replacing fixed defaults).
  * Default validity periods: CA ≈10 years, leaf ≈6 months.
* **Behavior Changes**
  * Certificate issuance now rejects lifetimes that would outlast the signing CA’s remaining validity.
  * Resource-proxy issuance allows suppressing SANs even when IP/DNS inputs are empty.
* **Documentation**
  * Updated command docs to describe `--days` usage and default/constraint details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->