### PR TITLE
fix: migrate from deprecated golang.org/x/net/http2/h2c to net/http.Protocols

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,6 @@ require (
 	go.opentelemetry.io/otel/sdk v1.44.0
 	go.opentelemetry.io/otel/trace v1.44.0
 	golang.org/x/crypto v0.50.0
-	golang.org/x/net v0.53.0
 	golang.org/x/sync v0.21.0
 	golang.stackrox.io/grpc-http1 v0.5.1
 	google.golang.org/genproto/googleapis/api v0.0.0-20260401024825-9d38bb4040a9
@@ -178,6 +177,7 @@ require (
 	go.uber.org/zap v1.27.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.2 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
+	golang.org/x/net v0.53.0 // indirect
 	golang.org/x/oauth2 v0.36.0 // indirect
 	golang.org/x/sys v0.45.0 // indirect
 	golang.org/x/term v0.42.0 // indirect

--- a/principal/listen.go
+++ b/principal/listen.go
@@ -25,8 +25,6 @@ import (
 
 	grpcprom "github.com/grpc-ecosystem/go-grpc-middleware/providers/prometheus"
 	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
-	"golang.org/x/net/http2"
-	"golang.org/x/net/http2/h2c"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/keepalive"
@@ -216,8 +214,12 @@ func (s *Server) serveGRPC(ctx context.Context, metrics *metrics.PrincipalMetric
 		downgradingHandler := grpchttp1server.CreateDowngradingHandler(s.grpcServer, http.NotFoundHandler(), opts...)
 		downgradingServer := &http.Server{
 			TLSConfig: tlsConfig,
-			Handler:   h2c.NewHandler(downgradingHandler, &http2.Server{}),
+			Handler:   downgradingHandler,
 		}
+		downgradingServer.Protocols = new(http.Protocols)
+		downgradingServer.Protocols.SetHTTP1(true)
+		downgradingServer.Protocols.SetHTTP2(true)
+		downgradingServer.Protocols.SetUnencryptedHTTP2(true)
 
 		go func() {
 			// Use plaintext HTTP if TLS is disabled (e.g., behind Istio)


### PR DESCRIPTION
**What does this PR do / why we need it**:
migrated from deprecated golang.org/x/net/http2/h2c to net/http.Protocols

**Which issue(s) this PR fixes**:

Fixes #1000 

**How to test changes / Special notes to the reviewer**:


**Checklist**

* [ ] Documentation update is required by this PR (and has been updated) OR no documentation update is required.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when serving mixed HTTP and gRPC traffic, especially for local and proxied connections.
  * Enhanced server protocol handling to better support standard HTTP, HTTP/2, and unencrypted HTTP/2 scenarios.
* **Chores**
  * Reclassified a dependency in the project configuration without changing its version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->