### PR TITLE
fix: e2e failures in cluster mode

### DIFF
--- a/hack/dev-env/create-agent-config.sh
+++ b/hack/dev-env/create-agent-config.sh
@@ -38,7 +38,12 @@ if test "${ARGOCD_AGENT_IN_CLUSTER}" = ""; then
 	ARGOCD_AGENT_RESOURCE_PROXY_SAN="--ip 127.0.0.1,${IPADDR}"
 else
 	ARGOCD_AGENT_GRPC_SVC=$(getExternalLoadBalancerIP ${ARGOCD_AGENT_PRINCIPAL_CONTEXT} ${ARGOCD_PRINCIPAL_NAMESPACE} argocd-agent-principal)
-	ARGOCD_AGENT_GRPC_SAN="--ip 127.0.0.1,$ARGOCD_AGENT_GRPC_SVC"
+	# OpenShift/AWS LoadBalancers often expose a hostname instead of an IP.
+	if [[ "$ARGOCD_AGENT_GRPC_SVC" =~ ^([0-9]{1,3}\.){3}[0-9]{1,3}$ ]]; then
+		ARGOCD_AGENT_GRPC_SAN="--ip 127.0.0.1,${ARGOCD_AGENT_GRPC_SVC}"
+	else
+		ARGOCD_AGENT_GRPC_SAN="--ip 127.0.0.1 --dns ${ARGOCD_AGENT_GRPC_SVC}"
+	fi
 	ARGOCD_AGENT_RESOURCE_PROXY=argocd-agent-resource-proxy
 	ARGOCD_AGENT_RESOURCE_PROXY_SAN="--dns ${ARGOCD_AGENT_RESOURCE_PROXY}"
 fi

--- a/hack/dev-env/deploy.sh
+++ b/hack/dev-env/deploy.sh
@@ -62,6 +62,7 @@ deploy_principal() {
 			kustomize edit set image argocd-agent=${IMAGE_NAME}
 		)
 		sed -i'' \
+			-e "s/  principal.listen.host:.*/  principal.listen.host: \"0.0.0.0\"/" \
 			-e "s/  principal.namespace:.*/  principal.namespace: \"${ARGOCD_PRINCIPAL_NAMESPACE}\"/" \
 			-e "s/  principal.allowed-namespaces:.*/  principal.allowed-namespaces: \"agent-*\"/" \
 			principal-params-cm.yaml
@@ -79,6 +80,45 @@ deploy_agent_managed() {
 			kustomize edit set namespace ${ARGOCD_MANAGED_NAMESPACE}
 			kustomize edit set image argocd-agent=${IMAGE_NAME}
 		)
+		# Modify the ClusterRole to include RBAC required by E2E tests (which are written for the configuration where agent runs locally via goreman)
+		cat >> agent-clusterrole.yaml <<-'EOF'
+		- apiGroups:
+		  - ""
+		  resources:
+		  - configmaps
+		  verbs:
+		  - create
+		  - delete
+		  - get
+		  - list
+		  - update
+		  - watch
+		  - patch
+		- apiGroups:
+		  - ""
+		  resources:
+		  - pods
+		  - pods/log
+		  - pods/exec
+		  verbs:
+		  - create
+		  - get
+		  - list
+		  - watch
+		- apiGroups:
+		  - apps
+		  resources:
+		  - deployments
+		  - replicasets
+		  verbs:
+		  - create
+		  - update
+		  - delete
+		  - get
+		  - list
+		  - watch
+		  - patch
+		EOF
 		sed -i'' \
 			-e "s/  agent.namespace:.*/  agent.namespace: \"${ARGOCD_MANAGED_NAMESPACE}\"/" \
 			-e "s/  agent.mode:.*/  agent.mode: \"managed\"/" \
@@ -98,6 +138,45 @@ deploy_agent_autonomous() {
 			kustomize edit set namespace ${ARGOCD_AUTONOMOUS_NAMESPACE}
 			kustomize edit set image argocd-agent=${IMAGE_NAME}
 		)
+		# Modify the ClusterRole to include RBAC required by E2E tests (which are written for the configuration where agent runs locally via goreman)
+		cat >> agent-clusterrole.yaml <<-'EOF'
+		- apiGroups:
+		  - ""
+		  resources:
+		  - configmaps
+		  verbs:
+		  - create
+		  - delete
+		  - get
+		  - list
+		  - update
+		  - watch
+		  - patch
+		- apiGroups:
+		  - ""
+		  resources:
+		  - pods
+		  - pods/log
+		  - pods/exec
+		  verbs:
+		  - create
+		  - get
+		  - list
+		  - watch
+		- apiGroups:
+		  - apps
+		  resources:
+		  - deployments
+		  - replicasets
+		  verbs:
+		  - create
+		  - update
+		  - delete
+		  - get
+		  - list
+		  - watch
+		  - patch
+		EOF
 		sed -i'' \
 			-e "s/  agent.namespace:.*/  agent.namespace: \"${ARGOCD_AUTONOMOUS_NAMESPACE}\"/" \
 			-e "s/  agent.mode:.*/  agent.mode: \"autonomous\"/" \

--- a/hack/dev-env/deploy.sh
+++ b/hack/dev-env/deploy.sh
@@ -51,6 +51,9 @@ cleanup() {
 trap cleanup EXIT
 
 cp -a ${BASEPATH}/install/kubernetes/* ${TMPDIR}
+cp -a ${BASEPATH}/install/kubernetes/agent ${TMPDIR}/agent-managed
+cp -a ${BASEPATH}/install/kubernetes/agent ${TMPDIR}/agent-autonomous
+rm -rf ${TMPDIR}/agent
 
 deploy_principal() {
 	(
@@ -62,6 +65,8 @@ deploy_principal() {
 			-e "s/  principal.namespace:.*/  principal.namespace: \"${ARGOCD_PRINCIPAL_NAMESPACE}\"/" \
 			-e "s/  principal.allowed-namespaces:.*/  principal.allowed-namespaces: \"agent-*\"/" \
 			principal-params-cm.yaml
+		set_rbac_subject_namespace ${ARGOCD_PRINCIPAL_NAMESPACE} \
+			principal-rolebinding.yaml principal-clusterrolebinding.yaml
 		kustomize build . | kubectl --context ${ARGOCD_AGENT_PRINCIPAL_CONTEXT} -n ${ARGOCD_PRINCIPAL_NAMESPACE} apply -f -
 		kubectl --context ${ARGOCD_AGENT_PRINCIPAL_CONTEXT} -n ${ARGOCD_PRINCIPAL_NAMESPACE} rollout restart deployment argocd-agent-principal
 	)
