### PR TITLE
chore: Reclaim disk space in GitHub runners

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -179,6 +179,12 @@ jobs:
           df -h
           sudo apt clean
           sudo docker system prune -a -f
+          sudo rm -rf /usr/lib/jvm
+          sudo rm -rf /usr/local/.ghcup
+          sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /usr/local/share/powershell
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /usr/share/swift
           df -h
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/test/run-e2e.sh
+++ b/test/run-e2e.sh
@@ -21,4 +21,4 @@ if ! kubectl config get-contexts | tail -n +2 | awk '{ print $2 }' | grep -qE '^
     exit 1
 fi
 
-go test -count=1 -v -race -timeout 30m github.com/argoproj-labs/argocd-agent/test/e2e
+go test -count=1 -v -race -timeout 45m github.com/argoproj-labs/argocd-agent/test/e2e


### PR DESCRIPTION
**What does this PR do / why we need it**:

We're running into some disk space issues with race condition builds enabled (see https://github.com/argoproj-labs/argocd-agent/actions/runs/27678558719/job/81859858614?pr=793 from #793)

This change removes some unused space hogs from the disk of the GitHub action's runner machines. This is brute-force (removing the directories instead of using apt to uninstall the packages), but it should be fine in our case.

Before this change:

```
Filesystem       Size  Used Avail Use% Mounted on
/dev/root         73G   58G   16G  79% /
tmpfs            7.9G  172K  7.9G   1% /dev/shm
tmpfs            3.2G  1.0M  3.2G   1% /run
tmpfs            5.0M     0  5.0M   0% /run/lock
/dev/nvme0n1p15  105M  6.1M   99M   6% /boot/efi
tmpfs            1.6G   12K  1.6G   1% /run/user/1001
```

After this change:

```
Filesystem      Size  Used Avail Use% Mounted on
/dev/root       146G   33G  113G  23% /
tmpfs           7.9G  172K  7.9G   1% /dev/shm
tmpfs           3.2G 1020K  3.2G   1% /run
tmpfs           5.0M     0  5.0M   0% /run/lock
efivarfs        128M   34K  128M   1% /sys/firmware/efi/efivars
/dev/sda15      105M  6.1M   99M   6% /boot/efi
tmpfs           1.6G   12K  1.6G   1% /run/user/1001
```

**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:


**Checklist**

* [ ] Documentation update is required by this PR (and has been updated) OR no documentation update is required.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved end-to-end CI stability by enhancing disk-space cleanup to remove additional preinstalled system components before tests run.
  * Increased the Go end-to-end test timeout for `github.com/argoproj-labs/argocd-agent/test/e2e` from 30 minutes to 45 minutes to better accommodate longer-running test scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->