### PR TITLE
fix(helm): prevent resource name collisions on long release names

### DIFF
--- a/install/helm-repo/argocd-agent-agent/Chart.yaml
+++ b/install/helm-repo/argocd-agent-agent/Chart.yaml
@@ -5,7 +5,7 @@ description: Argo CD Agent for connecting managed clusters to a Principal
 type: application
 
 # chart version
-version: 0.2.4
+version: 0.2.5
 
 # application version, ArgoCD Agent version
 appVersion: v0.8.1

--- a/install/helm-repo/argocd-agent-agent/README.md
+++ b/install/helm-repo/argocd-agent-agent/README.md
@@ -1,6 +1,6 @@
 # argocd-agent-agent
 
-![Version: 0.2.4](https://img.shields.io/badge/Version-0.2.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.8.1](https://img.shields.io/badge/AppVersion-v0.8.1-informational?style=flat-square)
+![Version: 0.2.5](https://img.shields.io/badge/Version-0.2.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.8.1](https://img.shields.io/badge/AppVersion-v0.8.1-informational?style=flat-square)
 
 Argo CD Agent for connecting managed clusters to a Principal
 

--- a/install/helm-repo/argocd-agent-agent/templates/_helpers.tpl
+++ b/install/helm-repo/argocd-agent-agent/templates/_helpers.tpl
@@ -35,6 +35,28 @@ Base name for Helm-created resources, derived from the release.
 {{- end }}
 
 {{/*
+Produce a Kubernetes-compliant name (<= 63 chars, the DNS label limit).
+
+If the input already fits, it is returned unchanged. Otherwise it is
+truncated to 54 chars and suffixed with an 8-char hash derived from the
+full, untruncated input. This guarantees that two inputs which only differ
+in their tail (e.g. "<base>-metrics" vs "<base>-healthz") still produce
+distinct, deterministic names after truncation, instead of silently
+colliding once the differentiating suffix is cut off.
+
+Usage: {{ include "argocd-agent-agent.safeName" "some-long-candidate-name" }}
+*/}}
+{{- define "argocd-agent-agent.safeName" -}}
+{{- $name := . -}}
+{{- if le (len $name) 63 -}}
+{{- $name -}}
+{{- else -}}
+{{- $hash := $name | sha256sum | trunc 8 -}}
+{{- printf "%s-%s" ($name | trunc 54 | trimSuffix "-") $hash -}}
+{{- end -}}
+{{- end }}
+
+{{/*
 Helper to append a suffix to the resource base name.
 Usage: {{ include "argocd-agent-agent.resourceName" (dict "root" . "suffix" "metrics") }}
 */}}
@@ -43,9 +65,9 @@ Usage: {{ include "argocd-agent-agent.resourceName" (dict "root" . "suffix" "met
 {{- $suffix := .suffix | default "" -}}
 {{- $base := include "argocd-agent-agent.agentBaseName" $root -}}
 {{- if $suffix }}
-{{- printf "%s-%s" $base $suffix | trunc 63 | trimSuffix "-" }}
+{{- include "argocd-agent-agent.safeName" (printf "%s-%s" $base $suffix) }}
 {{- else }}
-{{- $base }}
+{{- include "argocd-agent-agent.safeName" $base }}
 {{- end }}
 {{- end }}
 
@@ -91,7 +113,7 @@ Common resource-specific helpers.
 Name for resources used exclusively by Helm tests.
 */}}
 {{- define "argocd-agent-agent.testResourceName" -}}
-{{- printf "%s-test" (include "argocd-agent-agent.agentBaseName" .) | trunc 63 | trimSuffix "-" }}
+{{- include "argocd-agent-agent.resourceName" (dict "root" . "suffix" "test") }}
 {{- end }}
 
 {{/*

--- a/install/helm-repo/argocd-agent-principal/Chart.yaml
+++ b/install/helm-repo/argocd-agent-principal/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: argocd-agent-principal
 description: Argo CD Agent Principal component for multi-cluster application management
 type: application
-version: 0.3.1
+version: 0.3.2
 appVersion: "v0.8.1"
 home: https://github.com/argoproj-labs/argocd-agent
 sources:

--- a/install/helm-repo/argocd-agent-principal/README.md
+++ b/install/helm-repo/argocd-agent-principal/README.md
@@ -1,6 +1,6 @@
 # argocd-agent-principal
 
-![Version: 0.3.1](https://img.shields.io/badge/Version-0.3.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.8.1](https://img.shields.io/badge/AppVersion-v0.8.1-informational?style=flat-square)
+![Version: 0.3.2](https://img.shields.io/badge/Version-0.3.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.8.1](https://img.shields.io/badge/AppVersion-v0.8.1-informational?style=flat-square)
 
 Argo CD Agent Principal component for multi-cluster application management
 

--- a/install/helm-repo/argocd-agent-principal/templates/_helpers.tpl
+++ b/install/helm-repo/argocd-agent-principal/templates/_helpers.tpl
@@ -31,6 +31,28 @@ Create chart name and version as used by the chart label.
 {{- end }}
 
 {{/*
+Produce a Kubernetes-compliant name (<= 63 chars, the DNS label limit).
+
+If the input already fits, it is returned unchanged. Otherwise it is
+truncated to 54 chars and suffixed with an 8-char hash derived from the
+full, untruncated input. This guarantees that two inputs which only differ
+in their tail (e.g. "<base>-metrics" vs "<base>-healthz") still produce
+distinct, deterministic names after truncation, instead of silently
+colliding once the differentiating suffix is cut off.
+
+Usage: {{ include "argocd-agent-principal.safeName" "some-long-candidate-name" }}
+*/}}
+{{- define "argocd-agent-principal.safeName" -}}
+{{- $name := . -}}
+{{- if le (len $name) 63 -}}
+{{- $name -}}
+{{- else -}}
+{{- $hash := $name | sha256sum | trunc 8 -}}
+{{- printf "%s-%s" ($name | trunc 54 | trimSuffix "-") $hash -}}
+{{- end -}}
+{{- end }}
+
+{{/*
 Create default image tag. Defaults to chart appVersion if not set.
 */}}
 {{- define "argocd-agent-principal.defaultTag" -}}
@@ -89,19 +111,19 @@ Create the name of the service account to use
 Resource name helpers
 */}}
 {{- define "argocd-agent-principal.configMapName" -}}
-{{- printf "%s-params" (include "argocd-agent-principal.fullname" .) }}
+{{- include "argocd-agent-principal.safeName" (printf "%s-params" (include "argocd-agent-principal.fullname" .)) }}
 {{- end }}
 
 {{- define "argocd-agent-principal.serviceName" -}}
-{{- include "argocd-agent-principal.fullname" . }}
+{{- include "argocd-agent-principal.safeName" (include "argocd-agent-principal.fullname" .) }}
 {{- end }}
 
 {{- define "argocd-agent-principal.metricsServiceName" -}}
-{{- printf "%s-metrics" (include "argocd-agent-principal.fullname" .) }}
+{{- include "argocd-agent-principal.safeName" (printf "%s-metrics" (include "argocd-agent-principal.fullname" .)) }}
 {{- end }}
 
 {{- define "argocd-agent-principal.healthzServiceName" -}}
-{{- printf "%s-healthz" (include "argocd-agent-principal.fullname" .) }}
+{{- include "argocd-agent-principal.safeName" (printf "%s-healthz" (include "argocd-agent-principal.fullname" .)) }}
 {{- end }}
 
 {{- define "argocd-agent-principal.redisProxyServiceName" -}}
@@ -113,7 +135,7 @@ argocd-agent-resource-proxy
 {{- end }}
 
 {{- define "argocd-agent-principal.serviceMonitorName" -}}
-{{- printf "%s-servicemonitor" (include "argocd-agent-principal.fullname" .) }}
+{{- include "argocd-agent-principal.safeName" (printf "%s-servicemonitor" (include "argocd-agent-principal.fullname" .)) }}
 {{- end }}
 
 {{- define "argocd-agent-principal.clusterRoleName" -}}
@@ -137,5 +159,5 @@ argocd-agent-resource-proxy
 {{- end }}
 
 {{- define "argocd-agent-principal.testResourceName" -}}
-{{- printf "%s-test" (include "argocd-agent-principal.fullname" .) }}
+{{- include "argocd-agent-principal.safeName" (printf "%s-test" (include "argocd-agent-principal.fullname" .)) }}
 {{- end }}


### PR DESCRIPTION
**What does this PR do / why we need it**:

Installing the `argocd-agent-agent` chart with a sufficiently long release name fails with the error:

```shell
Error: 1 error occurred:
* services "<name>-agent-helm" already exists
```

`agentBaseName` (`<release>-agent-helm`) can itself reach the 63-char DNS label limit. `resourceName` appends a suffix (`-metrics`, `-healthz`, `-role`, etc.) and *then* truncates to 63 chars — by that point the suffix is the part sliced off, so every suffixed resource silently collapses to the same name as the base. In practice this means the metrics and healthz Services (and potentially Role/RoleBinding, ClusterRole/ClusterRoleBinding, etc. for even longer release names) render identically, and Kubernetes rejects the second one on apply.

**Fix**

Introduce `argocd-agent-agent.safeName`, which truncates to 54 chars and appends an 8-char hash of the *full* untruncated candidate name whenever it would exceed 63 chars. Because the hash is derived from the complete base+suffix string, two inputs that only differ in their suffix always produce different, deterministic names.

Short release names are unaffected and will have the full names that fit within the 63-char limit.

Another option I thought of is to truncate long names based on the longest suffix (e.g. `clusterrolebinding` = 18 chars + hyphen = 19 so max safe base is 63 - 19 = 44 for full suffix preservation) but that could be a bit hairy as other object Kinds are added and we need to reduce it even further/yet again. The advantage of this would be more human readable suffixes though so maybe it's worth the maintenance overhead? Open to other ideas.

## Testing

- `helm lint .` passes.
- `helm template <short-release>` output unchanged (no hash suffix added when not needed):

  ```shell
  helm template "test-release" install/helm-repo/argocd-agent-agent -n test 2>&1 \
  | grep "^kind:" -A3 | grep -B1 "name:" | grep -v "kind:" | grep "name:" | sort -u
  name: test-release-agent-helm
  name: test-release-agent-helm-clusterrole
  name: test-release-agent-helm-clusterrolebinding
  name: test-release-agent-helm-healthz
  name: test-release-agent-helm-metrics
  name: test-release-agent-helm-params
  name: test-release-agent-helm-role
  name: test-release-agent-helm-rolebinding
  name: test-release-agent-helm-sa
  ```

- `helm template <62-char-release-name>` previously produced duplicate names for the metrics/healthz Services (and would have for other suffixed resources with a longer name); now every resource has a unique name:

  ```shell
  helm template "argocd-agent-afs1-npintexample-dev-apex-sharedple-np" install/helm-repo/argocd-agent-agent -n test 2>&1 \
  | grep "^kind:" -A3 | grep -B1 "name:" | grep -v "kind:" | grep "name:" | sort -u
  name: argocd-agent-afs1-npintexample-dev-apex-sharedple-np-a-399f7b2d
  name: argocd-agent-afs1-npintexample-dev-apex-sharedple-np-a-4a8fac82
  name: argocd-agent-afs1-npintexample-dev-apex-sharedple-np-a-7d8f636d
  name: argocd-agent-afs1-npintexample-dev-apex-sharedple-np-a-8b34c90f
  name: argocd-agent-afs1-npintexample-dev-apex-sharedple-np-a-9d3ab2b1
  name: argocd-agent-afs1-npintexample-dev-apex-sharedple-np-a-cc1309a6
  name: argocd-agent-afs1-npintexample-dev-apex-sharedple-np-a-e7bf8d81
  name: argocd-agent-afs1-npintexample-dev-apex-sharedple-np-a-eb0819a4
  name: argocd-agent-afs1-npintexample-dev-apex-sharedple-np-agent-helm
  ```

**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:

Install release with a very long name:

  ```shell
  helm template "argocd-agent-afs1-npintexample-dev-apex-sharedple-np" \
  install/helm-repo/argocd-agent-agent \
  -n argocd \
  ```

**Checklist**

- [x] Documentation update is required by this PR (and has been updated) OR no documentation update is required.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

- **New Features**
  - Added deterministic, Kubernetes-safe resource name generation helpers (`safeName`) for long inputs across relevant charts.
- **Bug Fixes**
  - Updated generated resource names (including test resources) to use the new length-safe, hash-suffixed naming approach to avoid truncation-related collisions.
- **Chores**
  - Bumped Helm chart versions for the affected charts.
- **Documentation**
  - Updated chart version badges in the README files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->