### PR TITLE
fix(test): fix intermittent Test_ApplicationManagementAPI failure

### DIFF
--- a/test/e2e/application_test.go
+++ b/test/e2e/application_test.go
@@ -62,21 +62,20 @@ func (s *ApplicationTestSuite) Test_ApplicationManagementAPI() {
 		},
 	}
 
-	// CreateApplication may fail if the server's project informer cache is not synced.
-	// Retry if the error is "project does not exist".
+	// CreateApplication may fail if the server's project informer cache has not
+	// yet synced the "default" AppProject after startup. Only that specific
+	// error is retryable; any other failure stops the loop immediately.
 	var createdApp *v1alpha1.Application
+	var createErr error
 	requires.Eventually(func() bool {
-		var createErr error
 		createdApp, createErr = s.argoClient.CreateApplication(app)
-		if createErr != nil {
-			if strings.Contains(createErr.Error(), "project does not exist") {
-				s.T().Logf("Project does not exist, retrying...")
-				return false
-			}
-			requires.NoError(createErr, "failed to create application")
+		if createErr != nil && strings.Contains(createErr.Error(), "project does not exist") {
+			s.T().Logf("Project does not exist in informer cache, retrying...")
+			return false
 		}
 		return true
 	}, 60*time.Second, 2*time.Second)
+	requires.NoError(createErr, "failed to create application")
 	asserts.Equal(appName, createdApp.Name)
 
 	// 2. Get Application and verify

--- a/test/e2e/application_test.go
+++ b/test/e2e/application_test.go
@@ -1,7 +1,9 @@
 package e2e
 
 import (
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/argoproj-labs/argocd-agent/test/e2e/fixture"
 	"github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
@@ -60,9 +62,21 @@ func (s *ApplicationTestSuite) Test_ApplicationManagementAPI() {
 		},
 	}
 
-	// 1. Create Application
-	createdApp, err := s.argoClient.CreateApplication(app)
-	requires.NoError(err)
+	// CreateApplication may fail if the server's project informer cache is not synced.
+	// Retry if the error is "project does not exist".
+	var createdApp *v1alpha1.Application
+	requires.Eventually(func() bool {
+		var createErr error
+		createdApp, createErr = s.argoClient.CreateApplication(app)
+		if createErr != nil {
+			if strings.Contains(createErr.Error(), "project does not exist") {
+				s.T().Logf("Project does not exist, retrying...")
+				return false
+			}
+			requires.NoError(createErr, "failed to create application")
+		}
+		return true
+	}, 60*time.Second, 2*time.Second)
 	asserts.Equal(appName, createdApp.Name)
 
 	// 2. Get Application and verify


### PR DESCRIPTION
**What does this PR do / why we need it**:
`Test_ApplicationManagementAPI` creates the application via the argocd API. The Argo CD server relies on the AppProject informer cache, and the test may fail intermittently if the project referenced by the app doesn't exist in the cache. Retry creating the app if the API call fails due to the `project doesn't exist` error.

```shell
=== RUN   TestApplicationSuite/Test_ApplicationManagementAPI
    fixture.go:112: Test begun at: 2026-06-27 14:59:41.058546373 +0000 UTC m=+154.661252761
    application_test.go:65: 
        	Error Trace:	/home/runner/work/argocd-agent/argocd-agent/test/e2e/application_test.go:65
        	            				/home/runner/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.26.0.linux-amd64/src/runtime/asm_amd64.s:1771
        	Error:      	Received unexpected error:
        	            	failed to create application: status 400, body: {"error":"app is not allowed in project \"default\", or the project does not exist","code":3,"message":"app is not allowed in project \"default\", or the project does not exist"}
        	Test:       	TestApplicationSuite/Test_ApplicationManagementAPI
    fixture.go:116: Test ended at: 2026-06-27 14:59:41.065578321 +0000 UTC m=+154.668284729

```

**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:


**Checklist**

* [ ] Documentation update is required by this PR (and has been updated) OR no documentation update is required.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved application creation test resilience by retrying temporary “project does not exist” errors before failing, reducing flaky test failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->