### PR TITLE
ci(helm): add OCI chart release workflows for agent and principal

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,6 +20,7 @@ jobs:
       docs: ${{ steps.filter.outputs.docs_any_changed }}
       helm: ${{ steps.filter.outputs.helm_any_changed }}
       agent-helm-chart: ${{ steps.filter.outputs.agent-helm-chart_any_changed }}
+      principal-helm-chart: ${{ steps.filter.outputs.principal-helm-chart_any_changed }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -39,6 +40,8 @@ jobs:
               - 'install/helm-repo/**'
             agent-helm-chart:
               - 'install/helm-repo/argocd-agent-agent/**'
+            principal-helm-chart:
+              - 'install/helm-repo/argocd-agent-principal/**'
 
   check-go:
     name: Check go modules synchronicity
@@ -349,6 +352,55 @@ jobs:
         run: |
           set -euo pipefail
           CHART_PATH="install/helm-repo/argocd-agent-agent/Chart.yaml"
+          BASE_VERSION=$(git show origin/${{ github.base_ref }}:${CHART_PATH} | yq '.version')
+          HEAD_VERSION=$(yq '.version' ${CHART_PATH})
+
+          echo "Base version: ${BASE_VERSION}"
+          echo "Head version: ${HEAD_VERSION}"
+
+          if [ "${BASE_VERSION}" = "${HEAD_VERSION}" ]; then
+            echo "::error::Chart files changed but chart version was not bumped. Please update the 'version' field in ${CHART_PATH} (current: ${HEAD_VERSION})."
+            exit 1
+          fi
+
+          LOWEST=$(printf '%s\n%s' "${BASE_VERSION}" "${HEAD_VERSION}" | sort -V | head -n1)
+          if [ "${LOWEST}" != "${BASE_VERSION}" ]; then
+            echo "::error::Chart version in ${CHART_PATH} must be strictly greater than the base branch (${BASE_VERSION}), but is ${HEAD_VERSION}. Please update the 'version' field in ${CHART_PATH}."
+            exit 1
+          fi
+
+          echo "Chart version in ${CHART_PATH} was bumped: ${BASE_VERSION} -> ${HEAD_VERSION}"
+
+  check-principal-chart-version:
+    name: Check principal chart version bump
+    if: ${{ github.event_name == 'pull_request' && needs.changes.outputs.principal-helm-chart == 'true' }}
+    runs-on: ubuntu-22.04
+    needs:
+      - changes
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Install yq
+        env:
+          YQ_VERSION: v4.53.2
+          YQ_SHA256: d56bf5c6819e8e696340c312bd70f849dc1678a7cda9c2ad63eebd906371d56b
+        run: |
+          set -euo pipefail
+          curl --fail --silent --show-error --location --retry 3 \
+            --output /tmp/yq \
+            "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64"
+          echo "${YQ_SHA256}  /tmp/yq" | sha256sum --check --status
+          sudo install -m 0755 /tmp/yq /usr/local/bin/yq
+          rm -f /tmp/yq
+
+      - name: Check principal chart version was bumped
+        run: |
+          set -euo pipefail
+          CHART_PATH="install/helm-repo/argocd-agent-principal/Chart.yaml"
           BASE_VERSION=$(git show origin/${{ github.base_ref }}:${CHART_PATH} | yq '.version')
           HEAD_VERSION=$(yq '.version' ${CHART_PATH})
 

--- a/.github/workflows/release-agent-chart.yaml
+++ b/.github/workflows/release-agent-chart.yaml
@@ -6,40 +6,69 @@ on:
       - main
     paths:
       - 'install/helm-repo/argocd-agent-agent/**'
+concurrency:
+  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.ref }}
 
 permissions:
   contents: read
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
 jobs:
-  release-chart:
-    name: Build and push agent Helm chart
+  release-agent-chart:
+    name: Package, push, and sign agent Helm chart
     if: github.repository == 'argoproj-labs/argocd-agent'
     runs-on: ubuntu-22.04
     permissions:
