### PR TITLE
docs(getting-started): use server-side apply for install manifests

### DIFF
--- a/docs/getting-started/kubernetes/index.md
+++ b/docs/getting-started/kubernetes/index.md
@@ -168,7 +168,6 @@ Change <release-branch> to the release you wish to use:
 
 ```bash
 kubectl apply -n argocd \
-  --server-side \
   -k 'https://github.com/argoproj-labs/argocd-agent/install/kubernetes/principal?ref=<release-branch>' \
   --context <control-plane-context>
 ```
@@ -246,6 +245,7 @@ Replace <release-branch> with the release you wish to use:
 ```bash
 # For managed agents
 kubectl apply -n argocd \
+  --server-side \
   -k 'https://github.com/argoproj-labs/argocd-agent/install/kubernetes/argo-cd/agent-managed?ref=<release-branch>' \
   --context <workload-cluster-context>
 

--- a/docs/getting-started/kubernetes/index.md
+++ b/docs/getting-started/kubernetes/index.md
@@ -64,6 +64,9 @@ kubectl create namespace argocd --context <control-plane-context>
 
 Install a customized Argo CD instance that excludes components that will run on workload clusters replacing <release-branch> with the release you wish to use:
 
+!!! note "Server-side apply required"
+    The Argo CD principal manifest is large and exceeds Kubernetes annotation size limits when using client-side apply. Server-side apply prevents annotation size failures.
+
 ```bash
 # Apply the principal-specific Argo CD configuration
 kubectl apply -n argocd \
@@ -165,6 +168,7 @@ Change <release-branch> to the release you wish to use:
 
 ```bash
 kubectl apply -n argocd \
+  --server-side \
   -k 'https://github.com/argoproj-labs/argocd-agent/install/kubernetes/principal?ref=<release-branch>' \
   --context <control-plane-context>
 ```
@@ -242,7 +246,6 @@ Replace <release-branch> with the release you wish to use:
 ```bash
 # For managed agents
 kubectl apply -n argocd \
-  --server-side \
   -k 'https://github.com/argoproj-labs/argocd-agent/install/kubernetes/argo-cd/agent-managed?ref=<release-branch>' \
   --context <workload-cluster-context>
 

--- a/docs/getting-started/kubernetes/index.md
+++ b/docs/getting-started/kubernetes/index.md
@@ -65,7 +65,7 @@ kubectl create namespace argocd --context <control-plane-context>
 Install a customized Argo CD instance that excludes components that will run on workload clusters replacing <release-branch> with the release you wish to use:
 
 !!! note "Server-side apply required"
-    The Argo CD principal manifest is large and exceeds Kubernetes annotation size limits when using client-side apply. Server-side apply prevents annotation size failures.
+    The Argo CD manifest is large and exceeds Kubernetes annotation size limits when using client-side apply. Server-side apply prevents annotation size failures.
 
 ```bash
 # Apply the principal-specific Argo CD configuration

--- a/docs/getting-started/kubernetes/istio/index.md
+++ b/docs/getting-started/kubernetes/istio/index.md
@@ -396,7 +396,7 @@ kubectl label namespace $NAMESPACE_NAME istio-injection=enabled --context kind-$
 ### Install Argo CD for Workload Cluster
 
 ```bash
-kubectl apply -n $NAMESPACE_NAME \
+kubectl apply -n $NAMESPACE_NAME --server-side \
   -k "https://github.com/argoproj-labs/argocd-agent/install/kubernetes/argo-cd/agent-$AGENT_MODE?ref=$RELEASE_BRANCH" \
   --context kind-$AGENT_CLUSTER_NAME
 ```

--- a/docs/getting-started/kubernetes/istio/index.md
+++ b/docs/getting-started/kubernetes/istio/index.md
@@ -157,8 +157,11 @@ kubectl label namespace $NAMESPACE_NAME istio-injection=enabled --context kind-$
 ### Install Argo CD for Control Plane
 Install Principal-specific Argo CD configuration.
 
+!!! note "Server-side apply required"
+    The Argo CD principal manifest is large and exceeds Kubernetes annotation size limits when using client-side apply. Server-side apply prevents annotation size failures.
+
 ```bash
-kubectl apply -n $NAMESPACE_NAME \
+kubectl apply -n $NAMESPACE_NAME --server-side \
   -k "https://github.com/argoproj-labs/argocd-agent/install/kubernetes/argo-cd/principal?ref=$RELEASE_BRANCH" \
   --context kind-$PRINCIPAL_CLUSTER_NAME
 ```

