### PR TITLE
feat: Add TLS certificate blocklist to revoke agent access by fingerprint

### DIFF
--- a/cmd/argocd-agent/agent.go
+++ b/cmd/argocd-agent/agent.go
@@ -516,17 +516,17 @@ func parseCreds(credStr string) (string, auth.Credentials, error) {
 	var creds auth.Credentials
 	var err error
 	switch p[0] {
-	case "userpass":
+	case auth.MethodUserPass:
 		creds, err = loadCreds(p[1])
 		if err != nil {
 			return "", nil, err
 		}
-		return "userpass", creds, nil
-	case "mtls":
-		return "mtls", auth.Credentials{}, nil
-	case "header":
+		return auth.MethodUserPass, creds, nil
+	case auth.MethodMTLS:
+		return auth.MethodMTLS, auth.Credentials{}, nil
+	case auth.MethodHeader:
 		// Header-based auth doesn't require credentials - the sidecar/proxy injects the header
-		return "header", auth.Credentials{}, nil
+		return auth.MethodHeader, auth.Credentials{}, nil
 	default:
 		return "", nil, fmt.Errorf("unknown auth method: %s", p[0])
 	}

--- a/cmd/argocd-agent/principal.go
+++ b/cmd/argocd-agent/principal.go
@@ -30,6 +30,7 @@ import (
 	"github.com/argoproj-labs/argocd-agent/internal/auth/header"
 	"github.com/argoproj-labs/argocd-agent/internal/auth/mtls"
 	"github.com/argoproj-labs/argocd-agent/internal/auth/userpass"
+	"github.com/argoproj-labs/argocd-agent/internal/blocklist"
 	"github.com/argoproj-labs/argocd-agent/internal/config"
 	"github.com/argoproj-labs/argocd-agent/internal/env"
 	"github.com/argoproj-labs/argocd-agent/internal/grpcutil"
@@ -314,8 +315,20 @@ func NewPrincipalRunCommand() *cobra.Command {
 					}
 				}
 				mtlsauth := mtls.NewMTLSAuthentication(regex, source)
+
+				blockList := blocklist.New()
+				fingerprints, err := blocklist.LoadFromConfigMap(ctx, kubeConfig.Clientset, namespace)
+				if err != nil {
+					logrus.Warnf("Could not load TLS blocklist: %v", err)
+				} else {
+					blockList.Replace(fingerprints)
+					logrus.Infof("Loaded TLS blocklist with %d entries", blockList.Len())
+				}
+				mtlsauth.Blocklist = blockList
+				opts = append(opts, principal.WithBlocklist(blockList))
+
 				logrus.Infof("Using mTLS authentication (source: %s, pattern: %s)", source, regexStr)
-				err := authMethods.RegisterMethod("mtls", mtlsauth)
+				err = authMethods.RegisterMethod("mtls", mtlsauth)
 				if err != nil {
 					cmdutil.Fatal("Could not register mtls auth method: %v", err)
 				}

--- a/cmd/argocd-agent/principal.go
+++ b/cmd/argocd-agent/principal.go
@@ -305,7 +305,7 @@ func NewPrincipalRunCommand() *cobra.Command {
 			}
 
 			switch authMethod {
-			case "mtls":
+			case auth.MethodMTLS:
 				source, regexStr := parseMTLSConfig(authConfig)
 				var regex *regexp.Regexp
 				if regexStr != "" {
@@ -319,16 +319,15 @@ func NewPrincipalRunCommand() *cobra.Command {
 				blockList := blocklist.New()
 				fingerprints, err := blocklist.LoadFromConfigMap(ctx, kubeConfig.Clientset, namespace)
 				if err != nil {
-					logrus.Warnf("Could not load TLS blocklist: %v", err)
-				} else {
-					blockList.Replace(fingerprints)
-					logrus.Infof("Loaded TLS blocklist with %d entries", blockList.Len())
+					cmdutil.Fatal("Could not load TLS blocklist: %v", err)
 				}
+				blockList.Replace(fingerprints)
+				logrus.Infof("Loaded TLS blocklist with %d entries", blockList.Len())
 				mtlsauth.Blocklist = blockList
 				opts = append(opts, principal.WithBlocklist(blockList))
 
 				logrus.Infof("Using mTLS authentication (source: %s, pattern: %s)", source, regexStr)
-				err = authMethods.RegisterMethod("mtls", mtlsauth)
+				err = authMethods.RegisterMethod(auth.MethodMTLS, mtlsauth)
 				if err != nil {
 					cmdutil.Fatal("Could not register mtls auth method: %v", err)
 				}
@@ -337,17 +336,17 @@ func NewPrincipalRunCommand() *cobra.Command {
 				if !requireClientCerts {
 					opts = append(opts, principal.WithRequireClientCerts(true))
 				}
-			case "userpass":
+			case auth.MethodUserPass:
 				userauth := userpass.NewUserPassAuthentication(authConfig)
 				err = userauth.LoadAuthDataFromFile(authConfig)
 				if err != nil {
 					cmdutil.Fatal("Could not load user database: %v", err)
 				}
-				err = authMethods.RegisterMethod("userpass", userauth)
+				err = authMethods.RegisterMethod(auth.MethodUserPass, userauth)
 				if err != nil {
 					cmdutil.Fatal("Could not register userpass auth method: %v", err)
 				}
-			case "header":
+			case auth.MethodHeader:
 				// Generic header-based authentication extracts agent ID from any HTTP header
 				// Format: header:<header-name>:<extraction-regex>
 				headerName, extractionRegex, err := parseHeaderAuth(authConfig)
@@ -358,7 +357,7 @@ func NewPrincipalRunCommand() *cobra.Command {
 				if err := headerAuth.Init(); err != nil {
 					cmdutil.Fatal("Error initializing header auth: %v", err)
 				}
-				err = authMethods.RegisterMethod("header", headerAuth)
+				err = authMethods.RegisterMethod(auth.MethodHeader, headerAuth)
 				if err != nil {
 					cmdutil.Fatal("Could not register header auth method: %v", err)
 				}
@@ -786,12 +785,12 @@ func parseAuth(authStr string) (string, string, error) {
 		return "", "", fmt.Errorf("invalid auth string")
 	}
 	switch p[0] {
-	case "userpass":
-		return "userpass", p[1], nil
-	case "mtls":
-		return "mtls", p[1], nil
-	case "header":
-		return "header", p[1], nil
+	case auth.MethodUserPass:
+		return auth.MethodUserPass, p[1], nil
+	case auth.MethodMTLS:
+		return auth.MethodMTLS, p[1], nil
+	case auth.MethodHeader:
+		return auth.MethodHeader, p[1], nil
 	default:
 		return "", "", fmt.Errorf("unknown auth method: %s", p[0])
 	}
@@ -849,7 +848,7 @@ func parseMTLSConfig(config string) (mtls.IdentitySource, string) {
 //   - mtls auth requires TLS mode (needs client certificates)
 func validateAuthTLSPairing(authMethod string, insecurePlaintext bool) error {
 	switch authMethod {
-	case "header":
+	case auth.MethodHeader:
 		if !insecurePlaintext {
 			return fmt.Errorf("invalid configuration: header-based authentication requires --insecure-plaintext=true\n" +
 				"  Header authentication is designed for service mesh environments (e.g., Istio) where\n" +
@@ -858,7 +857,7 @@ func validateAuthTLSPairing(authMethod string, insecurePlaintext bool) error {
 				"  - Add --insecure-plaintext flag when using header auth behind a service mesh\n" +
 				"  - Use --auth=mtls:<regex> for direct TLS connections without a service mesh")
 		}
-	case "mtls":
+	case auth.MethodMTLS:
 		if insecurePlaintext {
 			return fmt.Errorf("invalid configuration: mtls authentication cannot be used with --insecure-plaintext\n" +
 				"  mTLS authentication requires TLS to be enabled to receive client certificates.\n" +

--- a/cmd/argocd-agent/principal_test.go
+++ b/cmd/argocd-agent/principal_test.go
@@ -17,6 +17,7 @@ package main
 import (
 	"testing"
 
+	"github.com/argoproj-labs/argocd-agent/internal/auth"
 	"github.com/stretchr/testify/require"
 )
 
@@ -30,38 +31,38 @@ func TestValidateAuthTLSPairing(t *testing.T) {
 	}{
 		{
 			name:              "valid: header auth with plaintext mode",
-			authMethod:        "header",
+			authMethod:        auth.MethodHeader,
 			insecurePlaintext: true,
 			expectError:       false,
 		},
 		{
 			name:              "valid: mtls auth with TLS mode",
-			authMethod:        "mtls",
+			authMethod:        auth.MethodMTLS,
 			insecurePlaintext: false,
 			expectError:       false,
 		},
 		{
 			name:              "valid: userpass auth with TLS mode",
-			authMethod:        "userpass",
+			authMethod:        auth.MethodUserPass,
 			insecurePlaintext: false,
 			expectError:       false,
 		},
 		{
 			name:              "valid: userpass auth with plaintext mode",
-			authMethod:        "userpass",
+			authMethod:        auth.MethodUserPass,
 			insecurePlaintext: true,
 			expectError:       false,
 		},
 		{
 			name:              "invalid: header auth without plaintext mode",
-			authMethod:        "header",
+			authMethod:        auth.MethodHeader,
 			insecurePlaintext: false,
 			expectError:       true,
 			errorContains:     "header-based authentication requires --insecure-plaintext=true",
 		},
 		{
 			name:              "invalid: mtls auth with plaintext mode",
-			authMethod:        "mtls",
+			authMethod:        auth.MethodMTLS,
 			insecurePlaintext: true,
 			expectError:       true,
 			errorContains:     "mtls authentication cannot be used with --insecure-plaintext",

--- a/cmd/ctl/agent.go
+++ b/cmd/ctl/agent.go
@@ -341,6 +341,7 @@ func NewAgentInspectCommand() *cobra.Command {
 				Name           string    `yaml:"name" json:"name" text:"Server name"`
 				NotValidBefore time.Time `yaml:"notValidBefore" json:"notValidBefore" text:"Not valid before"`
 				NotValidAfter  time.Time `yaml:"notValidAfter" json:"notValidAfter" text:"Not valid after"`
+				Fingerprint    string    `yaml:"fingerprint" json:"fingerprint" text:"Fingerprint (SHA-256)"`
 			}
 			agentName := args[0]
 			argoCluster, err := loadClusterSecret(agentName)
@@ -354,11 +355,18 @@ func NewAgentInspectCommand() *cobra.Command {
 			if err != nil {
 				cmdutil.Fatal("Not a valid certificate: %v", err)
 			}
+
+			certObj, parseErr := x509.ParseCertificate(cert.Certificate[0])
+			if parseErr != nil {
+				cmdutil.Fatal("Could not parse certificate: %v", parseErr)
+			}
+
 			cluster := &clusterOut{
 				ServerAddr:     argoCluster.Server,
 				Name:           argoCluster.Name,
 				NotValidAfter:  cert.Leaf.NotAfter,
 				NotValidBefore: cert.Leaf.NotBefore,
+				Fingerprint:    tlsutil.CertificateFingerprint(certObj),
 			}
 			var out []byte
 			switch strings.ToLower(outputFormat) {

--- a/cmd/ctl/agent.go
+++ b/cmd/ctl/agent.go
@@ -356,6 +356,9 @@ func NewAgentInspectCommand() *cobra.Command {
 				cmdutil.Fatal("Not a valid certificate: %v", err)
 			}
 
+			if len(cert.Certificate) == 0 {
+				cmdutil.Fatal("Certificate chain is empty")
+			}
 			certObj, parseErr := x509.ParseCertificate(cert.Certificate[0])
 			if parseErr != nil {
 				cmdutil.Fatal("Could not parse certificate: %v", parseErr)

--- a/cmd/ctl/agent.go
+++ b/cmd/ctl/agent.go
@@ -359,6 +359,9 @@ func NewAgentInspectCommand() *cobra.Command {
 			if len(cert.Certificate) == 0 {
 				cmdutil.Fatal("Certificate chain is empty")
 			}
+			if len(cert.Certificate) > 1 {
+				cmdutil.Fatal("Certificate chain contains %d entries, but only 1 is expected. Please ensure the secret contains a single certificate.", len(cert.Certificate))
+			}
 			certObj, parseErr := x509.ParseCertificate(cert.Certificate[0])
 			if parseErr != nil {
 				cmdutil.Fatal("Could not parse certificate: %v", parseErr)

--- a/cmd/ctl/blocklist.go
+++ b/cmd/ctl/blocklist.go
@@ -1,0 +1,162 @@
+// Copyright 2026 The argocd-agent Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/argoproj-labs/argocd-agent/internal/blocklist"
+	"github.com/argoproj-labs/argocd-agent/internal/kube"
+	"github.com/spf13/cobra"
+)
+
+const (
+	errFmtKubeClient    = "failed to create Kubernetes client: %w"
+	errFmtLoadBlocklist = "failed to load blocklist: %w"
+	errFmtSaveBlocklist = "failed to save blocklist: %w"
+)
+
+func NewBlocklistCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "blocklist",
+		Short: "Manage the TLS certificate blocklist",
+	}
+
+	cmd.AddCommand(NewBlocklistAddCommand())
+	cmd.AddCommand(NewBlocklistRemoveCommand())
+	cmd.AddCommand(NewBlocklistListCommand())
+
+	return cmd
+}
+
+func NewBlocklistAddCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "add <fingerprint>",
+		Short: "Add a certificate fingerprint to the blocklist",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			fingerprint := args[0]
+			ctx := context.TODO()
+
+			clt, err := kube.NewKubernetesClientFromConfig(ctx, principalCfg.Namespace, "", principalCfg.KubeContext)
+			if err != nil {
+				return fmt.Errorf(errFmtKubeClient, err)
+			}
+
+			fingerprints, err := blocklist.LoadFromConfigMap(ctx, clt.Clientset, principalCfg.Namespace)
+			if err != nil {
+				return fmt.Errorf(errFmtLoadBlocklist, err)
+			}
+
+			for _, fp := range fingerprints {
+				if fp == fingerprint {
+					fmt.Println("Fingerprint already in blocklist.")
+					return nil
+				}
+			}
+
+			fingerprints = append(fingerprints, fingerprint)
+
+			if err := blocklist.SaveToConfigMap(ctx, clt.Clientset, principalCfg.Namespace, fingerprints); err != nil {
+				return fmt.Errorf(errFmtSaveBlocklist, err)
+			}
+
+			fmt.Printf("Added to blocklist: %s\n", fingerprint)
+			return nil
+		},
+	}
+
+	return cmd
+}
+
+func NewBlocklistRemoveCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "remove <fingerprint>",
+		Short: "Remove a certificate fingerprint from the blocklist",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			fingerprint := args[0]
+			ctx := context.TODO()
+
+			clt, err := kube.NewKubernetesClientFromConfig(ctx, principalCfg.Namespace, "", principalCfg.KubeContext)
+			if err != nil {
+				return fmt.Errorf(errFmtKubeClient, err)
+			}
+
+			fingerprints, err := blocklist.LoadFromConfigMap(ctx, clt.Clientset, principalCfg.Namespace)
+			if err != nil {
+				return fmt.Errorf(errFmtLoadBlocklist, err)
+			}
+
+			found := false
+			filtered := make([]string, 0, len(fingerprints))
+			for _, fp := range fingerprints {
+				if fp == fingerprint {
+					found = true
+					continue
+				}
+				filtered = append(filtered, fp)
+			}
+
+			if !found {
+				fmt.Println("Fingerprint not found in blocklist.")
+				return nil
+			}
+
+			if err := blocklist.SaveToConfigMap(ctx, clt.Clientset, principalCfg.Namespace, filtered); err != nil {
+				return fmt.Errorf(errFmtSaveBlocklist, err)
+			}
+
+			fmt.Printf("Removed from blocklist: %s\n", fingerprint)
+			return nil
+		},
+	}
+
+	return cmd
+}
+
+func NewBlocklistListCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List all fingerprints in the blocklist",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := context.TODO()
+
+			clt, err := kube.NewKubernetesClientFromConfig(ctx, principalCfg.Namespace, "", principalCfg.KubeContext)
+			if err != nil {
+				return fmt.Errorf(errFmtKubeClient, err)
+			}
+
+			fingerprints, err := blocklist.LoadFromConfigMap(ctx, clt.Clientset, principalCfg.Namespace)
+			if err != nil {
+				return fmt.Errorf(errFmtLoadBlocklist, err)
+			}
+
+			if len(fingerprints) == 0 {
+				fmt.Println("No entries in the blocklist.")
+				return nil
+			}
+
+			fmt.Println("FINGERPRINT")
+			for _, fp := range fingerprints {
+				fmt.Println(fp)
+			}
+			return nil
+		},
+	}
+
+	return cmd
+}

--- a/cmd/ctl/blocklist.go
+++ b/cmd/ctl/blocklist.go
@@ -32,17 +32,28 @@ const (
 func NewBlocklistCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "blocklist",
-		Short: "Manage the TLS certificate blocklist",
+		Short: "Manage blocklists",
 	}
 
-	cmd.AddCommand(NewBlocklistAddCommand())
-	cmd.AddCommand(NewBlocklistRemoveCommand())
-	cmd.AddCommand(NewBlocklistListCommand())
+	cmd.AddCommand(NewBlocklistTLSCommand())
 
 	return cmd
 }
 
-func NewBlocklistAddCommand() *cobra.Command {
+func NewBlocklistTLSCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "tls",
+		Short: "Manage the TLS certificate fingerprint blocklist",
+	}
+
+	cmd.AddCommand(NewBlocklistTLSAddCommand())
+	cmd.AddCommand(NewBlocklistTLSRemoveCommand())
+	cmd.AddCommand(NewBlocklistTLSListCommand())
+
+	return cmd
+}
+
+func NewBlocklistTLSAddCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "add <fingerprint>",
 		Short: "Add a certificate fingerprint to the blocklist",
@@ -82,7 +93,7 @@ func NewBlocklistAddCommand() *cobra.Command {
 	return cmd
 }
 
-func NewBlocklistRemoveCommand() *cobra.Command {
+func NewBlocklistTLSRemoveCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "remove <fingerprint>",
 		Short: "Remove a certificate fingerprint from the blocklist",
@@ -128,7 +139,7 @@ func NewBlocklistRemoveCommand() *cobra.Command {
 	return cmd
 }
 
-func NewBlocklistListCommand() *cobra.Command {
+func NewBlocklistTLSListCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "list",
 		Short: "List all fingerprints in the blocklist",

--- a/cmd/ctl/main.go
+++ b/cmd/ctl/main.go
@@ -53,6 +53,7 @@ func NewRootCommand() *cobra.Command {
 	command.AddCommand(NewPKICommand())
 	command.AddCommand(NewJWTCommand())
 	command.AddCommand(NewHACommand())
+	command.AddCommand(NewBlocklistCommand())
 	command.AddCommand(NewVersionCommand())
 	addGlobalFlags(command, globalOpts)
 

--- a/docs/configuration/ctl.md
+++ b/docs/configuration/ctl.md
@@ -14,6 +14,8 @@ These are the available commands for argocd-agentctl. Some commands have subcomm
 
 `jwt` - Inspect and manage JWT signing keys
 
+`blocklist` - Manage the TLS certificate blocklist
+
 `pki` - Inspect and manage the principal's PKI **(NOT FOR PRODUCTION USE)**
 
 ## Global Flags
@@ -141,6 +143,21 @@ principal. JWT signing keys are used by the principal to sign authentication tok
 `delete-key` - Delete the JWT signing key secret
 
 `inspect-key` - Inspect the JWT signing key
+
+## `blocklist` Command
+
+Manage the TLS certificate blocklist for the principal. Agents whose certificate
+fingerprints appear in the blocklist are immediately disconnected and prevented
+from reconnecting. See [TLS Certificate Blocklist](../operations/blocklist.md) for
+full details.
+
+**Subcommands:**
+
+`add <fingerprint>` - Add a certificate fingerprint to the blocklist
+
+`remove <fingerprint>` - Remove a certificate fingerprint from the blocklist
+
+`list` - List all fingerprints currently in the blocklist
 
 ## `pki` Command **(NOT FOR PRODUCTION USE)**
 

--- a/docs/operations/blocklist.md
+++ b/docs/operations/blocklist.md
@@ -1,0 +1,48 @@
+# TLS Certificate Blocklist
+
+The TLS certificate blocklist allows administrators to revoke agent access by blocking their client certificate SHA-256 fingerprints. Blocklisted agents are immediately disconnected and prevented from reconnecting until their fingerprint is removed.
+
+The blocklist is stored in a ConfigMap (`argocd-agent-tls-blocklist`) in the principal's namespace. The principal watches this ConfigMap via an informer and updates its in-memory blocklist dynamically — no restart required. The blocklist persists across principal restarts.
+
+## Applicability
+
+The blocklist operates on client certificate fingerprints, so it applies only to agents using mTLS authentication.
+
+## Finding an Agent's Fingerprint
+
+Inspect an agent to retrieve its certificate fingerprint:
+
+```bash
+argocd-agentctl agent inspect <agent-name> -o json
+```
+
+The principal also logs each agent's fingerprint on successful authentication.
+
+## Managing the Blocklist
+
+### Using argocd-agentctl
+
+```bash
+# Add a fingerprint
+argocd-agentctl blocklist add "A1:2B:3C:4D:..."
+
+# Remove a fingerprint
+argocd-agentctl blocklist remove "A1:2B:3C:4D:..."
+
+# List all blocked fingerprints
+argocd-agentctl blocklist list
+```
+
+## ConfigMap Format
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: argocd-agent-tls-blocklist
+  namespace: argocd
+data:
+  checksums: '["A1:2B:3C:4D:...","E5:F6:7G:8H:..."]'
+```
+
+The `checksums` value is a JSON array of SHA-256 fingerprints in colon-separated uppercase hex format.

--- a/docs/operations/blocklist.md
+++ b/docs/operations/blocklist.md
@@ -43,7 +43,7 @@ metadata:
   namespace: argocd
 data:
   A12B3C4D...: ""
-  E5F67G8H...: ""
+  E5F6A7B8...: ""
 ```
 
 Each key in the `data` map is a SHA-256 fingerprint in uppercase hex format. Values are ignored.

--- a/docs/operations/blocklist.md
+++ b/docs/operations/blocklist.md
@@ -24,10 +24,10 @@ The principal also logs each agent's fingerprint on successful authentication.
 
 ```bash
 # Add a fingerprint
-argocd-agentctl blocklist add "A1:2B:3C:4D:..."
+argocd-agentctl blocklist add "A12B3C4D..."
 
 # Remove a fingerprint
-argocd-agentctl blocklist remove "A1:2B:3C:4D:..."
+argocd-agentctl blocklist remove "A12B3C4D..."
 
 # List all blocked fingerprints
 argocd-agentctl blocklist list
@@ -42,7 +42,8 @@ metadata:
   name: argocd-agent-tls-blocklist
   namespace: argocd
 data:
-  checksums: '["A1:2B:3C:4D:...","E5:F6:7G:8H:..."]'
+  A12B3C4D...: ""
+  E5F67G8H...: ""
 ```
 
-The `checksums` value is a JSON array of SHA-256 fingerprints in colon-separated uppercase hex format.
+Each key in the `data` map is a SHA-256 fingerprint in uppercase hex format. Values are ignored.

--- a/docs/operations/blocklist.md
+++ b/docs/operations/blocklist.md
@@ -24,13 +24,13 @@ The principal also logs each agent's fingerprint on successful authentication.
 
 ```bash
 # Add a fingerprint
-argocd-agentctl blocklist add "A12B3C4D..."
+argocd-agentctl blocklist tls add "A12B3C4D..."
 
 # Remove a fingerprint
-argocd-agentctl blocklist remove "A12B3C4D..."
+argocd-agentctl blocklist tls remove "A12B3C4D..."
 
 # List all blocked fingerprints
-argocd-agentctl blocklist list
+argocd-agentctl blocklist tls list
 ```
 
 ## ConfigMap Format

--- a/internal/auth/methods.go
+++ b/internal/auth/methods.go
@@ -19,6 +19,15 @@ import (
 	"sync"
 )
 
+const (
+	// MethodMTLS is the name of the mTLS authentication method.
+	MethodMTLS = "mtls"
+	// MethodUserPass is the name of the username/password authentication method.
+	MethodUserPass = "userpass"
+	// MethodHeader is the name of the header-based authentication method.
+	MethodHeader = "header"
+)
+
 // Methods provide a thread-safe way to register and look up available auth
 // methods.
 type Methods struct {

--- a/internal/auth/methods_test.go
+++ b/internal/auth/methods_test.go
@@ -35,26 +35,26 @@ func Test_AuthMethods(t *testing.T) {
 	t.Run("Register an auth method and verify", func(t *testing.T) {
 		m := NewMethods()
 		authmethod := &mockAuth{}
-		err := m.RegisterMethod("userpass", authmethod)
+		err := m.RegisterMethod(MethodUserPass, authmethod)
 		require.NoError(t, err)
-		require.NotNil(t, m.Method("userpass"))
+		require.NotNil(t, m.Method(MethodUserPass))
 	})
 
 	t.Run("Register two auth methods under same name", func(t *testing.T) {
 		m := NewMethods()
 		authmethod := &mockAuth{}
-		err := m.RegisterMethod("userpass", authmethod)
+		err := m.RegisterMethod(MethodUserPass, authmethod)
 		require.NoError(t, err)
-		err = m.RegisterMethod("userpass", authmethod)
+		err = m.RegisterMethod(MethodUserPass, authmethod)
 		require.Error(t, err)
 	})
 
 	t.Run("Look up non-existing auth method", func(t *testing.T) {
 		m := NewMethods()
 		authmethod := &mockAuth{}
-		err := m.RegisterMethod("userpass", authmethod)
+		err := m.RegisterMethod(MethodUserPass, authmethod)
 		require.NoError(t, err)
-		require.NotNil(t, m.Method("userpass"))
+		require.NotNil(t, m.Method(MethodUserPass))
 		require.Nil(t, m.Method("username"))
 	})
 

--- a/internal/auth/mtls/mtls.go
+++ b/internal/auth/mtls/mtls.go
@@ -20,6 +20,8 @@ import (
 	"regexp"
 
 	"github.com/argoproj-labs/argocd-agent/internal/auth"
+	"github.com/argoproj-labs/argocd-agent/internal/blocklist"
+	"github.com/argoproj-labs/argocd-agent/internal/tlsutil"
 	"github.com/sirupsen/logrus"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/peer"
@@ -42,6 +44,7 @@ const (
 type MTLSAuthentication struct {
 	AgentIDRegex   *regexp.Regexp
 	IdentitySource IdentitySource
+	Blocklist      *blocklist.Blocklist
 }
 
 func NewMTLSAuthentication(regex *regexp.Regexp, source IdentitySource) *MTLSAuthentication {
@@ -68,6 +71,14 @@ func (m *MTLSAuthentication) Authenticate(ctx context.Context, creds auth.Creden
 		return "", fmt.Errorf("no verified certificates found in TLS cred")
 	}
 	cert := tlsInfo.State.VerifiedChains[0][0]
+
+	if m.Blocklist != nil {
+		fingerprint := tlsutil.CertificateFingerprint(cert)
+		if m.Blocklist.Contains(fingerprint) {
+			logrus.WithField("module", "mtls").WithField("fingerprint", fingerprint).Warn("Rejected blocklisted certificate")
+			return "", fmt.Errorf("certificate is blocklisted")
+		}
+	}
 
 	var identityString string
 	var agentID string

--- a/internal/auth/mtls/mtls_test.go
+++ b/internal/auth/mtls/mtls_test.go
@@ -16,6 +16,8 @@ package mtls
 
 import (
 	"context"
+	"crypto/rand"
+	"crypto/rsa"
 	"crypto/tls"
 	"crypto/x509"
 	"crypto/x509/pkix"
@@ -23,8 +25,12 @@ import (
 	"regexp"
 	"testing"
 
+	"github.com/argoproj-labs/argocd-agent/internal/blocklist"
+	"github.com/argoproj-labs/argocd-agent/internal/tlsutil"
+	"github.com/argoproj-labs/argocd-agent/test/fake/testcerts"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/peer"
 )
@@ -175,6 +181,59 @@ func Test_AuthenticateWithSPIFFE(t *testing.T) {
 		assert.Empty(t, agentID)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "invalid agent ID")
+	})
+}
+
+func Test_Authenticate_Blocklist(t *testing.T) {
+	regex := regexp.MustCompile(`CN=([^,]+)`)
+	auth := NewMTLSAuthentication(regex, IdentitySourceSubject)
+
+	key := testcerts.GeneratePrivateKey(t, "rsa")
+	templ := testcerts.DefaultCertTempl
+	templ.Subject = pkix.Name{CommonName: "agent-1"}
+	raw, err := x509.CreateCertificate(rand.Reader, &templ, &templ, &key.(*rsa.PrivateKey).PublicKey, key)
+	require.NoError(t, err)
+	cert, err := x509.ParseCertificate(raw)
+	require.NoError(t, err)
+	fp := tlsutil.CertificateFingerprint(cert)
+
+	t.Run("allows when blocklist is nil", func(t *testing.T) {
+		auth.Blocklist = nil
+		ctx := generateContext([][]*x509.Certificate{{cert}})
+		agentID, err := auth.Authenticate(ctx, nil)
+		assert.NoError(t, err)
+		assert.Equal(t, "agent-1", agentID)
+	})
+
+	t.Run("allows when fingerprint is not blocklisted", func(t *testing.T) {
+		bl := blocklist.New()
+		auth.Blocklist = bl
+		ctx := generateContext([][]*x509.Certificate{{cert}})
+		agentID, err := auth.Authenticate(ctx, nil)
+		assert.NoError(t, err)
+		assert.Equal(t, "agent-1", agentID)
+	})
+
+	t.Run("rejects when fingerprint is blocklisted", func(t *testing.T) {
+		bl := blocklist.New()
+		bl.Add(fp)
+		auth.Blocklist = bl
+		ctx := generateContext([][]*x509.Certificate{{cert}})
+		agentID, err := auth.Authenticate(ctx, nil)
+		assert.Empty(t, agentID)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "blocklisted")
+	})
+
+	t.Run("allows after fingerprint is removed from blocklist", func(t *testing.T) {
+		bl := blocklist.New()
+		bl.Add(fp)
+		auth.Blocklist = bl
+		bl.Remove(fp)
+		ctx := generateContext([][]*x509.Certificate{{cert}})
+		agentID, err := auth.Authenticate(ctx, nil)
+		assert.NoError(t, err)
+		assert.Equal(t, "agent-1", agentID)
 	})
 }
 

--- a/internal/blocklist/blocklist.go
+++ b/internal/blocklist/blocklist.go
@@ -15,22 +15,8 @@
 package blocklist
 
 import (
-	"encoding/json"
 	"sync"
 )
-
-// ParseFingerprints parses a JSON-encoded list of fingerprint strings.
-// Returns an empty slice for empty input.
-func ParseFingerprints(data string) ([]string, error) {
-	if data == "" {
-		return []string{}, nil
-	}
-	var fingerprints []string
-	if err := json.Unmarshal([]byte(data), &fingerprints); err != nil {
-		return nil, err
-	}
-	return fingerprints, nil
-}
 
 // Blocklist is a thread-safe set of blocked certificate fingerprints.
 type Blocklist struct {

--- a/internal/blocklist/blocklist.go
+++ b/internal/blocklist/blocklist.go
@@ -1,0 +1,94 @@
+// Copyright 2026 The argocd-agent Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package blocklist
+
+import (
+	"encoding/json"
+	"sync"
+)
+
+// ParseFingerprints parses a JSON-encoded list of fingerprint strings.
+// Returns an empty slice for empty input.
+func ParseFingerprints(data string) ([]string, error) {
+	if data == "" {
+		return []string{}, nil
+	}
+	var fingerprints []string
+	if err := json.Unmarshal([]byte(data), &fingerprints); err != nil {
+		return nil, err
+	}
+	return fingerprints, nil
+}
+
+// Blocklist is a thread-safe set of blocked certificate fingerprints.
+type Blocklist struct {
+	entries map[string]bool
+	mu      sync.RWMutex
+}
+
+func New() *Blocklist {
+	return &Blocklist{
+		entries: make(map[string]bool),
+	}
+}
+
+// Add adds a fingerprint to the blocklist.
+func (b *Blocklist) Add(fingerprint string) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.entries[fingerprint] = true
+}
+
+// Remove removes a fingerprint from the blocklist.
+func (b *Blocklist) Remove(fingerprint string) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	delete(b.entries, fingerprint)
+}
+
+// Contains returns true if the given fingerprint is in the blocklist.
+func (b *Blocklist) Contains(fingerprint string) bool {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+	return b.entries[fingerprint]
+}
+
+// List returns all fingerprints in the blocklist.
+func (b *Blocklist) List() []string {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+	fps := make([]string, 0, len(b.entries))
+	for fp := range b.entries {
+		fps = append(fps, fp)
+	}
+	return fps
+}
+
+// Replace atomically replaces all fingerprints in the blocklist.
+func (b *Blocklist) Replace(fingerprints []string) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.entries = make(map[string]bool, len(fingerprints))
+	for _, fp := range fingerprints {
+		b.entries[fp] = true
+	}
+}
+
+// Len returns the number of entries in the blocklist.
+func (b *Blocklist) Len() int {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+	return len(b.entries)
+}

--- a/internal/blocklist/blocklist.go
+++ b/internal/blocklist/blocklist.go
@@ -16,17 +16,28 @@ package blocklist
 
 import (
 	"sync"
+
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/argoproj-labs/argocd-agent/internal/informer"
 )
 
 // Blocklist is a thread-safe set of blocked certificate fingerprints.
+// It also tracks which agent is using which fingerprint, for active
+// disconnects and holds the ConfigMap informer that watches for changes.
 type Blocklist struct {
-	entries map[string]bool
-	mu      sync.RWMutex
+	entries  map[string]bool
+	mu       sync.RWMutex
+	agents   map[string]string
+	agentsMu sync.RWMutex
+	// Informer watches the blocklist ConfigMap for changes.
+	Informer *informer.Informer[*corev1.ConfigMap]
 }
 
 func New() *Blocklist {
 	return &Blocklist{
 		entries: make(map[string]bool),
+		agents:  make(map[string]string),
 	}
 }
 
@@ -77,4 +88,19 @@ func (b *Blocklist) Len() int {
 	b.mu.RLock()
 	defer b.mu.RUnlock()
 	return len(b.entries)
+}
+
+// TrackAgent records that the given agent is using the given fingerprint.
+func (b *Blocklist) TrackAgent(fingerprint, agentName string) {
+	b.agentsMu.Lock()
+	defer b.agentsMu.Unlock()
+	b.agents[fingerprint] = agentName
+}
+
+// AgentForFingerprint returns the agent name associated with the given
+// fingerprint, or empty string if not tracked.
+func (b *Blocklist) AgentForFingerprint(fingerprint string) string {
+	b.agentsMu.RLock()
+	defer b.agentsMu.RUnlock()
+	return b.agents[fingerprint]
 }

--- a/internal/blocklist/blocklist_test.go
+++ b/internal/blocklist/blocklist_test.go
@@ -1,0 +1,111 @@
+// Copyright 2026 The argocd-agent Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package blocklist
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseFingerprints(t *testing.T) {
+	t.Run("empty string returns empty slice", func(t *testing.T) {
+		fps, err := ParseFingerprints("")
+		require.NoError(t, err)
+		assert.Empty(t, fps)
+	})
+
+	t.Run("valid JSON array", func(t *testing.T) {
+		fps, err := ParseFingerprints(`["AA:BB","CC:DD"]`)
+		require.NoError(t, err)
+		assert.Equal(t, []string{"AA:BB", "CC:DD"}, fps)
+	})
+
+	t.Run("empty JSON array", func(t *testing.T) {
+		fps, err := ParseFingerprints(`[]`)
+		require.NoError(t, err)
+		assert.Empty(t, fps)
+	})
+
+	t.Run("invalid JSON returns error", func(t *testing.T) {
+		_, err := ParseFingerprints(`not-json`)
+		assert.Error(t, err)
+	})
+}
+
+func TestBlocklist(t *testing.T) {
+	t.Run("new blocklist is empty", func(t *testing.T) {
+		bl := New()
+		assert.Equal(t, 0, bl.Len())
+		assert.False(t, bl.Contains("AA:BB"))
+	})
+
+	t.Run("add and contains", func(t *testing.T) {
+		bl := New()
+		bl.Add("AA:BB")
+		assert.True(t, bl.Contains("AA:BB"))
+		assert.False(t, bl.Contains("CC:DD"))
+		assert.Equal(t, 1, bl.Len())
+	})
+
+	t.Run("remove", func(t *testing.T) {
+		bl := New()
+		bl.Add("AA:BB")
+		bl.Remove("AA:BB")
+		assert.False(t, bl.Contains("AA:BB"))
+		assert.Equal(t, 0, bl.Len())
+	})
+
+	t.Run("remove non-existent is no-op", func(t *testing.T) {
+		bl := New()
+		bl.Remove("AA:BB")
+		assert.Equal(t, 0, bl.Len())
+	})
+
+	t.Run("list returns all entries", func(t *testing.T) {
+		bl := New()
+		bl.Add("AA:BB")
+		bl.Add("CC:DD")
+		listed := bl.List()
+		assert.Len(t, listed, 2)
+		assert.ElementsMatch(t, []string{"AA:BB", "CC:DD"}, listed)
+	})
+
+	t.Run("replace overwrites all entries", func(t *testing.T) {
+		bl := New()
+		bl.Add("AA:BB")
+		bl.Add("CC:DD")
+		bl.Replace([]string{"EE:FF"})
+		assert.Equal(t, 1, bl.Len())
+		assert.True(t, bl.Contains("EE:FF"))
+		assert.False(t, bl.Contains("AA:BB"))
+		assert.False(t, bl.Contains("CC:DD"))
+	})
+
+	t.Run("replace with empty clears all entries", func(t *testing.T) {
+		bl := New()
+		bl.Add("AA:BB")
+		bl.Replace([]string{})
+		assert.Equal(t, 0, bl.Len())
+	})
+
+	t.Run("add duplicate is idempotent", func(t *testing.T) {
+		bl := New()
+		bl.Add("AA:BB")
+		bl.Add("AA:BB")
+		assert.Equal(t, 1, bl.Len())
+	})
+}

--- a/internal/blocklist/blocklist_test.go
+++ b/internal/blocklist/blocklist_test.go
@@ -18,33 +18,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
-
-func TestParseFingerprints(t *testing.T) {
-	t.Run("empty string returns empty slice", func(t *testing.T) {
-		fps, err := ParseFingerprints("")
-		require.NoError(t, err)
-		assert.Empty(t, fps)
-	})
-
-	t.Run("valid JSON array", func(t *testing.T) {
-		fps, err := ParseFingerprints(`["AA:BB","CC:DD"]`)
-		require.NoError(t, err)
-		assert.Equal(t, []string{"AA:BB", "CC:DD"}, fps)
-	})
-
-	t.Run("empty JSON array", func(t *testing.T) {
-		fps, err := ParseFingerprints(`[]`)
-		require.NoError(t, err)
-		assert.Empty(t, fps)
-	})
-
-	t.Run("invalid JSON returns error", func(t *testing.T) {
-		_, err := ParseFingerprints(`not-json`)
-		assert.Error(t, err)
-	})
-}
 
 func TestBlocklist(t *testing.T) {
 	t.Run("new blocklist is empty", func(t *testing.T) {

--- a/internal/blocklist/blocklist_test.go
+++ b/internal/blocklist/blocklist_test.go
@@ -82,4 +82,22 @@ func TestBlocklist(t *testing.T) {
 		bl.Add("AA:BB")
 		assert.Equal(t, 1, bl.Len())
 	})
+
+	t.Run("track and lookup agent by fingerprint", func(t *testing.T) {
+		bl := New()
+		bl.TrackAgent("AABB", "agent-managed")
+		assert.Equal(t, "agent-managed", bl.AgentForFingerprint("AABB"))
+	})
+
+	t.Run("lookup unknown fingerprint returns empty", func(t *testing.T) {
+		bl := New()
+		assert.Empty(t, bl.AgentForFingerprint("UNKNOWN"))
+	})
+
+	t.Run("track overwrites previous agent", func(t *testing.T) {
+		bl := New()
+		bl.TrackAgent("AABB", "agent-old")
+		bl.TrackAgent("AABB", "agent-new")
+		assert.Equal(t, "agent-new", bl.AgentForFingerprint("AABB"))
+	})
 }

--- a/internal/blocklist/configmap.go
+++ b/internal/blocklist/configmap.go
@@ -16,7 +16,6 @@ package blocklist
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
 	"github.com/argoproj-labs/argocd-agent/internal/config"
@@ -25,6 +24,16 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 )
+
+// FingerprintsFromConfigMapData extracts the blocklist fingerprints from a
+// ConfigMap's Data map. Each key in the map is a fingerprint.
+func FingerprintsFromConfigMapData(data map[string]string) []string {
+	fps := make([]string, 0, len(data))
+	for fp := range data {
+		fps = append(fps, fp)
+	}
+	return fps
+}
 
 // LoadFromConfigMap reads the blocklist fingerprints from the Kubernetes ConfigMap.
 // Returns an empty slice if the ConfigMap does not exist yet.
@@ -37,20 +46,15 @@ func LoadFromConfigMap(ctx context.Context, client kubernetes.Interface, namespa
 		return nil, fmt.Errorf("failed to get blocklist ConfigMap: %w", err)
 	}
 
-	data := cm.Data[config.ConfigMapKeyBlocklistChecksums]
-	fingerPrints, err := ParseFingerprints(data)
-	if err != nil {
-		return nil, fmt.Errorf("failed to unmarshal blocklist data: %w", err)
-	}
-	return fingerPrints, nil
+	return FingerprintsFromConfigMapData(cm.Data), nil
 }
 
 // SaveToConfigMap writes the given fingerprints to the Kubernetes ConfigMap.
 // Creates the ConfigMap if it does not exist.
 func SaveToConfigMap(ctx context.Context, client kubernetes.Interface, namespace string, fingerprints []string) error {
-	data, err := json.Marshal(fingerprints)
-	if err != nil {
-		return fmt.Errorf("failed to marshal blocklist data: %w", err)
+	cmData := make(map[string]string, len(fingerprints))
+	for _, fp := range fingerprints {
+		cmData[fp] = ""
 	}
 
 	cm, err := client.CoreV1().ConfigMaps(namespace).Get(ctx, config.ConfigMapNameTLSBlocklist, metav1.GetOptions{})
@@ -63,9 +67,7 @@ func SaveToConfigMap(ctx context.Context, client kubernetes.Interface, namespace
 				Name:      config.ConfigMapNameTLSBlocklist,
 				Namespace: namespace,
 			},
-			Data: map[string]string{
-				config.ConfigMapKeyBlocklistChecksums: string(data),
-			},
+			Data: cmData,
 		}
 		if _, err := client.CoreV1().ConfigMaps(namespace).Create(ctx, cm, metav1.CreateOptions{}); err != nil {
 			return fmt.Errorf("failed to create blocklist ConfigMap: %w", err)
@@ -73,10 +75,7 @@ func SaveToConfigMap(ctx context.Context, client kubernetes.Interface, namespace
 		return nil
 	}
 
-	if cm.Data == nil {
-		cm.Data = make(map[string]string)
-	}
-	cm.Data[config.ConfigMapKeyBlocklistChecksums] = string(data)
+	cm.Data = cmData
 	if _, err := client.CoreV1().ConfigMaps(namespace).Update(ctx, cm, metav1.UpdateOptions{}); err != nil {
 		return fmt.Errorf("failed to update blocklist ConfigMap: %w", err)
 	}

--- a/internal/blocklist/configmap.go
+++ b/internal/blocklist/configmap.go
@@ -1,0 +1,84 @@
+// Copyright 2026 The argocd-agent Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package blocklist
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/argoproj-labs/argocd-agent/internal/config"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+// LoadFromConfigMap reads the blocklist fingerprints from the Kubernetes ConfigMap.
+// Returns an empty slice if the ConfigMap does not exist yet.
+func LoadFromConfigMap(ctx context.Context, client kubernetes.Interface, namespace string) ([]string, error) {
+	cm, err := client.CoreV1().ConfigMaps(namespace).Get(ctx, config.ConfigMapNameTLSBlocklist, metav1.GetOptions{})
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return []string{}, nil
+		}
+		return nil, fmt.Errorf("failed to get blocklist ConfigMap: %w", err)
+	}
+
+	data := cm.Data[config.ConfigMapKeyBlocklistChecksums]
+	fingerPrints, err := ParseFingerprints(data)
+	if err != nil {
+		return nil, fmt.Errorf("failed to unmarshal blocklist data: %w", err)
+	}
+	return fingerPrints, nil
+}
+
+// SaveToConfigMap writes the given fingerprints to the Kubernetes ConfigMap.
+// Creates the ConfigMap if it does not exist.
+func SaveToConfigMap(ctx context.Context, client kubernetes.Interface, namespace string, fingerprints []string) error {
+	data, err := json.Marshal(fingerprints)
+	if err != nil {
+		return fmt.Errorf("failed to marshal blocklist data: %w", err)
+	}
+
+	cm, err := client.CoreV1().ConfigMaps(namespace).Get(ctx, config.ConfigMapNameTLSBlocklist, metav1.GetOptions{})
+	if err != nil {
+		if !errors.IsNotFound(err) {
+			return fmt.Errorf("failed to get blocklist ConfigMap: %w", err)
+		}
+		cm = &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      config.ConfigMapNameTLSBlocklist,
+				Namespace: namespace,
+			},
+			Data: map[string]string{
+				config.ConfigMapKeyBlocklistChecksums: string(data),
+			},
+		}
+		if _, err := client.CoreV1().ConfigMaps(namespace).Create(ctx, cm, metav1.CreateOptions{}); err != nil {
+			return fmt.Errorf("failed to create blocklist ConfigMap: %w", err)
+		}
+		return nil
+	}
+
+	if cm.Data == nil {
+		cm.Data = make(map[string]string)
+	}
+	cm.Data[config.ConfigMapKeyBlocklistChecksums] = string(data)
+	if _, err := client.CoreV1().ConfigMaps(namespace).Update(ctx, cm, metav1.UpdateOptions{}); err != nil {
+		return fmt.Errorf("failed to update blocklist ConfigMap: %w", err)
+	}
+	return nil
+}

--- a/internal/blocklist/configmap_test.go
+++ b/internal/blocklist/configmap_test.go
@@ -1,0 +1,108 @@
+// Copyright 2026 The argocd-agent Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package blocklist
+
+import (
+	"context"
+	"testing"
+
+	"github.com/argoproj-labs/argocd-agent/internal/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestLoadFromConfigMap(t *testing.T) {
+	ns := "argocd"
+
+	t.Run("returns empty when ConfigMap does not exist", func(t *testing.T) {
+		client := fake.NewSimpleClientset()
+		fps, err := LoadFromConfigMap(context.Background(), client, ns)
+		require.NoError(t, err)
+		assert.Empty(t, fps)
+	})
+
+	t.Run("returns fingerprints from existing ConfigMap", func(t *testing.T) {
+		cm := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Name: config.ConfigMapNameTLSBlocklist, Namespace: ns},
+			Data:       map[string]string{config.ConfigMapKeyBlocklistChecksums: `["AA:BB","CC:DD"]`},
+		}
+		client := fake.NewSimpleClientset(cm)
+		fps, err := LoadFromConfigMap(context.Background(), client, ns)
+		require.NoError(t, err)
+		assert.Equal(t, []string{"AA:BB", "CC:DD"}, fps)
+	})
+
+	t.Run("returns error for malformed JSON", func(t *testing.T) {
+		cm := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Name: config.ConfigMapNameTLSBlocklist, Namespace: ns},
+			Data:       map[string]string{config.ConfigMapKeyBlocklistChecksums: `not-json`},
+		}
+		client := fake.NewSimpleClientset(cm)
+		_, err := LoadFromConfigMap(context.Background(), client, ns)
+		assert.Error(t, err)
+	})
+
+	t.Run("returns empty for missing data key", func(t *testing.T) {
+		cm := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Name: config.ConfigMapNameTLSBlocklist, Namespace: ns},
+			Data:       map[string]string{},
+		}
+		client := fake.NewSimpleClientset(cm)
+		fps, err := LoadFromConfigMap(context.Background(), client, ns)
+		require.NoError(t, err)
+		assert.Empty(t, fps)
+	})
+}
+
+func TestSaveToConfigMap(t *testing.T) {
+	ns := "argocd"
+
+	t.Run("creates ConfigMap when it does not exist", func(t *testing.T) {
+		client := fake.NewSimpleClientset()
+		err := SaveToConfigMap(context.Background(), client, ns, []string{"AA:BB"})
+		require.NoError(t, err)
+
+		cm, err := client.CoreV1().ConfigMaps(ns).Get(context.Background(), config.ConfigMapNameTLSBlocklist, metav1.GetOptions{})
+		require.NoError(t, err)
+		assert.Equal(t, `["AA:BB"]`, cm.Data[config.ConfigMapKeyBlocklistChecksums])
+	})
+
+	t.Run("updates existing ConfigMap", func(t *testing.T) {
+		cm := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Name: config.ConfigMapNameTLSBlocklist, Namespace: ns},
+			Data:       map[string]string{config.ConfigMapKeyBlocklistChecksums: `["AA:BB"]`},
+		}
+		client := fake.NewSimpleClientset(cm)
+		err := SaveToConfigMap(context.Background(), client, ns, []string{"AA:BB", "CC:DD"})
+		require.NoError(t, err)
+
+		updated, err := client.CoreV1().ConfigMaps(ns).Get(context.Background(), config.ConfigMapNameTLSBlocklist, metav1.GetOptions{})
+		require.NoError(t, err)
+		assert.Equal(t, `["AA:BB","CC:DD"]`, updated.Data[config.ConfigMapKeyBlocklistChecksums])
+	})
+
+	t.Run("saves empty list", func(t *testing.T) {
+		client := fake.NewSimpleClientset()
+		err := SaveToConfigMap(context.Background(), client, ns, []string{})
+		require.NoError(t, err)
+
+		cm, err := client.CoreV1().ConfigMaps(ns).Get(context.Background(), config.ConfigMapNameTLSBlocklist, metav1.GetOptions{})
+		require.NoError(t, err)
+		assert.Equal(t, `[]`, cm.Data[config.ConfigMapKeyBlocklistChecksums])
+	})
+}

