### PR TITLE
feat: dedupe incoming events on the principal

### DIFF
--- a/internal/metrics/queue.go
+++ b/internal/metrics/queue.go
@@ -21,6 +21,8 @@ import (
 
 var _ workqueue.MetricsProvider = &QueueMetrics{}
 
+var dqMetricsProvider *DedupeQueueMetrics
+
 // QueueMetrics implements the workqueue.MetricsProvider interface,
 // providing metrics for our send/recv queues.
 type QueueMetrics struct {
@@ -141,4 +143,60 @@ func RegisterQueueMetrics(prefix string) {
 		provider.retries,
 	)
 	workqueue.SetProvider(provider)
+}
+
+// DedupeQueueMetrics holds Prometheus metrics for dedupeQueue instances.
+type DedupeQueueMetrics struct {
+	Depth         *prometheus.GaugeVec
+	Adds          *prometheus.CounterVec
+	EventsDeduped *prometheus.CounterVec
+	Duration      *prometheus.HistogramVec
+}
+
+func NewDedupeQueueMetrics(prefix string) *DedupeQueueMetrics {
+	return &DedupeQueueMetrics{
+		Depth: prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Name: prefix + "_queue_depth",
+				Help: "Current depth of queue",
+			},
+			[]string{"queue"},
+		),
+		Adds: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Name: prefix + "_queue_adds_total",
+				Help: "Total number of adds to the deduped queue",
+			},
+			[]string{"queue"},
+		),
+		EventsDeduped: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Name: prefix + "_queue_events_deduped_total",
+				Help: "Total number of events deduped from the queue",
+			},
+			[]string{"queue"},
+		),
+		Duration: prometheus.NewHistogramVec(
+			prometheus.HistogramOpts{
+				Name:    prefix + "_queue_duration_seconds",
+				Help:    "Time an event spent waiting in the queue before being dequeued",
+				Buckets: prometheus.DefBuckets,
+			},
+			[]string{"queue"},
+		),
+	}
+}
+
+func RegisterDedupeQueueMetrics(prefix string) {
+	dqMetricsProvider = NewDedupeQueueMetrics(prefix)
+	prometheus.DefaultRegisterer.MustRegister(
+		dqMetricsProvider.Depth,
+		dqMetricsProvider.Adds,
+		dqMetricsProvider.EventsDeduped,
+		dqMetricsProvider.Duration,
+	)
+}
+
+func GetDedupeQueueMetrics() *DedupeQueueMetrics {
+	return dqMetricsProvider
 }

