### PR TITLE
test(e2e): run e2e tests with destination based mapping

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -166,11 +166,15 @@ jobs:
           flags: unit-tests
 
   test-e2e:
-    name: Run end-to-end tests
+    name: Run end-to-end tests (${{ matrix.mapping-mode }})
     if: ${{ needs.changes.outputs.code == 'true' }}
     runs-on: ubuntu-22.04
     needs:
       - changes
+    strategy:
+      fail-fast: false
+      matrix:
+        mapping-mode: [namespaced-mapping, destination-mapping]
     env:
       GOPATH: /home/runner/go
     steps:
@@ -230,6 +234,13 @@ jobs:
       - name: Set up the test environment
         run: |
           make setup-e2e
+      - name: Set destination-based mapping env vars
+        if: ${{ matrix.mapping-mode == 'destination' }}
+        run: |
+          echo "ARGOCD_AGENT_DESTINATION_BASED_MAPPING=true" >> $GITHUB_ENV
+          echo "ARGOCD_PRINCIPAL_DESTINATION_BASED_MAPPING=true" >> $GITHUB_ENV
+          echo "ARGOCD_AGENT_CREATE_NAMESPACE=true" >> $GITHUB_ENV
+          echo "E2E_DESTINATION_BASED_MAPPING=true" >> $GITHUB_ENV
       - name: Run the principal and agents
         run: |
           make all
@@ -250,31 +261,31 @@ jobs:
       - name: Upload e2e-argocd-agent logs
         uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
         with:
-          name: e2e-argocd-agent.log
+          name: e2e-argocd-agent-${{ matrix.mapping-mode }}.log
           path: /tmp/e2e-argocd-agent.log
         if: ${{ failure() }}
       - name: Upload test logs
         uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
         with:
-          name: test-e2e.log
+          name: test-e2e-${{ matrix.mapping-mode }}.log
           path: /tmp/test-e2e.log
         if: ${{ failure() }}
       - name: Upload vcluster-agent-autonomous-controller logs
         uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
         with:
-          name: vcluster-agent-autonomous-controller.log
+          name: vcluster-agent-autonomous-controller-${{ matrix.mapping-mode }}.log
           path: /tmp/vcluster-agent-autonomous-controller.log
         if: ${{ failure() }}
       - name: Upload vcluster-agent-managed-controller logs
         uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
         with:
-          name: vcluster-agent-managed-controller.log
+          name: vcluster-agent-managed-controller-${{ matrix.mapping-mode }}.log
           path: /tmp/vcluster-agent-managed-controller.log
         if: ${{ failure() }}
       - name: Upload vcluster-control-plane-server logs
         uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
         with:
-          name: vcluster-control-plane-server.log
+          name: vcluster-control-plane-server-${{ matrix.mapping-mode }}.log
           path: /tmp/vcluster-control-plane-server.log
         if: ${{ failure() }}
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -289,6 +289,22 @@ jobs:
           path: /tmp/vcluster-control-plane-server.log
         if: ${{ failure() }}
 
