### PR TITLE
fix: apply `on-application-recreate` action during application recreation

### DIFF
--- a/agent/outbound.go
+++ b/agent/outbound.go
@@ -136,13 +136,16 @@ func (a *Agent) addAppDeletionToQueue(app *v1alpha1.Application) {
 	defer span.End()
 
 	if isResourceFromPrincipal(app) {
-		reverted, err := manager.RevertUserInitiatedDeletion(a.context, app, a.deletions, a.appManager, logCtx, a.recreateTransform(logCtx))
+		var transforms []func(*v1alpha1.Application)
+		if a.mode == types.AgentModeManaged {
+			transforms = append(transforms, a.recreateTransform(logCtx))
+		}
+		reverted, err := manager.RevertUserInitiatedDeletion(a.context, app, a.deletions, a.appManager, logCtx, transforms...)
 		if err != nil {
 			logCtx.WithError(err).Error("failed to revert invalid deletion of application")
 			return
 		}
 		if reverted {
-			logCtx.Trace("Deleted application is recreated")
 			return
 		}
 	}

--- a/agent/outbound.go
+++ b/agent/outbound.go
@@ -22,7 +22,6 @@ import (
 	"github.com/argoproj-labs/argocd-agent/internal/event"
 	"github.com/argoproj-labs/argocd-agent/internal/logging/logfields"
 	"github.com/argoproj-labs/argocd-agent/internal/manager"
-	"github.com/argoproj-labs/argocd-agent/internal/manager/application"
 	"github.com/argoproj-labs/argocd-agent/internal/resources"
 	"github.com/argoproj-labs/argocd-agent/internal/tracing"
 	"github.com/argoproj-labs/argocd-agent/pkg/types"
@@ -137,17 +136,13 @@ func (a *Agent) addAppDeletionToQueue(app *v1alpha1.Application) {
 	defer span.End()
 
 	if isResourceFromPrincipal(app) {
-		reverted, err := manager.RevertUserInitiatedDeletion(a.context, app, a.deletions, a.appManager, logCtx)
+		reverted, err := manager.RevertUserInitiatedDeletion(a.context, app, a.deletions, a.appManager, logCtx, a.recreateTransform(logCtx))
 		if err != nil {
 			logCtx.WithError(err).Error("failed to revert invalid deletion of application")
 			return
 		}
 		if reverted {
 			logCtx.Trace("Deleted application is recreated")
-			// If the agent is in managed mode, handle the recreated application.
-			if a.mode == types.AgentModeManaged {
-				a.handleRecreatedApp(app, logCtx)
-			}
 			return
 		}
 	}
@@ -173,38 +168,18 @@ func (a *Agent) addAppDeletionToQueue(app *v1alpha1.Application) {
 	logCtx.WithField(logfields.SendQueueLen, q.Len()).Debugf("Added app delete event to send queue")
 }
 
-// handleRecreatedApp applies the configured recreateAction after an application
-// is recreated from an unauthorized deletion.
-func (a *Agent) handleRecreatedApp(app *v1alpha1.Application, logCtx *logrus.Entry) {
-	// If the recreate action is ignore, do nothing.
-	if a.recreateAction == manager.RecreateActionIgnore {
-		return
-	}
-
-	// Fetch the recreated app,
-	// deleted object is stale and still has DeletionTimestamp from the original deletion.
-	recreated, err := a.appManager.Get(a.context, app.Name, app.Namespace)
-	if err != nil {
-		logCtx.WithError(err).Error("failed to get recreated application")
-		return
-	}
-
-	switch a.recreateAction {
-	// If the recreate action is clear-status, clear the operationState on the recreated application.
-	case manager.RecreateActionClearStatus:
-		if err := a.appManager.ClearOperationState(a.context, recreated); err != nil {
-			logCtx.WithError(err).Error("failed to clear operationState on recreated application")
-		} else {
+// recreateTransform returns a pre-create transform that applies the configured
+// recreateAction to the application before it is created.
+func (a *Agent) recreateTransform(logCtx *logrus.Entry) func(*v1alpha1.Application) {
+	return func(app *v1alpha1.Application) {
+		switch a.recreateAction {
+		case manager.RecreateActionClearStatus:
+			app.Status.OperationState = nil
 			logCtx.Info("Cleared operationState on recreated application to allow auto-sync")
-		}
-	// If the recreate action is resync, set the sync operation on the recreated application.
-	case manager.RecreateActionResync:
-		recreated.Operation = &v1alpha1.Operation{
-			Sync: &v1alpha1.SyncOperation{},
-		}
-		if _, err := a.appManager.UpdateManagedApp(a.context, recreated, application.ManagedIdentity{}); err != nil {
-			logCtx.WithError(err).Error("failed to set sync operation on recreated application")
-		} else {
+		case manager.RecreateActionResync:
+			app.Operation = &v1alpha1.Operation{
+				Sync: &v1alpha1.SyncOperation{},
+			}
 			logCtx.Info("Triggered resync on recreated application")
 		}
 	}

--- a/agent/outbound_test.go
+++ b/agent/outbound_test.go
@@ -232,79 +232,12 @@ func Test_addAppDeletionToQueue(t *testing.T) {
 	})
 }
 
-func Test_handleRecreatedApp(t *testing.T) {
-	app := &v1alpha1.Application{
-		ObjectMeta: v1.ObjectMeta{
-			Name:      "guestbook",
-			Namespace: "argocd",
-			Annotations: map[string]string{
-				manager.SourceUIDAnnotation: "uid-123",
-			},
-		},
-		Status: v1alpha1.ApplicationStatus{
-			OperationState: &v1alpha1.OperationState{
-				Phase: "Succeeded",
-			},
-		},
-	}
-
-	t.Run("Ignore action does nothing", func(t *testing.T) {
-		a, _ := newAgent(t, app)
-		a.mode = types.AgentModeManaged
+func Test_recreateTransform(t *testing.T) {
+	t.Run("Ignore action does not modify the app", func(t *testing.T) {
+		a, _ := newAgent(t)
 		a.recreateAction = manager.RecreateActionIgnore
 
-		logCtx := log().WithField("test", true)
-		a.handleRecreatedApp(app, logCtx)
-
-		updated, err := a.appManager.Get(context.Background(), "guestbook", "argocd")
-		require.NoError(t, err)
-		assert.NotNil(t, updated.Status.OperationState)
-		assert.Equal(t, "Succeeded", string(updated.Status.OperationState.Phase))
-	})
-
-	t.Run("ClearStatus action clears operationState", func(t *testing.T) {
-		a, _ := newAgent(t, app)
-		a.mode = types.AgentModeManaged
-		a.recreateAction = manager.RecreateActionClearStatus
-		a.context = context.Background()
-
-		logCtx := log().WithField("test", true)
-		a.handleRecreatedApp(app, logCtx)
-
-		updated, err := a.appManager.Get(context.Background(), "guestbook", "argocd")
-		require.NoError(t, err)
-		assert.Nil(t, updated.Status.OperationState)
-	})
-
-	t.Run("Resync action sets Operation on the app", func(t *testing.T) {
-		a, _ := newAgentManaged(t, app)
-		a.recreateAction = manager.RecreateActionResync
-		a.context = context.Background()
-		_ = a.appManager.Manage("argocd/guestbook")
-		defer a.appManager.ClearManaged()
-
-		logCtx := log().WithField("test", true)
-		a.handleRecreatedApp(app, logCtx)
-
-		updated, err := a.appManager.Get(context.Background(), "guestbook", "argocd")
-		require.NoError(t, err)
-		assert.NotNil(t, updated.Operation)
-		assert.NotNil(t, updated.Operation.Sync)
-	})
-
-	t.Run("Resync action with DeletionTimestamp does not re-delete", func(t *testing.T) {
-		now := v1.Now()
-		appWithDeletion := &v1alpha1.Application{
-			ObjectMeta: v1.ObjectMeta{
-				Name:              "guestbook",
-				Namespace:         "argocd",
-				DeletionTimestamp: &now,
-				Finalizers:        []string{"resources-finalizer.argocd.argoproj.io"},
-				Annotations: map[string]string{
-					manager.SourceUIDAnnotation: "uid-123",
-				},
-			},
-			Spec: app.Spec,
+		app := &v1alpha1.Application{
 			Status: v1alpha1.ApplicationStatus{
 				OperationState: &v1alpha1.OperationState{
 					Phase: "Succeeded",
@@ -312,21 +245,54 @@ func Test_handleRecreatedApp(t *testing.T) {
 			},
 		}
 
-		a, _ := newAgentManaged(t, app)
-		a.recreateAction = manager.RecreateActionResync
-		a.context = context.Background()
-		_ = a.appManager.Manage("argocd/guestbook")
-		defer a.appManager.ClearManaged()
+		logCtx := log().WithField("test", true)
+		transform := a.recreateTransform(logCtx)
+		transform(app)
+
+		assert.NotNil(t, app.Status.OperationState)
+		assert.Equal(t, "Succeeded", string(app.Status.OperationState.Phase))
+		assert.Nil(t, app.Operation)
+	})
+
+	t.Run("ClearStatus action clears operationState", func(t *testing.T) {
+		a, _ := newAgent(t)
+		a.recreateAction = manager.RecreateActionClearStatus
+
+		app := &v1alpha1.Application{
+			Status: v1alpha1.ApplicationStatus{
+				OperationState: &v1alpha1.OperationState{
+					Phase: "Succeeded",
+				},
+			},
+		}
 
 		logCtx := log().WithField("test", true)
-		a.handleRecreatedApp(appWithDeletion, logCtx)
+		transform := a.recreateTransform(logCtx)
+		transform(app)
 
-		// App should still exist (not re-deleted) and have Operation.Sync set
-		updated, err := a.appManager.Get(context.Background(), "guestbook", "argocd")
-		require.NoError(t, err)
-		assert.NotNil(t, updated.Operation)
-		assert.NotNil(t, updated.Operation.Sync)
-		assert.Nil(t, updated.DeletionTimestamp)
+		assert.Nil(t, app.Status.OperationState)
+		assert.Nil(t, app.Operation)
+	})
+
+	t.Run("Resync action sets Operation.Sync on the app", func(t *testing.T) {
+		a, _ := newAgent(t)
+		a.recreateAction = manager.RecreateActionResync
+
+		app := &v1alpha1.Application{
+			Status: v1alpha1.ApplicationStatus{
+				OperationState: &v1alpha1.OperationState{
+					Phase: "Succeeded",
+				},
+			},
+		}
+
+		logCtx := log().WithField("test", true)
+		transform := a.recreateTransform(logCtx)
+		transform(app)
+
+		require.NotNil(t, app.Operation)
+		assert.NotNil(t, app.Operation.Sync)
+		assert.NotNil(t, app.Status.OperationState)
 	})
 }
 

--- a/internal/manager/manager.go
+++ b/internal/manager/manager.go
@@ -251,6 +251,7 @@ func RevertUserInitiatedDeletion[R kubeResource](ctx context.Context,
 	deletions *DeletionTracker,
 	mgr resourceManager[R],
 	logCtx *logrus.Entry,
+	preCreateTransforms ...func(R),
 ) (bool, error) {
 
 	logCtx = logCtx.WithFields(logrus.Fields{
@@ -275,6 +276,12 @@ func RevertUserInitiatedDeletion[R kubeResource](ctx context.Context,
 	resource.SetResourceVersion("")
 	resource.SetDeletionTimestamp(nil)
 	resource.SetUID(types.UID(sourceUID))
+
+	// apply the pre-create transforms to the resource
+	for _, transform := range preCreateTransforms {
+		transform(resource)
+	}
+
 	_, err := mgr.Create(ctx, resource)
 	if err != nil {
 		return false, err

--- a/internal/manager/manager_test.go
+++ b/internal/manager/manager_test.go
@@ -105,6 +105,37 @@ func TestRevertUserInitiatedDeletion(t *testing.T) {
 		requires.Nil(mgr.created.GetDeletionTimestamp())
 	})
 
+	t.Run("Application with preCreateTransform", func(t *testing.T) {
+		requires := require.New(t)
+
+		app := &argoapp.Application{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "app",
+				Namespace: "ns",
+				Annotations: map[string]string{
+					SourceUIDAnnotation: string(types.UID("u3")),
+				},
+			},
+			Status: argoapp.ApplicationStatus{
+				OperationState: &argoapp.OperationState{
+					Phase: "Succeeded",
+				},
+			},
+		}
+		mgr := &fakeManager[*argoapp.Application]{}
+		deletions := NewDeletionTracker()
+
+		clearOpState := func(a *argoapp.Application) {
+			a.Status.OperationState = nil
+		}
+		ok, err := RevertUserInitiatedDeletion(context.Background(), app, deletions, mgr, newLogger(), clearOpState)
+		requires.NoError(err)
+		requires.True(ok)
+		requires.NotNil(mgr.created)
+		requires.Nil(mgr.created.Status.OperationState)
+		requires.Equal(types.UID("u3"), mgr.created.GetUID())
+	})
+
 	t.Run("AppProject", func(t *testing.T) {
 		requires := require.New(t)
 


### PR DESCRIPTION
This PR is to update the logic introduced by https://github.com/argoproj-labs/argocd-agent/pull/959, because current implement might cause issue if app creation took more time and agent in between agent tries to update the app based on action provided by user for `--on-application-recreate` parameter. Now the logic to perform the action is combined with recreation logic, where an optional transform function is executed on resource object before it is sent to be recreated.

Assisted by: Cursor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved application deletion recovery by injecting optional pre-recreation adjustments before recreating resources.
  * Recreation now uses a single transform-based approach to either ignore, clear operation status, or trigger a resync, reducing extra post-recreation handling.

* **Tests**
  * Replaced recreated-application handling tests with targeted coverage for the new recreation transform behaviors.
  * Added assertions for Application recreation ensuring status handling matches the selected strategy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->