--- a/internal/blocklist/configmap_test.go
+++ b/internal/blocklist/configmap_test.go
@@ -26,6 +26,23 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 )
 
+func TestFingerprintsFromConfigMapData(t *testing.T) {
+	t.Run("nil data returns empty slice", func(t *testing.T) {
+		fps := FingerprintsFromConfigMapData(nil)
+		assert.Empty(t, fps)
+	})
+
+	t.Run("empty data returns empty slice", func(t *testing.T) {
+		fps := FingerprintsFromConfigMapData(map[string]string{})
+		assert.Empty(t, fps)
+	})
+
+	t.Run("returns all keys", func(t *testing.T) {
+		fps := FingerprintsFromConfigMapData(map[string]string{"AABB": "", "CCDD": ""})
+		assert.ElementsMatch(t, []string{"AABB", "CCDD"}, fps)
+	})
+}
+
 func TestLoadFromConfigMap(t *testing.T) {
 	ns := "argocd"
 
@@ -39,25 +56,15 @@ func TestLoadFromConfigMap(t *testing.T) {
 	t.Run("returns fingerprints from existing ConfigMap", func(t *testing.T) {
 		cm := &corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{Name: config.ConfigMapNameTLSBlocklist, Namespace: ns},
-			Data:       map[string]string{config.ConfigMapKeyBlocklistChecksums: `["AA:BB","CC:DD"]`},
+			Data:       map[string]string{"AABB": "", "CCDD": ""},
 		}
 		client := fake.NewSimpleClientset(cm)
 		fps, err := LoadFromConfigMap(context.Background(), client, ns)
 		require.NoError(t, err)
-		assert.Equal(t, []string{"AA:BB", "CC:DD"}, fps)
+		assert.ElementsMatch(t, []string{"AABB", "CCDD"}, fps)
 	})
 
-	t.Run("returns error for malformed JSON", func(t *testing.T) {
-		cm := &corev1.ConfigMap{
-			ObjectMeta: metav1.ObjectMeta{Name: config.ConfigMapNameTLSBlocklist, Namespace: ns},
-			Data:       map[string]string{config.ConfigMapKeyBlocklistChecksums: `not-json`},
-		}
-		client := fake.NewSimpleClientset(cm)
-		_, err := LoadFromConfigMap(context.Background(), client, ns)
-		assert.Error(t, err)
-	})
-
-	t.Run("returns empty for missing data key", func(t *testing.T) {
+	t.Run("returns empty for empty data", func(t *testing.T) {
 		cm := &corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{Name: config.ConfigMapNameTLSBlocklist, Namespace: ns},
 			Data:       map[string]string{},
@@ -74,26 +81,26 @@ func TestSaveToConfigMap(t *testing.T) {
 
 	t.Run("creates ConfigMap when it does not exist", func(t *testing.T) {
 		client := fake.NewSimpleClientset()
-		err := SaveToConfigMap(context.Background(), client, ns, []string{"AA:BB"})
+		err := SaveToConfigMap(context.Background(), client, ns, []string{"AABB"})
 		require.NoError(t, err)
 
 		cm, err := client.CoreV1().ConfigMaps(ns).Get(context.Background(), config.ConfigMapNameTLSBlocklist, metav1.GetOptions{})
 		require.NoError(t, err)
-		assert.Equal(t, `["AA:BB"]`, cm.Data[config.ConfigMapKeyBlocklistChecksums])
+		assert.Equal(t, map[string]string{"AABB": ""}, cm.Data)
 	})
 
 	t.Run("updates existing ConfigMap", func(t *testing.T) {
 		cm := &corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{Name: config.ConfigMapNameTLSBlocklist, Namespace: ns},
-			Data:       map[string]string{config.ConfigMapKeyBlocklistChecksums: `["AA:BB"]`},
+			Data:       map[string]string{"AABB": ""},
 		}
 		client := fake.NewSimpleClientset(cm)
-		err := SaveToConfigMap(context.Background(), client, ns, []string{"AA:BB", "CC:DD"})
+		err := SaveToConfigMap(context.Background(), client, ns, []string{"AABB", "CCDD"})
 		require.NoError(t, err)
 
 		updated, err := client.CoreV1().ConfigMaps(ns).Get(context.Background(), config.ConfigMapNameTLSBlocklist, metav1.GetOptions{})
 		require.NoError(t, err)
-		assert.Equal(t, `["AA:BB","CC:DD"]`, updated.Data[config.ConfigMapKeyBlocklistChecksums])
+		assert.Equal(t, map[string]string{"AABB": "", "CCDD": ""}, updated.Data)
 	})
 
 	t.Run("saves empty list", func(t *testing.T) {
@@ -103,6 +110,6 @@ func TestSaveToConfigMap(t *testing.T) {
 
 		cm, err := client.CoreV1().ConfigMaps(ns).Get(context.Background(), config.ConfigMapNameTLSBlocklist, metav1.GetOptions{})
 		require.NoError(t, err)
-		assert.Equal(t, `[]`, cm.Data[config.ConfigMapKeyBlocklistChecksums])
+		assert.Equal(t, map[string]string{}, cm.Data)
 	})
 }

--- a/internal/config/constants.go
+++ b/internal/config/constants.go
@@ -28,6 +28,13 @@ const SecretNameAgentClientCert = "argocd-agent-client-tls"
 // for the principal.
 const SecretNameJWT = "argocd-agent-jwt"
 
+// ConfigMapNameTLSBlocklist is the name of the ConfigMap containing the
+// TLS certificate blocklist for the principal.
+const ConfigMapNameTLSBlocklist = "argocd-agent-tls-blocklist"
+
+// ConfigMapKeyBlocklistChecksums is the data key inside the TLS blocklist ConfigMap.
+const ConfigMapKeyBlocklistChecksums = "checksums"
+
 // SkipSyncLabel is the label used to skip sync for an application.
 const SkipSyncLabel = "argocd-agent.argoproj-labs.io/ignore-sync"
 

--- a/internal/config/constants.go
+++ b/internal/config/constants.go
@@ -32,9 +32,6 @@ const SecretNameJWT = "argocd-agent-jwt"
 // TLS certificate blocklist for the principal.
 const ConfigMapNameTLSBlocklist = "argocd-agent-tls-blocklist"
 
-// ConfigMapKeyBlocklistChecksums is the data key inside the TLS blocklist ConfigMap.
-const ConfigMapKeyBlocklistChecksums = "checksums"
-
 // SkipSyncLabel is the label used to skip sync for an application.
 const SkipSyncLabel = "argocd-agent.argoproj-labs.io/ignore-sync"
 

--- a/internal/tlsutil/tlsutil.go
+++ b/internal/tlsutil/tlsutil.go
@@ -137,14 +137,14 @@ func KeyDataToPEM(k crypto.PrivateKey) (string, error) {
 }
 
 // CertificateFingerprint returns the SHA-256 fingerprint of a certificate as
-// a colon-separated uppercase hex string (e.g., "A1:2B:3C:...").
+// an uppercase hex string.
 func CertificateFingerprint(cert *x509.Certificate) string {
 	sum := sha256.Sum256(cert.Raw)
 	parts := make([]string, len(sum))
 	for i, b := range sum {
 		parts[i] = fmt.Sprintf("%02X", b)
 	}
-	return strings.Join(parts, ":")
+	return strings.Join(parts, "")
 }
 
 // FingerprintFromContext extracts the client certificate from a gRPC TLS

--- a/internal/tlsutil/tlsutil.go
+++ b/internal/tlsutil/tlsutil.go
@@ -16,18 +16,24 @@ package tlsutil
 
 import (
 	"bytes"
+	"context"
 	"crypto"
 	"crypto/ecdh"
 	"crypto/ecdsa"
 	"crypto/ed25519"
 	"crypto/rsa"
+	"crypto/sha256"
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
 	"os"
 	"slices"
+	"strings"
 	"time"
+
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/peer"
 )
 
 // TLSCertFromFile loads a TLS certificate and RSA private key from the
@@ -128,6 +134,32 @@ func KeyDataToPEM(k crypto.PrivateKey) (string, error) {
 
 	return keyPem.String(), err
 
+}
+
+// CertificateFingerprint returns the SHA-256 fingerprint of a certificate as
+// a colon-separated uppercase hex string (e.g., "A1:2B:3C:...").
+func CertificateFingerprint(cert *x509.Certificate) string {
+	sum := sha256.Sum256(cert.Raw)
+	parts := make([]string, len(sum))
+	for i, b := range sum {
+		parts[i] = fmt.Sprintf("%02X", b)
+	}
+	return strings.Join(parts, ":")
+}
+
+// FingerprintFromContext extracts the client certificate from a gRPC TLS
+// context and returns its SHA-256 fingerprint. Returns empty string if the
+// certificate cannot be extracted.
+func FingerprintFromContext(ctx context.Context) string {
+	p, ok := peer.FromContext(ctx)
+	if !ok {
+		return ""
+	}
+	tlsInfo, ok := p.AuthInfo.(credentials.TLSInfo)
+	if !ok || len(tlsInfo.State.VerifiedChains) < 1 {
+		return ""
+	}
+	return CertificateFingerprint(tlsInfo.State.VerifiedChains[0][0])
 }
 
 // supportedTLSVersions maps TLS version names to their constants.

--- a/internal/tlsutil/tlsutil.go
+++ b/internal/tlsutil/tlsutil.go
@@ -156,7 +156,7 @@ func FingerprintFromContext(ctx context.Context) string {
 		return ""
 	}
 	tlsInfo, ok := p.AuthInfo.(credentials.TLSInfo)
-	if !ok || len(tlsInfo.State.VerifiedChains) < 1 {
+	if !ok || len(tlsInfo.State.VerifiedChains) < 1 || len(tlsInfo.State.VerifiedChains[0]) < 1 {
 		return ""
 	}
 	return CertificateFingerprint(tlsInfo.State.VerifiedChains[0][0])

--- a/internal/tlsutil/tlsutil_test.go
+++ b/internal/tlsutil/tlsutil_test.go
@@ -440,12 +440,8 @@ func Test_CertificateFingerprint(t *testing.T) {
 		require.NoError(t, err)
 
 		fp := CertificateFingerprint(cert)
-		parts := strings.Split(fp, ":")
-		assert.Len(t, parts, sha256.Size)
-		for _, p := range parts {
-			assert.Len(t, p, 2)
-			assert.Equal(t, strings.ToUpper(p), p)
-		}
+		assert.Len(t, fp, sha256.Size*2)
+		assert.Equal(t, strings.ToUpper(fp), fp)
 	})
 
 	t.Run("same cert returns same fingerprint", func(t *testing.T) {
@@ -486,7 +482,7 @@ func Test_CertificateFingerprint(t *testing.T) {
 		for i, b := range sum {
 			parts[i] = fmt.Sprintf("%02X", b)
 		}
-		expected := strings.Join(parts, ":")
+		expected := strings.Join(parts, "")
 		assert.Equal(t, expected, CertificateFingerprint(cert))
 	})
 }

--- a/internal/tlsutil/tlsutil_test.go
+++ b/internal/tlsutil/tlsutil_test.go
@@ -15,18 +15,24 @@
 package tlsutil
 
 import (
+	"context"
 	"crypto/ecdsa"
 	"crypto/rand"
 	"crypto/rsa"
+	"crypto/sha256"
 	"crypto/tls"
 	"crypto/x509"
+	"fmt"
 	"path"
 	"slices"
+	"strings"
 	"testing"
 
 	"github.com/argoproj-labs/argocd-agent/test/fake/testcerts"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/peer"
 )
 
 func Test_LoadTlsCertFromFile(t *testing.T) {
@@ -422,5 +428,104 @@ func Test_SetTLSConfigFromFlags(t *testing.T) {
 		assert.Equal(t, uint16(tls.VersionTLS12), cfg.MinVersion)
 		assert.Equal(t, uint16(tls.VersionTLS13), cfg.MaxVersion, "maxVersion should be preserved")
 		assert.Equal(t, []uint16{cs.ID}, cfg.CipherSuites, "cipherSuites should be preserved")
+	})
+}
+
+func Test_CertificateFingerprint(t *testing.T) {
+	t.Run("returns colon-separated uppercase SHA-256 hex", func(t *testing.T) {
+		key := testcerts.GeneratePrivateKey(t, "rsa")
+		raw, err := x509.CreateCertificate(rand.Reader, &testcerts.DefaultCertTempl, &testcerts.DefaultCertTempl, &key.(*rsa.PrivateKey).PublicKey, key)
+		require.NoError(t, err)
+		cert, err := x509.ParseCertificate(raw)
+		require.NoError(t, err)
+
+		fp := CertificateFingerprint(cert)
+		parts := strings.Split(fp, ":")
+		assert.Len(t, parts, sha256.Size)
+		for _, p := range parts {
+			assert.Len(t, p, 2)
+			assert.Equal(t, strings.ToUpper(p), p)
+		}
+	})
+
+	t.Run("same cert returns same fingerprint", func(t *testing.T) {
+		key := testcerts.GeneratePrivateKey(t, "rsa")
+		raw, err := x509.CreateCertificate(rand.Reader, &testcerts.DefaultCertTempl, &testcerts.DefaultCertTempl, &key.(*rsa.PrivateKey).PublicKey, key)
+		require.NoError(t, err)
+		cert, err := x509.ParseCertificate(raw)
+		require.NoError(t, err)
+
+		assert.Equal(t, CertificateFingerprint(cert), CertificateFingerprint(cert))
+	})
+
+	t.Run("different certs return different fingerprints", func(t *testing.T) {
+		key1 := testcerts.GeneratePrivateKey(t, "rsa")
+		raw1, err := x509.CreateCertificate(rand.Reader, &testcerts.DefaultCertTempl, &testcerts.DefaultCertTempl, &key1.(*rsa.PrivateKey).PublicKey, key1)
+		require.NoError(t, err)
+		cert1, err := x509.ParseCertificate(raw1)
+		require.NoError(t, err)
+
+		key2 := testcerts.GeneratePrivateKey(t, "rsa")
+		raw2, err := x509.CreateCertificate(rand.Reader, &testcerts.DefaultCertTempl, &testcerts.DefaultCertTempl, &key2.(*rsa.PrivateKey).PublicKey, key2)
+		require.NoError(t, err)
+		cert2, err := x509.ParseCertificate(raw2)
+		require.NoError(t, err)
+
+		assert.NotEqual(t, CertificateFingerprint(cert1), CertificateFingerprint(cert2))
+	})
+
+	t.Run("matches manual SHA-256 computation", func(t *testing.T) {
+		key := testcerts.GeneratePrivateKey(t, "rsa")
+		raw, err := x509.CreateCertificate(rand.Reader, &testcerts.DefaultCertTempl, &testcerts.DefaultCertTempl, &key.(*rsa.PrivateKey).PublicKey, key)
+		require.NoError(t, err)
+		cert, err := x509.ParseCertificate(raw)
+		require.NoError(t, err)
+
+		sum := sha256.Sum256(cert.Raw)
+		parts := make([]string, len(sum))
+		for i, b := range sum {
+			parts[i] = fmt.Sprintf("%02X", b)
+		}
+		expected := strings.Join(parts, ":")
+		assert.Equal(t, expected, CertificateFingerprint(cert))
+	})
+}
+
+func Test_FingerprintFromContext(t *testing.T) {
+	t.Run("returns empty string without peer", func(t *testing.T) {
+		assert.Empty(t, FingerprintFromContext(context.Background()))
+	})
+
+	t.Run("returns empty string without TLS info", func(t *testing.T) {
+		ctx := peer.NewContext(context.Background(), &peer.Peer{})
+		assert.Empty(t, FingerprintFromContext(ctx))
+	})
+
+	t.Run("returns empty string without verified chains", func(t *testing.T) {
+		ctx := peer.NewContext(context.Background(), &peer.Peer{
+			AuthInfo: credentials.TLSInfo{
+				State: tls.ConnectionState{},
+			},
+		})
+		assert.Empty(t, FingerprintFromContext(ctx))
+	})
+
+	t.Run("returns fingerprint from verified chain", func(t *testing.T) {
+		key := testcerts.GeneratePrivateKey(t, "rsa")
+		raw, err := x509.CreateCertificate(rand.Reader, &testcerts.DefaultCertTempl, &testcerts.DefaultCertTempl, &key.(*rsa.PrivateKey).PublicKey, key)
+		require.NoError(t, err)
+		cert, err := x509.ParseCertificate(raw)
+		require.NoError(t, err)
+
+		ctx := peer.NewContext(context.Background(), &peer.Peer{
+			AuthInfo: credentials.TLSInfo{
+				State: tls.ConnectionState{
+					VerifiedChains: [][]*x509.Certificate{{cert}},
+				},
+			},
+		})
+		fp := FingerprintFromContext(ctx)
+		assert.NotEmpty(t, fp)
+		assert.Equal(t, CertificateFingerprint(cert), fp)
 	})
 }

--- a/internal/tlsutil/tlsutil_test.go
+++ b/internal/tlsutil/tlsutil_test.go
@@ -432,7 +432,7 @@ func Test_SetTLSConfigFromFlags(t *testing.T) {
 }
 
 func Test_CertificateFingerprint(t *testing.T) {
-	t.Run("returns colon-separated uppercase SHA-256 hex", func(t *testing.T) {
+	t.Run("returns uppercase SHA-256 hex without separators", func(t *testing.T) {
 		key := testcerts.GeneratePrivateKey(t, "rsa")
 		raw, err := x509.CreateCertificate(rand.Reader, &testcerts.DefaultCertTempl, &testcerts.DefaultCertTempl, &key.(*rsa.PrivateKey).PublicKey, key)
 		require.NoError(t, err)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -72,6 +72,7 @@ nav:
     - Metrics: operations/metrics.md
     - Profiling: operations/profiling.md
     - High availability: operations/ha-failover.md
+    - TLS Certificate Blocklist: operations/blocklist.md
     - Verifying artifacts: operations/provenance.md
   - Contributing:
     - Overview: contributing/index.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -73,6 +73,7 @@ nav:
     - Metrics: operations/metrics.md
     - Profiling: operations/profiling.md
     - High availability: operations/ha-failover.md
+    - TLS Certificate Blocklist: operations/blocklist.md
     - Verifying artifacts: operations/provenance.md
   - Contributing:
     - Overview: contributing/index.md

--- a/pkg/client/remote_test.go
+++ b/pkg/client/remote_test.go
@@ -60,7 +60,7 @@ func Test_Connect(t *testing.T) {
 
 	am := userpass.NewUserPassAuthentication("")
 	am.UpsertUser("default", "password")
-	s.AuthMethodsForE2EOnly().RegisterMethod("userpass", am)
+	s.AuthMethodsForE2EOnly().RegisterMethod(auth.MethodUserPass, am)
 	require.NoError(t, err)
 	errch := make(chan error)
 	err = s.Start(context.Background(), errch)
@@ -75,7 +75,7 @@ func Test_Connect(t *testing.T) {
 	t.Run("Connect to a server", func(t *testing.T) {
 		r, err := NewRemote("127.0.0.1", s.ListenerForE2EOnly().Port(),
 			WithInsecureSkipTLSVerify(),
-			WithAuth("userpass", auth.Credentials{userpass.ClientIDField: "default", userpass.ClientSecretField: "password"}),
+			WithAuth(auth.MethodUserPass, auth.Credentials{userpass.ClientIDField: "default", userpass.ClientSecretField: "password"}),
 			WithClientMode(types.AgentModeManaged),
 		)
 		require.NoError(t, err)
@@ -98,7 +98,7 @@ func Test_Connect(t *testing.T) {
 	t.Run("Invalid auth and context deadline reached", func(t *testing.T) {
 		r, err := NewRemote("127.0.0.1", s.ListenerForE2EOnly().Port(),
 			WithInsecureSkipTLSVerify(),
-			WithAuth("userpass", auth.Credentials{userpass.ClientIDField: "default", userpass.ClientSecretField: "passwor"}),
+			WithAuth(auth.MethodUserPass, auth.Credentials{userpass.ClientIDField: "default", userpass.ClientSecretField: "passwor"}),
 		)
 		require.NoError(t, err)
 		require.NotNil(t, r)
@@ -429,7 +429,7 @@ func Test_TokenRefresh(t *testing.T) {
 
 	am := userpass.NewUserPassAuthentication("")
 	am.UpsertUser("default", "password")
-	s.AuthMethodsForE2EOnly().RegisterMethod("userpass", am)
+	s.AuthMethodsForE2EOnly().RegisterMethod(auth.MethodUserPass, am)
 
 	errch := make(chan error)
 	err = s.Start(context.Background(), errch)
@@ -441,7 +441,7 @@ func Test_TokenRefresh(t *testing.T) {
 	t.Run("token refresh succeeds with valid connection", func(t *testing.T) {
 		r, err := NewRemote("127.0.0.1", s.ListenerForE2EOnly().Port(),
 			WithInsecureSkipTLSVerify(),
-			WithAuth("userpass", auth.Credentials{userpass.ClientIDField: "default", userpass.ClientSecretField: "password"}),
+			WithAuth(auth.MethodUserPass, auth.Credentials{userpass.ClientIDField: "default", userpass.ClientSecretField: "password"}),
 			WithClientMode(types.AgentModeManaged),
 		)
 		require.NoError(t, err)

--- a/principal/apis/auth/auth.go
+++ b/principal/apis/auth/auth.go
@@ -24,6 +24,7 @@ import (
 	"github.com/argoproj-labs/argocd-agent/internal/issuer"
 	"github.com/argoproj-labs/argocd-agent/internal/logging"
 	"github.com/argoproj-labs/argocd-agent/internal/queue"
+	"github.com/argoproj-labs/argocd-agent/internal/tlsutil"
 	"github.com/argoproj-labs/argocd-agent/internal/version"
 	"github.com/argoproj-labs/argocd-agent/pkg/api/grpc/authapi"
 	"github.com/argoproj-labs/argocd-agent/principal/registration"
@@ -62,6 +63,7 @@ var errAuthenticationFailed = status.Error(codes.Unauthenticated, authFailedMess
 type ServerOptions struct {
 	agentRegistrationManager *registration.AgentRegistrationManager
 	onAuthenticated          func(agentName, agentNamespace string)
+	onCertificateSeen        func(agentName, fingerprint string)
 }
 
 type ServerOption func(o *ServerOptions) error
@@ -151,7 +153,15 @@ func (s *Server) Authenticate(ctx context.Context, ar *authapi.AuthRequest) (*au
 		return nil, status.Errorf(codes.FailedPrecondition, "version mismatch")
 	}
 
-	logCtx.WithField("client", clientID).WithField("agent_version", agentVersion).Info("client authentication successful")
+	logFields := logrus.Fields{"client": clientID, "agent_version": agentVersion}
+	var fingerPrint string
+	if ar.Method == "mtls" {
+		fingerPrint = tlsutil.FingerprintFromContext(ctx)
+		if fingerPrint != "" {
+			logFields["fingerprint"] = fingerPrint
+		}
+	}
+	logCtx.WithFields(logFields).Info("client authentication successful")
 
 	// If self agent registration is enabled, register the agent and create cluster secret if it doesn't exist
 	if s.agentRegistrationManager != nil && s.agentRegistrationManager.IsSelfAgentRegistrationEnabled() {
@@ -176,6 +186,10 @@ func (s *Server) Authenticate(ctx context.Context, ar *authapi.AuthRequest) (*au
 
 	if s.options.onAuthenticated != nil {
 		s.options.onAuthenticated(clientID, ar.AgentNamespace)
+	}
+
+	if s.options.onCertificateSeen != nil && fingerPrint != "" {
+		s.options.onCertificateSeen(clientID, fingerPrint)
 	}
 
 	return &authapi.AuthResponse{

--- a/principal/apis/auth/auth.go
+++ b/principal/apis/auth/auth.go
@@ -154,11 +154,11 @@ func (s *Server) Authenticate(ctx context.Context, ar *authapi.AuthRequest) (*au
 	}
 
 	logFields := logrus.Fields{"client": clientID, "agent_version": agentVersion}
-	var fingerPrint string
-	if ar.Method == "mtls" {
-		fingerPrint = tlsutil.FingerprintFromContext(ctx)
-		if fingerPrint != "" {
-			logFields["fingerprint"] = fingerPrint
+	var fingerprint string
+	if ar.Method == auth.MethodMTLS {
+		fingerprint = tlsutil.FingerprintFromContext(ctx)
+		if fingerprint != "" {
+			logFields["fingerprint"] = fingerprint
 		}
 	}
 	logCtx.WithFields(logFields).Info("client authentication successful")
@@ -188,8 +188,8 @@ func (s *Server) Authenticate(ctx context.Context, ar *authapi.AuthRequest) (*au
 		s.options.onAuthenticated(clientID, ar.AgentNamespace)
 	}
 
-	if s.options.onCertificateSeen != nil && fingerPrint != "" {
-		s.options.onCertificateSeen(clientID, fingerPrint)
+	if s.options.onCertificateSeen != nil && fingerprint != "" {
+		s.options.onCertificateSeen(clientID, fingerprint)
 	}
 
 	return &authapi.AuthResponse{

--- a/principal/apis/auth/auth_test.go
+++ b/principal/apis/auth/auth_test.go
@@ -44,7 +44,7 @@ func Test_Authenticate(t *testing.T) {
 		auths, err := NewServer(queues, "argocd", nil, nil)
 		require.NoError(t, err)
 		_, err = auths.Authenticate(context.TODO(), &authapi.AuthRequest{
-			Method:      "userpass",
+			Method:      auth.MethodUserPass,
 			Credentials: map[string]string{userpass.ClientIDField: "user1", userpass.ClientSecretField: "password"},
 			Mode:        "managed",
 			Version:     testVersion,
@@ -57,12 +57,12 @@ func Test_Authenticate(t *testing.T) {
 		am := authmock.NewMethod(t)
 		// Mock authentication to succeed so we reach version validation
 		am.On("Authenticate", mock.Anything, mock.Anything).Return("user1", nil)
-		ams.RegisterMethod("userpass", am)
+		ams.RegisterMethod(auth.MethodUserPass, am)
 
 		auths, err := NewServer(queues, "argocd", ams, nil)
 		require.NoError(t, err)
 		_, err = auths.Authenticate(context.TODO(), &authapi.AuthRequest{
-			Method:      "userpass",
+			Method:      auth.MethodUserPass,
 			Credentials: map[string]string{userpass.ClientIDField: "user1", userpass.ClientSecretField: "password"},
 			Mode:        "managed",
 			Version:     "",
@@ -75,12 +75,12 @@ func Test_Authenticate(t *testing.T) {
 		am := authmock.NewMethod(t)
 		// Mock authentication to succeed so we reach version validation
 		am.On("Authenticate", mock.Anything, mock.Anything).Return("user1", nil)
-		ams.RegisterMethod("userpass", am)
+		ams.RegisterMethod(auth.MethodUserPass, am)
 
 		auths, err := NewServer(queues, "argocd", ams, nil)
 		require.NoError(t, err)
 		_, err = auths.Authenticate(context.TODO(), &authapi.AuthRequest{
-			Method:      "userpass",
+			Method:      auth.MethodUserPass,
 			Credentials: map[string]string{userpass.ClientIDField: "user1", userpass.ClientSecretField: "password"},
 			Mode:        "managed",
 			Version:     testVersion + "-mismatch",
@@ -92,7 +92,7 @@ func Test_Authenticate(t *testing.T) {
 		ams := auth.NewMethods()
 		am := authmock.NewMethod(t)
 		am.On("Authenticate", mock.Anything, mock.Anything).Return("user1", nil)
-		ams.RegisterMethod("userpass", am)
+		ams.RegisterMethod(auth.MethodUserPass, am)
 
 		iss := issuermock.NewIssuer(t)
 		iss.On("IssueAccessToken", encodedSubject, mock.Anything).Return("access", nil)
@@ -101,7 +101,7 @@ func Test_Authenticate(t *testing.T) {
 		auths, err := NewServer(queues, "argocd", ams, iss)
 		require.NoError(t, err)
 		r, err := auths.Authenticate(context.TODO(), &authapi.AuthRequest{
-			Method:         "userpass",
+			Method:         auth.MethodUserPass,
 			Credentials:    map[string]string{userpass.ClientIDField: "user1", userpass.ClientSecretField: "password"},
 			Mode:           "managed",
 			Version:        testVersion,
@@ -119,11 +119,11 @@ func Test_Authenticate(t *testing.T) {
 		ams := auth.NewMethods()
 		am := authmock.NewMethod(t)
 		am.On("Authenticate", mock.Anything, mock.Anything).Return("", errAuthenticationFailed)
-		ams.RegisterMethod("userpass", am)
+		ams.RegisterMethod(auth.MethodUserPass, am)
 		auths, err := NewServer(queues, "argocd", ams, nil)
 		require.NoError(t, err)
 		_, err = auths.Authenticate(context.TODO(), &authapi.AuthRequest{
-			Method:      "userpass",
+			Method:      auth.MethodUserPass,
 			Credentials: map[string]string{userpass.ClientIDField: "user1", userpass.ClientSecretField: "wordpass"},
 			Mode:        "managed",
 			Version:     testVersion,
@@ -135,13 +135,13 @@ func Test_Authenticate(t *testing.T) {
 		ams := auth.NewMethods()
 		am := authmock.NewMethod(t)
 		am.On("Authenticate", mock.Anything, mock.Anything).Return("user1", nil)
-		ams.RegisterMethod("userpass", am)
+		ams.RegisterMethod(auth.MethodUserPass, am)
 		iss := issuermock.NewIssuer(t)
 		iss.On("IssueAccessToken", encodedSubject, mock.Anything).Return("", fmt.Errorf("oops"))
 		auths, err := NewServer(queues, "argocd", ams, iss)
 		require.NoError(t, err)
 		_, err = auths.Authenticate(context.TODO(), &authapi.AuthRequest{
-			Method:      "userpass",
+			Method:      auth.MethodUserPass,
 			Credentials: map[string]string{userpass.ClientIDField: "user1", userpass.ClientSecretField: "wordpass"},
 			Mode:        "managed",
 			Version:     testVersion,
@@ -153,14 +153,14 @@ func Test_Authenticate(t *testing.T) {
 		ams := auth.NewMethods()
 		am := authmock.NewMethod(t)
 		am.On("Authenticate", mock.Anything, mock.Anything).Return("user1", nil)
-		ams.RegisterMethod("userpass", am)
+		ams.RegisterMethod(auth.MethodUserPass, am)
 		iss := issuermock.NewIssuer(t)
 		iss.On("IssueAccessToken", encodedSubject, mock.Anything).Return("access", nil)
 		iss.On("IssueRefreshToken", encodedSubject, mock.Anything).Return("", fmt.Errorf("oops"))
 		auths, err := NewServer(queues, "argocd", ams, iss)
 		require.NoError(t, err)
 		_, err = auths.Authenticate(context.TODO(), &authapi.AuthRequest{
-			Method:      "userpass",
+			Method:      auth.MethodUserPass,
 			Credentials: map[string]string{userpass.ClientIDField: "user1", userpass.ClientSecretField: "wordpass"},
 			Mode:        "managed",
 			Version:     testVersion,
@@ -172,7 +172,7 @@ func Test_Authenticate(t *testing.T) {
 		ams := auth.NewMethods()
 		am := authmock.NewMethod(t)
 		am.On("Authenticate", mock.Anything, mock.Anything).Return("user1", nil)
-		ams.RegisterMethod("userpass", am)
+		ams.RegisterMethod(auth.MethodUserPass, am)
 
 		iss := issuermock.NewIssuer(t)
 		iss.On("IssueAccessToken", encodedSubject, mock.Anything).Return("access", nil)
@@ -185,7 +185,7 @@ func Test_Authenticate(t *testing.T) {
 		auths, err := NewServer(queues, "argocd", ams, iss, WithAgentRegistrationManager(mgr))
 		require.NoError(t, err)
 		r, err := auths.Authenticate(context.TODO(), &authapi.AuthRequest{
-			Method:      "userpass",
+			Method:      auth.MethodUserPass,
 			Credentials: map[string]string{userpass.ClientIDField: "user1", userpass.ClientSecretField: "password"},
 			Mode:        "managed",
 			Version:     testVersion,
@@ -200,7 +200,7 @@ func Test_Authenticate(t *testing.T) {
 		ams := auth.NewMethods()
 		am := authmock.NewMethod(t)
 		am.On("Authenticate", mock.Anything, mock.Anything).Return("user1", nil)
-		ams.RegisterMethod("userpass", am)
+		ams.RegisterMethod(auth.MethodUserPass, am)
 
 		// Create manager with agent registration enabled but no CA cert path to make it fail
 		kubeclient := kube.NewFakeClientsetWithResources()
@@ -212,7 +212,7 @@ func Test_Authenticate(t *testing.T) {
 		require.NoError(t, err)
 
 		_, err = auths.Authenticate(context.TODO(), &authapi.AuthRequest{
-			Method:      "userpass",
+			Method:      auth.MethodUserPass,
 			Credentials: map[string]string{userpass.ClientIDField: "user1", userpass.ClientSecretField: "password"},
 			Mode:        "managed",
 			Version:     testVersion,
@@ -224,7 +224,7 @@ func Test_Authenticate(t *testing.T) {
 		ams := auth.NewMethods()
 		am := authmock.NewMethod(t)
 		am.On("Authenticate", mock.Anything, mock.Anything).Return("user1", nil)
-		ams.RegisterMethod("userpass", am)
+		ams.RegisterMethod(auth.MethodUserPass, am)
 
 		iss := issuermock.NewIssuer(t)
 		iss.On("IssueAccessToken", encodedSubject, mock.Anything).Return("access", nil)
@@ -234,7 +234,7 @@ func Test_Authenticate(t *testing.T) {
 		auths, err := NewServer(queues, "argocd", ams, iss)
 		require.NoError(t, err)
 		r, err := auths.Authenticate(context.TODO(), &authapi.AuthRequest{
-			Method:      "userpass",
+			Method:      auth.MethodUserPass,
 			Credentials: map[string]string{userpass.ClientIDField: "user1", userpass.ClientSecretField: "password"},
 			Mode:        "managed",
 			Version:     testVersion,

--- a/principal/apis/auth/options.go
+++ b/principal/apis/auth/options.go
@@ -31,3 +31,12 @@ func WithOnAuthenticated(fn func(name, namespace string)) ServerOption {
 		return nil
 	}
 }
+
+// WithOnCertificateSeen registers a callback that is invoked after a successful
+// mTLS authentication with the agent name and its certificate fingerprint.
+func WithOnCertificateSeen(fn func(agentName, fingerprint string)) ServerOption {
+	return func(o *ServerOptions) error {
+		o.onCertificateSeen = fn
+		return nil
+	}
+}

--- a/principal/apis/eventstream/eventstream.go
+++ b/principal/apis/eventstream/eventstream.go
@@ -506,6 +506,7 @@ func (s *Server) Subscribe(subs eventstreamapi.EventStream_SubscribeServer) erro
 	// Block until the client context is canceled.
 	<-c.ctx.Done()
 	c.logCtx.Info("Closing EventStream")
+	s.onDisconnect(c)
 
 	s.activeClientsMu.Lock()
 	if s.activeClients[c.agentName] == c {

--- a/principal/apis/eventstream/eventstream.go
+++ b/principal/apis/eventstream/eventstream.go
@@ -109,7 +109,6 @@ type client struct {
 	cancelFn  context.CancelFunc
 	logCtx    *logrus.Entry
 	agentName string
-	wg        *sync.WaitGroup
 	start     time.Time
 	// lock must be owned before read/writing to 'end' var
 	end            time.Time
@@ -166,7 +165,6 @@ func NewServer(queues queue.QueuePair, eventWriters *event.EventWritersMap, metr
 // send to the subscription stream.
 func (s *Server) newClientConnection(ctx context.Context, timeout time.Duration) (*client, error) {
 	c := &client{}
-	c.wg = &sync.WaitGroup{}
 
 	agentName, err := session.ClientIDFromContext(ctx)
 	if err != nil {
@@ -236,8 +234,6 @@ func (s *Server) onDisconnect(c *client) {
 		}
 		s.activeClientsMu.Unlock()
 	})
-
-	c.wg.Done()
 }
 
 // recvFunc retrieves exactly one message from the client c on the event stream
@@ -460,7 +456,6 @@ func (s *Server) Subscribe(subs eventstreamapi.EventStream_SubscribeServer) erro
 	}
 
 	// We receive events in a dedicated go routine
-	c.wg.Add(1)
 	go func() {
 		defer s.onDisconnect(c)
 		c.logCtx.Trace("Starting event receiver routine")
@@ -485,7 +480,6 @@ func (s *Server) Subscribe(subs eventstreamapi.EventStream_SubscribeServer) erro
 	}()
 
 	// We send events in a dedicated go routine
-	c.wg.Add(1)
 	go func() {
 		defer s.onDisconnect(c)
 		c.logCtx.Tracef("Starting event sender routine")
@@ -509,7 +503,8 @@ func (s *Server) Subscribe(subs eventstreamapi.EventStream_SubscribeServer) erro
 		}
 	}()
 
-	c.wg.Wait()
+	// Block until the client context is canceled.
+	<-c.ctx.Done()
 	c.logCtx.Info("Closing EventStream")
 
 	s.activeClientsMu.Lock()
@@ -521,7 +516,6 @@ func (s *Server) Subscribe(subs eventstreamapi.EventStream_SubscribeServer) erro
 	if s.metrics != nil {
 		// decrease counter when an agent is disconnected with principal
 		s.metrics.AgentConnected.Dec()
-
 		// remove connection time of agent
 		metrics.DeleteAgentConnectionTime(c.agentName)
 	}
@@ -548,6 +542,23 @@ func (s *Server) DisconnectAll() {
 		s.clusterMgr.SetAgentConnectionStatus(name, v1alpha1.ConnectionStatusFailed, time.Now())
 		c.cancelFn()
 	}
+}
+
+// DisconnectAgent cancels the event stream for a specific agent, forcing it
+// to disconnect. Returns true if the agent was connected and has been
+// disconnected, false otherwise.
+func (s *Server) DisconnectAgent(agentName string) bool {
+	s.activeClientsMu.Lock()
+	defer s.activeClientsMu.Unlock()
+	c, found := s.activeClients[agentName]
+	if !found || c == nil {
+		return false
+	}
+	delete(s.activeClients, agentName)
+	if c.cancelFn != nil {
+		c.cancelFn()
+	}
+	return true
 }
 
 // Push implements a client-side stream to receive updates for the client's
@@ -623,22 +634,6 @@ recvloop:
 	}
 
 	return nil
-}
-
-// DisconnectAgent cancels the event stream for a specific agent, forcing it to disconnect.
-// Returns true if the agent was connected and disconnected, false if it was not connected.
-func (s *Server) DisconnectAgent(agentName string) bool {
-	s.activeClientsMu.Lock()
-	defer s.activeClientsMu.Unlock()
-	c, found := s.activeClients[agentName]
-	if !found || c == nil {
-		return false
-	}
-	delete(s.activeClients, agentName)
-	if c.cancelFn != nil {
-		c.cancelFn()
-	}
-	return true
 }
 
 // IsAgentConnected returns true if the agent is connected to the server via the event stream.

--- a/principal/apis/eventstream/eventstream.go
+++ b/principal/apis/eventstream/eventstream.go
@@ -550,12 +550,15 @@ func (s *Server) DisconnectAll() {
 // disconnected, false otherwise.
 func (s *Server) DisconnectAgent(agentName string) bool {
 	s.activeClientsMu.Lock()
-	defer s.activeClientsMu.Unlock()
 	c, found := s.activeClients[agentName]
 	if !found || c == nil {
+		s.activeClientsMu.Unlock()
 		return false
 	}
 	delete(s.activeClients, agentName)
+	s.activeClientsMu.Unlock()
+
+	s.clusterMgr.SetAgentConnectionStatus(agentName, v1alpha1.ConnectionStatusFailed, time.Now())
 	if c.cancelFn != nil {
 		c.cancelFn()
 	}

--- a/principal/apis/eventstream/eventstream_test.go
+++ b/principal/apis/eventstream/eventstream_test.go
@@ -288,6 +288,75 @@ func TestDisconnectAll(t *testing.T) {
 	})
 }
 
+func TestDisconnectAgent(t *testing.T) {
+	t.Run("returns false for unknown agent", func(t *testing.T) {
+		qs := queue.NewSendRecvQueues()
+		s := NewServer(qs, event.NewEventWritersMap(), nil, &fakeStatusUpdater{})
+		assert.False(t, s.DisconnectAgent("unknown"))
+	})
+
+	t.Run("disconnects a connected agent", func(t *testing.T) {
+		qs := queue.NewSendRecvQueues()
+		qs.Create("agent-a")
+		statusUpdater := &fakeStatusUpdater{}
+		s := NewServer(qs, event.NewEventWritersMap(), nil, statusUpdater)
+
+		gate := make(chan struct{})
+		done := make(chan struct{})
+		st := &mock.MockEventServer{AgentName: "agent-a"}
+		st.AddRecvHook(func(_ *mock.MockEventServer) error {
+			<-gate
+			return io.EOF
+		})
+		go func() {
+			_ = s.Subscribe(st)
+			close(done)
+		}()
+
+		require.Eventually(t, func() bool {
+			return s.ConnectedAgentCount() == 1
+		}, time.Second, 10*time.Millisecond)
+
+		assert.True(t, s.DisconnectAgent("agent-a"))
+		close(gate)
+
+		require.Eventually(t, func() bool {
+			return s.ConnectedAgentCount() == 0
+		}, time.Second, 10*time.Millisecond)
+		<-done
+
+		statuses := statusUpdater.statusesFor("agent-a")
+		assert.Contains(t, statuses, v1alpha1.ConnectionStatusFailed)
+	})
+
+	t.Run("returns false after agent already disconnected", func(t *testing.T) {
+		qs := queue.NewSendRecvQueues()
+		qs.Create("agent-a")
+		s := NewServer(qs, event.NewEventWritersMap(), nil, &fakeStatusUpdater{})
+
+		gate := make(chan struct{})
+		done := make(chan struct{})
+		st := &mock.MockEventServer{AgentName: "agent-a"}
+		st.AddRecvHook(func(_ *mock.MockEventServer) error {
+			<-gate
+			return io.EOF
+		})
+		go func() {
+			_ = s.Subscribe(st)
+			close(done)
+		}()
+
+		require.Eventually(t, func() bool {
+			return s.ConnectedAgentCount() == 1
+		}, time.Second, 10*time.Millisecond)
+
+		assert.True(t, s.DisconnectAgent("agent-a"))
+		assert.False(t, s.DisconnectAgent("agent-a"))
+		close(gate)
+		<-done
+	})
+}
+
 func TestAcceptCheck(t *testing.T) {
 	clusterMgr := &cluster.Manager{}
 

--- a/principal/auth.go
+++ b/principal/auth.go
@@ -161,7 +161,7 @@ func isReplicationMethod(fullMethod string) bool {
 // server's mTLS auth method (same as agent auth) and optionally checks
 // the extracted identity against the allowed replication clients list.
 func (s *Server) authenticateReplication(ctx context.Context) error {
-	mtlsMethod := s.authMethods.Method("mtls")
+	mtlsMethod := s.authMethods.Method(auth.MethodMTLS)
 	if mtlsMethod == nil {
 		return status.Errorf(codes.Unauthenticated, "replication requires mTLS auth but no mtls method configured")
 	}

--- a/principal/callbacks.go
+++ b/principal/callbacks.go
@@ -19,6 +19,8 @@ import (
 	"fmt"
 	"sync"
 
+	"github.com/argoproj-labs/argocd-agent/internal/blocklist"
+	"github.com/argoproj-labs/argocd-agent/internal/config"
 	"github.com/argoproj-labs/argocd-agent/internal/event"
 	"github.com/argoproj-labs/argocd-agent/internal/event/targets"
 	"github.com/argoproj-labs/argocd-agent/internal/manager"
@@ -1151,6 +1153,79 @@ func (c *concurrentMap[K, V]) DeleteByValue(value V, eq func(a, b V) bool) {
 	for k, v := range c.m {
 		if eq(v, value) {
 			delete(c.m, k)
+		}
+	}
+}
+
+// trackAgentFingerprint records the mapping from a certificate fingerprint to
+// the connected agent name. This is used by the blocklist informer callback
+// to disconnect an agent by fingerprint without requiring an agent name in the
+// blocklist entry.
+func (s *Server) trackAgentFingerprint(agentName, fingerprint string) {
+	s.fingerprintToAgent.Set(fingerprint, agentName)
+}
+
+// addBlocklistCallback is called by the informer when the blocklist ConfigMap
+// is first added.
+func (s *Server) addBlocklistCallback(cm *corev1.ConfigMap) {
+	s.updateBlocklistCallback(nil, cm)
+}
+
+// updateBlocklistCallback is called by the informer when the blocklist
+// ConfigMap is updated. It replaces the in-memory blocklist with
+// the entries from the ConfigMap and disconnects any newly blocklisted agents.
+func (s *Server) updateBlocklistCallback(oldCM, newCM *corev1.ConfigMap) {
+	if s.blocklist == nil {
+		return
+	}
+	newFingerprints, err := blocklist.ParseFingerprints(newCM.Data[config.ConfigMapKeyBlocklistChecksums])
+	if err != nil {
+		log().WithError(err).Error("Failed to parse blocklist ConfigMap data")
+		return
+	}
+
+	oldFingerprints := make(map[string]bool)
+	if oldCM != nil {
+		oldList, _ := blocklist.ParseFingerprints(oldCM.Data[config.ConfigMapKeyBlocklistChecksums])
+		for _, fp := range oldList {
+			oldFingerprints[fp] = true
+		}
+	}
+
+	s.blocklist.Replace(newFingerprints)
+	log().Infof("Reloaded TLS blocklist: %d entries", s.blocklist.Len())
+
+	s.disconnectNewlyBlocklisted(newFingerprints, oldFingerprints)
+}
+
+// deleteBlocklistCallback is called by the informer when the blocklist
+// ConfigMap is deleted. It clears the in-memory blocklist so that previously
+// blocked agents can reconnect.
+func (s *Server) deleteBlocklistCallback(cm *corev1.ConfigMap) {
+	if s.blocklist == nil {
+		return
+	}
+	s.blocklist.Replace([]string{})
+	log().Info("Blocklist ConfigMap deleted, cleared in-memory blocklist")
+}
+
+// disconnectNewlyBlocklisted terminates active connections for any fingerprints
+// that were not present in the previous blocklist. It resolves the agent name
+// from the in-memory fingerprint-to-agent mapping.
+func (s *Server) disconnectNewlyBlocklisted(fingerprints []string, oldFingerprints map[string]bool) {
+	if s.eventStreamSrv == nil {
+		return
+	}
+	for _, fp := range fingerprints {
+		if oldFingerprints[fp] {
+			continue
+		}
+		agentName := s.fingerprintToAgent.Get(fp)
+		if agentName == "" {
+			continue
+		}
+		if s.eventStreamSrv.DisconnectAgent(agentName) {
+			log().Infof("Disconnected blocklisted agent %s (fingerprint: %s)", agentName, fp)
 		}
 	}
 }

--- a/principal/callbacks.go
+++ b/principal/callbacks.go
@@ -1173,7 +1173,7 @@ func (s *Server) addBlocklistCallback(cm *corev1.ConfigMap) {
 // updateBlocklistCallback is called by the informer when the blocklist
 // ConfigMap is updated. It replaces the in-memory blocklist with
 // the entries from the ConfigMap and disconnects all blocklisted agents.
-func (s *Server) updateBlocklistCallback(oldCM, newCM *corev1.ConfigMap) {
+func (s *Server) updateBlocklistCallback(_, newCM *corev1.ConfigMap) {
 	if s.blocklist == nil {
 		return
 	}

--- a/principal/callbacks.go
+++ b/principal/callbacks.go
@@ -1163,7 +1163,7 @@ func (s *Server) addBlocklistCallback(cm *corev1.ConfigMap) {
 // updateBlocklistCallback is called by the informer when the blocklist
 // ConfigMap is updated. It replaces the in-memory blocklist with
 // the entries from the ConfigMap and disconnects all blocklisted agents.
-func (s *Server) updateBlocklistCallback(oldCM, newCM *corev1.ConfigMap) {
+func (s *Server) updateBlocklistCallback(_, newCM *corev1.ConfigMap) {
 	if s.blocklist == nil {
 		return
 	}

--- a/principal/callbacks.go
+++ b/principal/callbacks.go
@@ -20,7 +20,6 @@ import (
 	"sync"
 
 	"github.com/argoproj-labs/argocd-agent/internal/blocklist"
-	"github.com/argoproj-labs/argocd-agent/internal/config"
 	"github.com/argoproj-labs/argocd-agent/internal/event"
 	"github.com/argoproj-labs/argocd-agent/internal/event/targets"
 	"github.com/argoproj-labs/argocd-agent/internal/manager"
@@ -1178,16 +1177,11 @@ func (s *Server) updateBlocklistCallback(oldCM, newCM *corev1.ConfigMap) {
 	if s.blocklist == nil {
 		return
 	}
-	newFingerprints, err := blocklist.ParseFingerprints(newCM.Data[config.ConfigMapKeyBlocklistChecksums])
-	if err != nil {
-		log().WithError(err).Error("Failed to parse blocklist ConfigMap data")
-		return
-	}
+	newFingerprints := blocklist.FingerprintsFromConfigMapData(newCM.Data)
 
 	oldFingerprints := make(map[string]bool)
 	if oldCM != nil {
-		oldList, _ := blocklist.ParseFingerprints(oldCM.Data[config.ConfigMapKeyBlocklistChecksums])
-		for _, fp := range oldList {
+		for _, fp := range blocklist.FingerprintsFromConfigMapData(oldCM.Data) {
 			oldFingerprints[fp] = true
 		}
 	}

--- a/principal/callbacks.go
+++ b/principal/callbacks.go
@@ -1151,7 +1151,7 @@ func (c *concurrentMap[K, V]) DeleteByValue(value V, eq func(a, b V) bool) {
 // to disconnect an agent by fingerprint without requiring an agent name in the
 // blocklist entry.
 func (s *Server) trackAgentFingerprint(agentName, fingerprint string) {
-	s.fingerprintToAgent.Set(fingerprint, agentName)
+	s.blocklist.TrackAgent(fingerprint, agentName)
 }
 
 // addBlocklistCallback is called by the informer when the blocklist ConfigMap
@@ -1162,24 +1162,15 @@ func (s *Server) addBlocklistCallback(cm *corev1.ConfigMap) {
 
 // updateBlocklistCallback is called by the informer when the blocklist
 // ConfigMap is updated. It replaces the in-memory blocklist with
-// the entries from the ConfigMap and disconnects any newly blocklisted agents.
+// the entries from the ConfigMap and disconnects all blocklisted agents.
 func (s *Server) updateBlocklistCallback(oldCM, newCM *corev1.ConfigMap) {
 	if s.blocklist == nil {
 		return
 	}
-	newFingerprints := blocklist.FingerprintsFromConfigMapData(newCM.Data)
-
-	oldFingerprints := make(map[string]bool)
-	if oldCM != nil {
-		for _, fp := range blocklist.FingerprintsFromConfigMapData(oldCM.Data) {
-			oldFingerprints[fp] = true
-		}
-	}
-
-	s.blocklist.Replace(newFingerprints)
+	fingerprints := blocklist.FingerprintsFromConfigMapData(newCM.Data)
+	s.blocklist.Replace(fingerprints)
 	log().Infof("Reloaded TLS blocklist: %d entries", s.blocklist.Len())
-
-	s.disconnectNewlyBlocklisted(newFingerprints, oldFingerprints)
+	s.disconnectBlocklisted(fingerprints)
 }
 
 // deleteBlocklistCallback is called by the informer when the blocklist
@@ -1193,18 +1184,15 @@ func (s *Server) deleteBlocklistCallback(cm *corev1.ConfigMap) {
 	log().Info("Blocklist ConfigMap deleted, cleared in-memory blocklist")
 }
 
-// disconnectNewlyBlocklisted terminates active connections for any fingerprints
-// that were not present in the previous blocklist. It resolves the agent name
-// from the in-memory fingerprint-to-agent mapping.
-func (s *Server) disconnectNewlyBlocklisted(fingerprints []string, oldFingerprints map[string]bool) {
+// disconnectBlocklisted terminates active connections for all blocklisted
+// fingerprints. It resolves the agent name from the in-memory
+// fingerprint-to-agent mapping.
+func (s *Server) disconnectBlocklisted(fingerprints []string) {
 	if s.eventStreamSrv == nil {
 		return
 	}
 	for _, fp := range fingerprints {
-		if oldFingerprints[fp] {
-			continue
-		}
-		agentName := s.fingerprintToAgent.Get(fp)
+		agentName := s.blocklist.AgentForFingerprint(fp)
 		if agentName == "" {
 			continue
 		}

--- a/principal/callbacks.go
+++ b/principal/callbacks.go
@@ -19,6 +19,8 @@ import (
 	"fmt"
 	"sync"
 
+	"github.com/argoproj-labs/argocd-agent/internal/blocklist"
+	"github.com/argoproj-labs/argocd-agent/internal/config"
 	"github.com/argoproj-labs/argocd-agent/internal/event"
 	"github.com/argoproj-labs/argocd-agent/internal/event/targets"
 	"github.com/argoproj-labs/argocd-agent/internal/manager"
@@ -1141,6 +1143,79 @@ func (c *concurrentMap[K, V]) DeleteByValue(value V, eq func(a, b V) bool) {
 	for k, v := range c.m {
 		if eq(v, value) {
 			delete(c.m, k)
+		}
+	}
+}
+
+// trackAgentFingerprint records the mapping from a certificate fingerprint to
+// the connected agent name. This is used by the blocklist informer callback
+// to disconnect an agent by fingerprint without requiring an agent name in the
+// blocklist entry.
+func (s *Server) trackAgentFingerprint(agentName, fingerprint string) {
+	s.fingerprintToAgent.Set(fingerprint, agentName)
+}
+
+// addBlocklistCallback is called by the informer when the blocklist ConfigMap
+// is first added.
+func (s *Server) addBlocklistCallback(cm *corev1.ConfigMap) {
+	s.updateBlocklistCallback(nil, cm)
+}
+
+// updateBlocklistCallback is called by the informer when the blocklist
+// ConfigMap is updated. It replaces the in-memory blocklist with
+// the entries from the ConfigMap and disconnects any newly blocklisted agents.
+func (s *Server) updateBlocklistCallback(oldCM, newCM *corev1.ConfigMap) {
+	if s.blocklist == nil {
+		return
+	}
+	newFingerprints, err := blocklist.ParseFingerprints(newCM.Data[config.ConfigMapKeyBlocklistChecksums])
+	if err != nil {
+		log().WithError(err).Error("Failed to parse blocklist ConfigMap data")
+		return
+	}
+
+	oldFingerprints := make(map[string]bool)
+	if oldCM != nil {
+		oldList, _ := blocklist.ParseFingerprints(oldCM.Data[config.ConfigMapKeyBlocklistChecksums])
+		for _, fp := range oldList {
+			oldFingerprints[fp] = true
+		}
+	}
+
+	s.blocklist.Replace(newFingerprints)
+	log().Infof("Reloaded TLS blocklist: %d entries", s.blocklist.Len())
+
+	s.disconnectNewlyBlocklisted(newFingerprints, oldFingerprints)
+}
+
+// deleteBlocklistCallback is called by the informer when the blocklist
+// ConfigMap is deleted. It clears the in-memory blocklist so that previously
+// blocked agents can reconnect.
+func (s *Server) deleteBlocklistCallback(cm *corev1.ConfigMap) {
+	if s.blocklist == nil {
+		return
+	}
+	s.blocklist.Replace([]string{})
+	log().Info("Blocklist ConfigMap deleted, cleared in-memory blocklist")
+}
+
+// disconnectNewlyBlocklisted terminates active connections for any fingerprints
+// that were not present in the previous blocklist. It resolves the agent name
+// from the in-memory fingerprint-to-agent mapping.
+func (s *Server) disconnectNewlyBlocklisted(fingerprints []string, oldFingerprints map[string]bool) {
+	if s.eventStreamSrv == nil {
+		return
+	}
+	for _, fp := range fingerprints {
+		if oldFingerprints[fp] {
+			continue
+		}
+		agentName := s.fingerprintToAgent.Get(fp)
+		if agentName == "" {
+			continue
+		}
+		if s.eventStreamSrv.DisconnectAgent(agentName) {
+			log().Infof("Disconnected blocklisted agent %s (fingerprint: %s)", agentName, fp)
 		}
 	}
 }

--- a/principal/callbacks.go
+++ b/principal/callbacks.go
@@ -20,7 +20,6 @@ import (
 	"sync"
 
 	"github.com/argoproj-labs/argocd-agent/internal/blocklist"
-	"github.com/argoproj-labs/argocd-agent/internal/config"
 	"github.com/argoproj-labs/argocd-agent/internal/event"
 	"github.com/argoproj-labs/argocd-agent/internal/event/targets"
 	"github.com/argoproj-labs/argocd-agent/internal/manager"
@@ -1168,16 +1167,11 @@ func (s *Server) updateBlocklistCallback(oldCM, newCM *corev1.ConfigMap) {
 	if s.blocklist == nil {
 		return
 	}
-	newFingerprints, err := blocklist.ParseFingerprints(newCM.Data[config.ConfigMapKeyBlocklistChecksums])
-	if err != nil {
-		log().WithError(err).Error("Failed to parse blocklist ConfigMap data")
-		return
-	}
+	newFingerprints := blocklist.FingerprintsFromConfigMapData(newCM.Data)
 
 	oldFingerprints := make(map[string]bool)
 	if oldCM != nil {
-		oldList, _ := blocklist.ParseFingerprints(oldCM.Data[config.ConfigMapKeyBlocklistChecksums])
-		for _, fp := range oldList {
+		for _, fp := range blocklist.FingerprintsFromConfigMapData(oldCM.Data) {
 			oldFingerprints[fp] = true
 		}
 	}

--- a/principal/callbacks.go
+++ b/principal/callbacks.go
@@ -1161,7 +1161,7 @@ func (c *concurrentMap[K, V]) DeleteByValue(value V, eq func(a, b V) bool) {
 // to disconnect an agent by fingerprint without requiring an agent name in the
 // blocklist entry.
 func (s *Server) trackAgentFingerprint(agentName, fingerprint string) {
-	s.fingerprintToAgent.Set(fingerprint, agentName)
+	s.blocklist.TrackAgent(fingerprint, agentName)
 }
 
 // addBlocklistCallback is called by the informer when the blocklist ConfigMap
@@ -1172,24 +1172,15 @@ func (s *Server) addBlocklistCallback(cm *corev1.ConfigMap) {
 
 // updateBlocklistCallback is called by the informer when the blocklist
 // ConfigMap is updated. It replaces the in-memory blocklist with
-// the entries from the ConfigMap and disconnects any newly blocklisted agents.
+// the entries from the ConfigMap and disconnects all blocklisted agents.
 func (s *Server) updateBlocklistCallback(oldCM, newCM *corev1.ConfigMap) {
 	if s.blocklist == nil {
 		return
 	}
-	newFingerprints := blocklist.FingerprintsFromConfigMapData(newCM.Data)
-
-	oldFingerprints := make(map[string]bool)
-	if oldCM != nil {
-		for _, fp := range blocklist.FingerprintsFromConfigMapData(oldCM.Data) {
-			oldFingerprints[fp] = true
-		}
-	}
-
-	s.blocklist.Replace(newFingerprints)
+	fingerprints := blocklist.FingerprintsFromConfigMapData(newCM.Data)
+	s.blocklist.Replace(fingerprints)
 	log().Infof("Reloaded TLS blocklist: %d entries", s.blocklist.Len())
-
-	s.disconnectNewlyBlocklisted(newFingerprints, oldFingerprints)
+	s.disconnectBlocklisted(fingerprints)
 }
 
 // deleteBlocklistCallback is called by the informer when the blocklist
@@ -1203,18 +1194,15 @@ func (s *Server) deleteBlocklistCallback(cm *corev1.ConfigMap) {
 	log().Info("Blocklist ConfigMap deleted, cleared in-memory blocklist")
 }
 
-// disconnectNewlyBlocklisted terminates active connections for any fingerprints
-// that were not present in the previous blocklist. It resolves the agent name
-// from the in-memory fingerprint-to-agent mapping.
-func (s *Server) disconnectNewlyBlocklisted(fingerprints []string, oldFingerprints map[string]bool) {
+// disconnectBlocklisted terminates active connections for all blocklisted
+// fingerprints. It resolves the agent name from the in-memory
+// fingerprint-to-agent mapping.
+func (s *Server) disconnectBlocklisted(fingerprints []string) {
 	if s.eventStreamSrv == nil {
 		return
 	}
 	for _, fp := range fingerprints {
-		if oldFingerprints[fp] {
-			continue
-		}
-		agentName := s.fingerprintToAgent.Get(fp)
+		agentName := s.blocklist.AgentForFingerprint(fp)
 		if agentName == "" {
 			continue
 		}

--- a/principal/listen.go
+++ b/principal/listen.go
@@ -257,9 +257,14 @@ func (l *Listener) Address() string {
 // This method should be called after the server is configured, and has all
 // required configuration properties set.
 func (s *Server) registerGrpcServices(metrics *metrics.PrincipalMetrics) error {
-	authSrv, err := auth.NewServer(s.queues, s.namespace, s.authMethods, s.issuer,
+	authOpts := []auth.ServerOption{
 		auth.WithAgentRegistrationManager(s.agentRegistrationManager),
-		auth.WithOnAuthenticated(s.setAgentNamespace))
+		auth.WithOnAuthenticated(s.setAgentNamespace),
+	}
+	if s.blocklist != nil {
+		authOpts = append(authOpts, auth.WithOnCertificateSeen(s.trackAgentFingerprint))
+	}
+	authSrv, err := auth.NewServer(s.queues, s.namespace, s.authMethods, s.issuer, authOpts...)
 	if err != nil {
 		return fmt.Errorf("could not create new auth server: %w", err)
 	}

--- a/principal/listen_test.go
+++ b/principal/listen_test.go
@@ -165,7 +165,7 @@ func Test_Serve(t *testing.T) {
 
 	// Create and register authentication method
 	up := userPass(t, "hello", "world")
-	s.authMethods.RegisterMethod("userpass", up)
+	s.authMethods.RegisterMethod(auth.MethodUserPass, up)
 
 	conn := grpcDialer(t, s)
 	defer conn.Close()
@@ -174,7 +174,7 @@ func Test_Serve(t *testing.T) {
 	a, err := authC.Authenticate(
 		context.Background(),
 		&authapi.AuthRequest{
-			Method:      "userpass",
+			Method:      auth.MethodUserPass,
 			Credentials: creds("hello", "world"),
 			Mode:        types.AgentModeAutonomous.String(),
 			Version:     testVersion,

--- a/principal/options.go
+++ b/principal/options.go
@@ -32,6 +32,7 @@ import (
 	"time"
 
 	"github.com/argoproj-labs/argocd-agent/internal/auth"
+	"github.com/argoproj-labs/argocd-agent/internal/blocklist"
 	"github.com/argoproj-labs/argocd-agent/internal/grpcutil"
 	"github.com/argoproj-labs/argocd-agent/internal/logging"
 	"github.com/argoproj-labs/argocd-agent/internal/tlsutil"
@@ -447,6 +448,14 @@ func WithMetricsPort(port int) ServerOption {
 func WithAuthMethods(am *auth.Methods) ServerOption {
 	return func(o *Server) error {
 		o.authMethods = am
+		return nil
+	}
+}
+
+// WithBlocklist sets the TLS certificate blocklist for the server.
+func WithBlocklist(bl *blocklist.Blocklist) ServerOption {
+	return func(o *Server) error {
+		o.blocklist = bl
 		return nil
 	}
 }

--- a/principal/server.go
+++ b/principal/server.go
@@ -895,8 +895,7 @@ func (s *Server) Start(ctx context.Context, errch chan error) error {
 	if s.blocklist != nil && s.blocklist.Informer != nil {
 		go func() {
 			if err := s.blocklist.Informer.Start(s.ctx); err != nil {
-				log().WithError(err).Error("Blocklist informer has exited non-successfully")
-				errch <- fmt.Errorf("blocklist informer failed: %w", err)
+				logrus.Fatalf("Blocklist informer has exited non-successfully: %v", err)
 			} else {
 				log().Info("Blocklist informer has exited")
 			}

--- a/principal/server.go
+++ b/principal/server.go
@@ -94,10 +94,6 @@ type Server struct {
 	grpcServer  *grpc.Server
 	authMethods *auth.Methods
 	blocklist   *blocklist.Blocklist
-	// blocklistInformer watches the TLS blocklist ConfigMap for changes
-	blocklistInformer *informer.Informer[*corev1.ConfigMap]
-	// fingerprintToAgent maps certificate fingerprints to connected agent names
-	fingerprintToAgent *concurrentMap[string, string]
 	// queues contains events that are EITHER queued to be sent to the agent ('outbox'), OR that have been received by the agent and are waiting to be processed ('inbox').
 	// Server uses clientID/namespace as a key, to refer to each specific agent's queue
 	queues *queue.SendRecvQueues
@@ -506,10 +502,8 @@ func NewServer(ctx context.Context, kubeClient *kube.KubernetesClient, namespace
 		if err != nil {
 			return nil, fmt.Errorf("could not create blocklist informer: %w", err)
 		}
-		s.blocklistInformer = blocklistInformer
+		s.blocklist.Informer = blocklistInformer
 	}
-
-	s.fingerprintToAgent = &concurrentMap[string, string]{m: make(map[string]string)}
 	s.clientMap = map[string]string{
 		`{"clientID":"argocd","mode":"autonomous"}`: "argocd",
 	}
@@ -898,10 +892,11 @@ func (s *Server) Start(ctx context.Context, errch chan error) error {
 	}
 
 	// Start the blocklist informer
-	if s.blocklistInformer != nil {
+	if s.blocklist != nil && s.blocklist.Informer != nil {
 		go func() {
-			if err := s.blocklistInformer.Start(s.ctx); err != nil {
+			if err := s.blocklist.Informer.Start(s.ctx); err != nil {
 				log().WithError(err).Error("Blocklist informer has exited non-successfully")
+				errch <- fmt.Errorf("blocklist informer failed: %w", err)
 			} else {
 				log().Info("Blocklist informer has exited")
 			}

--- a/principal/server.go
+++ b/principal/server.go
@@ -37,6 +37,7 @@ import (
 	kubegpgkey "github.com/argoproj-labs/argocd-agent/internal/backend/kubernetes/gpgkey"
 	kubenamespace "github.com/argoproj-labs/argocd-agent/internal/backend/kubernetes/namespace"
 	kuberepository "github.com/argoproj-labs/argocd-agent/internal/backend/kubernetes/repository"
+	"github.com/argoproj-labs/argocd-agent/internal/blocklist"
 	"github.com/argoproj-labs/argocd-agent/internal/cache"
 	"github.com/argoproj-labs/argocd-agent/internal/config"
 	"github.com/argoproj-labs/argocd-agent/internal/event"
@@ -92,6 +93,11 @@ type Server struct {
 	server      *http.Server
 	grpcServer  *grpc.Server
 	authMethods *auth.Methods
+	blocklist   *blocklist.Blocklist
+	// blocklistInformer watches the TLS blocklist ConfigMap for changes
+	blocklistInformer *informer.Informer[*corev1.ConfigMap]
+	// fingerprintToAgent maps certificate fingerprints to connected agent names
+	fingerprintToAgent *concurrentMap[string, string]
 	// queues contains events that are EITHER queued to be sent to the agent ('outbox'), OR that have been received by the agent and are waiting to be processed ('inbox').
 	// Server uses clientID/namespace as a key, to refer to each specific agent's queue
 	queues *queue.SendRecvQueues
@@ -480,6 +486,30 @@ func NewServer(ctx context.Context, kubeClient *kube.KubernetesClient, namespace
 	gpgKeyBackend := kubegpgkey.NewKubernetesBackend(kubeClient.Clientset, namespace, gpgKeyInformer)
 	s.gpgKeyManager = gpgkey.NewManager(gpgKeyBackend, namespace)
 
+	if s.blocklist != nil {
+		fieldSelector := fmt.Sprintf("metadata.name=%s", config.ConfigMapNameTLSBlocklist)
+		blocklistInformerOpts := []informer.InformerOption[*corev1.ConfigMap]{
+			informer.WithListHandler[*corev1.ConfigMap](func(ctx context.Context, opts v1.ListOptions) (runtime.Object, error) {
+				opts.FieldSelector = fieldSelector
+				return kubeClient.Clientset.CoreV1().ConfigMaps(namespace).List(ctx, opts)
+			}),
+			informer.WithWatchHandler[*corev1.ConfigMap](func(ctx context.Context, opts v1.ListOptions) (watch.Interface, error) {
+				opts.FieldSelector = fieldSelector
+				return kubeClient.Clientset.CoreV1().ConfigMaps(namespace).Watch(ctx, opts)
+			}),
+			informer.WithAddHandler[*corev1.ConfigMap](s.addBlocklistCallback),
+			informer.WithUpdateHandler[*corev1.ConfigMap](s.updateBlocklistCallback),
+			informer.WithDeleteHandler[*corev1.ConfigMap](s.deleteBlocklistCallback),
+			informer.WithGroupResource[*corev1.ConfigMap]("", "configmaps"),
+		}
+		blocklistInformer, err := informer.NewInformer(ctx, blocklistInformerOpts...)
+		if err != nil {
+			return nil, fmt.Errorf("could not create blocklist informer: %w", err)
+		}
+		s.blocklistInformer = blocklistInformer
+	}
+
+	s.fingerprintToAgent = &concurrentMap[string, string]{m: make(map[string]string)}
 	s.clientMap = map[string]string{
 		`{"clientID":"argocd","mode":"autonomous"}`: "argocd",
 	}
@@ -865,6 +895,17 @@ func (s *Server) Start(ctx context.Context, errch chan error) error {
 		if err := s.serveGRPC(ctx, s.metrics, s.grpcServerMetrics, errch); err != nil {
 			return err
 		}
+	}
+
+	// Start the blocklist informer
+	if s.blocklistInformer != nil {
+		go func() {
+			if err := s.blocklistInformer.Start(s.ctx); err != nil {
+				log().WithError(err).Error("Blocklist informer has exited non-successfully")
+			} else {
+				log().Info("Blocklist informer has exited")
+			}
+		}()
 	}
 
 	return nil

--- a/test/e2e/appproject_test.go
+++ b/test/e2e/appproject_test.go
@@ -222,7 +222,7 @@ func (suite *AppProjectTestSuite) Test_AppProject_Default_Managed() {
 			return false
 		}
 		return appProject.Spec.Description == testDescription
-	}, 30*time.Second, 1*time.Second)
+	}, 180*time.Second, 3*time.Second)
 }
 
 // Default AppProject updates on the autonomous agent should be propagated to the principal

--- a/test/e2e/appproject_test.go
+++ b/test/e2e/appproject_test.go
@@ -397,7 +397,7 @@ func (suite *AppProjectTestSuite) Test_AppProject_Default_Managed() {
 			return false
 		}
 		return appProject.Spec.Description == testDescription
-	}, 30*time.Second, 1*time.Second)
+	}, 180*time.Second, 3*time.Second)
 }
 
 // Default AppProject updates on the autonomous agent should be propagated to the principal

--- a/test/e2e/blocklist_test.go
+++ b/test/e2e/blocklist_test.go
@@ -1,0 +1,243 @@
+// Copyright 2026 The argocd-agent Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package e2e
+
+import (
+	"crypto/x509"
+	"encoding/json"
+	"encoding/pem"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/argoproj-labs/argocd-agent/internal/config"
+	"github.com/argoproj-labs/argocd-agent/internal/tlsutil"
+	"github.com/argoproj-labs/argocd-agent/test/e2e/fixture"
+	appv1 "github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
+	"github.com/stretchr/testify/suite"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+type BlocklistTestSuite struct {
+	fixture.BaseSuite
+}
+
+func TestBlocklistTestSuite(t *testing.T) {
+	suite.Run(t, new(BlocklistTestSuite))
+}
+
+func (suite *BlocklistTestSuite) SetupTest() {
+	for _, proc := range []string{fixture.PrincipalName, fixture.AgentManagedName, fixture.AgentAutonomousName} {
+		if !fixture.IsProcessRunning(proc) {
+			suite.Require().NoError(fixture.StartProcess(proc))
+		}
+		fixture.CheckReadiness(suite.T(), proc)
+	}
+	suite.deleteBlocklistConfigMap()
+	suite.BaseSuite.SetupTest()
+}
+
+func (suite *BlocklistTestSuite) TearDownTest() {
+	suite.deleteBlocklistConfigMap()
+	suite.BaseSuite.TearDownTest()
+}
+
+func (suite *BlocklistTestSuite) Test_BlocklistDisconnectsManagedAgent() {
+	suite.runBlocklistTest(fixture.AgentManagedName, fixture.ManagedAgentNamespace, suite.ManagedAgentClient)
+}
+
+func (suite *BlocklistTestSuite) Test_BlocklistDisconnectsAutonomousAgent() {
+	suite.runBlocklistTest(fixture.AgentAutonomousName, fixture.AutonomousAgentNamespace, suite.AutonomousAgentClient)
+}
+
+// Test_BlocklistPrincipalRestart verifies that a blocklisted agent
+// remains blocked after the principal is restarted, and that removing the
+// fingerprint after restart allows the agent to reconnect.
+func (suite *BlocklistTestSuite) Test_BlocklistPrincipalRestart() {
+	requires := suite.Require()
+	t := suite.T()
+
+	agentName := fixture.AgentManagedName
+	connectedMsg := fmt.Sprintf("Agent: '%s' is connected with principal", agentName)
+	disconnectedMsg := fmt.Sprintf("Agent: '%s' is disconnected with principal", agentName)
+
+	// Verify the agent is connected
+	t.Log("Verifying agent is connected")
+	requires.Eventually(func() bool {
+		return fixture.HasConnectionStatus(agentName, appv1.ConnectionState{
+			Status:  appv1.ConnectionStatusSuccessful,
+			Message: connectedMsg,
+		}, suite.ClusterDetails)
+	}, 60*time.Second, 3*time.Second)
+
+	// Add the agent's fingerprint to the blocklist
+	fingerprint := suite.getAgentFingerprint("argocd-agent-client-tls", fixture.ManagedAgentNamespace, suite.ManagedAgentClient)
+	t.Logf("Agent fingerprint: %s", fingerprint)
+	suite.saveBlocklistConfigMap([]string{fingerprint})
+
+	// Verify the agent is disconnected
+	t.Log("Verifying agent is disconnected")
+	requires.Eventually(func() bool {
+		return fixture.HasConnectionStatus(agentName, appv1.ConnectionState{
+			Status:  appv1.ConnectionStatusFailed,
+			Message: disconnectedMsg,
+		}, suite.ClusterDetails)
+	}, 120*time.Second, 3*time.Second)
+
+	// Restart the principal while the blocklist ConfigMap still exists
+	t.Log("Restarting principal")
+	requires.NoError(fixture.StopProcess(fixture.PrincipalName))
+	requires.Eventually(func() bool {
+		return !fixture.IsProcessRunning(fixture.PrincipalName)
+	}, 30*time.Second, 1*time.Second)
+	requires.NoError(fixture.StartProcess(fixture.PrincipalName))
+	fixture.CheckReadiness(suite.T(), fixture.PrincipalName)
+
+	// The agent should still be blocked after principal restart
+	t.Log("Verifying agent remains blocked after principal restart")
+	requires.Eventually(func() bool {
+		return fixture.HasConnectionStatus(agentName, appv1.ConnectionState{
+			Status:  appv1.ConnectionStatusFailed,
+			Message: disconnectedMsg,
+		}, suite.ClusterDetails)
+	}, 120*time.Second, 3*time.Second)
+
+	// Remove the fingerprint from the blocklist
+	t.Log("Removing fingerprint from blocklist")
+	suite.saveBlocklistConfigMap([]string{})
+
+	// Verify the agent reconnects
+	t.Log("Verifying agent reconnects")
+	requires.Eventually(func() bool {
+		return fixture.HasConnectionStatus(agentName, appv1.ConnectionState{
+			Status:  appv1.ConnectionStatusSuccessful,
+			Message: connectedMsg,
+		}, suite.ClusterDetails)
+	}, 120*time.Second, 3*time.Second)
+}
+
+// runBlocklistTest verifies that adding an agent's certificate fingerprint to
+// the blocklist ConfigMap disconnects the agent, and removing it allows the
+// agent to reconnect.
+func (suite *BlocklistTestSuite) runBlocklistTest(agentName, agentNamespace string, agentClient fixture.KubeClient) {
+	requires := suite.Require()
+	t := suite.T()
+
+	connectedMsg := fmt.Sprintf("Agent: '%s' is connected with principal", agentName)
+	disconnectedMsg := fmt.Sprintf("Agent: '%s' is disconnected with principal", agentName)
+
+	// Verify the agent is connected
+	t.Logf("Verifying %s is connected", agentName)
+	requires.Eventually(func() bool {
+		return fixture.HasConnectionStatus(agentName, appv1.ConnectionState{
+			Status:  appv1.ConnectionStatusSuccessful,
+			Message: connectedMsg,
+		}, suite.ClusterDetails)
+	}, 60*time.Second, 3*time.Second)
+
+	// Get the agent's client certificate fingerprint
+	fingerprint := suite.getAgentFingerprint("argocd-agent-client-tls", agentNamespace, agentClient)
+	t.Logf("%s fingerprint: %s", agentName, fingerprint)
+	requires.NotEmpty(fingerprint)
+
+	// Add the fingerprint to the blocklist ConfigMap on the principal
+	t.Logf("Adding %s fingerprint to blocklist", agentName)
+	suite.saveBlocklistConfigMap([]string{fingerprint})
+
+	// Verify the agent is disconnected
+	t.Logf("Verifying %s is disconnected", agentName)
+	requires.Eventually(func() bool {
+		return fixture.HasConnectionStatus(agentName, appv1.ConnectionState{
+			Status:  appv1.ConnectionStatusFailed,
+			Message: disconnectedMsg,
+		}, suite.ClusterDetails)
+	}, 120*time.Second, 3*time.Second)
+
+	// Remove the fingerprint from the blocklist
+	t.Logf("Removing %s fingerprint from blocklist", agentName)
+	suite.saveBlocklistConfigMap([]string{})
+
+	// Verify the agent reconnects
+	t.Logf("Verifying %s reconnects", agentName)
+	requires.Eventually(func() bool {
+		return fixture.HasConnectionStatus(agentName, appv1.ConnectionState{
+			Status:  appv1.ConnectionStatusSuccessful,
+			Message: connectedMsg,
+		}, suite.ClusterDetails)
+	}, 120*time.Second, 3*time.Second)
+}
+
+// getAgentFingerprint reads the agent's client TLS certificate from its
+// Kubernetes secret and returns the SHA-256 fingerprint.
+func (suite *BlocklistTestSuite) getAgentFingerprint(secretName, namespace string, client fixture.KubeClient) string {
+	secret := &corev1.Secret{}
+	key := types.NamespacedName{Name: secretName, Namespace: namespace}
+	err := client.Get(suite.Ctx, key, secret, metav1.GetOptions{})
+	suite.Require().NoError(err)
+
+	certPEM, ok := secret.Data["tls.crt"]
+	suite.Require().True(ok, "tls.crt not found in secret %s/%s", namespace, secretName)
+
+	block, _ := pem.Decode(certPEM)
+	suite.Require().NotNil(block, "failed to decode PEM from secret %s/%s", namespace, secretName)
+
+	cert, err := x509.ParseCertificate(block.Bytes)
+	suite.Require().NoError(err)
+
+	return tlsutil.CertificateFingerprint(cert)
+}
+
+// saveBlocklistConfigMap creates or updates the blocklist ConfigMap on the
+// principal cluster with the given fingerprints.
+func (suite *BlocklistTestSuite) saveBlocklistConfigMap(fingerprints []string) {
+	data, err := json.Marshal(fingerprints)
+	suite.Require().NoError(err)
+
+	cm := &corev1.ConfigMap{}
+	key := types.NamespacedName{Name: config.ConfigMapNameTLSBlocklist, Namespace: fixture.PrincipalNamespace}
+	err = suite.PrincipalClient.Get(suite.Ctx, key, cm, metav1.GetOptions{})
+	if errors.IsNotFound(err) {
+		cm = &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      config.ConfigMapNameTLSBlocklist,
+				Namespace: fixture.PrincipalNamespace,
+			},
+			Data: map[string]string{
+				config.ConfigMapKeyBlocklistChecksums: string(data),
+			},
+		}
+		suite.Require().NoError(suite.PrincipalClient.Create(suite.Ctx, cm, metav1.CreateOptions{}))
+		return
+	}
+	suite.Require().NoError(err)
+
+	cm.Data[config.ConfigMapKeyBlocklistChecksums] = string(data)
+	suite.Require().NoError(suite.PrincipalClient.Update(suite.Ctx, cm, metav1.UpdateOptions{}))
+}
+
+// deleteBlocklistConfigMap removes the blocklist ConfigMap from the principal
+// cluster to clean up after tests.
+func (suite *BlocklistTestSuite) deleteBlocklistConfigMap() {
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      config.ConfigMapNameTLSBlocklist,
+			Namespace: fixture.PrincipalNamespace,
+		},
+	}
+	suite.Require().NoError(suite.PrincipalClient.Delete(suite.Ctx, cm, metav1.DeleteOptions{}))
+}

--- a/test/e2e/blocklist_test.go
+++ b/test/e2e/blocklist_test.go
@@ -16,7 +16,6 @@ package e2e
 
 import (
 	"crypto/x509"
-	"encoding/json"
 	"encoding/pem"
 	"fmt"
 	"testing"
@@ -203,30 +202,31 @@ func (suite *BlocklistTestSuite) getAgentFingerprint(secretName, namespace strin
 }
 
 // saveBlocklistConfigMap creates or updates the blocklist ConfigMap on the
-// principal cluster with the given fingerprints.
+// principal cluster with the given fingerprints. Each fingerprint is stored
+// as its own key in the ConfigMap data.
 func (suite *BlocklistTestSuite) saveBlocklistConfigMap(fingerprints []string) {
-	data, err := json.Marshal(fingerprints)
-	suite.Require().NoError(err)
+	cmData := make(map[string]string, len(fingerprints))
+	for _, fp := range fingerprints {
+		cmData[fp] = ""
+	}
 
 	cm := &corev1.ConfigMap{}
 	key := types.NamespacedName{Name: config.ConfigMapNameTLSBlocklist, Namespace: fixture.PrincipalNamespace}
-	err = suite.PrincipalClient.Get(suite.Ctx, key, cm, metav1.GetOptions{})
+	err := suite.PrincipalClient.Get(suite.Ctx, key, cm, metav1.GetOptions{})
 	if errors.IsNotFound(err) {
 		cm = &corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      config.ConfigMapNameTLSBlocklist,
 				Namespace: fixture.PrincipalNamespace,
 			},
-			Data: map[string]string{
-				config.ConfigMapKeyBlocklistChecksums: string(data),
-			},
+			Data: cmData,
 		}
 		suite.Require().NoError(suite.PrincipalClient.Create(suite.Ctx, cm, metav1.CreateOptions{}))
 		return
 	}
 	suite.Require().NoError(err)
 
-	cm.Data[config.ConfigMapKeyBlocklistChecksums] = string(data)
+	cm.Data = cmData
 	suite.Require().NoError(suite.PrincipalClient.Update(suite.Ctx, cm, metav1.UpdateOptions{}))
 }
 

--- a/test/e2e/blocklist_test.go
+++ b/test/e2e/blocklist_test.go
@@ -239,5 +239,8 @@ func (suite *BlocklistTestSuite) deleteBlocklistConfigMap() {
 			Namespace: fixture.PrincipalNamespace,
 		},
 	}
-	suite.Require().NoError(suite.PrincipalClient.Delete(suite.Ctx, cm, metav1.DeleteOptions{}))
+	err := suite.PrincipalClient.Delete(suite.Ctx, cm, metav1.DeleteOptions{})
+	if err != nil && !errors.IsNotFound(err) {
+		suite.Require().NoError(err)
+	}
 }

--- a/test/e2e/blocklist_test.go
+++ b/test/e2e/blocklist_test.go
@@ -42,8 +42,8 @@ func TestBlocklistTestSuite(t *testing.T) {
 
 func (suite *BlocklistTestSuite) SetupTest() {
 	for _, proc := range []string{fixture.PrincipalName, fixture.AgentManagedName, fixture.AgentAutonomousName} {
-		if !fixture.IsProcessRunning(proc) {
-			suite.Require().NoError(fixture.StartProcess(proc))
+		if !fixture.IsProcessRunning(proc, suite.T()) {
+			suite.Require().NoError(fixture.StartProcess(proc, suite.T()))
 		}
 		fixture.CheckReadiness(suite.T(), proc)
 	}
@@ -100,11 +100,11 @@ func (suite *BlocklistTestSuite) Test_BlocklistPrincipalRestart() {
 
 	// Restart the principal while the blocklist ConfigMap still exists
 	t.Log("Restarting principal")
-	requires.NoError(fixture.StopProcess(fixture.PrincipalName))
+	requires.NoError(fixture.StopProcess(fixture.PrincipalName, t))
 	requires.Eventually(func() bool {
-		return !fixture.IsProcessRunning(fixture.PrincipalName)
+		return !fixture.IsProcessRunning(fixture.PrincipalName, t)
 	}, 30*time.Second, 1*time.Second)
-	requires.NoError(fixture.StartProcess(fixture.PrincipalName))
+	requires.NoError(fixture.StartProcess(fixture.PrincipalName, t))
 	fixture.CheckReadiness(suite.T(), fixture.PrincipalName)
 
 	// The agent should still be blocked after principal restart

--- a/test/e2e/clusterinfo_test.go
+++ b/test/e2e/clusterinfo_test.go
@@ -176,7 +176,7 @@ func (suite *ClusterInfoTestSuite) Test_ClusterCacheInfo() {
 	// and then agent updated principal with this information
 	requires.Eventually(func() bool {
 		return fixture.HasApplicationsCount(appCountBefore+1, clusterDetail)
-	}, 180*time.Second, 5*time.Second)
+	}, 240*time.Second, 5*time.Second)
 
 	requires.Eventually(func() bool {
 		return fixture.HasClusterCacheInfoSynced(fixture.AgentManagedName, clusterDetail)
@@ -238,7 +238,7 @@ func (suite *ClusterInfoTestSuite) Test_ClusterCacheInfo() {
 			Message:    fmt.Sprintf(message, fixture.AgentManagedName, "disconnected"),
 			ModifiedAt: &metav1.Time{Time: time.Now()},
 		}, clusterDetail)
-	}, 60*time.Second, 2*time.Second)
+	}, 120*time.Second, 2*time.Second)
 
 	// Step 9:
 	// Since agent is disconnected, cluster cache info should reset to default
@@ -261,7 +261,7 @@ func (suite *ClusterInfoTestSuite) Test_ClusterCacheInfo() {
 			Message:    fmt.Sprintf(message, fixture.AgentManagedName, "connected"),
 			ModifiedAt: &metav1.Time{Time: time.Now()},
 		}, clusterDetail)
-	}, 60*time.Second, 2*time.Second)
+	}, 120*time.Second, 2*time.Second)
 
 	requires.Eventually(func() bool {
 		return fixture.HasClusterCacheInfoSynced(fixture.AgentManagedName, clusterDetail)


### PR DESCRIPTION
This PR is to add support for TLS certificate blocklist that allows administrators to block agents by their client certificate fingerprint. The agents using blocked certificate are immediately disconnected and not allowed to reconnect until fingerprint is removed from blocklist or a new certificate is issued. This PR also adds new CLI commands to manage blocklist.

**Steps to testing**
- Build the CLI and use new CLI binary.
- Start principal and agent.
- Get fingerprint from principal logs
```
level=info msg="client authentication successful" agent_version=99.9.9-unreleased authmethod=mtls client=agent-autonomous fingerprint="D6:E6:2E:5F:10:CF" method=Authenticate module=grpc.AuthenticationServer
```
or get it from workload cluster using `argocd-agentctl agent inspect` CLI command

- Add the fingerprint to blocklist
```
argocd-agentctl blocklist --principal-context vcluster-control-plane --principal-namespace argocd-principal add <fingerprint>
```
- Agent having certificate of provided fingerprint will be disconnected and wont be allowed to reconnect.
- List the fingerprint 
```
argocd-agentctl blocklist --principal-context vcluster-control-plane --principal-namespace argocd-principal list
```
- Delete fingerprint to unblock the certificate
```
argocd-agentctl blocklist --principal-context vcluster-control-plane --principal-namespace argocd-principal remove <fingerprint>
```


Assisted by: Cursor



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added TLS certificate blocklist management via new `blocklist` CLI subcommands (`add`, `remove`, `list`).
  * Agent inspection now displays the client-certificate SHA-256 fingerprint.
  * The principal enforces the TLS blocklist for mTLS connections, immediately disconnecting matching agents and preventing reconnection until unblocked, including dynamic updates.
* **Documentation**
  * Documented blocklist behavior, how updates are applied, how to find fingerprints, and the ConfigMap data-key format.
* **Tests**
  * Added unit and end-to-end coverage for blocklist enforcement, reconnection behavior, and principal restart scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->