--- a/internal/queue/dedupe_queue.go
+++ b/internal/queue/dedupe_queue.go
@@ -15,6 +15,7 @@
 package queue
 
 import (
+	"fmt"
 	"sync"
 	"time"
 
@@ -47,6 +48,10 @@ func NewDedupeQueueForTest(maxSize int) *dedupeQueue {
 }
 
 func newDedupeQueue(maxSize int, name string) *dedupeQueue {
+	if maxSize <= 0 {
+		panic(fmt.Sprintf("maxSize must be positive, got %d", maxSize))
+	}
+
 	return &dedupeQueue{
 		items:   make([]*queueItem, 0),
 		notify:  make(chan struct{}, 10),
@@ -121,29 +126,29 @@ func (dq *dedupeQueue) Get() (*event.Event, bool) {
 	dq.mu.Unlock()
 
 	// Block until an item is available or shutdown
-	for {
-		select {
-		case <-dq.notify:
-			dq.mu.Lock()
-			if len(dq.items) > 0 {
-				item := dq.pop()
+	for range dq.notify {
+		dq.mu.Lock()
+		if len(dq.items) > 0 {
+			item := dq.pop()
 
-				if dq.metrics != nil {
-					dq.metrics.Depth.WithLabelValues(dq.name).Set(float64(len(dq.items)))
-					dq.metrics.Duration.WithLabelValues(dq.name).Observe(time.Since(item.enqueuedAt).Seconds())
-				}
-
-				dq.mu.Unlock()
-				return item.event, false
+			if dq.metrics != nil {
+				dq.metrics.Depth.WithLabelValues(dq.name).Set(float64(len(dq.items)))
+				dq.metrics.Duration.WithLabelValues(dq.name).Observe(time.Since(item.enqueuedAt).Seconds())
 			}
 
-			if dq.isShutdown {
-				dq.mu.Unlock()
-				return nil, true
-			}
 			dq.mu.Unlock()
+			return item.event, false
 		}
+
+		if dq.isShutdown {
+			dq.mu.Unlock()
+			return nil, true
+		}
+		dq.mu.Unlock()
 	}
+
+	// notify channel was closed (shutdown)
+	return nil, true
 }
 
 func (dq *dedupeQueue) Done(_ *event.Event) {

--- a/internal/queue/dedupe_queue.go
+++ b/internal/queue/dedupe_queue.go
@@ -179,6 +179,7 @@ func (dq *dedupeQueue) removeDuplicates(incoming *event.Event) {
 		return
 	}
 
+	// TODO: avoid this linear scan/shift for every incoming event.
 	for i := len(dq.items) - 1; i >= 0; i-- {
 		existingID, existingEvType := dedupeKey(dq.items[i].event)
 		if existingID == resID && existingEvType == evType {

--- a/internal/queue/dedupe_queue.go
+++ b/internal/queue/dedupe_queue.go
@@ -1,0 +1,199 @@
+// Copyright 2026 The argocd-agent Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package queue
+
+import (
+	"sync"
+	"time"
+
+	internalevent "github.com/argoproj-labs/argocd-agent/internal/event"
+	"github.com/argoproj-labs/argocd-agent/internal/metrics"
+	"github.com/cloudevents/sdk-go/v2/event"
+)
+
+// dedupeQueue is a bounded FIFO queue that de-duplicates resource events. When a new event
+// arrives for a resource of the same type, the older events are removed and the
+// newer event is appended to the tail of the queue.
+type dedupeQueue struct {
+	mu         sync.Mutex
+	items      []*queueItem
+	notify     chan struct{}
+	name       string
+	maxSize    int
+	isShutdown bool
+	metrics    *metrics.DedupeQueueMetrics
+}
+
+type queueItem struct {
+	event      *event.Event
+	enqueuedAt time.Time
+}
+
+// NewDedupeQueueForTest creates a dedupeQueue for use in tests.
+func NewDedupeQueueForTest(maxSize int) *dedupeQueue {
+	return newDedupeQueue(maxSize, "test")
+}
+
+func newDedupeQueue(maxSize int, name string) *dedupeQueue {
+	return &dedupeQueue{
+		items:   make([]*queueItem, 0),
+		notify:  make(chan struct{}, 10),
+		name:    name,
+		maxSize: maxSize,
+		metrics: metrics.GetDedupeQueueMetrics(),
+	}
+}
+
+// canDedupe returns true if the event type supports de-duplication.
+func canDedupe(ev *event.Event) bool {
+	evType := ev.Type()
+	return evType == internalevent.SpecUpdate.String() || evType == internalevent.StatusUpdate.String()
+}
+
+// dedupeKey returns a composite key of resourceID and event type for
+// identifying duplicate events.
+func dedupeKey(ev *event.Event) (string, string) {
+	return internalevent.ResourceID(ev), ev.Type()
+}
+
+func (dq *dedupeQueue) Add(item *event.Event) {
+	dq.mu.Lock()
+	defer dq.mu.Unlock()
+
+	if item == nil || dq.isShutdown {
+		return
+	}
+
+	if canDedupe(item) {
+		dq.removeDuplicates(item)
+	}
+
+	if len(dq.items) >= dq.maxSize {
+		dq.pop()
+	}
+
+	dq.items = append(dq.items, &queueItem{
+		event:      item,
+		enqueuedAt: time.Now(),
+	})
+
+	if dq.metrics != nil {
+		dq.metrics.Adds.WithLabelValues(dq.name).Inc()
+		dq.metrics.Depth.WithLabelValues(dq.name).Set(float64(len(dq.items)))
+	}
+
+	select {
+	case dq.notify <- struct{}{}:
+	default:
+	}
+}
+
+func (dq *dedupeQueue) Get() (*event.Event, bool) {
+	dq.mu.Lock()
+	if dq.isShutdown && len(dq.items) == 0 {
+		dq.mu.Unlock()
+		return nil, true
+	}
+
+	if len(dq.items) > 0 {
+		item := dq.pop()
+
+		if dq.metrics != nil {
+			dq.metrics.Depth.WithLabelValues(dq.name).Set(float64(len(dq.items)))
+			dq.metrics.Duration.WithLabelValues(dq.name).Observe(time.Since(item.enqueuedAt).Seconds())
+		}
+
+		dq.mu.Unlock()
+		return item.event, false
+	}
+	dq.mu.Unlock()
+
+	// Block until an item is available or shutdown
+	for {
+		select {
+		case <-dq.notify:
+			dq.mu.Lock()
+			if len(dq.items) > 0 {
+				item := dq.pop()
+
+				if dq.metrics != nil {
+					dq.metrics.Depth.WithLabelValues(dq.name).Set(float64(len(dq.items)))
+					dq.metrics.Duration.WithLabelValues(dq.name).Observe(time.Since(item.enqueuedAt).Seconds())
+				}
+
+				dq.mu.Unlock()
+				return item.event, false
+			}
+
+			if dq.isShutdown {
+				dq.mu.Unlock()
+				return nil, true
+			}
+			dq.mu.Unlock()
+		}
+	}
+}
+
+func (dq *dedupeQueue) Done(_ *event.Event) {
+	// No-op: the dedupe queue does not track in-flight items.
+}
+
+func (dq *dedupeQueue) Len() int {
+	dq.mu.Lock()
+	defer dq.mu.Unlock()
+	return len(dq.items)
+}
+
+func (dq *dedupeQueue) ShutDown() {
+	dq.mu.Lock()
+	defer dq.mu.Unlock()
+	if dq.isShutdown {
+		return
+	}
+	dq.isShutdown = true
+	close(dq.notify)
+}
+
+// removeDuplicates removes all queued events matching the same resourceID and
+// event type as item. Must be called with dq.mu held.
+func (dq *dedupeQueue) removeDuplicates(incoming *event.Event) {
+	resID, evType := dedupeKey(incoming)
+	if resID == "" {
+		return
+	}
+
+	for i := len(dq.items) - 1; i >= 0; i-- {
+		existingID, existingEvType := dedupeKey(dq.items[i].event)
+		if existingID == resID && existingEvType == evType {
+			dq.items[i] = nil
+			dq.items = append(dq.items[:i], dq.items[i+1:]...)
+			if dq.metrics != nil {
+				dq.metrics.EventsDeduped.WithLabelValues(dq.name).Inc()
+			}
+		}
+	}
+}
+
+// pop the first item from the queue.
+// Must be called with queue lock held.
+func (dq *dedupeQueue) pop() *queueItem {
+	if len(dq.items) == 0 {
+		return nil
+	}
+	item := dq.items[0]
+	dq.items[0] = nil
+	dq.items = dq.items[1:]
+	return item
+}

--- a/internal/queue/dedupe_queue_test.go
+++ b/internal/queue/dedupe_queue_test.go
@@ -1,0 +1,304 @@
+// Copyright 2026 The argocd-agent Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package queue
+
+import (
+	"strconv"
+	"testing"
+
+	internalevent "github.com/argoproj-labs/argocd-agent/internal/event"
+	"github.com/cloudevents/sdk-go/v2/event"
+	"github.com/stretchr/testify/assert"
+)
+
+func newTestEvent(id string, eventType string, resourceID string) *event.Event {
+	ev := event.New()
+	ev.SetID(id)
+	ev.SetType(eventType)
+	if resourceID != "" {
+		ev.SetExtension("resourceid", resourceID)
+	}
+	return &ev
+}
+
+func TestDedupeQueue_BasicFIFO(t *testing.T) {
+	t.Run("Events dequeue in FIFO order", func(t *testing.T) {
+		q := newDedupeQueue(1000, "test")
+		ev1 := newTestEvent("1", internalevent.Create.String(), "app-a")
+		ev2 := newTestEvent("2", internalevent.Create.String(), "app-b")
+		ev3 := newTestEvent("3", internalevent.Delete.String(), "app-c")
+
+		q.Add(ev1)
+		q.Add(ev2)
+		q.Add(ev3)
+
+		assert.Equal(t, 3, q.Len())
+
+		got, shutdown := q.Get()
+		assert.False(t, shutdown)
+		assert.Equal(t, "1", got.ID())
+
+		got, _ = q.Get()
+		assert.Equal(t, "2", got.ID())
+
+		got, _ = q.Get()
+		assert.Equal(t, "3", got.ID())
+
+		assert.Equal(t, 0, q.Len())
+	})
+}
+
+func TestDedupeQueue_SpecUpdateDedup(t *testing.T) {
+	t.Run("Newer SpecUpdate replaces older for same resource", func(t *testing.T) {
+		q := newDedupeQueue(1000, "test")
+		ev1 := newTestEvent("v1", internalevent.SpecUpdate.String(), "app-x_uid1")
+		ev2 := newTestEvent("v2", internalevent.SpecUpdate.String(), "app-x_uid1")
+		ev3 := newTestEvent("v3", internalevent.SpecUpdate.String(), "app-x_uid1")
+
+		q.Add(ev1)
+		q.Add(ev2)
+		q.Add(ev3)
+
+		assert.Equal(t, 1, q.Len())
+
+		got, _ := q.Get()
+		assert.Equal(t, "v3", got.ID())
+	})
+
+	t.Run("SpecUpdates for different resources are not deduped", func(t *testing.T) {
+		q := newDedupeQueue(1000, "test")
+		ev1 := newTestEvent("v1", internalevent.SpecUpdate.String(), "app-x_uid1")
+		ev2 := newTestEvent("v2", internalevent.SpecUpdate.String(), "app-y_uid2")
+
+		q.Add(ev1)
+		q.Add(ev2)
+
+		assert.Equal(t, 2, q.Len())
+
+		got, _ := q.Get()
+		assert.Equal(t, "v1", got.ID())
+
+		got, _ = q.Get()
+		assert.Equal(t, "v2", got.ID())
+	})
+}
+
+func TestDedupeQueue_StatusUpdateDedup(t *testing.T) {
+	t.Run("Newer StatusUpdate replaces older for same resource", func(t *testing.T) {
+		q := newDedupeQueue(1000, "test")
+		ev1 := newTestEvent("s1", internalevent.StatusUpdate.String(), "app-x_uid1")
+		ev2 := newTestEvent("s2", internalevent.StatusUpdate.String(), "app-x_uid1")
+
+		q.Add(ev1)
+		q.Add(ev2)
+
+		assert.Equal(t, 1, q.Len())
+
+		got, _ := q.Get()
+		assert.Equal(t, "s2", got.ID())
+	})
+}
+
+func TestDedupeQueue_DifferentTypesNotDeduped(t *testing.T) {
+	t.Run("SpecUpdate and StatusUpdate for same resource are both kept (different types)", func(t *testing.T) {
+		q := newDedupeQueue(1000, "test")
+		evSpec := newTestEvent("spec1", internalevent.SpecUpdate.String(), "app-x_uid1")
+		evStatus := newTestEvent("status1", internalevent.StatusUpdate.String(), "app-x_uid1")
+
+		q.Add(evSpec)
+		q.Add(evStatus)
+
+		assert.Equal(t, 2, q.Len())
+
+		got, _ := q.Get()
+		assert.Equal(t, "spec1", got.ID())
+
+		got, _ = q.Get()
+		assert.Equal(t, "status1", got.ID())
+	})
+
+	t.Run("Create event is never deduped even for same resource", func(t *testing.T) {
+		q := newDedupeQueue(1000, "test")
+		evCreate := newTestEvent("c1", internalevent.Create.String(), "app-x_uid1")
+		evSpec := newTestEvent("spec1", internalevent.SpecUpdate.String(), "app-x_uid1")
+
+		q.Add(evCreate)
+		q.Add(evSpec)
+
+		assert.Equal(t, 2, q.Len())
+
+		got, _ := q.Get()
+		assert.Equal(t, "c1", got.ID())
+
+		got, _ = q.Get()
+		assert.Equal(t, "spec1", got.ID())
+	})
+
+	t.Run("Delete event is never deduped", func(t *testing.T) {
+		q := newDedupeQueue(1000, "test")
+		evDel1 := newTestEvent("d1", internalevent.Delete.String(), "app-x_uid1")
+		evDel2 := newTestEvent("d2", internalevent.Delete.String(), "app-x_uid1")
+
+		q.Add(evDel1)
+		q.Add(evDel2)
+
+		assert.Equal(t, 2, q.Len())
+
+		got, _ := q.Get()
+		assert.Equal(t, "d1", got.ID())
+
+		got, _ = q.Get()
+		assert.Equal(t, "d2", got.ID())
+	})
+}
+
+func TestDedupeQueue_MoveToTail(t *testing.T) {
+	t.Run("Deduped event moves to tail preserving order", func(t *testing.T) {
+		q := newDedupeQueue(1000, "test")
+
+		evSpecX := newTestEvent("spec-x-v1", internalevent.SpecUpdate.String(), "app-x_uid1")
+		evCreate := newTestEvent("create-y", internalevent.Create.String(), "app-y_uid2")
+		evSpecXv2 := newTestEvent("spec-x-v2", internalevent.SpecUpdate.String(), "app-x_uid1")
+
+		q.Add(evSpecX)
+		q.Add(evCreate)
+		// This should remove evSpecX from position 0 and append evSpecXv2 at tail
+		q.Add(evSpecXv2)
+
+		assert.Equal(t, 2, q.Len())
+
+		got, _ := q.Get()
+		assert.Equal(t, "create-y", got.ID())
+
+		got, _ = q.Get()
+		assert.Equal(t, "spec-x-v2", got.ID())
+	})
+}
+
+func TestDedupeQueue_NonDedupEligibleEvents(t *testing.T) {
+	t.Run("Heartbeat events are never deduped", func(t *testing.T) {
+		q := newDedupeQueue(1000, "test")
+		ev1 := newTestEvent("hb1", internalevent.Ping.String(), "uuid-1")
+		ev2 := newTestEvent("hb2", internalevent.Ping.String(), "uuid-2")
+
+		q.Add(ev1)
+		q.Add(ev2)
+
+		assert.Equal(t, 2, q.Len())
+	})
+
+	t.Run("Events with empty resourceID are not deduped", func(t *testing.T) {
+		q := newDedupeQueue(1000, "test")
+		ev1 := newTestEvent("1", internalevent.SpecUpdate.String(), "")
+		ev2 := newTestEvent("2", internalevent.SpecUpdate.String(), "")
+
+		q.Add(ev1)
+		q.Add(ev2)
+
+		assert.Equal(t, 2, q.Len())
+	})
+}
+
+func TestDedupeQueue_MaxSize(t *testing.T) {
+	t.Run("Oldest item is dropped when max size is exceeded", func(t *testing.T) {
+		maxSize := 5
+		q := newDedupeQueue(maxSize, "test")
+
+		for i := 1; i <= maxSize; i++ {
+			q.Add(newTestEvent(strconv.Itoa(i), internalevent.Create.String(), "app-"+strconv.Itoa(i)))
+		}
+
+		assert.Equal(t, maxSize, q.Len())
+
+		q.Add(newTestEvent("6", internalevent.Create.String(), "app-6"))
+
+		assert.Equal(t, maxSize, q.Len())
+
+		got, _ := q.Get()
+		assert.Equal(t, "2", got.ID())
+	})
+}
+
+func TestDedupeQueue_Done(t *testing.T) {
+	t.Run("Done is a no-op", func(t *testing.T) {
+		q := newDedupeQueue(1000, "test")
+		ev := newTestEvent("1", internalevent.Create.String(), "app-a")
+		q.Add(ev)
+
+		got, _ := q.Get()
+		q.Done(got) // should not panic
+		assert.Equal(t, 0, q.Len())
+	})
+}
+
+func TestDedupeQueue_ShutDown(t *testing.T) {
+	t.Run("Get returns shutdown signal after ShutDown", func(t *testing.T) {
+		q := newDedupeQueue(1000, "test")
+		q.ShutDown()
+
+		_, shutdown := q.Get()
+		assert.True(t, shutdown)
+	})
+
+	t.Run("Double ShutDown does not panic", func(t *testing.T) {
+		q := newDedupeQueue(1000, "test")
+		q.ShutDown()
+		assert.NotPanics(t, func() { q.ShutDown() })
+	})
+
+	t.Run("Add after ShutDown does not panic and is ignored", func(t *testing.T) {
+		q := newDedupeQueue(1000, "test")
+		q.ShutDown()
+		assert.NotPanics(t, func() {
+			q.Add(newTestEvent("1", internalevent.SpecUpdate.String(), "app-x"))
+		})
+		assert.Equal(t, 0, q.Len())
+	})
+}
+
+func TestDedupeQueue_MixedScenario(t *testing.T) {
+	t.Run("Mixed dedup-eligible and non-dedup-eligible events", func(t *testing.T) {
+		q := newDedupeQueue(1000, "test")
+
+		q.Add(newTestEvent("create-x", internalevent.Create.String(), "app-x_uid1"))
+		q.Add(newTestEvent("spec-x-v1", internalevent.SpecUpdate.String(), "app-x_uid1"))
+		q.Add(newTestEvent("status-y-v1", internalevent.StatusUpdate.String(), "app-y_uid2"))
+		q.Add(newTestEvent("spec-x-v2", internalevent.SpecUpdate.String(), "app-x_uid1"))
+		q.Add(newTestEvent("status-y-v2", internalevent.StatusUpdate.String(), "app-y_uid2"))
+		q.Add(newTestEvent("delete-z", internalevent.Delete.String(), "app-z_uid3"))
+
+		// Expected order:
+		// create-x (non-dedup-eligible, stays at original position)
+		// spec-x-v2 (replaced spec-x-v1, moved to tail of where spec-x-v1 was... no, moved to tail)
+		// status-y-v2 (replaced status-y-v1, moved to tail)
+		// delete-z (non-dedup-eligible, appended)
+
+		assert.Equal(t, 4, q.Len())
+
+		got, _ := q.Get()
+		assert.Equal(t, "create-x", got.ID())
+
+		got, _ = q.Get()
+		assert.Equal(t, "spec-x-v2", got.ID())
+
+		got, _ = q.Get()
+		assert.Equal(t, "status-y-v2", got.ID())
+
+		got, _ = q.Get()
+		assert.Equal(t, "delete-z", got.ID())
+
+		assert.Equal(t, 0, q.Len())
+	})
+}

--- a/internal/queue/mocks/QueuePair.go
+++ b/internal/queue/mocks/QueuePair.go
@@ -6,6 +6,7 @@ import (
 	event "github.com/cloudevents/sdk-go/v2/event"
 	mock "github.com/stretchr/testify/mock"
 
+	queue "github.com/argoproj-labs/argocd-agent/internal/queue"
 	workqueue "k8s.io/client-go/util/workqueue"
 )
 
@@ -254,19 +255,19 @@ func (_c *QueuePair_Names_Call) RunAndReturn(run func() []string) *QueuePair_Nam
 }
 
 // RecvQ provides a mock function with given fields: name
-func (_m *QueuePair) RecvQ(name string) workqueue.TypedRateLimitingInterface[*event.Event] {
+func (_m *QueuePair) RecvQ(name string) queue.RecvQueue {
 	ret := _m.Called(name)
 
 	if len(ret) == 0 {
 		panic("no return value specified for RecvQ")
 	}
 
-	var r0 workqueue.TypedRateLimitingInterface[*event.Event]
-	if rf, ok := ret.Get(0).(func(string) workqueue.TypedRateLimitingInterface[*event.Event]); ok {
+	var r0 queue.RecvQueue
+	if rf, ok := ret.Get(0).(func(string) queue.RecvQueue); ok {
 		r0 = rf(name)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(workqueue.TypedRateLimitingInterface[*event.Event])
+			r0 = ret.Get(0).(queue.RecvQueue)
 		}
 	}
 
@@ -291,12 +292,12 @@ func (_c *QueuePair_RecvQ_Call) Run(run func(name string)) *QueuePair_RecvQ_Call
 	return _c
 }
 
-func (_c *QueuePair_RecvQ_Call) Return(_a0 workqueue.TypedRateLimitingInterface[*event.Event]) *QueuePair_RecvQ_Call {
+func (_c *QueuePair_RecvQ_Call) Return(_a0 queue.RecvQueue) *QueuePair_RecvQ_Call {
 	_c.Call.Return(_a0)
 	return _c
 }
 
-func (_c *QueuePair_RecvQ_Call) RunAndReturn(run func(string) workqueue.TypedRateLimitingInterface[*event.Event]) *QueuePair_RecvQ_Call {
+func (_c *QueuePair_RecvQ_Call) RunAndReturn(run func(string) queue.RecvQueue) *QueuePair_RecvQ_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/queue/queue.go
+++ b/internal/queue/queue.go
@@ -27,13 +27,24 @@ import (
 
 var _ QueuePair = &SendRecvQueues{}
 
+// RecvQueue is the minimal interface used by RecvQ consumers. It covers only
+// the methods actually called on receive queues (Add, Get, Done, Len,
+// ShutDown), avoiding a dependency on the full workqueue interface.
+type RecvQueue interface {
+	Add(item *event.Event)
+	Get() (*event.Event, bool)
+	Done(item *event.Event)
+	Len() int
+	ShutDown()
+}
+
 // QueuePair maintains a map (indexed by name) of send/receive queue pairs
 type QueuePair interface {
 	Names() []string
 	HasQueuePair(name string) bool
 	Len() int
 	SendQ(name string) workqueue.TypedRateLimitingInterface[*event.Event]
-	RecvQ(name string) workqueue.TypedRateLimitingInterface[*event.Event]
+	RecvQ(name string) RecvQueue
 	Create(name string) error
 	Delete(name string, shutdown bool) error
 }
@@ -44,7 +55,7 @@ const (
 )
 
 type queuepair struct {
-	recvq *boundedQueue
+	recvq *dedupeQueue
 	sendq *boundedQueue
 }
 
@@ -137,7 +148,7 @@ func (q *SendRecvQueues) SendQ(name string) workqueue.TypedRateLimitingInterface
 
 // RecvQ will return the receive queue from the queue pair named name. If no
 // such queue pair exists, returns nil
-func (q *SendRecvQueues) RecvQ(name string) workqueue.TypedRateLimitingInterface[*event.Event] {
+func (q *SendRecvQueues) RecvQ(name string) RecvQueue {
 	q.queuelock.RLock()
 	defer q.queuelock.RUnlock()
 	qp, ok := q.queues[name]
@@ -172,7 +183,7 @@ func (q *SendRecvQueues) Create(name string) error {
 	qp := &queuepair{}
 
 	qp.sendq = newBoundedQueue(sendQueueSize, name+"-send")
-	qp.recvq = newBoundedQueue(recvQueueSize, name+"-recv")
+	qp.recvq = newDedupeQueue(recvQueueSize, name+"-recv")
 	q.queues[name] = qp
 
 	return nil

--- a/principal/event.go
+++ b/principal/event.go
@@ -27,6 +27,7 @@ import (
 	"github.com/argoproj-labs/argocd-agent/internal/manager"
 	"github.com/argoproj-labs/argocd-agent/internal/metrics"
 	"github.com/argoproj-labs/argocd-agent/internal/namedlock"
+	"github.com/argoproj-labs/argocd-agent/internal/queue"
 	"github.com/argoproj-labs/argocd-agent/internal/resync"
 	"github.com/argoproj-labs/argocd-agent/internal/tracing"
 	"github.com/argoproj-labs/argocd-agent/pkg/replication"
@@ -41,7 +42,6 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/client-go/dynamic"
-	"k8s.io/client-go/util/workqueue"
 )
 
 // skipReplication returns true for event targets that are operational noise and
@@ -59,7 +59,7 @@ func skipReplication(target targets.EventTarget) bool {
 // processRecvQueue processes an entry from the receiver queue, which holds the
 // events received by agents. It will trigger updates of resources in the
 // server's backend.
-func (s *Server) processRecvQueue(ctx context.Context, agentName string, q workqueue.TypedRateLimitingInterface[*cloudevents.Event]) (*cloudevents.Event, error) {
+func (s *Server) processRecvQueue(ctx context.Context, agentName string, q queue.RecvQueue) (*cloudevents.Event, error) {
 	status := metrics.EventProcessingSuccess
 	ev, _ := q.Get()
 
@@ -805,7 +805,7 @@ func (s *Server) eventProcessor(ctx context.Context) error {
 
 				queueLogCtx.Trace("Acquired semaphore")
 
-				go func(agentName string, q workqueue.TypedRateLimitingInterface[*cloudevents.Event], logCtx *logrus.Entry) {
+				go func(agentName string, q queue.RecvQueue, logCtx *logrus.Entry) {
 					defer func() {
 						sem.Release(1)
 						queueLock.Unlock(agentName)

--- a/principal/event_test.go
+++ b/principal/event_test.go
@@ -23,11 +23,11 @@ import (
 	"github.com/argoproj-labs/argocd-agent/internal/event"
 	"github.com/argoproj-labs/argocd-agent/internal/event/targets"
 	"github.com/argoproj-labs/argocd-agent/internal/manager"
+	"github.com/argoproj-labs/argocd-agent/internal/queue"
 	"github.com/argoproj-labs/argocd-agent/internal/resources"
 	"github.com/argoproj-labs/argocd-agent/pkg/types"
 	"github.com/argoproj-labs/argocd-agent/principal/resourceproxy"
 	"github.com/argoproj-labs/argocd-agent/test/fake/kube"
-	wqmock "github.com/argoproj-labs/argocd-agent/test/mocks/k8s-workqueue"
 	"github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
 	cloudevents "github.com/cloudevents/sdk-go/v2"
 	"github.com/stretchr/testify/assert"
@@ -37,6 +37,14 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/utils/ptr"
 )
+
+// newTestRecvQueue creates a RecvQueue with a single event pre-loaded, for use in
+// tests that call processRecvQueue.
+func newTestRecvQueue(ev *cloudevents.Event) queue.RecvQueue {
+	q := queue.NewDedupeQueueForTest(1000)
+	q.Add(ev)
+	return q
+}
 
 func Test_EventProcessorRoutesACKToMatchingQueue(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
@@ -98,9 +106,7 @@ func Test_InvalidEvents(t *testing.T) {
 	t.Run("Unknown event schema", func(t *testing.T) {
 		ev := cloudevents.NewEvent()
 		ev.SetDataSchema("unknown")
-		wq := wqmock.NewTypedRateLimitingInterface[*cloudevents.Event](t)
-		wq.On("Get").Return(&ev, false)
-		wq.On("Done", &ev)
+		wq := newTestRecvQueue(&ev)
 		s, err := NewServer(context.Background(), kube.NewKubernetesFakeClientWithApps("argocd"), "argocd", WithGeneratedTokenSigningKey(), WithRedisProxyDisabled())
 		require.NoError(t, err)
 		got, err := s.processRecvQueue(context.Background(), "foo", wq)
@@ -112,9 +118,7 @@ func Test_InvalidEvents(t *testing.T) {
 		ev := cloudevents.NewEvent()
 		ev.SetDataSchema("application")
 		ev.SetType("application")
-		wq := wqmock.NewTypedRateLimitingInterface[*cloudevents.Event](t)
-		wq.On("Get").Return(&ev, false)
-		wq.On("Done", &ev)
+		wq := newTestRecvQueue(&ev)
 		s, err := NewServer(context.Background(), kube.NewKubernetesFakeClientWithApps("argocd"), "argocd", WithGeneratedTokenSigningKey(), WithRedisProxyDisabled())
 		require.NoError(t, err)
 		got, err := s.processRecvQueue(context.Background(), "foo", wq)
@@ -127,9 +131,7 @@ func Test_InvalidEvents(t *testing.T) {
 		ev.SetDataSchema("application")
 		ev.SetType(event.Create.String())
 		ev.SetData(cloudevents.ApplicationJSON, "something")
-		wq := wqmock.NewTypedRateLimitingInterface[*cloudevents.Event](t)
-		wq.On("Get").Return(&ev, false)
-		wq.On("Done", &ev)
+		wq := newTestRecvQueue(&ev)
 		s, err := NewServer(context.Background(), kube.NewKubernetesFakeClientWithApps("argocd"), "argocd", WithGeneratedTokenSigningKey(), WithRedisProxyDisabled())
 		require.NoError(t, err)
 		got, err := s.processRecvQueue(context.Background(), "foo", wq)
@@ -143,9 +145,7 @@ func Test_CreateEvents(t *testing.T) {
 		ev := cloudevents.NewEvent()
 		ev.SetDataSchema("application")
 		ev.SetType(event.Create.String())
-		wq := wqmock.NewTypedRateLimitingInterface[*cloudevents.Event](t)
-		wq.On("Get").Return(&ev, false)
-		wq.On("Done", &ev)
+		wq := newTestRecvQueue(&ev)
 		s, err := NewServer(context.Background(), kube.NewKubernetesFakeClientWithApps("argocd"), "argocd", WithGeneratedTokenSigningKey(), WithRedisProxyDisabled())
 		require.NoError(t, err)
 		got, err := s.processRecvQueue(context.Background(), "foo", wq)
@@ -182,9 +182,7 @@ func Test_CreateEvents(t *testing.T) {
 		// Update the application before sending the event
 		app.Spec.Source.TargetRevision = "test"
 		ev.SetData(cloudevents.ApplicationJSON, app)
-		wq := wqmock.NewTypedRateLimitingInterface[*cloudevents.Event](t)
-		wq.On("Get").Return(&ev, false)
-		wq.On("Done", &ev)
+		wq := newTestRecvQueue(&ev)
 		s, err := NewServer(context.Background(), fac, "argocd", WithGeneratedTokenSigningKey(), WithAutoNamespaceCreate(true, "", nil), WithRedisProxyDisabled())
 		s.Start(context.Background(), make(chan error))
 		s.clusterMgr.MapCluster("argocd", &v1alpha1.Cluster{Name: "argocd", Server: "https://argocd.com"})
@@ -236,9 +234,7 @@ func Test_CreateEvents(t *testing.T) {
 		ev.SetDataSchema("application")
 		ev.SetType(event.Create.String())
 		ev.SetData(cloudevents.ApplicationJSON, app)
-		wq := wqmock.NewTypedRateLimitingInterface[*cloudevents.Event](t)
-		wq.On("Get").Return(&ev, false)
-		wq.On("Done", &ev)
+		wq := newTestRecvQueue(&ev)
 		s, err := NewServer(context.Background(), fac, "argocd", WithGeneratedTokenSigningKey(), WithAutoNamespaceCreate(true, "", nil), WithRedisProxyDisabled())
 		require.NoError(t, err)
 		s.clusterMgr.MapCluster("foo", &v1alpha1.Cluster{Name: "foo", Server: "https://foo.com"})
@@ -305,9 +301,7 @@ func Test_CreateEvents(t *testing.T) {
 		ev.SetDataSchema("application")
 		ev.SetType(event.Create.String())
 		ev.SetData(cloudevents.ApplicationJSON, app)
-		wq := wqmock.NewTypedRateLimitingInterface[*cloudevents.Event](t)
-		wq.On("Get").Return(&ev, false)
-		wq.On("Done", &ev)
+		wq := newTestRecvQueue(&ev)
 		s, err := NewServer(context.Background(), fac, "argocd", WithGeneratedTokenSigningKey(), WithAutoNamespaceCreate(true, "", nil), WithRedisProxyDisabled())
 		require.NoError(t, err)
 		s.clusterMgr.MapCluster("agent-staging", &v1alpha1.Cluster{Name: "agent-staging", Server: "https://staging.com"})
@@ -363,9 +357,7 @@ func Test_CreateEvents(t *testing.T) {
 		ev.SetDataSchema("application")
 		ev.SetType(event.Create.String())
 		ev.SetData(cloudevents.ApplicationJSON, app)
-		wq := wqmock.NewTypedRateLimitingInterface[*cloudevents.Event](t)
-		wq.On("Get").Return(&ev, false)
-		wq.On("Done", &ev)
+		wq := newTestRecvQueue(&ev)
 
 		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		defer cancel()
@@ -745,9 +737,7 @@ func Test_UpdateEvents(t *testing.T) {
 		ev.SetDataSchema("application")
 		ev.SetType(event.SpecUpdate.String())
 		ev.SetData(cloudevents.ApplicationJSON, upApp)
-		wq := wqmock.NewTypedRateLimitingInterface[*cloudevents.Event](t)
-		wq.On("Get").Return(&ev, false)
-		wq.On("Done", &ev)
+		wq := newTestRecvQueue(&ev)
 
 		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 		defer cancel()
@@ -828,9 +818,7 @@ func Test_UpdateEvents(t *testing.T) {
 		ev.SetDataSchema("application")
 		ev.SetType(event.SpecUpdate.String())
 		ev.SetData(cloudevents.ApplicationJSON, upApp)
-		wq := wqmock.NewTypedRateLimitingInterface[*cloudevents.Event](t)
-		wq.On("Get").Return(&ev, false)
-		wq.On("Done", &ev)
+		wq := newTestRecvQueue(&ev)
 
 		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 		defer cancel()
@@ -889,9 +877,7 @@ func Test_UpdateEvents(t *testing.T) {
 		ev.SetDataSchema("application")
 		ev.SetType(event.SpecUpdate.String())
 		ev.SetData(cloudevents.ApplicationJSON, upApp)
-		wq := wqmock.NewTypedRateLimitingInterface[*cloudevents.Event](t)
-		wq.On("Get").Return(&ev, false)
-		wq.On("Done", &ev)
+		wq := newTestRecvQueue(&ev)
 		s, err := NewServer(context.Background(), fac, "argocd", WithGeneratedTokenSigningKey(), WithRedisProxyDisabled())
 		require.NoError(t, err)
 		s.setAgentMode("foo", types.AgentModeManaged)
@@ -957,9 +943,7 @@ func Test_DeleteEvents_ManagedMode(t *testing.T) {
 			ev.SetDataSchema("application")
 			ev.SetType(event.Delete.String())
 			ev.SetData(cloudevents.ApplicationJSON, delApp)
-			wq := wqmock.NewTypedRateLimitingInterface[*cloudevents.Event](t)
-			wq.On("Get").Return(&ev, false)
-			wq.On("Done", &ev)
+			wq := newTestRecvQueue(&ev)
 
 			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 			defer cancel()
@@ -1054,9 +1038,7 @@ func Test_processAppProjectEvent(t *testing.T) {
 		ev := cloudevents.NewEvent()
 		ev.SetDataSchema("appproject")
 		ev.SetType(event.Create.String())
-		wq := wqmock.NewTypedRateLimitingInterface[*cloudevents.Event](t)
-		wq.On("Get").Return(&ev, false)
-		wq.On("Done", &ev)
+		wq := newTestRecvQueue(&ev)
 		s, err := NewServer(context.Background(), kube.NewKubernetesFakeClientWithApps("argocd"), "argocd", WithGeneratedTokenSigningKey(), WithRedisProxyDisabled())
 		require.NoError(t, err)
 		got, err := s.processRecvQueue(context.Background(), "foo", wq)
@@ -1099,9 +1081,7 @@ func Test_processAppProjectEvent(t *testing.T) {
 		ev.SetType(event.Create.String())
 		ev.SetData(cloudevents.ApplicationJSON, project)
 
-		wq := wqmock.NewTypedRateLimitingInterface[*cloudevents.Event](t)
-		wq.On("Get").Return(&ev, false)
-		wq.On("Done", &ev)
+		wq := newTestRecvQueue(&ev)
 
 		s, err := NewServer(context.Background(), fac, "argocd", WithGeneratedTokenSigningKey(), WithRedisProxyDisabled())
 		require.NoError(t, err)
@@ -1160,9 +1140,7 @@ func Test_processAppProjectEvent(t *testing.T) {
 		updatedProject.Name = "test" // Use original name (will be prefixed)
 		ev.SetData(cloudevents.ApplicationJSON, updatedProject)
 
-		wq := wqmock.NewTypedRateLimitingInterface[*cloudevents.Event](t)
-		wq.On("Get").Return(&ev, false)
-		wq.On("Done", &ev)
+		wq := newTestRecvQueue(&ev)
 
 		s, err := NewServer(context.Background(), fac, "argocd", WithGeneratedTokenSigningKey(), WithRedisProxyDisabled())
 		require.NoError(t, err)
@@ -1205,9 +1183,7 @@ func Test_processAppProjectEvent(t *testing.T) {
 		ev.SetDataSchema("appproject")
 		ev.SetType(event.Delete.String())
 		ev.SetData(cloudevents.ApplicationJSON, upApp)
-		wq := wqmock.NewTypedRateLimitingInterface[*cloudevents.Event](t)
-		wq.On("Get").Return(&ev, false)
-		wq.On("Done", &ev)
+		wq := newTestRecvQueue(&ev)
 		s, err := NewServer(context.Background(), fac, "argocd", WithGeneratedTokenSigningKey(), WithRedisProxyDisabled())
 		require.NoError(t, err)
 		s.setAgentMode("foo", types.AgentModeManaged)

--- a/principal/server.go
+++ b/principal/server.go
@@ -262,6 +262,7 @@ func NewServer(ctx context.Context, kubeClient *kube.KubernetesClient, namespace
 		metricsRegistered.Do(func() {
 			metrics.RegisterK8sClientMetrics()
 			metrics.RegisterQueueMetrics("argocd_principal")
+			metrics.RegisterDedupeQueueMetrics("argocd_principal")
 		})
 	}
 


### PR DESCRIPTION
**What does this PR do / why we need it**:

In this PR, we de-dupe the incoming events on the principal. When running the principal at scale, the event processing rate might be slower than the inbound rate. This leads to more events accumulated in the principal's workqueue, increasing the memory usage. In this PR, we replace the standard workqueue with a custom queue that deduplicates any incoming event. The queue discards any older events before appending the latest event to the end of the queue. 

Alternate approach:
We don't have to replace the existing workqueue. We can add the dedupe queue as a separate component between the gRPC stream and the standard RecvQ work queue. There could be a goroutine that periodically drains the dedupe queue and fills the RecvQ workqueue. The downside is that we cannot remove the old events once it enters the workqueue. So, there is a possibility that the principal might still process a few old events. 

Assisted-by: Cursor

**Which issue(s) this PR fixes**:

Fixes https://github.com/argoproj-labs/argocd-agent/issues/958

**How to test changes / Special notes to the reviewer**:


**Checklist**

* [ ] Documentation update is required by this PR (and has been updated) OR no documentation update is required.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Implemented a bounded deduplicating in-memory FIFO queue that automatically replaces eligible queued events for spec and status updates (while preserving non-deduped event types).
  * Added Prometheus metrics for the deduplication queue, including depth, adds, deduped events, and dequeue duration, and ensured they’re registered when metrics are enabled.

* **Tests**
  * Expanded unit tests to validate FIFO order, replacement behavior, max-size dropping, shutdown behavior, and mixed dedup/non-dedup scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->