### PR TITLE
fix(agent): return error on nil item in sender instead of calling Done(nil)

### DIFF
--- a/agent/connection.go
+++ b/agent/connection.go
@@ -86,9 +86,7 @@ func (a *Agent) sender(stream eventstreamapi.EventStream_SubscribeClient) error 
 	}
 	logCtx.Trace("Grabbed an item")
 	if ev == nil {
-		// TODO: Is this really the right thing to do?
-		q.Done(ev)
-		return nil
+		return fmt.Errorf("nil item in send queue")
 	}
 	defer q.Done(ev)
 	logCtx = logCtx.WithFields(logrus.Fields{

--- a/internal/event/event.go
+++ b/internal/event/event.go
@@ -374,7 +374,7 @@ func (r *ResourceRequest) IsValid() bool {
 }
 
 // ResourceResponse is an event that holds the response to a resource request.
-// It is usually sent by an agent to the princiapl in response to a prior
+// It is usually sent by an agent to the principal in response to a prior
 // resource request.
 type ResourceResponse struct {
 	// UUID is the unique ID of the request this response is targeted at


### PR DESCRIPTION
**What does this PR do / why we need it**:

The agent `sender()` had a nil-item guard that called `q.Done(nil)` before returning. Thats wrong: the item was never inserted into the processing set by `Get()`, so calling `Done(nil)` operates on something that was never tracked. The `TODO` comment in the code explicitly flagged this as uncertain behavior.

The principal's equivalent `sendFunc()` already handles the nil case correctly - it returns an error. This PR makes the agent consistent with that.

Also fixes a typo in a comment: `princiapl` -> `principal`.

**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:

The nil path itself is unreachable today (all `sendQ.Add()` callers pass non-nil events, and `Get()` only returns nil with `shutdown=true` which is caught earlier). But the code in that branch was still wrong.

To confirm the old behavior was broken, you can trace through:
1. `q.Get()` returns `(nil, false)` - only possible if `nil` was explicitly enqueued
2. shutdown check passes
3. `q.Done(nil)` - looks up nil in `q.processing`, which never had nil inserted, so its a no-op with wrong semantics
4. `return nil` - silently swallows the unexpected state

The principal does `return fmt.Errorf("panic: nil item in queue")` in the same situation. This PR brings the agent in line with that.

**Checklist**

* [ ] Documentation update is required by this PR (and has been updated) OR no documentation update is required.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Message-queue sender now surfaces an error when an unexpected nil queue item is encountered, improving visibility into delivery failures and preventing silent no-ops.

* **Documentation**
  * Fixed a spelling mistake in event-related documentation to improve clarity of message direction between agent and principal.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->