--- a/docs/getting-started/kubernetes/istio/index.md
+++ b/docs/getting-started/kubernetes/istio/index.md
@@ -395,6 +395,9 @@ kubectl label namespace $NAMESPACE_NAME istio-injection=enabled --context kind-$
 
 ### Install Argo CD for Workload Cluster
 
+!!! note "Server-side apply required"
+    The Argo CD principal manifest is large and exceeds Kubernetes annotation size limits when using client-side apply. Server-side apply prevents annotation size failures.
+
 ```bash
 kubectl apply -n $NAMESPACE_NAME --server-side \
   -k "https://github.com/argoproj-labs/argocd-agent/install/kubernetes/argo-cd/agent-$AGENT_MODE?ref=$RELEASE_BRANCH" \

--- a/docs/getting-started/kubernetes/istio/index.md
+++ b/docs/getting-started/kubernetes/istio/index.md
@@ -158,7 +158,7 @@ kubectl label namespace $NAMESPACE_NAME istio-injection=enabled --context kind-$
 Install Principal-specific Argo CD configuration.
 
 !!! note "Server-side apply required"
-    The Argo CD principal manifest is large and exceeds Kubernetes annotation size limits when using client-side apply. Server-side apply prevents annotation size failures.
+    The Argo CD manifest is large and exceeds Kubernetes annotation size limits when using client-side apply. Server-side apply prevents annotation size failures.
 
 ```bash
 kubectl apply -n $NAMESPACE_NAME --server-side \
@@ -396,7 +396,7 @@ kubectl label namespace $NAMESPACE_NAME istio-injection=enabled --context kind-$
 ### Install Argo CD for Workload Cluster
 
 !!! note "Server-side apply required"
-    The Argo CD principal manifest is large and exceeds Kubernetes annotation size limits when using client-side apply. Server-side apply prevents annotation size failures.
+    The Argo CD manifest is large and exceeds Kubernetes annotation size limits when using client-side apply. Server-side apply prevents annotation size failures.
 
 ```bash
 kubectl apply -n $NAMESPACE_NAME --server-side \

--- a/docs/getting-started/kubernetes/kind/index.md
+++ b/docs/getting-started/kubernetes/kind/index.md
@@ -334,6 +334,9 @@ kubectl create namespace $NAMESPACE_NAME --context kind-$AGENT_CLUSTER_NAME
 
 ### Install Argo CD for Workload Cluster
 
+!!! note "Server-side apply required"
+    The Argo CD principal manifest is large and exceeds Kubernetes annotation size limits when using client-side apply. Server-side apply prevents annotation size failures.
+
 ```bash
 kubectl apply -n $NAMESPACE_NAME --server-side \
   -k "https://github.com/argoproj-labs/argocd-agent/install/kubernetes/argo-cd/agent-$AGENT_MODE?ref=$RELEASE_BRANCH" \

--- a/docs/getting-started/kubernetes/kind/index.md
+++ b/docs/getting-started/kubernetes/kind/index.md
@@ -335,7 +335,7 @@ kubectl create namespace $NAMESPACE_NAME --context kind-$AGENT_CLUSTER_NAME
 ### Install Argo CD for Workload Cluster
 
 ```bash
-kubectl apply -n $NAMESPACE_NAME \
+kubectl apply -n $NAMESPACE_NAME --server-side \
   -k "https://github.com/argoproj-labs/argocd-agent/install/kubernetes/argo-cd/agent-$AGENT_MODE?ref=$RELEASE_BRANCH" \
   --context kind-$AGENT_CLUSTER_NAME
 ```
@@ -354,10 +354,10 @@ This configuration includes:
 
 ### (Optional) Install Argo CD for Workload Cluster with ApplicationSet (Autonomous mode only)
 
-**Instead of the standard install above**, use the following command with `--server-side=true` (required due to the large ApplicationSet CRD):
+**Instead of the standard install above**, use the following command with `--server-side` (required due to the large ApplicationSet CRD):
 
 ```bash
-kubectl apply -n $NAMESPACE_NAME --server-side=true \
+kubectl apply -n $NAMESPACE_NAME --server-side \
   -k "https://github.com/argoproj-labs/argocd-agent/install/kubernetes/argo-cd/agent-autonomous-appset?ref=$RELEASE_BRANCH" \
   --context kind-$AGENT_CLUSTER_NAME
 ```