+  test-e2e-result:
+    name: Run end-to-end tests
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    needs:
+      - changes
+      - test-e2e
+    steps:
+      - run: |
+          if [ "${{ needs.test-e2e.result }}" = "success" ] || [ "${{ needs.test-e2e.result }}" = "skipped" ]; then
+            exit 0
+          else
+            echo "One or more e2e test jobs failed"
+            exit 1
+          fi
+
   validate-helm-charts:
     name: Validate Helm charts
     if: ${{ needs.changes.outputs.helm == 'true' }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -235,7 +235,7 @@ jobs:
         run: |
           make setup-e2e
       - name: Set destination-based mapping env vars
-        if: ${{ matrix.mapping-mode == 'destination' }}
+        if: ${{ matrix.mapping-mode == 'destination-mapping' }}
         run: |
           echo "ARGOCD_AGENT_DESTINATION_BASED_MAPPING=true" >> $GITHUB_ENV
           echo "ARGOCD_PRINCIPAL_DESTINATION_BASED_MAPPING=true" >> $GITHUB_ENV

--- a/Makefile
+++ b/Makefile
@@ -101,6 +101,14 @@ start-e2e: cli install-goreman
 test-e2e:
 	./test/run-e2e.sh
 
+.PHONY: test-e2e-destmap
+test-e2e-destmap:
+	E2E_DESTINATION_BASED_MAPPING=true ./test/run-e2e.sh
+
+.PHONY: start-e2e-destmap
+start-e2e-destmap: cli install-goreman
+	ARGOCD_AGENT_DESTINATION_BASED_MAPPING=true ARGOCD_PRINCIPAL_DESTINATION_BASED_MAPPING=true ARGOCD_AGENT_CREATE_NAMESPACE=true ENABLE_DATA_RACE_DETECTOR=$(ENABLE_DATA_RACE_DETECTOR) ./hack/dev-env/start-e2e.sh
+
 .PHONY: test
 test:
 	mkdir -p test/out

--- a/hack/dev-env/start-agent-autonomous.sh
+++ b/hack/dev-env/start-agent-autonomous.sh
@@ -46,6 +46,8 @@ go run ${RACE_FLAG} github.com/argoproj-labs/argocd-agent/cmd/argocd-agent agent
     --server-address 127.0.0.1 \
     --kubecontext vcluster-agent-autonomous \
     --namespace ${ARGOCD_AUTONOMOUS_NAMESPACE} \
+    --destination-based-mapping=false \
+    --create-namespace=false \
     --log-level ${ARGOCD_AGENT_LOG_LEVEL:-trace} $ARGS \
     --metrics-port 8182 \
     --healthz-port 8002 \

--- a/hack/dev-env/start-agent-managed.sh
+++ b/hack/dev-env/start-agent-managed.sh
@@ -50,6 +50,8 @@ go run ${RACE_FLAG} github.com/argoproj-labs/argocd-agent/cmd/argocd-agent agent
     --server-address 127.0.0.1 \
     --kubecontext vcluster-agent-managed \
     --namespace ${ARGOCD_MANAGED_NAMESPACE} \
+    --destination-based-mapping=${ARGOCD_AGENT_DESTINATION_BASED_MAPPING:-false} \
+    --create-namespace=${ARGOCD_AGENT_CREATE_NAMESPACE:-false} \
     --log-level ${ARGOCD_AGENT_LOG_LEVEL:-trace} $ARGS \
     --healthz-port 8001 \
     #--enable-compression true

--- a/hack/dev-env/start-principal.sh
+++ b/hack/dev-env/start-principal.sh
@@ -66,6 +66,7 @@ go run ${RACE_FLAG} github.com/argoproj-labs/argocd-agent/cmd/argocd-agent princ
 	--kubecontext vcluster-control-plane \
 	--log-level ${ARGOCD_AGENT_LOG_LEVEL:-trace} \
 	--namespace ${ARGOCD_PRINCIPAL_NAMESPACE} \
+    --destination-based-mapping=${ARGOCD_PRINCIPAL_DESTINATION_BASED_MAPPING:-false}\
 	--auth "mtls:CN=([^,]+)" \
     --resource-proxy-address "${ARGOCD_AGENT_RESOURCE_PROXY}:9090" \
 	$ARGS

--- a/test/e2e/adoption_test.go
+++ b/test/e2e/adoption_test.go
@@ -62,7 +62,7 @@ func (suite *AdoptionTestSuite) Test_ApplicationIsAdoptedIfExists() {
 	app := argoapp.Application{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "guestbook-adopt",
-			Namespace: fixture.ManagedAgentNamespace,
+			Namespace: fixture.ManagedAgentAppNamespace(),
 		},
 		Spec: argoapp.ApplicationSpec{
 			Project: "default",
@@ -71,10 +71,7 @@ func (suite *AdoptionTestSuite) Test_ApplicationIsAdoptedIfExists() {
 				TargetRevision: "HEAD",
 				Path:           "kustomize-guestbook",
 			},
-			Destination: argoapp.ApplicationDestination{
-				Server:    "https://kubernetes.default.svc",
-				Namespace: "adoption-test",
-			},
+			Destination: fixture.ManagedDestination("adoption-test"),
 			SyncPolicy: &argoapp.SyncPolicy{
 				SyncOptions: argoapp.SyncOptions{
 					"CreateNamespace=true",
@@ -98,7 +95,7 @@ func (suite *AdoptionTestSuite) Test_ApplicationIsAdoptedIfExists() {
 	app2 := argoapp.Application{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "guestbook-adopt",
-			Namespace: fixture.AgentManagedName,
+			Namespace: fixture.ManagedPrincipalAppNamespace(),
 		},
 		Spec: argoapp.ApplicationSpec{
 			Project: "default",
@@ -107,10 +104,7 @@ func (suite *AdoptionTestSuite) Test_ApplicationIsAdoptedIfExists() {
 				TargetRevision: "HEAD",
 				Path:           "kustomize-guestbook",
 			},
-			Destination: argoapp.ApplicationDestination{
-				Name:      "agent-managed",
-				Namespace: "adoption-test",
-			},
+			Destination: fixture.ManagedDestination("adoption-test"),
 		},
 	}
 
@@ -149,7 +143,7 @@ func (suite *AdoptionTestSuite) Test_ApplicationIsNotAdoptedIfPolicyIsNever() {
 	app := argoapp.Application{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "guestbook-dontadopt",
-			Namespace: fixture.ManagedAgentNamespace,
+			Namespace: fixture.ManagedAgentAppNamespace(),
 			Annotations: map[string]string{
 				manager.AdoptionPolicyAnnotation: string(manager.AdoptionPolicyNever),
 			},
@@ -161,10 +155,7 @@ func (suite *AdoptionTestSuite) Test_ApplicationIsNotAdoptedIfPolicyIsNever() {
 				TargetRevision: "HEAD",
 				Path:           "kustomize-guestbook",
 			},
-			Destination: argoapp.ApplicationDestination{
-				Server:    "https://kubernetes.default.svc",
-				Namespace: "adoption-test",
-			},
+			Destination: fixture.ManagedDestination("adoption-test"),
 			SyncPolicy: &argoapp.SyncPolicy{
 				SyncOptions: argoapp.SyncOptions{
 					"CreateNamespace=true",
@@ -188,7 +179,7 @@ func (suite *AdoptionTestSuite) Test_ApplicationIsNotAdoptedIfPolicyIsNever() {
 	app2 := argoapp.Application{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "guestbook-dontadopt",
-			Namespace: fixture.AgentManagedName,
+			Namespace: fixture.ManagedPrincipalAppNamespace(),
 		},
 		Spec: argoapp.ApplicationSpec{
 			Project: "default",
@@ -197,10 +188,7 @@ func (suite *AdoptionTestSuite) Test_ApplicationIsNotAdoptedIfPolicyIsNever() {
 				TargetRevision: "HEAD",
 				Path:           "kustomize-guestbook",
 			},
-			Destination: argoapp.ApplicationDestination{
-				Name:      fixture.AgentManagedName,
-				Namespace: "adoption-test",
-			},
+			Destination: fixture.ManagedDestination("adoption-test"),
 		},
 	}
 

--- a/test/e2e/appcache_test.go
+++ b/test/e2e/appcache_test.go
@@ -73,7 +73,7 @@ func (suite *CacheTestSuite) Test_RevertManagedClusterChanges() {
 	// Create a managed application in the principal-cluster and ensure it is deployed into managed-cluster
 	app := createApp(suite.Ctx, suite.PrincipalClient, requires)
 	principalKey := fixture.ToNamespacedName(&app)
-	agentKey := types.NamespacedName{Name: app.Name, Namespace: fixture.ManagedAgentNamespace}
+	agentKey := types.NamespacedName{Name: app.Name, Namespace: fixture.ManagedAgentAppNamespace()}
 	app = validateManagedAppCreated(suite.Ctx, suite.ManagedAgentClient, suite.PrincipalClient, principalKey, agentKey, requires)
 
 	// Case 1: Modify the application directly in the managed-cluster,
@@ -103,7 +103,7 @@ func (suite *CacheTestSuite) Test_RevertDisconnectedManagedClusterChanges() {
 	// Create a managed application in the principal-cluster and ensure it is deployed into managed-cluster
 	app := createApp(suite.Ctx, suite.PrincipalClient, requires)
 	principalKey := fixture.ToNamespacedName(&app)
-	agentKey := types.NamespacedName{Name: app.Name, Namespace: fixture.ManagedAgentNamespace}
+	agentKey := types.NamespacedName{Name: app.Name, Namespace: fixture.ManagedAgentAppNamespace()}
 	app = validateManagedAppCreated(suite.Ctx, suite.ManagedAgentClient, suite.PrincipalClient, principalKey, agentKey, requires)
 
 	// Case 1: Agent is disconnected with principal, now modify the application directly in the managed-cluster,
@@ -133,7 +133,7 @@ func (suite *CacheTestSuite) Test_CacheRecreatedOnRestart() {
 	// Create a managed application in the principal-cluster and ensure it is deployed into managed-cluster
 	app := createApp(suite.Ctx, suite.PrincipalClient, requires)
 	principalKey := fixture.ToNamespacedName(&app)
-	agentKey := types.NamespacedName{Name: app.Name, Namespace: fixture.ManagedAgentNamespace}
+	agentKey := types.NamespacedName{Name: app.Name, Namespace: fixture.ManagedAgentAppNamespace()}
 	app = validateManagedAppCreated(suite.Ctx, suite.ManagedAgentClient, suite.PrincipalClient, principalKey, agentKey, requires)
 
 	// Case 1: Agent is restarted, now make direct changes in the managed-cluster,
@@ -158,7 +158,7 @@ func (suite *CacheTestSuite) Test_RevertManagedClusterOfflineChanges() {
 	// Create a managed application in the principal-cluster and ensure it is deployed into managed-cluster
 	app := createApp(suite.Ctx, suite.PrincipalClient, requires)
 	principalKey := fixture.ToNamespacedName(&app)
-	agentKey := types.NamespacedName{Name: app.Name, Namespace: fixture.ManagedAgentNamespace}
+	agentKey := types.NamespacedName{Name: app.Name, Namespace: fixture.ManagedAgentAppNamespace()}
 	app = validateManagedAppCreated(suite.Ctx, suite.ManagedAgentClient, suite.PrincipalClient, principalKey, agentKey, requires)
 
 	// Agent in not running, but still make changes in the managed-cluster application manifest.
@@ -268,14 +268,14 @@ func (suite *CacheTestSuite) Test_RevertManagedAppDeletion() {
 	// Create a managed application in the principal-cluster and ensure it is deployed into managed-cluster
 	app := createApp(suite.Ctx, suite.PrincipalClient, requires)
 	principalKey := fixture.ToNamespacedName(&app)
-	agentKey := types.NamespacedName{Name: app.Name, Namespace: fixture.ManagedAgentNamespace}
+	agentKey := types.NamespacedName{Name: app.Name, Namespace: fixture.ManagedAgentAppNamespace()}
 	app = validateManagedAppCreated(suite.Ctx, suite.ManagedAgentClient, suite.PrincipalClient, principalKey, agentKey, requires)
 
 	t.Log("Delete application directly from managed agent")
 	requires.NoError(suite.ManagedAgentClient.Delete(suite.Ctx, &argoapp.Application{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      app.Name,
-			Namespace: fixture.ManagedAgentNamespace,
+			Namespace: fixture.ManagedAgentAppNamespace(),
 		},
 	}, metav1.DeleteOptions{}))
 
@@ -468,7 +468,7 @@ func createApp(ctx context.Context, client fixture.KubeClient, requires *require
 	app := argoapp.Application{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
-			Namespace: fixture.AgentManagedName,
+			Namespace: fixture.ManagedPrincipalAppNamespace(),
 		},
 		Spec: argoapp.ApplicationSpec{
 			Project: "default",
@@ -477,10 +477,7 @@ func createApp(ctx context.Context, client fixture.KubeClient, requires *require
 				TargetRevision: "HEAD",
 				Path:           "kustomize-guestbook",
 			},
-			Destination: argoapp.ApplicationDestination{
-				Server:    fixture.AgentClusterServerURL,
-				Namespace: namespace,
-			},
+			Destination: fixture.ManagedDestination(namespace),
 			SyncPolicy: &argoapp.SyncPolicy{
 				SyncOptions: argoapp.SyncOptions{
 					"CreateNamespace=true",

--- a/test/e2e/appproject_test.go
+++ b/test/e2e/appproject_test.go
@@ -74,7 +74,11 @@ func (suite *AppProjectTestSuite) Test_AppProject_Managed() {
 	requires.Equal("in-cluster", mappProject.Spec.Destinations[0].Name)
 	requires.Equal("https://kubernetes.default.svc", mappProject.Spec.Destinations[0].Server)
 
-	requires.Nil(mappProject.Spec.SourceNamespaces)
+	if fixture.IsDestinationBased() {
+		requires.Equal(appProject.Spec.SourceNamespaces, mappProject.Spec.SourceNamespaces)
+	} else {
+		requires.Nil(mappProject.Spec.SourceNamespaces)
+	}
 
 	// Modify the appProject on the principal and ensure the change is propagated
 	// to the managed-agent

--- a/test/e2e/basic_test.go
+++ b/test/e2e/basic_test.go
@@ -37,7 +37,7 @@ func (suite *BasicTestSuite) Test_AgentManaged() {
 	app := argoapp.Application{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "guestbook",
-			Namespace: "agent-managed",
+			Namespace: fixture.ManagedPrincipalAppNamespace(),
 		},
 		Spec: argoapp.ApplicationSpec{
 			Project: "default",
@@ -46,10 +46,7 @@ func (suite *BasicTestSuite) Test_AgentManaged() {
 				TargetRevision: "HEAD",
 				Path:           "kustomize-guestbook",
 			},
-			Destination: argoapp.ApplicationDestination{
-				Server:    "https://kubernetes.default.svc",
-				Namespace: "guestbook",
-			},
+			Destination: fixture.ManagedDestination("guestbook"),
 			SyncPolicy: &argoapp.SyncPolicy{
 				SyncOptions: argoapp.SyncOptions{
 					"CreateNamespace=true",
@@ -61,7 +58,7 @@ func (suite *BasicTestSuite) Test_AgentManaged() {
 	requires.NoError(err)
 
 	principalKey := fixture.ToNamespacedName(&app)
-	agentKey := types.NamespacedName{Name: app.Name, Namespace: fixture.ManagedAgentNamespace}
+	agentKey := types.NamespacedName{Name: app.Name, Namespace: fixture.ManagedAgentAppNamespace()}
 
 	// Ensure the app has been pushed to the managed-agent
 	requires.Eventually(func() bool {

--- a/test/e2e/clusterinfo_test.go
+++ b/test/e2e/clusterinfo_test.go
@@ -169,7 +169,7 @@ func (suite *ClusterInfoTestSuite) Test_ClusterCacheInfo() {
 	// Create the first application in the principal cluster and validate deployment to managed cluster
 	appFirst := createApp(suite.Ctx, suite.PrincipalClient, requires)
 	appFirst = validateManagedAppCreated(suite.Ctx, suite.ManagedAgentClient, suite.PrincipalClient,
-		fixture.ToNamespacedName(&appFirst), types.NamespacedName{Name: appFirst.Name, Namespace: fixture.ManagedAgentNamespace}, requires)
+		fixture.ToNamespacedName(&appFirst), types.NamespacedName{Name: appFirst.Name, Namespace: fixture.ManagedAgentAppNamespace()}, requires)
 
 	// Step 2:
 	// Verify that cluster cache info has been updated for first application in agent cluster by Argo CD
@@ -186,7 +186,7 @@ func (suite *ClusterInfoTestSuite) Test_ClusterCacheInfo() {
 	// Create the second application having different name and namespace, also validate deployment to managed cluster
 	appSecond := createApp(suite.Ctx, suite.PrincipalClient, requires, struct{ Name, Namespace string }{Name: "guestbook1", Namespace: "guestbook1"})
 	appSecond = validateManagedAppCreated(suite.Ctx, suite.ManagedAgentClient, suite.PrincipalClient,
-		fixture.ToNamespacedName(&appSecond), types.NamespacedName{Name: appSecond.Name, Namespace: fixture.ManagedAgentNamespace}, requires)
+		fixture.ToNamespacedName(&appSecond), types.NamespacedName{Name: appSecond.Name, Namespace: fixture.ManagedAgentAppNamespace()}, requires)
 
 	// Step 4:
 	// Verify that cluster cache info has been updated by Argo CD for second application in agent cluster
@@ -206,7 +206,7 @@ func (suite *ClusterInfoTestSuite) Test_ClusterCacheInfo() {
 	requires.Eventually(func() bool {
 		app := argoapp.Application{}
 		return errors.IsNotFound(suite.ManagedAgentClient.Get(suite.Ctx,
-			types.NamespacedName{Name: appFirst.Name, Namespace: fixture.ManagedAgentNamespace}, &app, metav1.GetOptions{}))
+			types.NamespacedName{Name: appFirst.Name, Namespace: fixture.ManagedAgentAppNamespace()}, &app, metav1.GetOptions{}))
 	}, 60*time.Second, 2*time.Second)
 
 	// Step 6:

--- a/test/e2e/delete_test.go
+++ b/test/e2e/delete_test.go
@@ -41,7 +41,7 @@ func (suite *DeleteTestSuite) Test_CascadeDeleteOnManagedAgent() {
 	appOnPrincipal := v1alpha1.Application{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "my-app",
-			Namespace: "agent-managed",
+			Namespace: fixture.ManagedPrincipalAppNamespace(),
 		},
 		Spec: v1alpha1.ApplicationSpec{
 			Project: "default",
@@ -50,10 +50,7 @@ func (suite *DeleteTestSuite) Test_CascadeDeleteOnManagedAgent() {
 				TargetRevision: "HEAD",
 				Path:           "kustomize-guestbook",
 			},
-			Destination: v1alpha1.ApplicationDestination{
-				Name:      "agent-managed",
-				Namespace: "guestbook",
-			},
+			Destination: fixture.ManagedDestination("guestbook"),
 			SyncPolicy: &v1alpha1.SyncPolicy{
 				Automated: &v1alpha1.SyncPolicyAutomated{},
 				SyncOptions: v1alpha1.SyncOptions{
@@ -109,7 +106,7 @@ func (suite *DeleteTestSuite) Test_CascadeDeleteOnManagedAgent() {
 		app := argoapp.Application{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      appOnPrincipal.Name,
-				Namespace: fixture.ManagedAgentNamespace,
+				Namespace: fixture.ManagedAgentAppNamespace(),
 			},
 		}
 		err := suite.ManagedAgentClient.Get(suite.Ctx, fixture.ToNamespacedName(&app), &app, metav1.GetOptions{})

--- a/test/e2e/dest_mapping_test.go
+++ b/test/e2e/dest_mapping_test.go
@@ -61,6 +61,9 @@ type DestinationMappingTestSuite struct {
 
 // SetupSuite runs before the tests in the suite are run.
 func (suite *DestinationMappingTestSuite) SetupSuite() {
+	if fixture.IsDestinationBased() {
+		suite.T().Skip("DestinationMappingTestSuite is redundant when all suites already run in destination-based mode")
+	}
 	suite.BaseSuite.SetupSuite()
 	var err error
 

--- a/test/e2e/dest_mapping_test.go
+++ b/test/e2e/dest_mapping_test.go
@@ -150,6 +150,9 @@ ARGOCD_PRINCIPAL_DESTINATION_BASED_MAPPING=true`)
 }
 
 func (suite *DestinationMappingTestSuite) TearDownSuite() {
+	if fixture.IsDestinationBased() {
+		return
+	}
 	suite.BaseSuite.TearDownTest()
 	requires := suite.Require()
 

--- a/test/e2e/fixture/fixture.go
+++ b/test/e2e/fixture/fixture.go
@@ -214,10 +214,19 @@ func (suite *BaseSuite) setupDestinationBasedMapping() {
 	requires.NoError(err)
 
 	// Create the agent-test namespace on the principal so Application CRs can be
-	// placed there. The agent will create the namespace on its side
-	// automatically when create-namespace is enabled.
+	// placed there.
 	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: DestMappingAppNamespace}}
 	if createErr := suite.PrincipalClient.Create(suite.Ctx, ns, metav1.CreateOptions{}); createErr != nil {
+		if !errors.IsAlreadyExists(createErr) {
+			requires.NoError(createErr)
+		}
+	}
+
+	// Also create the namespace on the managed agent so that tests which
+	// directly create Application CRs on the agent (e.g. adoption tests)
+	// can do so before the agent's auto-create logic kicks in.
+	agentNs := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: DestMappingAppNamespace}}
+	if createErr := suite.ManagedAgentClient.Create(suite.Ctx, agentNs, metav1.CreateOptions{}); createErr != nil {
 		if !errors.IsAlreadyExists(createErr) {
 			requires.NoError(createErr)
 		}

--- a/test/e2e/fixture/fixture.go
+++ b/test/e2e/fixture/fixture.go
@@ -19,6 +19,8 @@ import (
 	"fmt"
 	"os"
 	"reflect"
+	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -49,7 +51,112 @@ const (
 
 	// AutonomousAgentNamespace is the namespace where autonomous agent components run in the agent-autonomous vcluster.
 	AutonomousAgentNamespace = "argocd-autonomous"
+
+	// E2EDestinationBasedEnv is the environment variable that enables
+	// destination-based mapping mode for e2e tests.
+	E2EDestinationBasedEnv = "E2E_DESTINATION_BASED_MAPPING"
+
+	// DestMappingAppNamespace is the namespace used on the principal for
+	// Application CRs when running in destination-based mapping mode. It
+	// intentionally differs from the agent name to verify that apps in
+	// arbitrary namespaces are routed correctly.
+	DestMappingAppNamespace = "agent-test"
 )
+
+// IsDestinationBased returns true when the e2e suite is running in
+// destination-based mapping mode.
+func IsDestinationBased() bool {
+	return strings.ToLower(os.Getenv(E2EDestinationBasedEnv)) == "true"
+}
+
+// ManagedDestination returns the ApplicationDestination for a managed-agent
+// application. In namespace-scoped mode it uses the server URL; in
+// destination-based mode it uses the cluster name.
+func ManagedDestination(targetNs string) argoapp.ApplicationDestination {
+	if IsDestinationBased() {
+		return argoapp.ApplicationDestination{
+			Name:      "agent-managed",
+			Namespace: targetNs,
+		}
+	}
+	return argoapp.ApplicationDestination{
+		Server:    "https://kubernetes.default.svc",
+		Namespace: targetNs,
+	}
+}
+
+// ManagedAgentAppNamespace returns the namespace where an application exists
+// on the managed agent cluster. In namespace-scoped mode apps are placed in
+// the agent's argocd namespace; in destination-based mode the app stays in
+// DestMappingAppNamespace.
+func ManagedAgentAppNamespace() string {
+	if IsDestinationBased() {
+		return DestMappingAppNamespace
+	}
+	return ManagedAgentNamespace
+}
+
+// ManagedPrincipalAppNamespace returns the namespace where a managed
+// application is created on the principal cluster. In namespace-scoped mode
+// this is always "agent-managed"; in destination-based mode it is
+// DestMappingAppNamespace.
+func ManagedPrincipalAppNamespace() string {
+	if IsDestinationBased() {
+		return DestMappingAppNamespace
+	}
+	return "agent-managed"
+}
+
+func managedPrincipalCleanupNamespaces() []string {
+	if IsDestinationBased() {
+		return []string{"agent-managed", DestMappingAppNamespace}
+	}
+	return []string{"agent-managed"}
+}
+
+func managedAgentCleanupNamespaces() []string {
+	if IsDestinationBased() {
+		return []string{ManagedAgentNamespace, DestMappingAppNamespace}
+	}
+	return []string{ManagedAgentNamespace, "agent-managed"}
+}
+
+// WriteEnvVarsToFile writes environment variables to the e2e config file.
+// In destination-based mode the destination mapping variables are always
+// included. Pass nil to write only the base destination variables (or clear
+// the file in namespace-scoped mode).
+func WriteEnvVarsToFile(vars map[string]string) error {
+	allVars := make(map[string]string)
+	if IsDestinationBased() {
+		allVars["ARGOCD_AGENT_DESTINATION_BASED_MAPPING"] = "true"
+		allVars["ARGOCD_AGENT_CREATE_NAMESPACE"] = "true"
+		allVars["ARGOCD_PRINCIPAL_DESTINATION_BASED_MAPPING"] = "true"
+	}
+	for k, v := range vars {
+		allVars[k] = v
+	}
+	if len(allVars) == 0 {
+		os.Remove(EnvVariablesFromE2EFile)
+		return nil
+	}
+	var buf strings.Builder
+	for k, v := range allVars {
+		fmt.Fprintf(&buf, "%s=%s\n", k, v)
+	}
+	return os.WriteFile(EnvVariablesFromE2EFile, []byte(buf.String()), 0644)
+}
+
+// ClearEnvVarsFile removes extra environment variables from the config file,
+// keeping destination-based mapping variables when running in that mode.
+func ClearEnvVarsFile() {
+	if IsDestinationBased() {
+		_ = WriteEnvVarsToFile(nil)
+	} else {
+		os.Remove(EnvVariablesFromE2EFile)
+	}
+}
+
+var destinationSetupOnce sync.Once
 
 type BaseSuite struct {
 	suite.Suite
@@ -84,6 +191,118 @@ func (suite *BaseSuite) SetupSuite() {
 	suite.ClusterDetails = &ClusterDetails{}
 	err = getClusterConfigurations(suite.Ctx, suite.ManagedAgentClient, suite.PrincipalClient, suite.ClusterDetails)
 	requires.Nil(err)
+
+	if IsDestinationBased() {
+		destinationSetupOnce.Do(func() {
+			suite.setupDestinationBasedMapping()
+		})
+	}
+}
+
+// setupDestinationBasedMapping configures the cluster for destination-based
+// mapping: writes env vars to the config file, patches the default AppProject
+// on the principal, patches argocd-cmd-params-cm on the managed agent, and
+// restarts the application controller so it watches all namespaces.
+//
+// The agent and principal processes are expected to have been started in
+// destination-based mode already.
+func (suite *BaseSuite) setupDestinationBasedMapping() {
+	requires := suite.Require()
+	suite.T().Log("Setting up destination-based mapping mode")
+
+	err := WriteEnvVarsToFile(nil)
+	requires.NoError(err)
+
+	// Create the agent-test namespace on the principal so Application CRs can be
+	// placed there. The agent will create the namespace on its side
+	// automatically when create-namespace is enabled.
+	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: DestMappingAppNamespace}}
+	if createErr := suite.PrincipalClient.Create(suite.Ctx, ns, metav1.CreateOptions{}); createErr != nil {
+		if !errors.IsAlreadyExists(createErr) {
+			requires.NoError(createErr)
+		}
+	}
+
+	// Update the principal's default AppProject to allow apps in any source namespace.
+	defaultAppProject := &argoapp.AppProject{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "default",
+			Namespace: PrincipalNamespace,
+		},
+	}
+	err = EnsureUpdate(suite.Ctx, suite.PrincipalClient, defaultAppProject, func(obj KubeObject) {
+		appProject := obj.(*argoapp.AppProject)
+		appProject.Spec.SourceNamespaces = []string{"*"}
+	})
+	requires.NoError(err)
+
+	// Wait for the SourceNamespaces change to propagate to the managed agent
+	requires.Eventually(func() bool {
+		proj := &argoapp.AppProject{}
+		err := suite.ManagedAgentClient.Get(suite.Ctx, types.NamespacedName{
+			Name: "default", Namespace: ManagedAgentNamespace,
+		}, proj, metav1.GetOptions{})
+		if err != nil {
+			return false
+		}
+		for _, ns := range proj.Spec.SourceNamespaces {
+			if ns == "*" {
+				return true
+			}
+		}
+		return false
+	}, 30*time.Second, 1*time.Second, "SourceNamespaces should propagate to managed agent")
+
+	// Update argocd-cmd-params-cm to allow applications in any namespace.
+	// This ConfigMap is local Argo CD configuration and is not synced by
+	// the agent, so a direct update is safe.
+	acm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "argocd-cmd-params-cm",
+			Namespace: ManagedAgentNamespace,
+		},
+	}
+	err = EnsureUpdate(suite.Ctx, suite.ManagedAgentClient, acm, func(obj KubeObject) {
+		configMap := obj.(*corev1.ConfigMap)
+		if configMap.Data == nil {
+			configMap.Data = map[string]string{}
+		}
+		configMap.Data["application.namespaces"] = "*"
+	})
+	requires.NoError(err)
+
+	suite.RestartApplicationController()
+}
+
+// RestartApplicationController deletes the application controller pod on the
+// managed agent and waits for the replacement to become ready.
+func (suite *BaseSuite) RestartApplicationController() {
+	requires := suite.Require()
+	podList := &corev1.PodList{}
+	err := suite.ManagedAgentClient.List(suite.Ctx, ManagedAgentNamespace, podList, metav1.ListOptions{
+		LabelSelector: "app.kubernetes.io/name=argocd-application-controller",
+	})
+	requires.NoError(err)
+	requires.True(len(podList.Items) > 0, "expected at least one application controller pod")
+
+	err = suite.ManagedAgentClient.Delete(suite.Ctx, &podList.Items[0], metav1.DeleteOptions{})
+	requires.NoError(err)
+
+	requires.Eventually(func() bool {
+		pod := &corev1.Pod{}
+		err := suite.ManagedAgentClient.Get(suite.Ctx, types.NamespacedName{
+			Name: podList.Items[0].Name, Namespace: ManagedAgentNamespace,
+		}, pod, metav1.GetOptions{})
+		if err != nil {
+			return false
+		}
+		for _, cond := range pod.Status.Conditions {
+			if cond.Type == corev1.PodReady && cond.Status == corev1.ConditionTrue {
+				return true
+			}
+		}
+		return false
+	}, 120*time.Second, 2*time.Second, "Application controller pod should become ready")
 }
 
 func (suite *BaseSuite) SetupTest() {
@@ -223,8 +442,9 @@ func CleanUp(ctx context.Context, principalClient KubeClient, managedAgentClient
 	var list argoapp.ApplicationList
 	var err error
 
-	// Remove any previously configured env variables from the config file
-	os.Remove(EnvVariablesFromE2EFile)
+	// Remove any previously configured env variables from the config file,
+	// preserving destination-based mapping vars when running in that mode.
+	ClearEnvVarsFile()
 
 	// Deletion should always propagate from the source of truth to the managed cluster
 	// Skip deletion of resources that have been created from a source
@@ -261,39 +481,43 @@ func CleanUp(ctx context.Context, principalClient KubeClient, managedAgentClient
 	}
 
 	// Delete all managed applications from the principal
-	list = argoapp.ApplicationList{}
-	err = principalClient.List(ctx, "agent-managed", &list, metav1.ListOptions{})
-	if err != nil {
-		return err
-	}
-	for _, app := range list.Items {
-		if isFromSource(app.GetAnnotations()) {
-			continue
-		}
-
-		err = EnsureDeletion(ctx, principalClient, &app)
+	for _, principalNs := range managedPrincipalCleanupNamespaces() {
+		list = argoapp.ApplicationList{}
+		err = principalClient.List(ctx, principalNs, &list, metav1.ListOptions{})
 		if err != nil {
 			return err
 		}
+		for _, app := range list.Items {
+			if isFromSource(app.GetAnnotations()) {
+				continue
+			}
 
-		// Wait for the app to be deleted from the managed cluster
-		app.SetNamespace(ManagedAgentNamespace)
-		err = WaitForDeletion(ctx, managedAgentClient, &app, "managed agent")
-		if err != nil {
-			return err
+			err = EnsureDeletion(ctx, principalClient, &app)
+			if err != nil {
+				return err
+			}
+
+			// Wait for the app to be deleted from the managed cluster
+			app.SetNamespace(ManagedAgentAppNamespace())
+			err = WaitForDeletion(ctx, managedAgentClient, &app, "managed agent")
+			if err != nil {
+				return err
+			}
 		}
 	}
 
 	// Delete any remaining managed applications left on the managed agent
-	list = argoapp.ApplicationList{}
-	err = managedAgentClient.List(ctx, ManagedAgentNamespace, &list, metav1.ListOptions{})
-	if err != nil {
-		return err
-	}
-	for _, app := range list.Items {
-		err = EnsureDeletion(ctx, managedAgentClient, &app)
+	for _, agentNs := range managedAgentCleanupNamespaces() {
+		list = argoapp.ApplicationList{}
+		err = managedAgentClient.List(ctx, agentNs, &list, metav1.ListOptions{})
 		if err != nil {
 			return err
+		}
+		for _, app := range list.Items {
+			err = EnsureDeletion(ctx, managedAgentClient, &app)
+			if err != nil {
+				return err
+			}
 		}
 	}
 

--- a/test/e2e/fixture/fixture.go
+++ b/test/e2e/fixture/fixture.go
@@ -294,6 +294,7 @@ func (suite *BaseSuite) RestartApplicationController() {
 	requires.NoError(err)
 	requires.True(len(podList.Items) > 0, "expected at least one application controller pod")
 
+	oldUID := podList.Items[0].UID
 	err = suite.ManagedAgentClient.Delete(suite.Ctx, &podList.Items[0], metav1.DeleteOptions{})
 	requires.NoError(err)
 
@@ -305,6 +306,12 @@ func (suite *BaseSuite) RestartApplicationController() {
 		if err != nil {
 			return false
 		}
+
+		if oldUID == pod.UID {
+			suite.T().Log("Old application controller pod still terminating...")
+			return false
+		}
+
 		for _, cond := range pod.Status.Conditions {
 			if cond.Type == corev1.PodReady && cond.Status == corev1.ConditionTrue {
 				return true
@@ -506,8 +513,12 @@ func CleanUp(ctx context.Context, principalClient KubeClient, managedAgentClient
 				return err
 			}
 
-			// Wait for the app to be deleted from the managed cluster
-			app.SetNamespace(ManagedAgentAppNamespace())
+			// Wait for the app to be deleted from the managed cluster.
+			agentNs := ManagedAgentNamespace
+			if principalNs == DestMappingAppNamespace {
+				agentNs = DestMappingAppNamespace
+			}
+			app.SetNamespace(agentNs)
 			err = WaitForDeletion(ctx, managedAgentClient, &app, "managed agent")
 			if err != nil {
 				return err

--- a/test/e2e/logs_test.go
+++ b/test/e2e/logs_test.go
@@ -40,7 +40,7 @@ func (suite *LogsStreamingTestSuite) Test_logs_streaming_managed() {
 	app := &v1alpha1.Application{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      appName,
-			Namespace: "agent-managed",
+			Namespace: fixture.ManagedPrincipalAppNamespace(),
 		},
 		Spec: v1alpha1.ApplicationSpec{
 			Project: "default",
@@ -49,10 +49,7 @@ func (suite *LogsStreamingTestSuite) Test_logs_streaming_managed() {
 				Path:           "kustomize-guestbook",
 				TargetRevision: "HEAD",
 			},
-			Destination: v1alpha1.ApplicationDestination{
-				Name:      "agent-managed",
-				Namespace: "guestbook",
-			},
+			Destination: fixture.ManagedDestination("guestbook"),
 			SyncPolicy: &v1alpha1.SyncPolicy{
 				Automated: &v1alpha1.SyncPolicyAutomated{},
 				SyncOptions: v1alpha1.SyncOptions{
@@ -78,11 +75,13 @@ func (suite *LogsStreamingTestSuite) Test_logs_streaming_managed() {
 	err = argoClient.Login()
 	requires.NoError(err)
 
+	principalKey := types.NamespacedName{Namespace: app.Namespace, Name: appName}
+
 	// Wait until the app is synced and healthy
 	retries := 0
 	requires.Eventually(func() bool {
 		a := &v1alpha1.Application{}
-		if err := suite.PrincipalClient.Get(suite.Ctx, types.NamespacedName{Namespace: "agent-managed", Name: appName}, a, metav1.GetOptions{}); err != nil {
+		if err := suite.PrincipalClient.Get(suite.Ctx, principalKey, a, metav1.GetOptions{}); err != nil {
 			return false
 		}
 		if a.Status.Sync.Status == v1alpha1.SyncStatusCodeSynced &&

--- a/test/e2e/recreate_action_test.go
+++ b/test/e2e/recreate_action_test.go
@@ -15,7 +15,6 @@
 package e2e
 
 import (
-	"os"
 	"testing"
 	"time"
 
@@ -35,10 +34,8 @@ func (suite *RecreateActionTestSuite) TearDownTest() {
 	suite.BaseSuite.TearDownTest()
 	requires := suite.Require()
 
-	if _, err := os.Stat(fixture.EnvVariablesFromE2EFile); err == nil {
-		requires.NoError(os.Remove(fixture.EnvVariablesFromE2EFile))
-		fixture.RestartAgent(suite.T(), "agent-managed")
-	}
+	fixture.ClearEnvVarsFile()
+	fixture.RestartAgent(suite.T(), "agent-managed")
 
 	if !fixture.IsProcessRunning("agent-managed", suite.T()) {
 		err := fixture.StartProcess("agent-managed", suite.T())
@@ -53,8 +50,9 @@ func (suite *RecreateActionTestSuite) createAndDeleteApp(action, appName string)
 	t := suite.T()
 
 	t.Logf("Configure agent with --on-application-recreate=%s", action)
-	envVar := "ARGOCD_AGENT_ON_APPLICATION_RECREATE=" + action
-	err := os.WriteFile(fixture.EnvVariablesFromE2EFile, []byte(envVar+"\n"), 0644)
+	err := fixture.WriteEnvVarsToFile(map[string]string{
+		"ARGOCD_AGENT_ON_APPLICATION_RECREATE": action,
+	})
 	requires.NoError(err)
 
 	fixture.RestartAgent(t, "agent-managed")
@@ -64,7 +62,7 @@ func (suite *RecreateActionTestSuite) createAndDeleteApp(action, appName string)
 	app := &argoapp.Application{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      appName,
-			Namespace: fixture.AgentManagedName,
+			Namespace: fixture.ManagedPrincipalAppNamespace(),
 			// add resources-finalizer to produce the cascade delete scenario
 			Finalizers: []string{
 				"resources-finalizer.argocd.argoproj.io",
@@ -77,10 +75,7 @@ func (suite *RecreateActionTestSuite) createAndDeleteApp(action, appName string)
 				TargetRevision: "HEAD",
 				Path:           "kustomize-guestbook",
 			},
-			Destination: argoapp.ApplicationDestination{
-				Name:      fixture.AgentManagedName,
-				Namespace: "guestbook",
-			},
+			Destination: fixture.ManagedDestination("guestbook"),
 			SyncPolicy: &argoapp.SyncPolicy{
 				Automated: &argoapp.SyncPolicyAutomated{},
 				SyncOptions: argoapp.SyncOptions{
@@ -96,7 +91,7 @@ func (suite *RecreateActionTestSuite) createAndDeleteApp(action, appName string)
 	fixture.WaitForAppSyncedAndHealthy(t, suite.Ctx, suite.PrincipalClient, nil, app)
 
 	t.Log("Delete the application directly from the agent cluster (unauthorized)")
-	agentApp := &argoapp.Application{ObjectMeta: metav1.ObjectMeta{Name: appName, Namespace: fixture.ManagedAgentNamespace}}
+	agentApp := &argoapp.Application{ObjectMeta: metav1.ObjectMeta{Name: appName, Namespace: fixture.ManagedAgentAppNamespace()}}
 	err = suite.ManagedAgentClient.Delete(suite.Ctx, agentApp, metav1.DeleteOptions{})
 	requires.NoError(err)
 
@@ -122,7 +117,7 @@ func (suite *RecreateActionTestSuite) Test_UnauthorizedDeleteWithClearStatus() {
 	app := suite.createAndDeleteApp("clear-status", "recreate-clear-test")
 
 	suite.T().Log("Verify the application is recreated and returns to Synced and Healthy on the agent")
-	agentAppKey := types.NamespacedName{Name: app.Name, Namespace: fixture.ManagedAgentNamespace}
+	agentAppKey := types.NamespacedName{Name: app.Name, Namespace: fixture.ManagedAgentAppNamespace()}
 	suite.Require().Eventually(func() bool {
 		agentApp := argoapp.Application{}
 		err := suite.ManagedAgentClient.Get(suite.Ctx, agentAppKey, &agentApp, metav1.GetOptions{})

--- a/test/e2e/redis_proxy_test.go
+++ b/test/e2e/redis_proxy_test.go
@@ -58,7 +58,7 @@ func (suite *RedisProxyTestSuite) Test_RedisProxy_ManagedAgent_Argo() {
 	appOnPrincipal := v1alpha1.Application{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "my-app",
-			Namespace: "agent-managed",
+			Namespace: fixture.ManagedPrincipalAppNamespace(),
 		},
 		Spec: v1alpha1.ApplicationSpec{
 			Project: "default",
@@ -67,10 +67,7 @@ func (suite *RedisProxyTestSuite) Test_RedisProxy_ManagedAgent_Argo() {
 				TargetRevision: "HEAD",
 				Path:           "kustomize-guestbook",
 			},
-			Destination: v1alpha1.ApplicationDestination{
-				Name:      "agent-managed",
-				Namespace: "guestbook",
-			},
+			Destination: fixture.ManagedDestination("guestbook"),
 			SyncPolicy: &v1alpha1.SyncPolicy{
 				Automated: &v1alpha1.SyncPolicyAutomated{},
 				SyncOptions: v1alpha1.SyncOptions{

--- a/test/e2e/repocreds_test.go
+++ b/test/e2e/repocreds_test.go
@@ -213,9 +213,17 @@ func (suite *RepoCredsTestSuite) Test_RepoCreds_AppProjectUpdate() {
 	appProjectKeyPrincipal := fixture.ToNamespacedName(appProjectPrincipal)
 	repoCredsKeyAgent := types.NamespacedName{Name: repoCredsPrincipal.Name, Namespace: fixture.ManagedAgentNamespace}
 
-	// Update the appProject on the principal's cluster to no longer match the agent name
+	// Update the appProject on the principal's cluster to no longer match the agent name.
+	// In destination-based mapping mode, agent matching ignores SourceNamespaces and
+	// only checks Destinations, so we must change Destinations instead.
 	err := suite.PrincipalClient.EnsureAppProjectUpdate(suite.Ctx, appProjectKeyPrincipal, func(ap *argoapp.AppProject) error {
-		ap.Spec.SourceNamespaces = []string{"random"}
+		if fixture.IsDestinationBased() {
+			ap.Spec.Destinations = []argoapp.ApplicationDestination{
+				{Namespace: "*", Name: "no-match-*"},
+			}
+		} else {
+			ap.Spec.SourceNamespaces = []string{"random"}
+		}
 		return nil
 	}, metav1.UpdateOptions{})
 	requires.NoError(err)

--- a/test/e2e/repository_test.go
+++ b/test/e2e/repository_test.go
@@ -286,7 +286,13 @@ func (suite *RepositoryTestSuite) Test_Repository_AppProjectUpdate() {
 
 	// Update the appProject on the principal's cluster to no longer match the agent name
 	err = suite.PrincipalClient.EnsureAppProjectUpdate(suite.Ctx, projKeyPrincipal, func(appProject *argoapp.AppProject) error {
-		appProject.Spec.SourceNamespaces = []string{"random"}
+		if fixture.IsDestinationBased() {
+			appProject.Spec.Destinations = []argoapp.ApplicationDestination{
+				{Namespace: "*", Name: "no-match-*"},
+			}
+		} else {
+			appProject.Spec.SourceNamespaces = []string{"random"}
+		}
 		return nil
 	}, metav1.UpdateOptions{})
 	requires.NoError(err)
@@ -362,7 +368,13 @@ func (suite *RepositoryTestSuite) Test_Repository_Change_AppProject() {
 	appProject2 := appProject.DeepCopy()
 	appProject2.Name = "sample2"
 	appProject2.ResourceVersion = ""
-	appProject2.Spec.SourceNamespaces = []string{"random"}
+	if fixture.IsDestinationBased() {
+		appProject2.Spec.Destinations = []argoapp.ApplicationDestination{
+			{Namespace: "*", Name: "no-match-*"},
+		}
+	} else {
+		appProject2.Spec.SourceNamespaces = []string{"random"}
+	}
 
 	err = suite.PrincipalClient.Create(suite.Ctx, appProject2, metav1.CreateOptions{})
 	requires.NoError(err)

--- a/test/e2e/resource_tracking_test.go
+++ b/test/e2e/resource_tracking_test.go
@@ -159,7 +159,10 @@ func (suite *ResourceTrackingTestSuite) runTrackingTest(
 				TargetRevision: "HEAD",
 				Path:           "guestbook",
 			},
-			Destination: fixture.ManagedDestination(suite.getTestNamespace()),
+			Destination: argoapp.ApplicationDestination{
+				Name:      "agent-managed",
+				Namespace: suite.getTestNamespace(),
+			},
 			SyncPolicy: &argoapp.SyncPolicy{
 				Automated: &argoapp.SyncPolicyAutomated{
 					Prune:    ptr.To(true),

--- a/test/e2e/resource_tracking_test.go
+++ b/test/e2e/resource_tracking_test.go
@@ -150,7 +150,7 @@ func (suite *ResourceTrackingTestSuite) runTrackingTest(
 	app := argoapp.Application{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      appName,
-			Namespace: "agent-managed",
+			Namespace: fixture.ManagedPrincipalAppNamespace(),
 		},
 		Spec: argoapp.ApplicationSpec{
 			Project: "default",
@@ -159,10 +159,7 @@ func (suite *ResourceTrackingTestSuite) runTrackingTest(
 				TargetRevision: "HEAD",
 				Path:           "guestbook",
 			},
-			Destination: argoapp.ApplicationDestination{
-				Name:      "agent-managed",
-				Namespace: suite.getTestNamespace(),
-			},
+			Destination: fixture.ManagedDestination(suite.getTestNamespace()),
 			SyncPolicy: &argoapp.SyncPolicy{
 				Automated: &argoapp.SyncPolicyAutomated{
 					Prune:    ptr.To(true),
@@ -185,7 +182,7 @@ func (suite *ResourceTrackingTestSuite) runTrackingTest(
 		agentApp := &argoapp.Application{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      app.Name,
-				Namespace: fixture.ManagedAgentNamespace,
+				Namespace: fixture.ManagedAgentAppNamespace(),
 			},
 		}
 		if err := fixture.WaitForDeletion(suite.Ctx, suite.ManagedAgentClient, agentApp, "managed agent"); err != nil {
@@ -193,7 +190,7 @@ func (suite *ResourceTrackingTestSuite) runTrackingTest(
 		}
 	})
 
-	agentKey := types.NamespacedName{Name: app.Name, Namespace: fixture.ManagedAgentNamespace}
+	agentKey := types.NamespacedName{Name: app.Name, Namespace: fixture.ManagedAgentAppNamespace()}
 
 	// Ensure the app has been pushed to the managed-agent
 	requires.Eventually(func() bool {
@@ -237,7 +234,7 @@ func (suite *ResourceTrackingTestSuite) runTrackingTest(
 	requires.Eventually(func() bool {
 		err := suite.PrincipalClient.Get(suite.Ctx, types.NamespacedName{
 			Name:      appName,
-			Namespace: "agent-managed",
+			Namespace: fixture.ManagedPrincipalAppNamespace(),
 		}, &principalApp, metav1.GetOptions{})
 		if err != nil || principalApp.Status.Health.Status != health.HealthStatusHealthy {
 			return false

--- a/test/e2e/resync_test.go
+++ b/test/e2e/resync_test.go
@@ -16,7 +16,6 @@ package e2e
 
 import (
 	"fmt"
-	"os"
 	"reflect"
 	"testing"
 	"time"
@@ -39,11 +38,7 @@ func (suite *ResyncTestSuite) TearDownTest() {
 	suite.BaseSuite.TearDownTest()
 	requires := suite.Require()
 
-	if _, err := os.Stat(fixture.EnvVariablesFromE2EFile); err == nil {
-		requires.NoError(os.Remove(fixture.EnvVariablesFromE2EFile))
-		fixture.RestartAgent(suite.T(), "agent-managed")
-		fixture.RestartAgent(suite.T(), "agent-autonomous")
-	}
+	fixture.ClearEnvVarsFile()
 
 	// Ensure that all the components are running after runnings the tests
 	if !fixture.IsProcessRunning("principal", suite.T()) {
@@ -74,7 +69,7 @@ func (suite *ResyncTestSuite) Test_ResyncDeletionOnPrincipalStartupManaged() {
 	requires := suite.Require()
 
 	app := suite.createManagedApp()
-	key := types.NamespacedName{Name: app.Name, Namespace: fixture.ManagedAgentNamespace}
+	key := types.NamespacedName{Name: app.Name, Namespace: fixture.ManagedAgentAppNamespace()}
 
 	// Stop the principal and delete the app from the control-plane
 	err := fixture.StopProcess("principal", suite.T())
@@ -111,7 +106,7 @@ func (suite *ResyncTestSuite) Test_ResyncUpdatesOnPrincipalStartupManaged() {
 
 	app := suite.createManagedApp()
 	principalKey := fixture.ToNamespacedName(app)
-	agentKey := types.NamespacedName{Name: app.Name, Namespace: fixture.ManagedAgentNamespace}
+	agentKey := types.NamespacedName{Name: app.Name, Namespace: fixture.ManagedAgentAppNamespace()}
 
 	// Stop the principal and update the app on the control-plane
 	err := fixture.StopProcess("principal", suite.T())
@@ -152,7 +147,7 @@ func (suite *ResyncTestSuite) Test_ResyncDeletionOnAgentStartupManaged() {
 	requires := suite.Require()
 
 	app := suite.createManagedApp()
-	key := types.NamespacedName{Name: app.Name, Namespace: fixture.ManagedAgentNamespace}
+	key := types.NamespacedName{Name: app.Name, Namespace: fixture.ManagedAgentAppNamespace()}
 
 	// Stop the agent and delete the app
 	err := fixture.StopProcess("agent-managed", suite.T())
@@ -165,7 +160,7 @@ func (suite *ResyncTestSuite) Test_ResyncDeletionOnAgentStartupManaged() {
 	err = suite.ManagedAgentClient.Delete(suite.Ctx, &argoapp.Application{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      app.Name,
-			Namespace: fixture.ManagedAgentNamespace,
+			Namespace: fixture.ManagedAgentAppNamespace(),
 		},
 	}, metav1.DeleteOptions{})
 	requires.NoError(err)
@@ -189,7 +184,7 @@ func (suite *ResyncTestSuite) Test_ResyncUpdatesOnAgentStartupManaged() {
 	requires := suite.Require()
 
 	app := suite.createManagedApp()
-	key := types.NamespacedName{Name: app.Name, Namespace: fixture.ManagedAgentNamespace}
+	key := types.NamespacedName{Name: app.Name, Namespace: fixture.ManagedAgentAppNamespace()}
 
 	// Stop the agent and update the app on the workload cluster
 	err := fixture.StopProcess("agent-managed", suite.T())
@@ -390,7 +385,7 @@ func (suite *ResyncTestSuite) Test_ResyncOnConnectionLostManagedMode() {
 	// Create a managed app
 	app := suite.createManagedApp()
 	requires.NotNil(app)
-	key := types.NamespacedName{Name: app.Name, Namespace: fixture.ManagedAgentNamespace}
+	key := types.NamespacedName{Name: app.Name, Namespace: fixture.ManagedAgentAppNamespace()}
 
 	// Disable the connection between the agent and the principal
 	requires.NoError(proxy.Disable())
@@ -1315,7 +1310,7 @@ func (suite *ResyncTestSuite) createManagedApp() *argoapp.Application {
 	app := argoapp.Application{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "guestbook",
-			Namespace: "agent-managed",
+			Namespace: fixture.ManagedPrincipalAppNamespace(),
 		},
 		Spec: argoapp.ApplicationSpec{
 			Project: "default",
@@ -1324,10 +1319,7 @@ func (suite *ResyncTestSuite) createManagedApp() *argoapp.Application {
 				TargetRevision: "HEAD",
 				Path:           "kustomize-guestbook",
 			},
-			Destination: argoapp.ApplicationDestination{
-				Server:    "https://kubernetes.default.svc",
-				Namespace: "guestbook",
-			},
+			Destination: fixture.ManagedDestination("guestbook"),
 			SyncPolicy: &argoapp.SyncPolicy{
 				SyncOptions: argoapp.SyncOptions{
 					"CreateNamespace=true",
@@ -1339,7 +1331,7 @@ func (suite *ResyncTestSuite) createManagedApp() *argoapp.Application {
 	requires.NoError(err)
 
 	principalKey := fixture.ToNamespacedName(&app)
-	agentKey := types.NamespacedName{Name: app.Name, Namespace: fixture.ManagedAgentNamespace}
+	agentKey := types.NamespacedName{Name: app.Name, Namespace: fixture.ManagedAgentAppNamespace()}
 
 	// Ensure the app has been pushed to the workload cluster
 	requires.Eventually(func() bool {

--- a/test/e2e/rp_test.go
+++ b/test/e2e/rp_test.go
@@ -182,7 +182,7 @@ func (suite *ResourceProxyTestSuite) validateResourceProxyViaArgoAPI(appName str
 	app := v1alpha1.Application{
 		ObjectMeta: v1.ObjectMeta{
 			Name:      appName,
-			Namespace: "agent-managed",
+			Namespace: fixture.ManagedPrincipalAppNamespace(),
 		},
 		Spec: v1alpha1.ApplicationSpec{
 			Project: "default",
@@ -191,10 +191,7 @@ func (suite *ResourceProxyTestSuite) validateResourceProxyViaArgoAPI(appName str
 				TargetRevision: "HEAD",
 				Path:           "kustomize-guestbook",
 			},
-			Destination: v1alpha1.ApplicationDestination{
-				Name:      "agent-managed",
-				Namespace: "guestbook",
-			},
+			Destination: fixture.ManagedDestination("guestbook"),
 			SyncPolicy: &v1alpha1.SyncPolicy{
 				Automated: &v1alpha1.SyncPolicyAutomated{},
 				SyncOptions: v1alpha1.SyncOptions{
@@ -215,7 +212,10 @@ func (suite *ResourceProxyTestSuite) validateResourceProxyViaArgoAPI(appName str
 	retries := 0
 	requires.Eventually(func() bool {
 		app := &v1alpha1.Application{}
-		err = suite.PrincipalClient.Get(suite.Ctx, types.NamespacedName{Namespace: "agent-managed", Name: appName}, app, v1.GetOptions{})
+		err = suite.PrincipalClient.Get(suite.Ctx, types.NamespacedName{
+			Namespace: fixture.ManagedPrincipalAppNamespace(),
+			Name:      appName,
+		}, app, v1.GetOptions{})
 		if err != nil {
 			return false
 		}
@@ -400,7 +400,7 @@ func (suite *ResourceProxyTestSuite) Test_ResourceProxy_ResourceActions() {
 	app := v1alpha1.Application{
 		ObjectMeta: v1.ObjectMeta{
 			Name:      appName,
-			Namespace: "agent-managed",
+			Namespace: fixture.ManagedPrincipalAppNamespace(),
 		},
 		Spec: v1alpha1.ApplicationSpec{
 			Project: "default",
@@ -409,10 +409,7 @@ func (suite *ResourceProxyTestSuite) Test_ResourceProxy_ResourceActions() {
 				TargetRevision: "HEAD",
 				Path:           "kustomize-guestbook",
 			},
-			Destination: v1alpha1.ApplicationDestination{
-				Name:      "agent-managed",
-				Namespace: "guestbook",
-			},
+			Destination: fixture.ManagedDestination("guestbook"),
 			SyncPolicy: &v1alpha1.SyncPolicy{
 				Automated: &v1alpha1.SyncPolicyAutomated{},
 				SyncOptions: v1alpha1.SyncOptions{
@@ -429,7 +426,9 @@ func (suite *ResourceProxyTestSuite) Test_ResourceProxy_ResourceActions() {
 	retries := 0
 	requires.Eventually(func() bool {
 		app := &v1alpha1.Application{}
-		err = suite.PrincipalClient.Get(suite.Ctx, types.NamespacedName{Namespace: "agent-managed", Name: appName}, app, v1.GetOptions{})
+		err = suite.PrincipalClient.Get(suite.Ctx, types.NamespacedName{
+			Namespace: fixture.ManagedPrincipalAppNamespace(), Name: appName,
+		}, app, v1.GetOptions{})
 		if err != nil {
 			return false
 		}

--- a/test/e2e/rp_test.go
+++ b/test/e2e/rp_test.go
@@ -191,7 +191,10 @@ func (suite *ResourceProxyTestSuite) validateResourceProxyViaArgoAPI(appName str
 				TargetRevision: "HEAD",
 				Path:           "kustomize-guestbook",
 			},
-			Destination: fixture.ManagedDestination("guestbook"),
+			Destination: v1alpha1.ApplicationDestination{
+				Name:      "agent-managed",
+				Namespace: "guestbook",
+			},
 			SyncPolicy: &v1alpha1.SyncPolicy{
 				Automated: &v1alpha1.SyncPolicyAutomated{},
 				SyncOptions: v1alpha1.SyncOptions{
@@ -409,7 +412,10 @@ func (suite *ResourceProxyTestSuite) Test_ResourceProxy_ResourceActions() {
 				TargetRevision: "HEAD",
 				Path:           "kustomize-guestbook",
 			},
-			Destination: fixture.ManagedDestination("guestbook"),
+			Destination: v1alpha1.ApplicationDestination{
+				Name:      "agent-managed",
+				Namespace: "guestbook",
+			},
 			SyncPolicy: &v1alpha1.SyncPolicy{
 				Automated: &v1alpha1.SyncPolicyAutomated{},
 				SyncOptions: v1alpha1.SyncOptions{

--- a/test/e2e/skip_sync_test.go
+++ b/test/e2e/skip_sync_test.go
@@ -40,7 +40,7 @@ func (suite *SkipSyncTestSuite) Test_Application_SkipSync() {
 	app := argoapp.Application{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "skip-sync-app",
-			Namespace: "agent-managed",
+			Namespace: fixture.ManagedPrincipalAppNamespace(),
 			Labels: map[string]string{
 				config.SkipSyncLabel: "true",
 			},
@@ -51,10 +51,7 @@ func (suite *SkipSyncTestSuite) Test_Application_SkipSync() {
 				RepoURL: "https://github.com/argoproj/argocd-example-apps.git",
 				Path:    "guestbook",
 			},
-			Destination: argoapp.ApplicationDestination{
-				Name:      "agent-managed",
-				Namespace: "guestbook",
-			},
+			Destination: fixture.ManagedDestination("guestbook"),
 		},
 	}
 
@@ -62,7 +59,7 @@ func (suite *SkipSyncTestSuite) Test_Application_SkipSync() {
 	requires.NoError(err)
 
 	appKeyPrincipal := fixture.ToNamespacedName(&app)
-	appKeyAgent := types.NamespacedName{Name: app.Name, Namespace: fixture.ManagedAgentNamespace}
+	appKeyAgent := types.NamespacedName{Name: app.Name, Namespace: fixture.ManagedAgentAppNamespace()}
 
 	// Ensure the Application is NOT pushed to the managed-agent (should be filtered out)
 	suite.Require().Never(func() bool {
@@ -85,7 +82,7 @@ func (suite *SkipSyncTestSuite) Test_Application_SkipSync_False() {
 	app := argoapp.Application{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "no-skip-sync-app",
-			Namespace: "agent-managed",
+			Namespace: fixture.ManagedPrincipalAppNamespace(),
 			Labels: map[string]string{
 				config.SkipSyncLabel: "false",
 			},
@@ -96,17 +93,14 @@ func (suite *SkipSyncTestSuite) Test_Application_SkipSync_False() {
 				RepoURL: "https://github.com/argoproj/argocd-example-apps.git",
 				Path:    "guestbook",
 			},
-			Destination: argoapp.ApplicationDestination{
-				Server:    "https://kubernetes.default.svc",
-				Namespace: "default",
-			},
+			Destination: fixture.ManagedDestination("default"),
 		},
 	}
 
 	err := suite.PrincipalClient.Create(suite.Ctx, &app, metav1.CreateOptions{})
 	requires.NoError(err)
 
-	appKey := types.NamespacedName{Name: app.Name, Namespace: fixture.ManagedAgentNamespace}
+	appKey := types.NamespacedName{Name: app.Name, Namespace: fixture.ManagedAgentAppNamespace()}
 
 	// Ensure the Application IS pushed to the managed-agent (skip sync is false)
 	requires.Eventually(func() bool {
@@ -234,7 +228,7 @@ func (suite *SkipSyncTestSuite) Test_Application_SkipSync_Update() {
 	app := argoapp.Application{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "update-skip-sync-app",
-			Namespace: "agent-managed",
+			Namespace: fixture.ManagedPrincipalAppNamespace(),
 		},
 		Spec: argoapp.ApplicationSpec{
 			Project: "default",
@@ -242,10 +236,7 @@ func (suite *SkipSyncTestSuite) Test_Application_SkipSync_Update() {
 				RepoURL: "https://github.com/argoproj/argocd-example-apps.git",
 				Path:    "guestbook",
 			},
-			Destination: argoapp.ApplicationDestination{
-				Name:      "agent-managed",
-				Namespace: "guestbook",
-			},
+			Destination: fixture.ManagedDestination("guestbook"),
 		},
 	}
 
@@ -253,7 +244,7 @@ func (suite *SkipSyncTestSuite) Test_Application_SkipSync_Update() {
 	requires.NoError(err)
 
 	appKeyPrincipal := fixture.ToNamespacedName(&app)
-	appKeyAgent := types.NamespacedName{Name: app.Name, Namespace: fixture.ManagedAgentNamespace}
+	appKeyAgent := types.NamespacedName{Name: app.Name, Namespace: fixture.ManagedAgentAppNamespace()}
 
 	// Ensure the Application IS pushed to the managed-agent initially
 	requires.Eventually(func() bool {

--- a/test/e2e/sync_test.go
+++ b/test/e2e/sync_test.go
@@ -68,7 +68,7 @@ func (suite *SyncTestSuite) Test_SyncManaged() {
 	app := argoapp.Application{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "guestbook",
-			Namespace: "agent-managed",
+			Namespace: fixture.ManagedPrincipalAppNamespace(),
 		},
 		Spec: argoapp.ApplicationSpec{
 			Project: "default",
@@ -77,10 +77,7 @@ func (suite *SyncTestSuite) Test_SyncManaged() {
 				TargetRevision: "HEAD",
 				Path:           "kustomize-guestbook",
 			},
-			Destination: argoapp.ApplicationDestination{
-				Server:    "https://kubernetes.default.svc",
-				Namespace: "guestbook",
-			},
+			Destination: fixture.ManagedDestination("guestbook"),
 			SyncPolicy: &argoapp.SyncPolicy{
 				SyncOptions: argoapp.SyncOptions{
 					"CreateNamespace=true",
@@ -92,7 +89,7 @@ func (suite *SyncTestSuite) Test_SyncManaged() {
 	requires.NoError(err)
 
 	principalKey := fixture.ToNamespacedName(&app)
-	agentKey := types.NamespacedName{Name: app.Name, Namespace: fixture.ManagedAgentNamespace}
+	agentKey := types.NamespacedName{Name: app.Name, Namespace: fixture.ManagedAgentAppNamespace()}
 
 	// Ensure the app has been pushed to the managed-agent
 	requires.Eventually(func() bool {
@@ -299,7 +296,7 @@ func (suite *SyncTestSuite) Test_TerminateOperationManaged() {
 	app := argoapp.Application{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "guestbook",
-			Namespace: "agent-managed",
+			Namespace: fixture.ManagedPrincipalAppNamespace(),
 		},
 		Spec: argoapp.ApplicationSpec{
 			Project: "default",
@@ -308,10 +305,7 @@ func (suite *SyncTestSuite) Test_TerminateOperationManaged() {
 				TargetRevision: "HEAD",
 				Path:           "test/data/pre-sync",
 			},
-			Destination: argoapp.ApplicationDestination{
-				Server:    "https://kubernetes.default.svc",
-				Namespace: "guestbook",
-			},
+			Destination: fixture.ManagedDestination("guestbook"),
 			SyncPolicy: &argoapp.SyncPolicy{
 				SyncOptions: argoapp.SyncOptions{
 					"CreateNamespace=true",
@@ -323,7 +317,7 @@ func (suite *SyncTestSuite) Test_TerminateOperationManaged() {
 	requires.NoError(err)
 
 	principalKey := fixture.ToNamespacedName(&app)
-	agentKey := types.NamespacedName{Name: app.Name, Namespace: fixture.ManagedAgentNamespace}
+	agentKey := types.NamespacedName{Name: app.Name, Namespace: fixture.ManagedAgentAppNamespace()}
 
 	// Ensure the app has been pushed to the managed-agent
 	requires.Eventually(func() bool {

--- a/test/e2e/terminal_test.go
+++ b/test/e2e/terminal_test.go
@@ -36,7 +36,7 @@ func (suite *TerminalStreamingTestSuite) validateTerminalStreaming() {
 	app := &v1alpha1.Application{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "guestbook",
-			Namespace: "agent-managed",
+			Namespace: fixture.ManagedPrincipalAppNamespace(),
 		},
 		Spec: v1alpha1.ApplicationSpec{
 			Project: "default",
@@ -45,10 +45,7 @@ func (suite *TerminalStreamingTestSuite) validateTerminalStreaming() {
 				Path:           "kustomize-guestbook",
 				TargetRevision: "HEAD",
 			},
-			Destination: v1alpha1.ApplicationDestination{
-				Name:      "agent-managed",
-				Namespace: "guestbook",
-			},
+			Destination: fixture.ManagedDestination("guestbook"),
 			SyncPolicy: &v1alpha1.SyncPolicy{
 				Automated: &v1alpha1.SyncPolicyAutomated{},
 				SyncOptions: v1alpha1.SyncOptions{

--- a/test/e2e/terminal_test.go
+++ b/test/e2e/terminal_test.go
@@ -45,7 +45,10 @@ func (suite *TerminalStreamingTestSuite) validateTerminalStreaming() {
 				Path:           "kustomize-guestbook",
 				TargetRevision: "HEAD",
 			},
-			Destination: fixture.ManagedDestination("guestbook"),
+			Destination: v1alpha1.ApplicationDestination{
+				Name:      "agent-managed",
+				Namespace: "guestbook",
+			},
 			SyncPolicy: &v1alpha1.SyncPolicy{
 				Automated: &v1alpha1.SyncPolicyAutomated{},
 				SyncOptions: v1alpha1.SyncOptions{

--- a/test/e2e/websocket_test.go
+++ b/test/e2e/websocket_test.go
@@ -17,7 +17,6 @@ package e2e
 import (
 	"context"
 	"fmt"
-	"os"
 	"testing"
 
 	"github.com/argoproj-labs/argocd-agent/internal/config"
@@ -36,11 +35,9 @@ func (suite *HTTP1DowngradeTestSuite) TearDownTest() {
 	suite.BaseSuite.TearDownTest()
 	requires := suite.Require()
 
-	if _, err := os.Stat(fixture.EnvVariablesFromE2EFile); err == nil {
-		requires.NoError(os.Remove(fixture.EnvVariablesFromE2EFile))
-		fixture.RestartAgent(suite.T(), "agent-managed")
-		fixture.RestartAgent(suite.T(), "agent-autonomous")
-	}
+	fixture.ClearEnvVarsFile()
+	fixture.RestartAgent(suite.T(), "agent-managed")
+	fixture.RestartAgent(suite.T(), "agent-autonomous")
 
 	// Ensure that all the components are running after runnings the tests
 	if !fixture.IsProcessRunning("process", suite.T()) {
@@ -101,16 +98,15 @@ func (suite *HTTP1DowngradeTestSuite) Test_WithHTTP1Downgrade() {
 	defer http1Proxy.Close()
 
 	// The agent must connect to the principal via the proxy and explicitly disable WebSocket
-	envVar := fmt.Sprintf(`ARGOCD_AGENT_REMOTE_PORT=%d
-ARGOCD_AGENT_ENABLE_WEBSOCKET=false
-ARGOCD_PRINCIPAL_ENABLE_WEBSOCKET=false`, proxyPort)
-	err = os.WriteFile(fixture.EnvVariablesFromE2EFile, []byte(envVar+"\n"), 0644)
+	err = fixture.WriteEnvVarsToFile(map[string]string{
+		"ARGOCD_AGENT_REMOTE_PORT":          fmt.Sprintf("%d", proxyPort),
+		"ARGOCD_AGENT_ENABLE_WEBSOCKET":     "false",
+		"ARGOCD_PRINCIPAL_ENABLE_WEBSOCKET": "false",
+	})
 	requires.NoError(err)
 
 	defer func() {
-		if err := os.Remove(fixture.EnvVariablesFromE2EFile); err != nil {
-			suite.T().Errorf("failed to remove env file: %v", err)
-		}
+		fixture.ClearEnvVarsFile()
 
 		// Restart the agent process
 		fixture.RestartAgent(suite.T(), "agent-managed")
@@ -133,10 +129,11 @@ ARGOCD_PRINCIPAL_ENABLE_WEBSOCKET=false`, proxyPort)
 	fixture.IsNotReady(suite.T(), "agent-managed")
 
 	// Restart the principal and the agent with the Websocket enabled
-	envVar = fmt.Sprintf(`ARGOCD_AGENT_REMOTE_PORT=%d
-ARGOCD_AGENT_ENABLE_WEBSOCKET=true
-ARGOCD_PRINCIPAL_ENABLE_WEBSOCKET=true`, proxyPort)
-	err = os.WriteFile(fixture.EnvVariablesFromE2EFile, []byte(envVar+"\n"), 0644)
+	err = fixture.WriteEnvVarsToFile(map[string]string{
+		"ARGOCD_AGENT_REMOTE_PORT":          fmt.Sprintf("%d", proxyPort),
+		"ARGOCD_AGENT_ENABLE_WEBSOCKET":     "true",
+		"ARGOCD_PRINCIPAL_ENABLE_WEBSOCKET": "true",
+	})
 	requires.NoError(err)
 
 	fixture.RestartAgent(suite.T(), "principal")

--- a/test/run-e2e.sh
+++ b/test/run-e2e.sh
@@ -21,6 +21,7 @@ if ! kubectl config get-contexts | tail -n +2 | awk '{ print $2 }' | grep -qE '^
     exit 1
 fi
 
+E2E_DESTINATION_BASED_MAPPING="${E2E_DESTINATION_BASED_MAPPING:-}" \
 go test -count=1 -v -race -timeout 45m github.com/argoproj-labs/argocd-agent/test/e2e
 
 # If we detect a data race in the 'make start-e2e' output, then fail here to cause the overall test job to fail.


### PR DESCRIPTION
**What does this PR do / why we need it**:

Currently, the e2e tests cover scenarios for namespace-based mapping and have minimal coverage for destination-based mapping. This can lead to issues where a feature may not work properly in one of the mappings. We need to ensure the quality of the argocd-agent in both the mapping modes. In this PR, we update the existing e2e tests to run in both modes. Using environment variables, we can run the same e2e tests with different configurations in the GitHub actions.

Assisted-by: Cursor

**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:


**Checklist**

* [ ] Documentation update is required by this PR (and has been updated) OR no documentation update is required.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added destination-based mapping support for end-to-end testing and local dev workflows, including dedicated commands to start and run destination-based scenarios.
  * Improved agent startup behavior to control destination-based mapping and namespace creation.
* **Tests**
  * Expanded CI to run end-to-end tests in a matrix across mapping modes, with clearer per-mode naming.
  * Updated end-to-end suites to use fixture-driven namespaces/destinations and to adjust assertions/skip behavior for destination-based mode.
  * Enhanced failure artifacts to be labeled by active mapping mode.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->