-      contents: write
+      contents: read
       packages: write
+      id-token: write
+    outputs:
+      digest: ${{ steps.release.outputs.digest }}
+      chart_version: ${{ steps.release.outputs.chart_version }}
+      chart_ref: ${{ steps.release.outputs.chart_ref }}
+      pushed: ${{ steps.release.outputs.pushed }}
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          fetch-depth: 0
           persist-credentials: false
 
-      - name: Configure Git
-        run: |
-          git config user.name "$GITHUB_ACTOR"
-          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
-
-      - name: Release chart
-        uses: bitdeps/helm-oci-charts-releaser@caedceea2a5ab997c7e5469a999811dbb3d5b070 # v0.1.5
+      - name: Install Helm
+        uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
         with:
-          charts_dir: install/helm-repo/argocd-agent-agent
-          oci_registry: ghcr.io/${{ github.repository }}
-          oci_username: ${{ github.actor }}
-          oci_password: ${{ secrets.GITHUB_TOKEN }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          tag_name_pattern: '{chartName}-chart'
+          version: v3.20.2
+
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@ba7bc0a3fef59531c69a25acd34668d6d3fe6f22 # v4.1.0
+
+      - name: Login to GHCR
+        run: |
+          echo "${GITHUB_TOKEN}" | helm registry login ghcr.io --username "${{ github.actor }}" --password-stdin
+          echo "${GITHUB_TOKEN}" | cosign login ghcr.io --username "${{ github.actor }}" --password-stdin
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Helm chart
+        id: release
+        run: ./hack/release-helm-chart.sh install/helm-repo/argocd-agent-agent "ghcr.io/${{ github.repository }}"
+
+      - name: Sign Helm chart with Cosign
+        if: steps.release.outputs.pushed == 'true'
+        run: |
+          cosign sign \
+            -a "repo=${{ github.repository }}" \
+            -a "workflow=${GITHUB_WORKFLOW}" \
+            -a "sha=${{ github.sha }}" \
+            -y \
+            ${CHART_REF}@${DIGEST}
+        env:
+          CHART_REF: ${{ steps.release.outputs.chart_ref }}
+          DIGEST: ${{ steps.release.outputs.digest }}
+
+      - name: Upload chart package
+        if: steps.release.outputs.pushed == 'true'
+        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+        with:
+          name: helm-chart-package
+          path: ${{ steps.release.outputs.package }}
+          retention-days: 1

--- a/.github/workflows/release-agent-chart.yaml
+++ b/.github/workflows/release-agent-chart.yaml
@@ -1,0 +1,40 @@
+name: Release agent Helm chart
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'install/helm-repo/argocd-agent-agent/**'
+
+permissions:
+  contents: read
+
+jobs:
+  release-chart:
+    name: Build and push agent Helm chart
+    if: github.repository == 'argoproj-labs/argocd-agent'
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: write
+      packages: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+      - name: Release chart
+        uses: bitdeps/helm-oci-charts-releaser@caedceea2a5ab997c7e5469a999811dbb3d5b070 # v0.1.5
+        with:
+          charts_dir: install/helm-repo/argocd-agent-agent
+          oci_registry: ghcr.io/${{ github.repository }}
+          oci_username: ${{ github.actor }}
+          oci_password: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          tag_name_pattern: '{chartName}-chart'

--- a/.github/workflows/release-agent-chart.yaml
+++ b/.github/workflows/release-agent-chart.yaml
@@ -43,10 +43,11 @@ jobs:
 
       - name: Login to GHCR
         run: |
-          echo "${GITHUB_TOKEN}" | helm registry login ghcr.io --username "${{ github.actor }}" --password-stdin
-          echo "${GITHUB_TOKEN}" | cosign login ghcr.io --username "${{ github.actor }}" --password-stdin
+          echo "${GITHUB_TOKEN}" | helm registry login ghcr.io --username "${GH_ACTOR}" --password-stdin
+          echo "${GITHUB_TOKEN}" | cosign login ghcr.io --username "${GH_ACTOR}" --password-stdin
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_ACTOR: ${{ github.actor }}
 
       - name: Build and push Helm chart
         id: release

--- a/.github/workflows/release-agent-chart.yaml
+++ b/.github/workflows/release-agent-chart.yaml
@@ -23,6 +23,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Configure Git
         run: |

--- a/.github/workflows/release-agent-chart.yaml
+++ b/.github/workflows/release-agent-chart.yaml
@@ -10,6 +10,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   release-chart:
     name: Build and push agent Helm chart

--- a/.github/workflows/release-principal-chart.yaml
+++ b/.github/workflows/release-principal-chart.yaml
@@ -10,6 +10,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   release-chart:
     name: Build and push principal Helm chart

--- a/.github/workflows/release-principal-chart.yaml
+++ b/.github/workflows/release-principal-chart.yaml
@@ -1,0 +1,40 @@
+name: Release principal Helm chart
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'install/helm-repo/argocd-agent-principal/**'
+
+permissions:
+  contents: read
+
+jobs:
+  release-chart:
+    name: Build and push principal Helm chart
+    if: github.repository == 'argoproj-labs/argocd-agent'
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: write
+      packages: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+      - name: Release chart
+        uses: bitdeps/helm-oci-charts-releaser@caedceea2a5ab997c7e5469a999811dbb3d5b070 # v0.1.5
+        with:
+          charts_dir: install/helm-repo/argocd-agent-principal
+          oci_registry: ghcr.io/${{ github.repository }}
+          oci_username: ${{ github.actor }}
+          oci_password: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          tag_name_pattern: '{chartName}-chart'

--- a/.github/workflows/release-principal-chart.yaml
+++ b/.github/workflows/release-principal-chart.yaml
@@ -44,10 +44,11 @@ jobs:
 
       - name: Login to GHCR
         run: |
-          echo "${GITHUB_TOKEN}" | helm registry login ghcr.io --username "${{ github.actor }}" --password-stdin
-          echo "${GITHUB_TOKEN}" | cosign login ghcr.io --username "${{ github.actor }}" --password-stdin
+          echo "${GITHUB_TOKEN}" | helm registry login ghcr.io --username "${GH_ACTOR}" --password-stdin
+          echo "${GITHUB_TOKEN}" | cosign login ghcr.io --username "${GH_ACTOR}" --password-stdin
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_ACTOR: ${{ github.actor }}
 
       - name: Build and push Helm chart
         id: release

--- a/.github/workflows/release-principal-chart.yaml
+++ b/.github/workflows/release-principal-chart.yaml
@@ -7,39 +7,69 @@ on:
     paths:
       - 'install/helm-repo/argocd-agent-principal/**'
 
+concurrency:
+  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.ref }}
+
 permissions:
   contents: read
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
 jobs:
