### PR TITLE
fix: send agent processed-event ACKs directly to avoid replay loops

### DIFF
--- a/agent/connection.go
+++ b/agent/connection.go
@@ -160,11 +160,17 @@ func (a *Agent) receiver(stream eventstreamapi.EventStream_SubscribeClient) erro
 	}
 
 	// Send an ACK if the event is processed successfully.
-	sendQ := a.queues.SendQ(defaultQueueName)
-	if sendQ == nil {
-		return fmt.Errorf("no send queue found for the default queue pair")
+	//
+	// ACKs are sent directly on the stream instead of through the normal send
+	// queue / EventWriter. The ACK shares the inbound event's resourceID, so
+	// routing it through the per-resource EventWriter queue would let it be
+	// coalesced or blocked behind normal status-update traffic for the same
+	// application. Under heavy status churn that delayed the ACK long enough for
+	// the principal to retry the original event, causing replay loops (see #839).
+	if err := a.eventWriter.SendDirect(a.emitter.ProcessedEvent(event.EventProcessed, ev)); err != nil {
+		logCtx.Errorf("Could not send ACK for event: %v", err)
+		return nil
 	}
-	sendQ.Add(a.emitter.ProcessedEvent(event.EventProcessed, ev))
 	logCtx.Trace("Sent an ACK for an event")
 
 	return nil

--- a/internal/event/event_writer.go
+++ b/internal/event/event_writer.go
@@ -2,6 +2,7 @@ package event
 
 import (
 	"context"
+	"fmt"
 	"math"
 	"math/rand/v2"
 	"strings"
@@ -32,6 +33,12 @@ type streamWriter interface {
 // It resends the event with exponential backoff until the event is ACK'd and removed from its list.
 type EventWriter struct {
 	mu sync.RWMutex
+
+	// sendMu serializes all writes to the underlying gRPC stream. A gRPC stream
+	// does not support concurrent Send calls, and events may be written both by
+	// the SendWaitingEvents loop and by SendDirect, so every send must hold it.
+	// It is a leaf lock: never acquire mu or an eventMessage lock while holding it.
+	sendMu sync.Mutex
 
 	// key: resource name + UID
 	// value: queue of unsent events for a resource
@@ -236,6 +243,36 @@ func (ew *EventWriter) Remove(ev *cloudevents.Event) {
 	}
 }
 
+// sendOnStream serializes all writes to the underlying gRPC stream, which does
+// not support concurrent Send calls.
+func (ew *EventWriter) sendOnStream(target streamWriter, ev *eventstreamapi.Event) error {
+	ew.sendMu.Lock()
+	defer ew.sendMu.Unlock()
+	return target.Send(ev)
+}
+
+// SendDirect sends an event immediately on the stream, bypassing the per-resource
+// queue and coalescing logic. It is intended for control-plane traffic such as
+// processed-event ACKs, which must not be delayed behind normal resource updates
+// for the same resource (see issue #839). The event is fire-and-forget: it is not
+// tracked for retries.
+func (ew *EventWriter) SendDirect(ev *cloudevents.Event) error {
+	pev, err := format.ToProto(ev)
+	if err != nil {
+		return fmt.Errorf("could not wire event: %w", err)
+	}
+
+	ew.mu.RLock()
+	target := ew.target
+	ew.mu.RUnlock()
+
+	if target == nil {
+		return fmt.Errorf("no target stream available")
+	}
+
+	return ew.sendOnStream(target, &eventstreamapi.Event{Event: pev})
+}
+
 // SendWaitingEvents will periodically send the events waiting in the EventWriter.
 // Note: This function will never return unless the context is done, and therefore
 // should be started in a separate goroutine.
@@ -362,7 +399,7 @@ func (ew *EventWriter) retrySentEvent(resID string, sentMsg *eventMessage) {
 		return
 	}
 
-	err = target.Send(&eventstreamapi.Event{Event: pev})
+	err = ew.sendOnStream(target, &eventstreamapi.Event{Event: pev})
 	sentMsg.mu.Unlock()
 
 	if err != nil {
@@ -445,7 +482,7 @@ func (ew *EventWriter) sendUnsentEvent(resID string) {
 	}
 
 	// A Send() on the stream is actually not blocking.
-	err = sendTarget.Send(&eventstreamapi.Event{Event: pev})
+	err = ew.sendOnStream(sendTarget, &eventstreamapi.Event{Event: pev})
 	if err != nil {
 		logCtx.Errorf("Error while sending: %v\n", err)
 		return

--- a/internal/event/event_writer_test.go
+++ b/internal/event/event_writer_test.go
@@ -314,6 +314,65 @@ func TestEventWriter(t *testing.T) {
 		require.Len(t, fs.events[resID], 1)
 	})
 
+	t.Run("SendDirect delivers an ACK even when the resource queue is blocked (#839)", func(t *testing.T) {
+		fs := &fakeStream{}
+		evSender := NewEventWriter("test", fs, eventWriterLogger)
+
+		app1.ResourceVersion = "1"
+		appEv := es.ApplicationEvent(SpecUpdate, app1)
+		resID := createResourceID(app1.ObjectMeta)
+
+		// A status update for this app has been sent and is now awaiting its
+		// ACK from the peer. This occupies sentEvents[resID] and blocks the
+		// resource's normal send path.
+		evSender.Add(appEv)
+		evSender.sendEvent(resID)
+		require.Contains(t, evSender.sentEvents, resID)
+
+		// Build the processed-event ACK for an inbound event. It carries the
+		// same resourceID as the app's status updates.
+		ack := cloudevents.NewEvent()
+		ack.SetSource("test")
+		ack.SetType(EventProcessed.String())
+		ack.SetDataSchema(targets.EventAck.String())
+		ack.SetExtension(eventID, "inbound-ack")
+		ack.SetExtension(resourceID, resID)
+
+		// Root cause (#839): routing the ACK through the per-resource queue the
+		// way the agent used to (sendQ -> EventWriter.Add) leaves it stuck,
+		// because sendEvent will not drain the queue while sentEvents[resID] is
+		// still occupied by the sent-but-unacked status update.
+		evSender.Add(&ack)
+		evSender.sendEvent(resID)
+		require.NotContains(t, fs.events[resID], "inbound-ack",
+			"a queued ACK stays blocked behind the sent-but-unacked update")
+
+		// The fix: SendDirect writes the ACK straight to the stream, bypassing
+		// the per-resource queue, so it is delivered immediately despite the block.
+		require.NoError(t, evSender.SendDirect(&ack))
+		require.Contains(t, fs.events[resID], "inbound-ack")
+
+		// The blocked status update is untouched and still awaiting its own ACK.
+		require.NotNil(t, evSender.sentEvents[resID])
+		require.Equal(t, EventID(appEv), EventID(evSender.sentEvents[resID].event))
+	})
+
+	t.Run("SendDirect returns an error when no target stream is set", func(t *testing.T) {
+		evSender := NewEventWriter("test", &fakeStream{}, eventWriterLogger)
+		evSender.mu.Lock()
+		evSender.target = nil
+		evSender.mu.Unlock()
+
+		ack := cloudevents.NewEvent()
+		ack.SetSource("test")
+		ack.SetType(EventProcessed.String())
+		ack.SetDataSchema(targets.EventAck.String())
+		ack.SetExtension(eventID, "x")
+		ack.SetExtension(resourceID, "r")
+
+		require.Error(t, evSender.SendDirect(&ack))
+	})
+
 	t.Run("should not send heartbeat events to sentEvents (fire-and-forget)", func(t *testing.T) {
 		fs := &fakeStream{}
 		evSender := NewEventWriter("test", fs, eventWriterLogger)


### PR DESCRIPTION
## Summary

Fixes #839. In managed mode the agent could repeatedly re-process the same inbound principal `spec-update` for an `Application` because the processed-event ACK shared the normal per-resource send path with the app's own status updates.

A processed ACK carries the inbound event's `resourceID`, so it lands in the same `EventWriter` queue as that application's status updates. `EventWriter` keeps one sent-but-unacked event per resource and drains nothing else for that resource until it is ACK'd, so the outbound ACK could sit behind a status update that was itself awaiting an ACK. Under heavy status churn this delayed the ACK long enough for the principal to retry the original `spec-update`, producing replay loops and temporary principal-side lag.

## Change

- Add `EventWriter.SendDirect`, which writes an event straight to the stream, bypassing the per-resource queue and coalescing logic. The agent now sends processed ACKs through it (`agent/connection.go`) instead of enqueuing them on the send queue.
- Serialize all stream writes behind a dedicated `sendMu`. `SendDirect` and the `SendWaitingEvents` loop can otherwise call the gRPC stream's `Send` concurrently, which a gRPC stream does not support.

This matches the first fix option suggested by @jannfis on the issue ("sending ACKs directly without using event writer to queue those behind other updates").

## Scope

The principal emits processed ACKs the same way (`principal/event.go`). That path is entangled with the broader per-agent queue QoS/prioritization discussion raised on the issue, so it is intentionally left out of this focused fix.

## Testing

- New unit tests in `internal/event/event_writer_test.go`:
  - an ACK is delivered on the stream even while the resource's normal queue is blocked behind a sent-but-unacked event;
  - `SendDirect` returns an error when no target stream is set.
- `go test ./internal/event/... ./agent/... -race` passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * ACKs for processed inbound events are now sent immediately, even when the normal send queue is busy.
  * Stream writes are now serialized to reduce the risk of concurrent send issues.
  * Better handling was added for cases where an immediate send cannot be delivered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->