@@ -70,7 +75,7 @@ deploy_principal() {
 deploy_agent_managed() {
 	(
 		principal_addr=$(getExternalLoadBalancerIP ${ARGOCD_AGENT_PRINCIPAL_CONTEXT} ${ARGOCD_PRINCIPAL_NAMESPACE} argocd-agent-principal)
-		cd ${TMPDIR}/agent && (
+		cd ${TMPDIR}/agent-managed && (
 			kustomize edit set namespace ${ARGOCD_MANAGED_NAMESPACE}
 			kustomize edit set image argocd-agent=${IMAGE_NAME}
 		)
@@ -80,6 +85,8 @@ deploy_agent_managed() {
 			-e "s/  agent.creds:.*/  agent.creds: \"mtls:any\"/" \
 			-e "s/  agent.server.address:.*/  agent.server.address: \"$principal_addr\"/" \
 			agent-params-cm.yaml
+		set_rbac_subject_namespace ${ARGOCD_MANAGED_NAMESPACE} \
+			agent-rolebinding.yaml agent-clusterrolebinding.yaml
 		kustomize build . | kubectl --context ${ARGOCD_AGENT_MANAGED_CONTEXT} -n ${ARGOCD_MANAGED_NAMESPACE} apply -f -
 	)
 }
@@ -87,7 +94,7 @@ deploy_agent_managed() {
 deploy_agent_autonomous() {
 	(
 		principal_addr=$(getExternalLoadBalancerIP ${ARGOCD_AGENT_PRINCIPAL_CONTEXT} ${ARGOCD_PRINCIPAL_NAMESPACE} argocd-agent-principal)
-		cd ${TMPDIR}/agent && (
+		cd ${TMPDIR}/agent-autonomous && (
 			kustomize edit set namespace ${ARGOCD_AUTONOMOUS_NAMESPACE}
 			kustomize edit set image argocd-agent=${IMAGE_NAME}
 		)
@@ -97,6 +104,8 @@ deploy_agent_autonomous() {
 			-e "s/  agent.creds:.*/  agent.creds: \"mtls:any\"/" \
 			-e "s/  agent.server.address:.*/  agent.server.address: \"$principal_addr\"/" \
 			agent-params-cm.yaml
+		set_rbac_subject_namespace ${ARGOCD_AUTONOMOUS_NAMESPACE} \
+			agent-rolebinding.yaml agent-clusterrolebinding.yaml
 		kustomize build . | kubectl --context ${ARGOCD_AGENT_AUTONOMOUS_CONTEXT} -n ${ARGOCD_AUTONOMOUS_NAMESPACE} apply -f -
 	)
 }
@@ -110,14 +119,14 @@ undeploy_principal() {
 
 undeploy_agent_managed() {
 	(
-		cd ${TMPDIR}/agent && kustomize edit set namespace ${ARGOCD_MANAGED_NAMESPACE}
+		cd ${TMPDIR}/agent-managed && kustomize edit set namespace ${ARGOCD_MANAGED_NAMESPACE}
 		kustomize build . | kubectl --context ${ARGOCD_AGENT_MANAGED_CONTEXT} -n ${ARGOCD_MANAGED_NAMESPACE} delete -f -
 	)
 }
 
 undeploy_agent_autonomous() {
 	(
-		cd ${TMPDIR}/agent && kustomize edit set namespace ${ARGOCD_AUTONOMOUS_NAMESPACE}
+		cd ${TMPDIR}/agent-autonomous && kustomize edit set namespace ${ARGOCD_AUTONOMOUS_NAMESPACE}
 		kustomize build . | kubectl --context ${ARGOCD_AGENT_AUTONOMOUS_CONTEXT} -n ${ARGOCD_AUTONOMOUS_NAMESPACE} delete -f -
 	)
 }

--- a/hack/dev-env/utility.sh
+++ b/hack/dev-env/utility.sh
@@ -12,6 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# set_rbac_subject_namespace rewrites the ServiceAccount subject namespace in
+# RoleBinding/ClusterRoleBinding manifests. Required when deploying to namespaces
+# other than the install default of "argocd" (e.g. argocd-principal).
+set_rbac_subject_namespace() {
+  local namespace="$1"
+  shift
+  sed -i.bak -e "s/  namespace: argocd/  namespace: ${namespace}/" "$@"
+}
+
 # getExternalLoadBalancerIP will set EXTERNAL_IP with the load balancer hostname from the specified Service
 getExternalLoadBalancerIP() {
   CONTEXT=$1

--- a/test/e2e/adoption_test.go
+++ b/test/e2e/adoption_test.go
@@ -40,15 +40,15 @@ func (suite *AdoptionTestSuite) SetupTest() {
 	suite.BaseSuite.SetupTest()
 
 	// Ensure principal and managed agent are running
-	if !fixture.IsProcessRunning(fixture.PrincipalName) {
-		suite.Require().NoError(fixture.StartProcess(fixture.PrincipalName))
+	if !fixture.IsProcessRunning(fixture.PrincipalName, suite.T()) {
+		suite.Require().NoError(fixture.StartProcess(fixture.PrincipalName, suite.T()))
 		fixture.CheckReadiness(suite.T(), fixture.PrincipalName)
 	} else {
 		fixture.CheckReadiness(suite.T(), fixture.PrincipalName)
 	}
 
-	if !fixture.IsProcessRunning(fixture.AgentManagedName) {
-		suite.Require().NoError(fixture.StartProcess(fixture.AgentManagedName))
+	if !fixture.IsProcessRunning(fixture.AgentManagedName, suite.T()) {
+		suite.Require().NoError(fixture.StartProcess(fixture.AgentManagedName, suite.T()))
 		fixture.CheckReadiness(suite.T(), fixture.AgentManagedName)
 	} else {
 		fixture.CheckReadiness(suite.T(), fixture.AgentManagedName)

--- a/test/e2e/appcache_test.go
+++ b/test/e2e/appcache_test.go
@@ -43,18 +43,18 @@ func (suite *CacheTestSuite) TearDownTest() {
 }
 
 func (suite *CacheTestSuite) SetupTest() {
-	if !fixture.IsProcessRunning(fixture.PrincipalName) {
+	if !fixture.IsProcessRunning(fixture.PrincipalName, suite.T()) {
 		// Start the principal if it is not running and wait for it to be ready
-		suite.Require().NoError(fixture.StartProcess(fixture.PrincipalName))
+		suite.Require().NoError(fixture.StartProcess(fixture.PrincipalName, suite.T()))
 		fixture.CheckReadiness(suite.T(), fixture.PrincipalName)
 	} else {
 		// If principal is already running, verify that it is ready
 		fixture.CheckReadiness(suite.T(), fixture.PrincipalName)
 	}
 
-	if !fixture.IsProcessRunning(fixture.AgentManagedName) {
+	if !fixture.IsProcessRunning(fixture.AgentManagedName, suite.T()) {
 		// Start the agent if it is not running and wait for it to be ready
-		suite.Require().NoError(fixture.StartProcess(fixture.AgentManagedName))
+		suite.Require().NoError(fixture.StartProcess(fixture.AgentManagedName, suite.T()))
 		fixture.CheckReadiness(suite.T(), fixture.AgentManagedName)
 	} else {
 		// If agent is already running, verify that it is ready
@@ -108,16 +108,16 @@ func (suite *CacheTestSuite) Test_RevertDisconnectedManagedClusterChanges() {
 
 	// Case 1: Agent is disconnected with principal, now modify the application directly in the managed-cluster,
 	// but changes should be reverted, to be in sync with last known state of principal application
-	requires.NoError(fixture.StopProcess(fixture.PrincipalName))
+	requires.NoError(fixture.StopProcess(fixture.PrincipalName, suite.T()))
 	requires.Eventually(func() bool {
-		return !fixture.IsProcessRunning(fixture.PrincipalName)
+		return !fixture.IsProcessRunning(fixture.PrincipalName, suite.T())
 	}, 30*time.Second, 1*time.Second)
 
 	updateAppInfo(suite.Ctx, suite.ManagedAgentClient, agentKey, []string{"a", "b"}, requires)
 	validateAppReverted(suite.Ctx, suite.ManagedAgentClient, &app, agentKey, requires, suite.T())
 
 	// Case 2: Agent is reconnected with principal and now changes done in principal should reflect in managed-cluster
-	requires.NoError(fixture.StartProcess(fixture.PrincipalName))
+	requires.NoError(fixture.StartProcess(fixture.PrincipalName, suite.T()))
 	fixture.CheckReadiness(suite.T(), fixture.PrincipalName)
 
 	updateAppInfo(suite.Ctx, suite.PrincipalClient, principalKey, []string{"a", "b"}, requires)
@@ -164,17 +164,17 @@ func (suite *CacheTestSuite) Test_RevertManagedClusterOfflineChanges() {
 	// Agent in not running, but still make changes in the managed-cluster application manifest.
 	// When agent is restarted, these changes should be reverted to be in sync with principal.
 	requires.Eventually(func() bool {
-		return fixture.IsProcessRunning(fixture.AgentManagedName)
+		return fixture.IsProcessRunning(fixture.AgentManagedName, suite.T())
 	}, 60*time.Second, 1*time.Second)
 
-	requires.NoError(fixture.StopProcess(fixture.AgentManagedName))
+	requires.NoError(fixture.StopProcess(fixture.AgentManagedName, suite.T()))
 	requires.Eventually(func() bool {
-		return !fixture.IsProcessRunning(fixture.AgentManagedName)
+		return !fixture.IsProcessRunning(fixture.AgentManagedName, suite.T())
 	}, 60*time.Second, 1*time.Second)
 
 	updateAppInfo(suite.Ctx, suite.ManagedAgentClient, agentKey, []string{"a", "b"}, requires)
 
-	requires.NoError(fixture.StartProcess(fixture.AgentManagedName))
+	requires.NoError(fixture.StartProcess(fixture.AgentManagedName, suite.T()))
 	fixture.CheckReadiness(suite.T(), fixture.AgentManagedName)
 	validateAppReverted(suite.Ctx, suite.ManagedAgentClient, &app, agentKey, requires, suite.T())
 }

--- a/test/e2e/clusterinfo_test.go
+++ b/test/e2e/clusterinfo_test.go
@@ -41,27 +41,27 @@ func TestClusterTestSuite(t *testing.T) {
 }
 
 func (suite *ClusterInfoTestSuite) SetupTest() {
-	if !fixture.IsProcessRunning(fixture.PrincipalName) {
+	if !fixture.IsProcessRunning(fixture.PrincipalName, suite.T()) {
 		// Start the principal if it is not running and wait for it to be ready
-		suite.Require().NoError(fixture.StartProcess(fixture.PrincipalName))
+		suite.Require().NoError(fixture.StartProcess(fixture.PrincipalName, suite.T()))
 		fixture.CheckReadiness(suite.T(), fixture.PrincipalName)
 	} else {
 		// If principal is already running, verify that it is ready
 		fixture.CheckReadiness(suite.T(), fixture.PrincipalName)
 	}
 
-	if !fixture.IsProcessRunning(fixture.AgentManagedName) {
+	if !fixture.IsProcessRunning(fixture.AgentManagedName, suite.T()) {
 		// Start the agent if it is not running and wait for it to be ready
-		suite.Require().NoError(fixture.StartProcess(fixture.AgentManagedName))
+		suite.Require().NoError(fixture.StartProcess(fixture.AgentManagedName, suite.T()))
 		fixture.CheckReadiness(suite.T(), fixture.AgentManagedName)
 	} else {
 		// If agent is already running, verify that it is ready
 		fixture.CheckReadiness(suite.T(), fixture.AgentManagedName)
 	}
 
-	if !fixture.IsProcessRunning(fixture.AgentAutonomousName) {
+	if !fixture.IsProcessRunning(fixture.AgentAutonomousName, suite.T()) {
 		// Start the agent if it is not running and wait for it to be ready
-		suite.Require().NoError(fixture.StartProcess(fixture.AgentAutonomousName))
+		suite.Require().NoError(fixture.StartProcess(fixture.AgentAutonomousName, suite.T()))
 		fixture.CheckReadiness(suite.T(), fixture.AgentAutonomousName)
 	} else {
 		// If agent is already running, verify that it is ready
@@ -87,7 +87,7 @@ func (suite *ClusterInfoTestSuite) Test_ClusterInfo_Managed() {
 	}, 60*time.Second, 1*time.Second)
 
 	// Stop the agent
-	err := fixture.StopProcess(fixture.AgentManagedName)
+	err := fixture.StopProcess(fixture.AgentManagedName, suite.T())
 	requires.NoError(err)
 
 	// Verify that connection status is updated when agent is disconnected
@@ -100,7 +100,7 @@ func (suite *ClusterInfoTestSuite) Test_ClusterInfo_Managed() {
 	}, 60*time.Second, 1*time.Second)
 
 	// Restart the agent
-	err = fixture.StartProcess(fixture.AgentManagedName)
+	err = fixture.StartProcess(fixture.AgentManagedName, suite.T())
 	requires.NoError(err)
 	fixture.CheckReadiness(suite.T(), fixture.AgentManagedName)
 
@@ -127,7 +127,7 @@ func (suite *ClusterInfoTestSuite) Test_ClusterInfo_Autonomous() {
 	}, 60*time.Second, 1*time.Second)
 
 	// Stop the agent
-	err := fixture.StopProcess(fixture.AgentAutonomousName)
+	err := fixture.StopProcess(fixture.AgentAutonomousName, suite.T())
 	requires.NoError(err)
 
 	// Verify that connection status is updated when agent is disconnected
@@ -140,7 +140,7 @@ func (suite *ClusterInfoTestSuite) Test_ClusterInfo_Autonomous() {
 	}, 60*time.Second, 1*time.Second)
 
 	// Restart the agent
-	err = fixture.StartProcess(fixture.AgentAutonomousName)
+	err = fixture.StartProcess(fixture.AgentAutonomousName, suite.T())
 	requires.NoError(err)
 	fixture.CheckReadiness(suite.T(), fixture.AgentAutonomousName)
 
@@ -231,7 +231,7 @@ func (suite *ClusterInfoTestSuite) Test_ClusterCacheInfo() {
 
 	// Step 8:
 	// Disconnect agent and verify that connection status is changed to Failed
-	requires.NoError(fixture.StopProcess(fixture.AgentManagedName))
+	requires.NoError(fixture.StopProcess(fixture.AgentManagedName, suite.T()))
 	requires.Eventually(func() bool {
 		return fixture.HasConnectionStatus(fixture.AgentManagedName, appv1.ConnectionState{
 			Status:     appv1.ConnectionStatusFailed,
@@ -252,7 +252,7 @@ func (suite *ClusterInfoTestSuite) Test_ClusterCacheInfo() {
 
 	// Step 10:
 	// Reconnect agent and verify that connection status and cluster cache info are updated again with correct values
-	requires.NoError(fixture.StartProcess(fixture.AgentManagedName))
+	requires.NoError(fixture.StartProcess(fixture.AgentManagedName, suite.T()))
 	fixture.CheckReadiness(suite.T(), fixture.AgentManagedName)
 
 	requires.Eventually(func() bool {

--- a/test/e2e/fixture/fixture.go
+++ b/test/e2e/fixture/fixture.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"os"
 	"reflect"
+	"testing"
 	"time"
 
 	"github.com/argoproj-labs/argocd-agent/internal/manager"
@@ -521,4 +522,12 @@ func resetManagedAgentClusterInfo(clusterDetails *ClusterDetails) error {
 		return err
 	}
 	return nil
+}
+
+// SkipIfAgentInClusterEnvVarIsSet should be called to verify that the test (or utility function) is running locally (that is, not on cluster). If the test is running on cluster, the correct step is to skip the test.
+func SkipIfAgentInClusterEnvVarIsSet(t *testing.T) {
+	t.Helper()
+	if os.Getenv("ARGOCD_AGENT_IN_CLUSTER") == "true" {
+		t.Skip("skipping because ARGOCD_AGENT_IN_CLUSTER=true")
+	}
 }

--- a/test/e2e/fixture/goreman.go
+++ b/test/e2e/fixture/goreman.go
@@ -4,23 +4,30 @@ import (
 	"bufio"
 	"bytes"
 	"os/exec"
+	"testing"
 )
 
 // StopProcess stops the named process managed by goreman
-func StopProcess(processName string) error {
+func StopProcess(processName string, t *testing.T) error {
+	// Goreman is only usable in local case
+	SkipIfAgentInClusterEnvVarIsSet(t)
 	cmd := exec.Command("goreman", "run", "stop", processName)
 	return cmd.Run()
 }
 
 // StartProcess starts the named process managed by goreman
-func StartProcess(processName string) error {
+func StartProcess(processName string, t *testing.T) error {
+	// Goreman is only usable in local case
+	SkipIfAgentInClusterEnvVarIsSet(t)
 	cmd := exec.Command("goreman", "run", "start", processName)
 	return cmd.Run()
 }
 
 // IsProcessRunning returns whether the named process managed by goreman is
 // running
-func IsProcessRunning(processName string) bool {
+func IsProcessRunning(processName string, t *testing.T) bool {
+	// Goreman is only usable in local case
+	SkipIfAgentInClusterEnvVarIsSet(t)
 	out := &bytes.Buffer{}
 	cmd := exec.Command("goreman", "run", "status")
 	cmd.Stdout = out

--- a/test/e2e/fixture/toxyproxy.go
+++ b/test/e2e/fixture/toxyproxy.go
@@ -4,6 +4,7 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"testing"
 	"time"
 
 	toxiproxy "github.com/Shopify/toxiproxy/v2"
@@ -14,7 +15,7 @@ import (
 
 // SetupToxiproxy configures and starts a Toxiproxy server on the specified host and port. It also sets the environment
 // variable for the remote port and provides a cleanup function to stop the server and remove the variable.
-func SetupToxiproxy(t require.TestingT, agentName string, proxyAddress string) (*toxiproxyClient.Proxy, func(), error) {
+func SetupToxiproxy(t *testing.T, agentName string, proxyAddress string) (*toxiproxyClient.Proxy, func(), error) {
 
 	// Start the Toxiproxy server
 	proxyServer, err := startToxiproxyServer("localhost", "8474")
@@ -90,19 +91,19 @@ func startToxiproxyServer(host, port string) (*http.Server, error) {
 	return proxyServer, nil
 }
 
-func RestartAgent(t require.TestingT, agentName string) {
-	err := StopProcess(agentName)
+func RestartAgent(t *testing.T, agentName string) {
+	err := StopProcess(agentName, t)
 	require.NoError(t, err)
 
 	require.Eventually(t, func() bool {
-		return !IsProcessRunning(agentName)
+		return !IsProcessRunning(agentName, t)
 	}, 30*time.Second, 1*time.Second)
 
-	err = StartProcess(agentName)
+	err = StartProcess(agentName, t)
 	require.NoError(t, err)
 
 	require.Eventually(t, func() bool {
-		return IsProcessRunning(agentName)
+		return IsProcessRunning(agentName, t)
 	}, 30*time.Second, 1*time.Second)
 }
 

--- a/test/e2e/fixture_test.go
+++ b/test/e2e/fixture_test.go
@@ -551,10 +551,10 @@ func (suite *FixtureTestSuite) Test_SyncApplication() {
 func (suite *FixtureTestSuite) Test_Goreman_StartStopStatus_Sanity() {
 	const process = "principal"
 	requires := suite.Require()
-	requires.True(fixture.IsProcessRunning(process))
-	requires.NoError(fixture.StopProcess(process))
-	requires.False(fixture.IsProcessRunning(process))
-	requires.NoError(fixture.StartProcess(process))
+	requires.True(fixture.IsProcessRunning(process, suite.T()))
+	requires.NoError(fixture.StopProcess(process, suite.T()))
+	requires.False(fixture.IsProcessRunning(process, suite.T()))
+	requires.NoError(fixture.StartProcess(process, suite.T()))
 }
 
 func XTestFixtureTestSuite(t *testing.T) {

--- a/test/e2e/recreate_action_test.go
+++ b/test/e2e/recreate_action_test.go
@@ -40,8 +40,8 @@ func (suite *RecreateActionTestSuite) TearDownTest() {
 		fixture.RestartAgent(suite.T(), "agent-managed")
 	}
 
-	if !fixture.IsProcessRunning("agent-managed") {
-		err := fixture.StartProcess("agent-managed")
+	if !fixture.IsProcessRunning("agent-managed", suite.T()) {
+		err := fixture.StartProcess("agent-managed", suite.T())
 		requires.NoError(err)
 	}
 

--- a/test/e2e/resync_test.go
+++ b/test/e2e/resync_test.go
@@ -46,22 +46,22 @@ func (suite *ResyncTestSuite) TearDownTest() {
 	}
 
 	// Ensure that all the components are running after runnings the tests
-	if !fixture.IsProcessRunning("principal") {
-		err := fixture.StartProcess("principal")
+	if !fixture.IsProcessRunning("principal", suite.T()) {
+		err := fixture.StartProcess("principal", suite.T())
 		requires.NoError(err)
 	}
 
 	fixture.CheckReadiness(suite.T(), "principal")
 
-	if !fixture.IsProcessRunning("agent-managed") {
-		err := fixture.StartProcess("agent-managed")
+	if !fixture.IsProcessRunning("agent-managed", suite.T()) {
+		err := fixture.StartProcess("agent-managed", suite.T())
 		requires.NoError(err)
 	}
 
 	fixture.CheckReadiness(suite.T(), "agent-managed")
 
-	if !fixture.IsProcessRunning("agent-autonomous") {
-		err := fixture.StartProcess("agent-autonomous")
+	if !fixture.IsProcessRunning("agent-autonomous", suite.T()) {
+		err := fixture.StartProcess("agent-autonomous", suite.T())
 		requires.NoError(err)
 	}
 
@@ -77,11 +77,11 @@ func (suite *ResyncTestSuite) Test_ResyncDeletionOnPrincipalStartupManaged() {
 	key := types.NamespacedName{Name: app.Name, Namespace: fixture.ManagedAgentNamespace}
 
 	// Stop the principal and delete the app from the control-plane
-	err := fixture.StopProcess("principal")
+	err := fixture.StopProcess("principal", suite.T())
 	requires.NoError(err)
 
 	requires.Eventually(func() bool {
-		return !fixture.IsProcessRunning("principal")
+		return !fixture.IsProcessRunning("principal", suite.T())
 	}, 30*time.Second, 1*time.Second)
 
 	err = suite.PrincipalClient.Delete(suite.Ctx, app, metav1.DeleteOptions{})
@@ -92,7 +92,7 @@ func (suite *ResyncTestSuite) Test_ResyncDeletionOnPrincipalStartupManaged() {
 	requires.NoError(err)
 
 	// Start the principal and ensure that the app is deleted from the workload cluster
-	err = fixture.StartProcess("principal")
+	err = fixture.StartProcess("principal", suite.T())
 	requires.NoError(err)
 
 	fixture.CheckReadiness(suite.T(), "principal")
@@ -114,11 +114,11 @@ func (suite *ResyncTestSuite) Test_ResyncUpdatesOnPrincipalStartupManaged() {
 	agentKey := types.NamespacedName{Name: app.Name, Namespace: fixture.ManagedAgentNamespace}
 
 	// Stop the principal and update the app on the control-plane
-	err := fixture.StopProcess("principal")
+	err := fixture.StopProcess("principal", suite.T())
 	requires.NoError(err)
 
 	requires.Eventually(func() bool {
-		return !fixture.IsProcessRunning("principal")
+		return !fixture.IsProcessRunning("principal", suite.T())
 	}, 30*time.Second, 1*time.Second)
 
 	err = suite.PrincipalClient.EnsureApplicationUpdate(suite.Ctx, principalKey, func(a *argoapp.Application) error {
@@ -133,7 +133,7 @@ func (suite *ResyncTestSuite) Test_ResyncUpdatesOnPrincipalStartupManaged() {
 	requires.Equal("kustomize-guestbook", app.Spec.Source.Path)
 
 	// Start the principal and ensure that the app is updated on the workload cluster
-	err = fixture.StartProcess("principal")
+	err = fixture.StartProcess("principal", suite.T())
 	requires.NoError(err)
 
 	fixture.CheckReadiness(suite.T(), "principal")
@@ -155,11 +155,11 @@ func (suite *ResyncTestSuite) Test_ResyncDeletionOnAgentStartupManaged() {
 	key := types.NamespacedName{Name: app.Name, Namespace: fixture.ManagedAgentNamespace}
 
 	// Stop the agent and delete the app
-	err := fixture.StopProcess("agent-managed")
+	err := fixture.StopProcess("agent-managed", suite.T())
 	requires.NoError(err)
 
 	requires.Eventually(func() bool {
-		return !fixture.IsProcessRunning("agent-managed")
+		return !fixture.IsProcessRunning("agent-managed", suite.T())
 	}, 30*time.Second, 1*time.Second)
 
 	err = suite.ManagedAgentClient.Delete(suite.Ctx, &argoapp.Application{
@@ -171,7 +171,7 @@ func (suite *ResyncTestSuite) Test_ResyncDeletionOnAgentStartupManaged() {
 	requires.NoError(err)
 
 	// Start the agent and ensure that the app is recreated on the agent side
-	err = fixture.StartProcess("agent-managed")
+	err = fixture.StartProcess("agent-managed", suite.T())
 	requires.NoError(err)
 
 	fixture.CheckReadiness(suite.T(), "agent-managed")
@@ -192,11 +192,11 @@ func (suite *ResyncTestSuite) Test_ResyncUpdatesOnAgentStartupManaged() {
 	key := types.NamespacedName{Name: app.Name, Namespace: fixture.ManagedAgentNamespace}
 
 	// Stop the agent and update the app on the workload cluster
-	err := fixture.StopProcess("agent-managed")
+	err := fixture.StopProcess("agent-managed", suite.T())
 	requires.NoError(err)
 
 	requires.Eventually(func() bool {
-		return !fixture.IsProcessRunning("agent-managed")
+		return !fixture.IsProcessRunning("agent-managed", suite.T())
 	}, 30*time.Second, 1*time.Second)
 
 	err = suite.ManagedAgentClient.EnsureApplicationUpdate(suite.Ctx, key, func(a *argoapp.Application) error {
@@ -206,7 +206,7 @@ func (suite *ResyncTestSuite) Test_ResyncUpdatesOnAgentStartupManaged() {
 	requires.NoError(err)
 
 	// Start the agent and ensure that the app is updated back on the agent side
-	err = fixture.StartProcess("agent-managed")
+	err = fixture.StartProcess("agent-managed", suite.T())
 	requires.NoError(err)
 
 	fixture.CheckReadiness(suite.T(), "agent-managed")
@@ -228,11 +228,11 @@ func (suite *ResyncTestSuite) Test_ResyncDeletionOnAgentStartupAutonomous() {
 	principalKey := types.NamespacedName{Name: app.Name, Namespace: "agent-autonomous"}
 
 	// Stop the agent process and delete the app on the agent side
-	err := fixture.StopProcess("agent-autonomous")
+	err := fixture.StopProcess("agent-autonomous", suite.T())
 	requires.NoError(err)
 
 	requires.Eventually(func() bool {
-		return !fixture.IsProcessRunning("agent-autonomous")
+		return !fixture.IsProcessRunning("agent-autonomous", suite.T())
 	}, 30*time.Second, 1*time.Second)
 
 	err = suite.AutonomousAgentClient.Delete(suite.Ctx, app, metav1.DeleteOptions{})
@@ -243,7 +243,7 @@ func (suite *ResyncTestSuite) Test_ResyncDeletionOnAgentStartupAutonomous() {
 	requires.NoError(err)
 
 	// Start the agent process and ensure that the app is deleted on the principal
-	err = fixture.StartProcess("agent-autonomous")
+	err = fixture.StartProcess("agent-autonomous", suite.T())
 	requires.NoError(err)
 
 	fixture.CheckReadiness(suite.T(), "agent-autonomous")
@@ -265,11 +265,11 @@ func (suite *ResyncTestSuite) Test_ResyncUpdatesOnAgentStartupAutonomous() {
 	agentKey := fixture.ToNamespacedName(app)
 
 	// Stop the agent process and update the app on the agent side
-	err := fixture.StopProcess("agent-autonomous")
+	err := fixture.StopProcess("agent-autonomous", suite.T())
 	requires.NoError(err)
 
 	requires.Eventually(func() bool {
-		return !fixture.IsProcessRunning("agent-autonomous")
+		return !fixture.IsProcessRunning("agent-autonomous", suite.T())
 	}, 30*time.Second, 1*time.Second)
 
 	err = suite.AutonomousAgentClient.EnsureApplicationUpdate(suite.Ctx, agentKey, func(a *argoapp.Application) error {
@@ -284,7 +284,7 @@ func (suite *ResyncTestSuite) Test_ResyncUpdatesOnAgentStartupAutonomous() {
 	requires.Equal("kustomize-guestbook", app.Spec.Source.Path)
 
 	// Start the agent process and ensure that the app is updated on the principal
-	err = fixture.StartProcess("agent-autonomous")
+	err = fixture.StartProcess("agent-autonomous", suite.T())
 	requires.NoError(err)
 
 	fixture.CheckReadiness(suite.T(), "agent-autonomous")
@@ -307,11 +307,11 @@ func (suite *ResyncTestSuite) Test_ResyncDeletionOnPrincipalStartupAutonomous() 
 	agentKey := fixture.ToNamespacedName(app)
 
 	// Stop the principal process and delete the app on the principal side
-	err := fixture.StopProcess("principal")
+	err := fixture.StopProcess("principal", suite.T())
 	requires.NoError(err)
 
 	requires.Eventually(func() bool {
-		return !fixture.IsProcessRunning("principal")
+		return !fixture.IsProcessRunning("principal", suite.T())
 	}, 30*time.Second, 1*time.Second)
 
 	principalApp := app.DeepCopy()
@@ -324,7 +324,7 @@ func (suite *ResyncTestSuite) Test_ResyncDeletionOnPrincipalStartupAutonomous() 
 	requires.NoError(err)
 
 	// Start the principal process and ensure that the app is created on the principal
-	err = fixture.StartProcess("principal")
+	err = fixture.StartProcess("principal", suite.T())
 	requires.NoError(err)
 
 	fixture.CheckReadiness(suite.T(), "principal")
@@ -344,11 +344,11 @@ func (suite *ResyncTestSuite) Test_ResyncUpdatesOnPrincipalStartupAutonomous() {
 	principalKey := types.NamespacedName{Name: app.Name, Namespace: "agent-autonomous"}
 
 	// Stop the principal process and update the app on the principal side
-	err := fixture.StopProcess("principal")
+	err := fixture.StopProcess("principal", suite.T())
 	requires.NoError(err)
 
 	requires.Eventually(func() bool {
-		return !fixture.IsProcessRunning("principal")
+		return !fixture.IsProcessRunning("principal", suite.T())
 	}, 30*time.Second, 1*time.Second)
 
 	principalApp := app.DeepCopy()
@@ -361,7 +361,7 @@ func (suite *ResyncTestSuite) Test_ResyncUpdatesOnPrincipalStartupAutonomous() {
 	requires.NoError(err)
 
 	// Start the principal process and ensure that the app is updated back on the principal
-	err = fixture.StartProcess("principal")
+	err = fixture.StartProcess("principal", suite.T())
 	requires.NoError(err)
 
 	fixture.CheckReadiness(suite.T(), "principal")
@@ -467,11 +467,11 @@ func (suite *ResyncTestSuite) Test_RepositoryResync_OnAppProjectUpdate() {
 	keyManaged := managedClusterRepoKey(repo)
 
 	// Stop the principal and update the AppProject rules
-	err := fixture.StopProcess("principal")
+	err := fixture.StopProcess("principal", suite.T())
 	requires.NoError(err)
 
 	requires.Eventually(func() bool {
-		return !fixture.IsProcessRunning("principal")
+		return !fixture.IsProcessRunning("principal", suite.T())
 	}, 30*time.Second, 1*time.Second)
 
 	// Update the AppProject rules to not match any agent
@@ -482,7 +482,7 @@ func (suite *ResyncTestSuite) Test_RepositoryResync_OnAppProjectUpdate() {
 	requires.NoError(err)
 
 	// Start the principal and ensure that the repository and the appProject are deleted from the managed-agent
-	err = fixture.StartProcess("principal")
+	err = fixture.StartProcess("principal", suite.T())
 	requires.NoError(err)
 
 	fixture.CheckReadiness(suite.T(), "principal")
@@ -507,11 +507,11 @@ func (suite *ResyncTestSuite) Test_RepositoryResync_OnCreation() {
 	requires := suite.Require()
 
 	// Stop the principal process
-	err := fixture.StopProcess("principal")
+	err := fixture.StopProcess("principal", suite.T())
 	requires.NoError(err)
 
 	requires.Eventually(func() bool {
-		return !fixture.IsProcessRunning("principal")
+		return !fixture.IsProcessRunning("principal", suite.T())
 	}, 30*time.Second, 1*time.Second)
 
 	// Create an appProject on the control plane cluster
@@ -529,7 +529,7 @@ func (suite *ResyncTestSuite) Test_RepositoryResync_OnCreation() {
 	requires.NoError(err)
 
 	// Start the principal and ensure that the repository is created on the workload cluster
-	err = fixture.StartProcess("principal")
+	err = fixture.StartProcess("principal", suite.T())
 	requires.NoError(err)
 
 	fixture.CheckReadiness(suite.T(), "principal")
@@ -563,11 +563,11 @@ func (suite *ResyncTestSuite) Test_RepositoryResync_OnUpdate() {
 	keyManaged := managedClusterRepoKey(sourceRepo)
 
 	// Stop the principal and update the AppProject rules
-	err := fixture.StopProcess("principal")
+	err := fixture.StopProcess("principal", suite.T())
 	requires.NoError(err)
 
 	requires.Eventually(func() bool {
-		return !fixture.IsProcessRunning("principal")
+		return !fixture.IsProcessRunning("principal", suite.T())
 	}, 30*time.Second, 1*time.Second)
 
 	// Update the repository secret
@@ -579,7 +579,7 @@ func (suite *ResyncTestSuite) Test_RepositoryResync_OnUpdate() {
 	requires.NoError(err)
 
 	// Start the principal and ensure that the repository is updated on the workload cluster
-	err = fixture.StartProcess("principal")
+	err = fixture.StartProcess("principal", suite.T())
 	requires.NoError(err)
 
 	// Wait for the principal to be ready
@@ -622,11 +622,11 @@ func (suite *ResyncTestSuite) Test_RepositoryResync_OnDeletion() {
 	}, 30*time.Second, 1*time.Second, "GET repository from managed-agent")
 
 	// Stop the principal and update the AppProject rules
-	err := fixture.StopProcess("principal")
+	err := fixture.StopProcess("principal", suite.T())
 	requires.NoError(err)
 
 	requires.Eventually(func() bool {
-		return !fixture.IsProcessRunning("principal")
+		return !fixture.IsProcessRunning("principal", suite.T())
 	}, 30*time.Second, 1*time.Second)
 
 	// Delete the repository
@@ -634,7 +634,7 @@ func (suite *ResyncTestSuite) Test_RepositoryResync_OnDeletion() {
 	requires.NoError(err)
 
 	// Start the principal and ensure that the repository is deleted from the workload cluster
-	err = fixture.StartProcess("principal")
+	err = fixture.StartProcess("principal", suite.T())
 	requires.NoError(err)
 
 	fixture.CheckReadiness(suite.T(), "principal")
@@ -653,11 +653,11 @@ func (suite *ResyncTestSuite) Test_AppProjectResync_OnCreate() {
 	requires := suite.Require()
 
 	// Stop the principal
-	err := fixture.StopProcess("principal")
+	err := fixture.StopProcess("principal", suite.T())
 	requires.NoError(err)
 
 	requires.Eventually(func() bool {
-		return !fixture.IsProcessRunning("principal")
+		return !fixture.IsProcessRunning("principal", suite.T())
 	}, 30*time.Second, 1*time.Second)
 
 	// Create an appProject on the control plane cluster
@@ -667,7 +667,7 @@ func (suite *ResyncTestSuite) Test_AppProjectResync_OnCreate() {
 	requires.NoError(err)
 
 	// Start the principal and ensure that the appProject is created on the workload cluster
-	err = fixture.StartProcess("principal")
+	err = fixture.StartProcess("principal", suite.T())
 	requires.NoError(err)
 
 	fixture.CheckReadiness(suite.T(), "principal")
@@ -694,11 +694,11 @@ func (suite *ResyncTestSuite) Test_AppProjectResync_OnUpdate() {
 	projKeyManaged := managedClusterAppProjectKey(appProject)
 
 	// Stop the principal
-	err := fixture.StopProcess("principal")
+	err := fixture.StopProcess("principal", suite.T())
 	requires.NoError(err)
 
 	requires.Eventually(func() bool {
-		return !fixture.IsProcessRunning("principal")
+		return !fixture.IsProcessRunning("principal", suite.T())
 	}, 30*time.Second, 1*time.Second)
 
 	// Update the appProject spec
@@ -710,7 +710,7 @@ func (suite *ResyncTestSuite) Test_AppProjectResync_OnUpdate() {
 	requires.NoError(err)
 
 	// Start the principal and ensure that the appProject is updated on the workload cluster
-	err = fixture.StartProcess("principal")
+	err = fixture.StartProcess("principal", suite.T())
 	requires.NoError(err)
 
 	fixture.CheckReadiness(suite.T(), "principal")
@@ -733,11 +733,11 @@ func (suite *ResyncTestSuite) Test_AppProjectResync_OnDeletion() {
 	projKeyManaged := managedClusterAppProjectKey(appProject)
 
 	// Stop the principal
-	err := fixture.StopProcess("principal")
+	err := fixture.StopProcess("principal", suite.T())
 	requires.NoError(err)
 
 	requires.Eventually(func() bool {
-		return !fixture.IsProcessRunning("principal")
+		return !fixture.IsProcessRunning("principal", suite.T())
 	}, 30*time.Second, 1*time.Second)
 
 	// Delete the appProject
@@ -745,7 +745,7 @@ func (suite *ResyncTestSuite) Test_AppProjectResync_OnDeletion() {
 	requires.NoError(err)
 
 	// Start the principal and ensure that the appProject is deleted from the workload cluster
-	err = fixture.StartProcess("principal")
+	err = fixture.StartProcess("principal", suite.T())
 	requires.NoError(err)
 
 	fixture.CheckReadiness(suite.T(), "principal")
@@ -767,11 +767,11 @@ func (suite *ResyncTestSuite) Test_AppProjectResync_DeleteOnAgentDelete() {
 	projKeyManaged := managedClusterAppProjectKey(appProject)
 
 	// Stop the agent
-	err := fixture.StopProcess("agent-managed")
+	err := fixture.StopProcess("agent-managed", suite.T())
 	requires.NoError(err)
 
 	requires.Eventually(func() bool {
-		return !fixture.IsProcessRunning("agent-managed")
+		return !fixture.IsProcessRunning("agent-managed", suite.T())
 	}, 30*time.Second, 1*time.Second)
 
 	// Delete the appProject from the control plane
@@ -783,7 +783,7 @@ func (suite *ResyncTestSuite) Test_AppProjectResync_DeleteOnAgentDelete() {
 	requires.NoError(err)
 
 	// Start the agent and ensure that the appProject is deleted from the workload cluster
-	err = fixture.StartProcess("agent-managed")
+	err = fixture.StartProcess("agent-managed", suite.T())
 	requires.NoError(err)
 
 	fixture.CheckReadiness(suite.T(), "agent-managed")
@@ -802,11 +802,11 @@ func (suite *ResyncTestSuite) Test_AppProjectResync_CreateOnAgentDelete() {
 	requires := suite.Require()
 
 	// Stop the agent
-	err := fixture.StopProcess("agent-managed")
+	err := fixture.StopProcess("agent-managed", suite.T())
 	requires.NoError(err)
 
 	requires.Eventually(func() bool {
-		return !fixture.IsProcessRunning("agent-managed")
+		return !fixture.IsProcessRunning("agent-managed", suite.T())
 	}, 30*time.Second, 1*time.Second)
 
 	// Create an appProject on the control plane cluster
@@ -817,7 +817,7 @@ func (suite *ResyncTestSuite) Test_AppProjectResync_CreateOnAgentDelete() {
 	projKeyManaged := managedClusterAppProjectKey(appProject)
 
 	// Start the agent and ensure that the appProject is created on the workload cluster
-	err = fixture.StartProcess("agent-managed")
+	err = fixture.StartProcess("agent-managed", suite.T())
 	requires.NoError(err)
 
 	fixture.CheckReadiness(suite.T(), "agent-managed")
@@ -840,15 +840,15 @@ func (suite *ResyncTestSuite) Test_AppProjectResyncOnPrincipalRestart_Autonomous
 	agentKey := types.NamespacedName{Name: appProject.Name, Namespace: fixture.AutonomousAgentNamespace}
 
 	// Restart the principal
-	err := fixture.StopProcess("principal")
+	err := fixture.StopProcess("principal", suite.T())
 	requires.NoError(err)
 
 	requires.Eventually(func() bool {
-		return !fixture.IsProcessRunning("principal")
+		return !fixture.IsProcessRunning("principal", suite.T())
 	}, 30*time.Second, 1*time.Second)
 
 	// Start the principal and ensure that the appProject is still present on the workload cluster
-	err = fixture.StartProcess("principal")
+	err = fixture.StartProcess("principal", suite.T())
 	requires.NoError(err)
 
 	fixture.CheckReadiness(suite.T(), "principal")
@@ -890,15 +890,15 @@ func (suite *ResyncTestSuite) Test_AppProjectResyncOnAgentRestart_Autonomous() {
 	agentKey := types.NamespacedName{Name: appProject.Name, Namespace: fixture.AutonomousAgentNamespace}
 
 	// Restart the autonomous-agent
-	err := fixture.StopProcess("agent-autonomous")
+	err := fixture.StopProcess("agent-autonomous", suite.T())
 	requires.NoError(err)
 
 	requires.Eventually(func() bool {
-		return !fixture.IsProcessRunning("agent-autonomous")
+		return !fixture.IsProcessRunning("agent-autonomous", suite.T())
 	}, 30*time.Second, 1*time.Second)
 
 	// Start the agent and ensure that the appProject is still present on both the clusters
-	err = fixture.StartProcess("agent-autonomous")
+	err = fixture.StartProcess("agent-autonomous", suite.T())
 	requires.NoError(err)
 
 	fixture.CheckReadiness(suite.T(), "agent-autonomous")
@@ -936,11 +936,11 @@ func (suite *ResyncTestSuite) Test_AppProjectResyncOnPrincipalRestartWithUpdateO
 	principalKey := types.NamespacedName{Name: "agent-autonomous-" + appProject.Name, Namespace: fixture.PrincipalNamespace}
 
 	// Stop the principal
-	err := fixture.StopProcess("principal")
+	err := fixture.StopProcess("principal", suite.T())
 	requires.NoError(err)
 
 	requires.Eventually(func() bool {
-		return !fixture.IsProcessRunning("principal")
+		return !fixture.IsProcessRunning("principal", suite.T())
 	}, 30*time.Second, 1*time.Second)
 
 	// Update the AppProject on the control-plane cluster
@@ -954,7 +954,7 @@ func (suite *ResyncTestSuite) Test_AppProjectResyncOnPrincipalRestartWithUpdateO
 	requires.NoError(err)
 
 	// Restart the principal
-	err = fixture.StartProcess("principal")
+	err = fixture.StartProcess("principal", suite.T())
 	requires.NoError(err)
 
 	fixture.CheckReadiness(suite.T(), "principal")
@@ -976,11 +976,11 @@ func (suite *ResyncTestSuite) Test_AppProjectResyncOnPrincipalRestartWithUpdateO
 	principalKey := types.NamespacedName{Name: "agent-autonomous-" + appProject.Name, Namespace: fixture.PrincipalNamespace}
 
 	// Stop the principal
-	err := fixture.StopProcess("principal")
+	err := fixture.StopProcess("principal", suite.T())
 	requires.NoError(err)
 
 	requires.Eventually(func() bool {
-		return !fixture.IsProcessRunning("principal")
+		return !fixture.IsProcessRunning("principal", suite.T())
 	}, 30*time.Second, 1*time.Second)
 
 	// Update the AppProject on the agent's cluster
@@ -992,7 +992,7 @@ func (suite *ResyncTestSuite) Test_AppProjectResyncOnPrincipalRestartWithUpdateO
 	requires.NoError(err)
 
 	// Restart the principal
-	err = fixture.StartProcess("principal")
+	err = fixture.StartProcess("principal", suite.T())
 	requires.NoError(err)
 
 	fixture.CheckReadiness(suite.T(), "principal")
@@ -1014,11 +1014,11 @@ func (suite *ResyncTestSuite) Test_AppProjectResyncOnAgentRestartWithUpdateOnAge
 	principalKey := types.NamespacedName{Name: "agent-autonomous-" + appProject.Name, Namespace: fixture.PrincipalNamespace}
 
 	// Stop the autonomous-agent
-	err := fixture.StopProcess("agent-autonomous")
+	err := fixture.StopProcess("agent-autonomous", suite.T())
 	requires.NoError(err)
 
 	requires.Eventually(func() bool {
-		return !fixture.IsProcessRunning("agent-autonomous")
+		return !fixture.IsProcessRunning("agent-autonomous", suite.T())
 	}, 30*time.Second, 1*time.Second)
 
 	// Update the AppProject on the autonomous-agent's cluster
@@ -1029,7 +1029,7 @@ func (suite *ResyncTestSuite) Test_AppProjectResyncOnAgentRestartWithUpdateOnAge
 	requires.NoError(err)
 
 	// Restart the autonomous-agent
-	err = fixture.StartProcess("agent-autonomous")
+	err = fixture.StartProcess("agent-autonomous", suite.T())
 	requires.NoError(err)
 
 	fixture.CheckReadiness(suite.T(), "agent-autonomous")
@@ -1051,11 +1051,11 @@ func (suite *ResyncTestSuite) Test_AppProjectResyncOnAgentRestartWithUpdateOnPri
 	principalKey := types.NamespacedName{Name: "agent-autonomous-" + appProject.Name, Namespace: fixture.PrincipalNamespace}
 
 	// Stop the autonomous-agent
-	err := fixture.StopProcess("agent-autonomous")
+	err := fixture.StopProcess("agent-autonomous", suite.T())
 	requires.NoError(err)
 
 	requires.Eventually(func() bool {
-		return !fixture.IsProcessRunning("agent-autonomous")
+		return !fixture.IsProcessRunning("agent-autonomous", suite.T())
 	}, 30*time.Second, 1*time.Second)
 
 	// Update the AppProject on the principal's cluster
@@ -1069,7 +1069,7 @@ func (suite *ResyncTestSuite) Test_AppProjectResyncOnAgentRestartWithUpdateOnPri
 	requires.NoError(err)
 
 	// Restart the autonomous-agent
-	err = fixture.StartProcess("agent-autonomous")
+	err = fixture.StartProcess("agent-autonomous", suite.T())
 	requires.NoError(err)
 
 	fixture.CheckReadiness(suite.T(), "agent-autonomous")
@@ -1091,11 +1091,11 @@ func (suite *ResyncTestSuite) Test_AppProjectResyncOnPrincipalRestartWithDeleteO
 	principalKey := types.NamespacedName{Name: "agent-autonomous-" + appProject.Name, Namespace: fixture.PrincipalNamespace}
 
 	// Stop the principal
-	err := fixture.StopProcess("principal")
+	err := fixture.StopProcess("principal", suite.T())
 	requires.NoError(err)
 
 	requires.Eventually(func() bool {
-		return !fixture.IsProcessRunning("principal")
+		return !fixture.IsProcessRunning("principal", suite.T())
 	}, 30*time.Second, 1*time.Second)
 
 	// Delete the AppProject on the control-plane cluster
@@ -1106,7 +1106,7 @@ func (suite *ResyncTestSuite) Test_AppProjectResyncOnPrincipalRestartWithDeleteO
 	requires.NoError(err)
 
 	// Restart the principal
-	err = fixture.StartProcess("principal")
+	err = fixture.StartProcess("principal", suite.T())
 	requires.NoError(err)
 
 	fixture.CheckReadiness(suite.T(), "principal")
@@ -1139,11 +1139,11 @@ func (suite *ResyncTestSuite) Test_AppProjectResyncOnPrincipalRestartWithDeleteO
 	principalKey := types.NamespacedName{Name: "agent-autonomous-" + appProject.Name, Namespace: fixture.PrincipalNamespace}
 
 	// Stop the principal
-	err := fixture.StopProcess("principal")
+	err := fixture.StopProcess("principal", suite.T())
 	requires.NoError(err)
 
 	requires.Eventually(func() bool {
-		return !fixture.IsProcessRunning("principal")
+		return !fixture.IsProcessRunning("principal", suite.T())
 	}, 30*time.Second, 1*time.Second)
 
 	// Delete the AppProject on the agent's cluster
@@ -1151,7 +1151,7 @@ func (suite *ResyncTestSuite) Test_AppProjectResyncOnPrincipalRestartWithDeleteO
 	requires.NoError(err)
 
 	// Restart the principal
-	err = fixture.StartProcess("principal")
+	err = fixture.StartProcess("principal", suite.T())
 	requires.NoError(err)
 
 	fixture.CheckReadiness(suite.T(), "principal")
@@ -1173,11 +1173,11 @@ func (suite *ResyncTestSuite) Test_AppProjectResyncOnAgentRestartWithDeleteOnAge
 	principalKey := types.NamespacedName{Name: "agent-autonomous-" + appProject.Name, Namespace: fixture.PrincipalNamespace}
 
 	// Stop the autonomous-agent
-	err := fixture.StopProcess("agent-autonomous")
+	err := fixture.StopProcess("agent-autonomous", suite.T())
 	requires.NoError(err)
 
 	requires.Eventually(func() bool {
-		return !fixture.IsProcessRunning("agent-autonomous")
+		return !fixture.IsProcessRunning("agent-autonomous", suite.T())
 	}, 30*time.Second, 1*time.Second)
 
 	// Delete the AppProject on the autonomous-agent's cluster
@@ -1186,7 +1186,7 @@ func (suite *ResyncTestSuite) Test_AppProjectResyncOnAgentRestartWithDeleteOnAge
 	requires.NoError(err)
 
 	// Restart the autonomous-agent
-	err = fixture.StartProcess("agent-autonomous")
+	err = fixture.StartProcess("agent-autonomous", suite.T())
 	requires.NoError(err)
 
 	fixture.CheckReadiness(suite.T(), "agent-autonomous")
@@ -1208,11 +1208,11 @@ func (suite *ResyncTestSuite) Test_AppProjectResyncOnAgentRestartWithDeleteOnPri
 	principalKey := types.NamespacedName{Name: "agent-autonomous-" + appProject.Name, Namespace: fixture.PrincipalNamespace}
 
 	// Stop the autonomous-agent
-	err := fixture.StopProcess("agent-autonomous")
+	err := fixture.StopProcess("agent-autonomous", suite.T())
 	requires.NoError(err)
 
 	requires.Eventually(func() bool {
-		return !fixture.IsProcessRunning("agent-autonomous")
+		return !fixture.IsProcessRunning("agent-autonomous", suite.T())
 	}, 30*time.Second, 1*time.Second)
 
 	// Delete the AppProject on the principal's cluster
@@ -1223,7 +1223,7 @@ func (suite *ResyncTestSuite) Test_AppProjectResyncOnAgentRestartWithDeleteOnPri
 	requires.NoError(err)
 
 	// Restart the autonomous-agent
-	err = fixture.StartProcess("agent-autonomous")
+	err = fixture.StartProcess("agent-autonomous", suite.T())
 	requires.NoError(err)
 
 	fixture.CheckReadiness(suite.T(), "agent-autonomous")
@@ -1518,14 +1518,14 @@ func (suite *ResyncTestSuite) assertAppProjectSurvivesPrincipalRestart(projectNa
 	}, 30*time.Second, 1*time.Second, "AppProject should sync to principal")
 
 	// Restart the principal
-	err = fixture.StopProcess("principal")
+	err = fixture.StopProcess("principal", suite.T())
 	requires.NoError(err)
 
 	requires.Eventually(func() bool {
-		return !fixture.IsProcessRunning("principal")
+		return !fixture.IsProcessRunning("principal", suite.T())
 	}, 30*time.Second, 1*time.Second)
 
-	err = fixture.StartProcess("principal")
+	err = fixture.StartProcess("principal", suite.T())
 	requires.NoError(err)
 
 	fixture.CheckReadiness(suite.T(), "principal")

--- a/test/e2e/rp_test.go
+++ b/test/e2e/rp_test.go
@@ -83,6 +83,10 @@ func (suite *ResourceProxyTestSuite) getRpClient(agentName string) *http.Client 
 }
 
 func (suite *ResourceProxyTestSuite) Test_ResourceProxy_HTTP() {
+
+	// This test assumes that resource proxy is available at 127.0.0.1, which is not true when agent is on cluster.
+	fixture.SkipIfAgentInClusterEnvVarIsSet(suite.T())
+
 	requires := suite.Require()
 
 	rpClient := suite.getRpClient("agent-managed")
@@ -163,6 +167,7 @@ func (suite *ResourceProxyTestSuite) Test_ResourceProxy_HTTP() {
 }
 
 func (suite *ResourceProxyTestSuite) validateResourceProxyViaArgoAPI(appName string) {
+
 	requires := suite.Require()
 
 	// Get the Argo server endpoint to use
@@ -256,6 +261,7 @@ func (suite *ResourceProxyTestSuite) Test_ResourceProxy_Argo() {
 
 // Test_SelfRegisteredSecret_ResourceProxy tests resource proxy via Argo CD API with self-registered cluster secret
 func (suite *ResourceProxyTestSuite) Test_SelfRegisteredSecret_ResourceProxy() {
+
 	requires := suite.Require()
 
 	// Get original secret before any modifications for restoration later
@@ -284,10 +290,10 @@ func (suite *ResourceProxyTestSuite) Test_SelfRegisteredSecret_ResourceProxy() {
 	}()
 
 	// Stop agent
-	err = fixture.StopProcess(fixture.AgentManagedName)
+	err = fixture.StopProcess(fixture.AgentManagedName, suite.T())
 	requires.NoError(err)
 	requires.Eventually(func() bool {
-		return !fixture.IsProcessRunning(fixture.AgentManagedName)
+		return !fixture.IsProcessRunning(fixture.AgentManagedName, suite.T())
 	}, 30*time.Second, 1*time.Second)
 
 	// Delete manual secret
@@ -529,6 +535,9 @@ func getCustomResourceAction() string {
 }
 
 func (suite *ResourceProxyTestSuite) Test_ResourceProxy_Subresources() {
+	// This test assumes that resource proxy is available at 127.0.0.1, which is not true when agent is on cluster.
+	fixture.SkipIfAgentInClusterEnvVarIsSet(suite.T())
+
 	requires := suite.Require()
 
 	rpClient := suite.getRpClient("agent-managed")

--- a/test/e2e/self_agent_registration_test.go
+++ b/test/e2e/self_agent_registration_test.go
@@ -55,15 +55,15 @@ func (suite *SelfAgentRegistrationTestSuite) SetupSuite() {
 func (suite *SelfAgentRegistrationTestSuite) SetupTest() {
 	suite.BaseSuite.SetupTest()
 
-	if !fixture.IsProcessRunning(fixture.PrincipalName) {
-		suite.Require().NoError(fixture.StartProcess(fixture.PrincipalName))
+	if !fixture.IsProcessRunning(fixture.PrincipalName, suite.T()) {
+		suite.Require().NoError(fixture.StartProcess(fixture.PrincipalName, suite.T()))
 		fixture.CheckReadiness(suite.T(), fixture.PrincipalName)
 	} else {
 		fixture.CheckReadiness(suite.T(), fixture.PrincipalName)
 	}
 
-	if !fixture.IsProcessRunning(fixture.AgentManagedName) {
-		suite.Require().NoError(fixture.StartProcess(fixture.AgentManagedName))
+	if !fixture.IsProcessRunning(fixture.AgentManagedName, suite.T()) {
+		suite.Require().NoError(fixture.StartProcess(fixture.AgentManagedName, suite.T()))
 		fixture.CheckReadiness(suite.T(), fixture.AgentManagedName)
 	} else {
 		fixture.CheckReadiness(suite.T(), fixture.AgentManagedName)
@@ -83,8 +83,8 @@ func (suite *SelfAgentRegistrationTestSuite) TearDownTest() {
 	fixture.CheckReadiness(suite.T(), fixture.PrincipalName)
 
 	// Ensure agent is running
-	if !fixture.IsProcessRunning(fixture.AgentManagedName) {
-		suite.Require().NoError(fixture.StartProcess(fixture.AgentManagedName))
+	if !fixture.IsProcessRunning(fixture.AgentManagedName, suite.T()) {
+		suite.Require().NoError(fixture.StartProcess(fixture.AgentManagedName, suite.T()))
 	}
 	fixture.CheckReadiness(suite.T(), fixture.AgentManagedName)
 
@@ -272,7 +272,7 @@ func (suite *SelfAgentRegistrationTestSuite) Test_SelfRegistrationCreatesSecret(
 	suite.waitForFreshConnection(oldInfo.ConnectionState.ModifiedAt)
 
 	// Stop the agent
-	err = fixture.StopProcess(fixture.AgentManagedName)
+	err = fixture.StopProcess(fixture.AgentManagedName, suite.T())
 	requires.NoError(err)
 
 	// Wait for agent to disconnect
@@ -348,11 +348,11 @@ func (suite *SelfAgentRegistrationTestSuite) Test_ManuallyCreatedAndSelfRegister
 	suite.waitForFreshConnection(oldInfo.ConnectionState.ModifiedAt)
 
 	// Stop agent and delete manually created cluster secret
-	err = fixture.StopProcess(fixture.AgentManagedName)
+	err = fixture.StopProcess(fixture.AgentManagedName, suite.T())
 	requires.NoError(err)
 
 	requires.Eventually(func() bool {
-		return !fixture.IsProcessRunning(fixture.AgentManagedName)
+		return !fixture.IsProcessRunning(fixture.AgentManagedName, suite.T())
 	}, 30*time.Second, 1*time.Second)
 
 	// Delete manually created cluster secret
@@ -407,11 +407,11 @@ func (suite *SelfAgentRegistrationTestSuite) Test_NoSecretAndSelfRegistrationDis
 	suite.waitForFreshConnection(oldInfo.ConnectionState.ModifiedAt)
 
 	// Stop agent to trigger agent disconnection
-	err = fixture.StopProcess(fixture.AgentManagedName)
+	err = fixture.StopProcess(fixture.AgentManagedName, suite.T())
 	requires.NoError(err)
 
 	requires.Eventually(func() bool {
-		return !fixture.IsProcessRunning(fixture.AgentManagedName)
+		return !fixture.IsProcessRunning(fixture.AgentManagedName, suite.T())
 	}, 30*time.Second, 1*time.Second)
 
 	// Delete manually created cluster secret

--- a/test/e2e/terminal_test.go
+++ b/test/e2e/terminal_test.go
@@ -170,10 +170,10 @@ func (suite *TerminalStreamingTestSuite) Test_SelfRegisteredSecret_Terminal() {
 	}()
 
 	// Stop agent
-	err = fixture.StopProcess(fixture.AgentManagedName)
+	err = fixture.StopProcess(fixture.AgentManagedName, suite.T())
 	requires.NoError(err)
 	requires.Eventually(func() bool {
-		return !fixture.IsProcessRunning(fixture.AgentManagedName)
+		return !fixture.IsProcessRunning(fixture.AgentManagedName, suite.T())
 	}, 30*time.Second, 1*time.Second)
 
 	// Delete manual secret

--- a/test/e2e/websocket_test.go
+++ b/test/e2e/websocket_test.go
@@ -43,26 +43,30 @@ func (suite *HTTP1DowngradeTestSuite) TearDownTest() {
 	}
 
 	// Ensure that all the components are running after runnings the tests
-	if !fixture.IsProcessRunning("process") {
-		err := fixture.StartProcess("principal")
+	if !fixture.IsProcessRunning("process", suite.T()) {
+		err := fixture.StartProcess("principal", suite.T())
 		requires.NoError(err)
 		fixture.CheckReadiness(suite.T(), "principal")
 	}
 
-	if !fixture.IsProcessRunning("agent-managed") {
-		err := fixture.StartProcess("agent-managed")
+	if !fixture.IsProcessRunning("agent-managed", suite.T()) {
+		err := fixture.StartProcess("agent-managed", suite.T())
 		requires.NoError(err)
 		fixture.CheckReadiness(suite.T(), "agent-managed")
 	}
 
-	if !fixture.IsProcessRunning("agent-autonomous") {
-		err := fixture.StartProcess("agent-autonomous")
+	if !fixture.IsProcessRunning("agent-autonomous", suite.T()) {
+		err := fixture.StartProcess("agent-autonomous", suite.T())
 		requires.NoError(err)
 		fixture.CheckReadiness(suite.T(), "agent-autonomous")
 	}
 }
 
 func (suite *HTTP1DowngradeTestSuite) Test_WithHTTP1Downgrade() {
+
+	// This test assumes that resource proxy is available at localhost, which is not true when agent is on cluster.
+	fixture.SkipIfAgentInClusterEnvVarIsSet(suite.T())
+
 	requires := suite.Require()
 
 	// Verify that the agent has connected to the principal


### PR DESCRIPTION
**What does this PR do / why we need it**:
ARGOCD_AGENT_IN_CLUSTER=true make setup-e2e runs principal/agents as pods in vclusters [PR #939](https://github.com/argoproj-labs/argocd-agent/pull/939) renamed E2E namespaces to argocd-principal, argocd-managed, and argocd-autonomous. The out-of-cluster path (local processes with --namespace) was updated but the in-cluster path was not fully covered.
It was failing with below error - 
```
time="2026-06-11T08:51:09Z" level=info msg="Loading gRPC TLS certificate from secret argocd-principal/argocd-agent-principal-tls"
time="2026-06-11T08:51:09Z" level=info msg="Loading root CA certificate from secret argocd-principal/argocd-agent-ca"
time="2026-06-11T08:51:09Z" level=info msg="Loading resource proxy TLS certificate from secrets argocd-principal/argocd-agent-resource-proxy-tls and argocd-principal/argocd-agent-ca"
[FATAL]: Could not load resource proxy TLS configuration: error getting proxy certificate: could not read TLS secret argocd-principal/argocd-agent-resource-proxy-tls: secrets "argocd-agent-resource-proxy-tls" is forbidden: User "system:serviceaccount:argocd-principal:argocd-agent-principal" cannot get resource "secrets" in API group "" in the namespace "argocd-principal"
```
Pods run in argocd-principal, but install manifests bind RBAC to the ServiceAccount in argocd, kustomize edit set namespace argocd-principal updates resource metadata, not subject namespaces. The Role never binds to the actual ServiceAccount, so secret reads are forbidden.

fix -
Added set_rbac_subject_namespace() in utility.sh which rewrites namespace: argocd → argocd-principal / argocd-managed / argocd-autonomous in RoleBinding/ClusterRoleBinding before apply
Called from deploy_principal(), deploy_agent_managed(), and deploy_agent_autonomous()

**Which issue(s) this PR fixes**:
https://redhat.atlassian.net/browse/GITOPS-9851

**How to test changes / Special notes to the reviewer**:
run  ARGOCD_AGENT_IN_CLUSTER=true make setup-e2e

**Checklist**

* [ ] Documentation update is required by this PR (and has been updated) OR no documentation update is required.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Split Kubernetes deployment artifacts into separate managed vs autonomous deploy/undeploy flows for clearer apply/delete behavior.
  * Improved deployment-time RBAC handling by updating ServiceAccount namespaces across the manifests before applying.
* **Bug Fixes**
  * Fixed principal TLS SAN generation to distinguish IPv4 service addresses from hostname-based services, while still including the local SAN.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->