-  release-chart:
-    name: Build and push principal Helm chart
+  release-principal-chart:
+    name: Package, push, and sign principal Helm chart
     if: github.repository == 'argoproj-labs/argocd-agent'
     runs-on: ubuntu-22.04
     permissions:
-      contents: write
+      contents: read
       packages: write
+      id-token: write
+    outputs:
+      digest: ${{ steps.release.outputs.digest }}
+      chart_version: ${{ steps.release.outputs.chart_version }}
+      chart_ref: ${{ steps.release.outputs.chart_ref }}
+      pushed: ${{ steps.release.outputs.pushed }}
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          fetch-depth: 0
           persist-credentials: false
 
-      - name: Configure Git
-        run: |
-          git config user.name "$GITHUB_ACTOR"
-          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
-
-      - name: Release chart
-        uses: bitdeps/helm-oci-charts-releaser@caedceea2a5ab997c7e5469a999811dbb3d5b070 # v0.1.5
+      - name: Install Helm
+        uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
         with:
-          charts_dir: install/helm-repo/argocd-agent-principal
-          oci_registry: ghcr.io/${{ github.repository }}
-          oci_username: ${{ github.actor }}
-          oci_password: ${{ secrets.GITHUB_TOKEN }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          tag_name_pattern: '{chartName}-chart'
+          version: v3.20.2
+
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@ba7bc0a3fef59531c69a25acd34668d6d3fe6f22 # v4.1.0
+
+      - name: Login to GHCR
+        run: |
+          echo "${GITHUB_TOKEN}" | helm registry login ghcr.io --username "${{ github.actor }}" --password-stdin
+          echo "${GITHUB_TOKEN}" | cosign login ghcr.io --username "${{ github.actor }}" --password-stdin
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Helm chart
+        id: release
+        run: ./hack/release-helm-chart.sh install/helm-repo/argocd-agent-principal "ghcr.io/${{ github.repository }}"
+
+      - name: Sign Helm chart with Cosign
+        if: steps.release.outputs.pushed == 'true'
+        run: |
+          cosign sign \
+            -a "repo=${{ github.repository }}" \
+            -a "workflow=${GITHUB_WORKFLOW}" \
+            -a "sha=${{ github.sha }}" \
+            -y \
+            ${CHART_REF}@${DIGEST}
+        env:
+          CHART_REF: ${{ steps.release.outputs.chart_ref }}
+          DIGEST: ${{ steps.release.outputs.digest }}
+
+      - name: Upload chart package
+        if: steps.release.outputs.pushed == 'true'
+        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+        with:
+          name: helm-chart-package
+          path: ${{ steps.release.outputs.package }}
+          retention-days: 1

--- a/.github/workflows/release-principal-chart.yaml
+++ b/.github/workflows/release-principal-chart.yaml
@@ -23,6 +23,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Configure Git
         run: |

--- a/hack/release-helm-chart.sh
+++ b/hack/release-helm-chart.sh
@@ -48,11 +48,21 @@ if [[ ! -f "${PACKAGE_FILE}" ]]; then
 fi
 
 echo "==> Checking if ${CHART_NAME}:${CHART_VERSION} already exists in registry..."
-if helm show chart "oci://${REGISTRY}/${CHART_NAME}" --version "${CHART_VERSION}" >/dev/null 2>&1; then
+SHOW_STDERR=$(mktemp)
+if helm show chart "oci://${REGISTRY}/${CHART_NAME}" --version "${CHART_VERSION}" >/dev/null 2>"${SHOW_STDERR}"; then
 	echo "Chart ${CHART_NAME}:${CHART_VERSION} already exists in registry, skipping push"
 	echo "pushed=false" >> "${GITHUB_OUTPUT:-/dev/null}"
-	rm -rf "${PACKAGE_DIR}"
+	rm -rf "${PACKAGE_DIR}" "${SHOW_STDERR}"
 	exit 0
+fi
+SHOW_ERR=$(cat "${SHOW_STDERR}")
+rm -f "${SHOW_STDERR}"
+if echo "${SHOW_ERR}" | grep -qiE 'not found|404|manifest unknown|no such host.*no such chart'; then
+	echo "==> Chart not found in registry, proceeding with push"
+else
+	echo "Error: unexpected failure checking registry for ${CHART_NAME}:${CHART_VERSION}" >&2
+	echo "${SHOW_ERR}" >&2
+	exit 1
 fi
 
 echo "==> Pushing chart to oci://${REGISTRY}..."

--- a/hack/release-helm-chart.sh
+++ b/hack/release-helm-chart.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+# Copyright 2025 The argocd-agent Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+CHART_DIR="${1:?Usage: $0 <chart-dir> <registry>}"
+REGISTRY="${2:?Usage: $0 <chart-dir> <registry>}"
+
+if [[ ! -f "${CHART_DIR}/Chart.yaml" ]]; then
+	echo "Error: ${CHART_DIR}/Chart.yaml not found" >&2
+	exit 1
+fi
+
+CHART_NAME=$(grep '^name:' "${CHART_DIR}/Chart.yaml" | awk '{print $2}')
+CHART_VERSION=$(grep '^version:' "${CHART_DIR}/Chart.yaml" | awk '{print $2}')
+
+if [[ -z "${CHART_NAME}" || -z "${CHART_VERSION}" ]]; then
+	echo "Error: could not extract name or version from ${CHART_DIR}/Chart.yaml" >&2
+	exit 1
+fi
+
+echo "==> Chart: ${CHART_NAME} v${CHART_VERSION}"
+echo "==> Registry: ${REGISTRY}"
+
+echo "==> Linting chart..."
+helm lint "${CHART_DIR}"
+
+echo "==> Packaging chart..."
+PACKAGE_DIR=$(mktemp -d)
+helm package "${CHART_DIR}" --destination "${PACKAGE_DIR}"
+PACKAGE_FILE="${PACKAGE_DIR}/${CHART_NAME}-${CHART_VERSION}.tgz"
+
+if [[ ! -f "${PACKAGE_FILE}" ]]; then
+	echo "Error: expected package ${PACKAGE_FILE} not found" >&2
+	exit 1
+fi
+
+echo "==> Checking if ${CHART_NAME}:${CHART_VERSION} already exists in registry..."
+if helm show chart "oci://${REGISTRY}/${CHART_NAME}" --version "${CHART_VERSION}" >/dev/null 2>&1; then
+	echo "Chart ${CHART_NAME}:${CHART_VERSION} already exists in registry, skipping push"
+	echo "pushed=false" >> "${GITHUB_OUTPUT:-/dev/null}"
+	rm -rf "${PACKAGE_DIR}"
+	exit 0
+fi
+
+echo "==> Pushing chart to oci://${REGISTRY}..."
+OUTPUT=$(helm push "${PACKAGE_FILE}" "oci://${REGISTRY}" 2>&1)
+echo "${OUTPUT}"
+
+DIGEST=$(echo "${OUTPUT}" | grep "Digest:" | awk '{print $2}')
+if [[ -z "${DIGEST}" ]]; then
+	echo "Error: could not extract digest from helm push output" >&2
+	exit 1
+fi
+
+echo "==> Pushed ${CHART_NAME}:${CHART_VERSION} with digest ${DIGEST}"
+
+if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+	{
+		echo "chart_name=${CHART_NAME}"
+		echo "chart_version=${CHART_VERSION}"
+		echo "chart_ref=${REGISTRY}/${CHART_NAME}"
+		echo "digest=${DIGEST}"
+		echo "package=${PACKAGE_FILE}"
+		echo "pushed=true"
+	} >> "${GITHUB_OUTPUT}"
+fi


### PR DESCRIPTION
assisted-by: ClaudeCode

**What does this PR do / why we need it**:
~Use [helm-oci-charts-releaser](https://github.com/bitdeps/helm-oci-charts-releaser) to build, push to GHCR, and~ Build and release  both agent and principal charts. Separate workflows per chart for independent configurability. 

**Which issue(s) this PR fixes**:

Fixes #883

**How to test changes / Special notes to the reviewer**:


**Checklist**

* [ ] Documentation update is required by this PR (and has been updated) OR no documentation update is required.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Chores**
  * Added automated pipelines to package, publish, and (when publishing occurs) sign Helm charts to the container registry for both the agent and principal variants.
  * Introduced a shared Helm release script that lints, packages, avoids republishing existing versions, publishes to OCI, and provides chart metadata.
* **Bug Fixes**
  * Enhanced CI to ensure the principal chart version is bumped on pull requests (head version must be greater than base).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->