--- a/docs/getting-started/kubernetes/kind/index.md
+++ b/docs/getting-started/kubernetes/kind/index.md
@@ -120,7 +120,7 @@ kubectl create namespace $NAMESPACE_NAME --context kind-$PRINCIPAL_CLUSTER_NAME
 Install Principal-specific Argo CD configuration.
 
 !!! note "Server-side apply required"
-    The Argo CD principal manifest is large and exceeds Kubernetes annotation size limits when using client-side apply. Server-side apply prevents annotation size failures.
+    The Argo CD manifest is large and exceeds Kubernetes annotation size limits when using client-side apply. Server-side apply prevents annotation size failures.
 
 ```bash
 kubectl apply -n $NAMESPACE_NAME --server-side \
@@ -335,7 +335,7 @@ kubectl create namespace $NAMESPACE_NAME --context kind-$AGENT_CLUSTER_NAME
 ### Install Argo CD for Workload Cluster
 
 !!! note "Server-side apply required"
-    The Argo CD principal manifest is large and exceeds Kubernetes annotation size limits when using client-side apply. Server-side apply prevents annotation size failures.
+    The Argo CD manifest is large and exceeds Kubernetes annotation size limits when using client-side apply. Server-side apply prevents annotation size failures.
 
 ```bash
 kubectl apply -n $NAMESPACE_NAME --server-side \

--- a/docs/getting-started/kubernetes/kind/index.md
+++ b/docs/getting-started/kubernetes/kind/index.md
@@ -119,8 +119,11 @@ kubectl create namespace $NAMESPACE_NAME --context kind-$PRINCIPAL_CLUSTER_NAME
 ### Install Argo CD for Control Plane
 Install Principal-specific Argo CD configuration.
 
+!!! note "Server-side apply required"
+    The Argo CD principal manifest is large and exceeds Kubernetes annotation size limits when using client-side apply. Server-side apply prevents annotation size failures.
+
 ```bash
-kubectl apply -n $NAMESPACE_NAME \
+kubectl apply -n $NAMESPACE_NAME --server-side \
   -k "https://github.com/argoproj-labs/argocd-agent/install/kubernetes/argo-cd/principal?ref=$RELEASE_BRANCH" \
   --context kind-$PRINCIPAL_CLUSTER_NAME
 ```


### PR DESCRIPTION
## Summary
This PR updates getting-started documentation to consistently use server-side apply for install kustomizations.

## Why
Client-side apply stores full manifests in the `kubectl.kubernetes.io/last-applied-configuration` annotation. Large CRDs such as `applicationsets.argoproj.io` can exceed Kubernetes annotation size limits and fail installation. Server-side apply avoids that failure mode.

## Changes
1. Updated install commands in `docs/getting-started/kubernetes/kind/index.md` to use `--server-side`.
2. Updated install commands in `docs/getting-started/kubernetes/istio/index.md` to use `--server-side`.
3. Updated remaining install commands in `docs/getting-started/kubernetes/index.md` to use `--server-side` where client-side apply was still used.
4. Kept command structure, variables, and contexts unchanged apart from apply mode.

## Validation
1. Verified command snippets still render correctly in docs.
2. Verified all updated commands preserve existing env vars and contexts.
3. Confirmed consistency across Kubernetes, Kind, and Istio getting-started docs.

## References
1. https://github.com/argoproj-labs/argocd-agent/issues/788
2. https://github.com/argoproj-labs/argocd-agent/pull/789
3. https://github.com/argoproj-labs/argocd-agent/pull/614
4. https://github.com/argoproj-labs/argocd-agent/pull/731
5. https://github.com/argoproj-labs/argocd-agent/pull/810

## Notes
This is a docs-only change intended to align getting-started guidance with current install constraints and avoid CRD annotation-size failures.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Kubernetes getting-started guides (Kubernetes, Istio, and Kind) to instruct installing the Argo CD principal using `kubectl apply --server-side`, with a note that the manifest may exceed Kubernetes annotation size limits with client-side apply.
  * Updated Kind install steps for both the control plane and workload cluster to require server-side apply, and simplified the ApplicationSet `--server-side` flag for autonomous-mode installation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->