### PR TITLE
docs: clarify that sync and terminate operations are allowed on autonomous apps from the hub

### DIFF
--- a/docs/concepts/agent-modes/autonomous.md
+++ b/docs/concepts/agent-modes/autonomous.md
@@ -4,14 +4,14 @@
 
 In *autonomous mode*, the workload cluster is wholly responsible for maintaining its own configuration. As opposed to the [managed mode](./managed.md), all configuration is first created on the workload cluster. The agent on this workload cluster will observe creation, modification and deletion of configuration and transmit them to the principal on the control plane cluster.
 
-The principal will then create, update or delete this configuration on the control plane cluster. Users can use the Argo CD UI, CLI or API to inspect the status of the configuration, but they are not able to perform changes to the configuration or delete it.
+The principal will then create, update or delete this configuration on the control plane cluster. Users can use the Argo CD UI, CLI or API to inspect the status of the configuration, but they are not able to modify the configuration spec or delete it. Sync and terminate operations can still be triggered from the control plane and will be forwarded to the agent.
 
-Keep in mind that you will not be able to perform any changes whatsoever on the control plane (i.e. through the Argo CD UI, CLI or API) to Applications that are governed by an agent running in *autonomous* configuration mode. This includes parametrization (e.g. Kustomize or Helm parameters) as well as annotations, labels, changing Git parameters, sync options and others.
+Keep in mind that you will not be able to perform configuration changes on the control plane (i.e. through the Argo CD UI, CLI or API) to Applications that are governed by an agent running in *autonomous* configuration mode. This includes parametrization (e.g. Kustomize or Helm parameters) as well as annotations, labels, changing Git parameters, sync options and others. Such spec-level modifications are automatically reverted to match the agent's version.
 
 ## Architectural considerations
 
 * Autonomous mode requires all components except argocd-server and argocd-dex to be running on a workload cluster. 
-* In this mode, workload clusters are truly autonomous and only report back to the control plane. The control plane is merely an observation tool for autonomous agents.
+* In this mode, workload clusters are truly autonomous and own their configuration. The control plane serves primarily as an observation tool, though sync and terminate operations can still be triggered from it.
 * Argo CD configuration management must be externalized (e.g. app-of-apps, all changes must go through Git)
 
 ## Why chose this mode

--- a/docs/user-guide/applications.md
+++ b/docs/user-guide/applications.md
@@ -138,9 +138,9 @@ For more information, refer to [Managing AppProjects](./appprojects.md#autonomou
 In autonomous mode, the agent is the source of truth:
 
 - **Agent → Principal**: Both spec and status changes
-- **Principal → Agent**: Read-only mirror (no modifications sent back)
+- **Principal → Agent**: Spec modifications are reverted; sync and terminate operations are forwarded
 
-The principal serves as a centralized view of all Applications across autonomous agents but doesn't control them.
+The principal serves as a centralized view of all Applications across autonomous agents but doesn't control their configuration.
 
 ### Lifecycle Management
 


### PR DESCRIPTION
**What does this PR do / why we need it**:

I was reviewing a backup/restore design doc authored by someone and he didn't realize you can sync/terminate from the hub even in autonomous mode. This PR clarifies that sync and terminate operations are allowed on autonomous apps from the hub.

**Which issue(s) this PR fixes**:

Fixes #

**How to test changes / Special notes to the reviewer**:

**Checklist**

* [x] Documentation update is required by this PR (and has been updated) OR no documentation update is required.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

* Clarified autonomous mode behavior: users can inspect but not modify application configuration specs
* Configuration spec changes are automatically reverted to match agent versions
* Updated guidance on how sync and terminate operations are forwarded from the principal to the agent
* Emphasized that workload clusters operate fully autonomously with the control plane serving as an observation tool

<!-- end of auto-generated comment: release notes by coderabbit.ai -->