### PR TITLE
fix: cleanup agent resources after the deletion of the agent cluster secret

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -33,6 +33,7 @@ require (
 	go.opentelemetry.io/otel/trace v1.44.0
 	golang.org/x/crypto v0.54.0
 	golang.org/x/sync v0.22.0
+	golang.org/x/time v0.15.0
 	golang.stackrox.io/grpc-http1 v0.5.1
 	google.golang.org/genproto/googleapis/api v0.0.0-20260414002931-afd174a4e478
 	google.golang.org/grpc v1.82.1
@@ -42,6 +43,7 @@ require (
 	k8s.io/api v0.34.0
 	k8s.io/apimachinery v0.34.0
 	k8s.io/client-go v0.34.0
+	k8s.io/klog/v2 v2.130.1
 	k8s.io/utils v0.0.0-20250604170112-4c0f3b243397
 )
 
@@ -194,7 +196,6 @@ require (
 	k8s.io/component-base v0.34.0 // indirect
 	k8s.io/component-helpers v0.34.0 // indirect
 	k8s.io/controller-manager v0.34.0 // indirect
-	k8s.io/klog/v2 v2.130.1 // indirect
 	k8s.io/kube-aggregator v0.34.0 // indirect
 	k8s.io/kube-openapi v0.0.0-20250710124328-f3f2b991d03b // indirect
 	k8s.io/kubectl v0.34.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/grpc-ecosystem/go-grpc-middleware/providers/prometheus v1.1.0
 	github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.3.3
 	github.com/prometheus/client_golang v1.24.1
+	github.com/prometheus/client_model v0.6.2
 	github.com/redis/go-redis/v9 v9.21.0
 	github.com/rs/zerolog v1.35.1
 	github.com/sirupsen/logrus v1.9.4
@@ -33,7 +34,6 @@ require (
 	go.opentelemetry.io/otel/trace v1.44.0
 	golang.org/x/crypto v0.54.0
 	golang.org/x/sync v0.22.0
-	golang.org/x/time v0.15.0
 	golang.stackrox.io/grpc-http1 v0.5.1
 	google.golang.org/genproto/googleapis/api v0.0.0-20260414002931-afd174a4e478
 	google.golang.org/grpc v1.82.1
@@ -43,7 +43,6 @@ require (
 	k8s.io/api v0.34.0
 	k8s.io/apimachinery v0.34.0
 	k8s.io/client-go v0.34.0
-	k8s.io/klog/v2 v2.130.1
 	k8s.io/utils v0.0.0-20250604170112-4c0f3b243397
 )
 
@@ -150,7 +149,6 @@ require (
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
-	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.70.1 // indirect
 	github.com/prometheus/procfs v0.21.1 // indirect
 	github.com/r3labs/diff/v3 v3.0.2 // indirect
@@ -196,6 +194,7 @@ require (
 	k8s.io/component-base v0.34.0 // indirect
 	k8s.io/component-helpers v0.34.0 // indirect
 	k8s.io/controller-manager v0.34.0 // indirect
+	k8s.io/klog/v2 v2.130.1 // indirect
 	k8s.io/kube-aggregator v0.34.0 // indirect
 	k8s.io/kube-openapi v0.0.0-20250710124328-f3f2b991d03b // indirect
 	k8s.io/kubectl v0.34.0 // indirect

--- a/internal/argocd/cluster/informer.go
+++ b/internal/argocd/cluster/informer.go
@@ -19,16 +19,17 @@ that are used for the Manager's informer on add/update/delete events.
 func (m *Manager) onClusterAdded(res *v1.Secret) {
 	log().Tracef("Executing cluster add handler for secret %s/%s", res.Namespace, res.Name)
 	m.mutex.Lock()
-	defer m.mutex.Unlock()
 
 	// The informer filter should have already ensured that the following
 	// labels are set. But we check again just to be sure.
 	agent, ok := res.Labels[LabelKeyClusterAgentMapping]
 	if !ok || agent == "" {
+		m.mutex.Unlock()
 		log().Warnf("Processing invalid cluster secret (missing labels): %s", res.Name)
 		return
 	}
 	if v, ok := res.Labels[common.LabelKeySecretType]; !ok || v != common.LabelValueSecretTypeCluster {
+		m.mutex.Unlock()
 		log().Warnf("Processing invalid cluster secret (missing labels): %s", res.Name)
 		return
 	}
@@ -36,6 +37,7 @@ func (m *Manager) onClusterAdded(res *v1.Secret) {
 	// Check if we already have a mapping for the requested agent
 	existing := m.mapping(agent)
 	if existing != nil {
+		m.mutex.Unlock()
 		log().Errorf("Agent %s is already mapped to cluster %s", agent, existing.Name)
 		return
 	}
@@ -43,20 +45,27 @@ func (m *Manager) onClusterAdded(res *v1.Secret) {
 	// Unmarshal the cluster from the secret
 	cluster, err := db.SecretToCluster(res)
 	if err != nil {
+		m.mutex.Unlock()
 		log().WithError(err).Error("Not a cluster secret or malformed data")
 		return
 	}
 
-	// TODO(jannfis): Do we want to validate cluster configuration here?
-
 	// Map the cluster to the agent
 	err = m.mapCluster(agent, cluster)
 	if err != nil {
+		m.mutex.Unlock()
 		log().WithError(err).Infof("Error mapping cluster %s to agent %s", cluster.Name, agent)
 		return
 	}
 
+	clusterAddedCb := m.clusterAddedCb
+	m.mutex.Unlock()
+
 	log().Infof("Mapped cluster %s to agent %s", cluster.Name, agent)
+
+	if clusterAddedCb != nil {
+		clusterAddedCb(agent)
+	}
 }
 
 // onClusterUpdated is called by the informer whenever there is a change to a

--- a/internal/argocd/cluster/informer.go
+++ b/internal/argocd/cluster/informer.go
@@ -117,11 +117,11 @@ func (m *Manager) onClusterUpdated(old *v1.Secret, new *v1.Secret) {
 func (m *Manager) onClusterDeleted(res *v1.Secret) {
 	log().Trace("Executing cluster delete callback")
 	m.mutex.Lock()
-	defer m.mutex.Unlock()
 
 	// This situation should not happen, but we test anyway.
 	agent, ok := res.Labels[LabelKeyClusterAgentMapping]
 	if !ok {
+		m.mutex.Unlock()
 		log().Errorf("Secret %s should have agent mapping label, but does not", res.Name)
 		return
 	}
@@ -131,15 +131,24 @@ func (m *Manager) onClusterDeleted(res *v1.Secret) {
 	// investigated.
 	var c *v1alpha1.Cluster
 	if c = m.mapping(agent); c == nil {
+		m.mutex.Unlock()
 		log().Errorf("There should be a cluster mapped to agent %s, but there is not.", agent)
 		return
 	}
 
 	// Finally, unmap the cluster
 	if err := m.unmapCluster(agent); err != nil {
+		m.mutex.Unlock()
 		log().WithError(err).Errorf("Could not unmap cluster %s from agent %s", c.Name, agent)
 		return
 	}
 
+	cleanupAgentState := m.clusterDeletedCb
+	m.mutex.Unlock()
+
 	log().Infof("Unmapped cluster from agent %s", agent)
+
+	if cleanupAgentState != nil {
+		cleanupAgentState(agent)
+	}
 }

--- a/internal/argocd/cluster/informer_test.go
+++ b/internal/argocd/cluster/informer_test.go
@@ -82,6 +82,72 @@ func Test_onClusterAdded(t *testing.T) {
 	})
 }
 
+func Test_onClusterAdded_InvokesCallback(t *testing.T) {
+	t.Run("Callback invoked on successful add", func(t *testing.T) {
+		m, err := NewManager(context.TODO(), "argocd", "", "", cacheutil.RedisCompressionGZip, kube.NewFakeKubeClient("argocd"), nil)
+		require.NoError(t, err)
+
+		var callbackAgent atomic.Value
+		m.SetOnClusterAdded(func(agentName string) {
+			callbackAgent.Store(agentName)
+		})
+
+		s := &v1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: map[string]string{
+					LabelKeyClusterAgentMapping: "agent1",
+					common.LabelKeySecretType:   common.LabelValueSecretTypeCluster,
+				},
+			},
+		}
+		m.onClusterAdded(s)
+		assert.Len(t, m.clusters, 1)
+		assert.Equal(t, "agent1", callbackAgent.Load())
+	})
+
+	t.Run("Callback not invoked on malformed secret", func(t *testing.T) {
+		m, err := NewManager(context.TODO(), "argocd", "", "", cacheutil.RedisCompressionGZip, kube.NewFakeKubeClient("argocd"), nil)
+		require.NoError(t, err)
+
+		callbackCalled := atomic.Bool{}
+		m.SetOnClusterAdded(func(agentName string) {
+			callbackCalled.Store(true)
+		})
+
+		s := &v1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: map[string]string{
+					LabelKeyClusterAgentMapping: "agent1",
+					common.LabelKeySecretType:   common.LabelValueSecretTypeCluster,
+				},
+			},
+			Data: map[string][]byte{
+				"config": []byte("invalid json"),
+			},
+		}
+		m.onClusterAdded(s)
+		assert.False(t, callbackCalled.Load())
+	})
+
+	t.Run("No callback registered does not panic", func(t *testing.T) {
+		m, err := NewManager(context.TODO(), "argocd", "", "", cacheutil.RedisCompressionGZip, kube.NewFakeKubeClient("argocd"), nil)
+		require.NoError(t, err)
+
+		s := &v1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: map[string]string{
+					LabelKeyClusterAgentMapping: "agent1",
+					common.LabelKeySecretType:   common.LabelValueSecretTypeCluster,
+				},
+			},
+		}
+		assert.NotPanics(t, func() {
+			m.onClusterAdded(s)
+		})
+		assert.Len(t, m.clusters, 1)
+	})
+}
+
 func Test_onClusterUpdated(t *testing.T) {
 	t.Run("Successfully remap a cluster to another agent", func(t *testing.T) {
 		old := &v1.Secret{

--- a/internal/argocd/cluster/informer_test.go
+++ b/internal/argocd/cluster/informer_test.go
@@ -2,6 +2,7 @@ package cluster
 
 import (
 	"context"
+	"sync/atomic"
 	"testing"
 
 	"github.com/argoproj-labs/argocd-agent/test/fake/kube"
@@ -183,5 +184,68 @@ func Test_onClusterUpdated(t *testing.T) {
 		assert.NotNil(t, m.mapping("agent1"))
 		assert.NotNil(t, m.mapping("agent2"))
 
+	})
+}
+
+func Test_onClusterDeleted(t *testing.T) {
+	t.Run("Successfully delete a cluster and invoke callback", func(t *testing.T) {
+		m, err := NewManager(context.TODO(), "argocd", "", "", cacheutil.RedisCompressionGZip, kube.NewFakeKubeClient("argocd"), nil)
+		require.NoError(t, err)
+		m.mapCluster("agent1", &v1alpha1.Cluster{Name: "cluster1"})
+		assert.NotNil(t, m.mapping("agent1"))
+
+		var callbackAgent atomic.Value
+		m.SetOnClusterDeleted(func(agentName string) {
+			callbackAgent.Store(agentName)
+		})
+
+		s := &v1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: map[string]string{
+					LabelKeyClusterAgentMapping: "agent1",
+				},
+			},
+		}
+		m.onClusterDeleted(s)
+		assert.Nil(t, m.mapping("agent1"))
+		assert.Equal(t, "agent1", callbackAgent.Load())
+	})
+
+	t.Run("Callback not invoked when no mapping exists", func(t *testing.T) {
+		m, err := NewManager(context.TODO(), "argocd", "", "", cacheutil.RedisCompressionGZip, kube.NewFakeKubeClient("argocd"), nil)
+		require.NoError(t, err)
+
+		callbackCalled := atomic.Bool{}
+		m.SetOnClusterDeleted(func(agentName string) {
+			callbackCalled.Store(true)
+		})
+
+		s := &v1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: map[string]string{
+					LabelKeyClusterAgentMapping: "nonexistent",
+				},
+			},
+		}
+		m.onClusterDeleted(s)
+		assert.False(t, callbackCalled.Load())
+	})
+
+	t.Run("No callback registered does not panic", func(t *testing.T) {
+		m, err := NewManager(context.TODO(), "argocd", "", "", cacheutil.RedisCompressionGZip, kube.NewFakeKubeClient("argocd"), nil)
+		require.NoError(t, err)
+		m.mapCluster("agent1", &v1alpha1.Cluster{Name: "cluster1"})
+
+		s := &v1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: map[string]string{
+					LabelKeyClusterAgentMapping: "agent1",
+				},
+			},
+		}
+		assert.NotPanics(t, func() {
+			m.onClusterDeleted(s)
+		})
+		assert.Nil(t, m.mapping("agent1"))
 	})
 }

--- a/internal/argocd/cluster/manager.go
+++ b/internal/argocd/cluster/manager.go
@@ -56,6 +56,10 @@ const syncTimeout = 30 * time.Second
 // The agentName parameter is the value of the agent-mapping label from the deleted secret.
 type ClusterDeletedCallback func(agentName string)
 
+// ClusterAddedCallback is invoked after a cluster secret is added and mapped.
+// The agentName parameter is the agent that was mapped.
+type ClusterAddedCallback func(agentName string)
+
 // Manager manages Argo CD cluster secrets on the principal
 type Manager struct {
 	mutex      sync.RWMutex
@@ -74,6 +78,10 @@ type Manager struct {
 	// clusterDeletedCb is a callback invoked after a cluster secret
 	// is deleted and unmapped. Used by the principal to clean up per-agent state.
 	clusterDeletedCb ClusterDeletedCallback
+
+	// clusterAddedCb is a callback invoked after a cluster secret is added
+	// and mapped. Used by the principal to resync applications for the agent.
+	clusterAddedCb ClusterAddedCallback
 }
 
 // SetOnClusterDeleted registers a callback that fires after a cluster secret
@@ -82,6 +90,14 @@ func (m *Manager) SetOnClusterDeleted(fn ClusterDeletedCallback) {
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
 	m.clusterDeletedCb = fn
+}
+
+// SetOnClusterAdded registers a callback that fires after a cluster secret
+// is added and the agent mapping is created.
+func (m *Manager) SetOnClusterAdded(fn ClusterAddedCallback) {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+	m.clusterAddedCb = fn
 }
 
 // NewManager instantiates and initializes a new Manager.

--- a/internal/argocd/cluster/manager.go
+++ b/internal/argocd/cluster/manager.go
@@ -52,6 +52,10 @@ const LabelValueManagerName = "argocd-agent"
 // syncTimeout is the duration to wait until the manager's informer has synced
 const syncTimeout = 30 * time.Second
 
+// ClusterDeletedCallback is invoked after a cluster secret is deleted and unmapped.
+// The agentName parameter is the value of the agent-mapping label from the deleted secret.
+type ClusterDeletedCallback func(agentName string)
+
 // Manager manages Argo CD cluster secrets on the principal
 type Manager struct {
 	mutex      sync.RWMutex
@@ -66,6 +70,18 @@ type Manager struct {
 	filters *filter.Chain[*v1.Secret]
 
 	clusterCache *appstatecache.Cache
+
+	// clusterDeletedCb is a callback invoked after a cluster secret
+	// is deleted and unmapped. Used by the principal to clean up per-agent state.
+	clusterDeletedCb ClusterDeletedCallback
+}
+
+// SetOnClusterDeleted registers a callback that fires after a cluster secret
+// is deleted and the agent mapping is removed.
+func (m *Manager) SetOnClusterDeleted(fn ClusterDeletedCallback) {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+	m.clusterDeletedCb = fn
 }
 
 // NewManager instantiates and initializes a new Manager.

--- a/internal/resources/resources.go
+++ b/internal/resources/resources.go
@@ -148,6 +148,13 @@ func (r *AgentResources) Remove(agent string, key ResourceKey) {
 	}
 }
 
+// RemoveAgent removes all tracked resources for the given agent.
+func (r *AgentResources) RemoveAgent(agent string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	delete(r.resources, agent)
+}
+
 func (r *AgentResources) GetAllResources(agent string) []ResourceKey {
 	r.mu.RLock()
 	defer r.mu.RUnlock()

--- a/internal/resources/resources_test.go
+++ b/internal/resources/resources_test.go
@@ -202,3 +202,29 @@ func Test_AgentResources(t *testing.T) {
 	assert.Empty(t, res.Checksum("first"))
 	assert.Empty(t, res.Checksum("second"))
 }
+
+func Test_AgentResources_RemoveAgent(t *testing.T) {
+	res := NewAgentResources()
+
+	res.Add("agent1", ResourceKey{Name: "app1", Namespace: "ns1"})
+	res.Add("agent1", ResourceKey{Name: "app2", Namespace: "ns1"})
+	res.Add("agent2", ResourceKey{Name: "app3", Namespace: "ns2"})
+
+	assert.Equal(t, 2, res.Len())
+
+	res.RemoveAgent("agent1")
+
+	assert.Equal(t, 1, res.Len())
+	assert.Empty(t, res.GetAllResources("agent1"))
+	assert.Len(t, res.GetAllResources("agent2"), 1)
+}
+
+func Test_AgentResources_RemoveAgent_NonExistent(t *testing.T) {
+	res := NewAgentResources()
+	res.Add("agent1", ResourceKey{Name: "app1", Namespace: "ns1"})
+
+	assert.NotPanics(t, func() {
+		res.RemoveAgent("nonexistent")
+	})
+	assert.Equal(t, 1, res.Len())
+}

--- a/principal/apis/eventstream/eventstream.go
+++ b/principal/apis/eventstream/eventstream.go
@@ -625,6 +625,21 @@ recvloop:
 	return nil
 }
 
+// DisconnectAgent cancels the event stream for a specific agent, forcing it to disconnect.
+// Returns true if the agent was connected and disconnected, false if it was not connected.
+func (s *Server) DisconnectAgent(agentName string) bool {
+	s.activeClientsMu.Lock()
+	c, found := s.activeClients[agentName]
+	s.activeClientsMu.Unlock()
+	if !found || c == nil {
+		return false
+	}
+	if c.cancelFn != nil {
+		c.cancelFn()
+	}
+	return true
+}
+
 // IsAgentConnected returns true if the agent is connected to the server via the event stream.
 func (s *Server) IsAgentConnected(agentName string) bool {
 	s.activeClientsMu.Lock()

--- a/principal/apis/eventstream/eventstream.go
+++ b/principal/apis/eventstream/eventstream.go
@@ -629,11 +629,12 @@ recvloop:
 // Returns true if the agent was connected and disconnected, false if it was not connected.
 func (s *Server) DisconnectAgent(agentName string) bool {
 	s.activeClientsMu.Lock()
+	defer s.activeClientsMu.Unlock()
 	c, found := s.activeClients[agentName]
-	s.activeClientsMu.Unlock()
 	if !found || c == nil {
 		return false
 	}
+	delete(s.activeClients, agentName)
 	if c.cancelFn != nil {
 		c.cancelFn()
 	}

--- a/principal/callbacks.go
+++ b/principal/callbacks.go
@@ -746,10 +746,20 @@ func (s *Server) syncGPGKeyToManagedAgents(ctx context.Context, cm *corev1.Confi
 // deleteNamespaceCallback is called when the user deletes the agent namespace.
 // Since there is no namespace we can remove the queue associated with this agent.
 func (s *Server) deleteNamespaceCallback(outbound *corev1.Namespace) {
+	logCtx := log().WithFields(logrus.Fields{
+		"component":      "EventCallback",
+		"queue":          outbound.Name,
+		"event":          "namespace_delete",
+		"namespace_name": outbound.Name,
+	})
+
 	if !s.queues.HasQueuePair(outbound.Name) {
 		return
 	}
+
 	s.cleanupAgentState(outbound.Name)
+
+	logCtx.Tracef("Deleted the queue pair since the agent namespace is deleted")
 }
 
 // mapAppProjectToAgents returns the set of managed agents that should receive this AppProject.

--- a/principal/callbacks.go
+++ b/principal/callbacks.go
@@ -136,10 +136,15 @@ func (s *Server) updateAppCallback(old *v1alpha1.Application, new *v1alpha1.Appl
 		return
 	}
 
+	logCtx = logCtx.WithField("queue", agentName)
+
+	if s.clusterMgr != nil && !s.clusterMgr.HasMapping(agentName) {
+		logCtx.Warn("Application is targeting an invalid agent, skipping update")
+		return
+	}
+
 	s.resources.Add(agentName, resources.NewResourceKeyFromApp(new))
 	s.trackAppToAgent(new, agentName)
-
-	logCtx = logCtx.WithField("queue", agentName)
 
 	if s.isResourceFromAutonomousAgent(new) {
 		// Remove finalizers from autonomous agent applications if it is being deleted
@@ -171,10 +176,6 @@ func (s *Server) updateAppCallback(old *v1alpha1.Application, new *v1alpha1.Appl
 		return
 	}
 	if !s.queues.HasQueuePair(agentName) {
-		if s.clusterMgr != nil && !s.clusterMgr.HasMapping(agentName) {
-			logCtx.Warn("Application is targeting an invalid agent, skipping update")
-			return
-		}
 		if err := s.queues.Create(agentName); err != nil {
 			logCtx.WithError(err).Error("failed to create a queue pair for agent")
 			return

--- a/principal/callbacks.go
+++ b/principal/callbacks.go
@@ -160,7 +160,7 @@ func (s *Server) updateAppCallback(old *v1alpha1.Application, new *v1alpha1.Appl
 		}
 
 		// Revert modifications on autonomous agent applications
-		if s.appManager.RevertAutonomousAppChanges(s.ctx, new, s.sourceCache.Application) {
+		if s.appManager.RevertAutonomousAppChanges(s.ctx, new.DeepCopy(), s.sourceCache.Application) {
 			logCtx.Trace("Modifications to the application are reverted")
 			return
 		}

--- a/principal/callbacks.go
+++ b/principal/callbacks.go
@@ -310,15 +310,6 @@ func (s *Server) newAppProjectCallback(outbound *v1alpha1.AppProject) {
 	ctx, span := s.startSpan(operationcreate, "AppProject", outbound)
 	defer span.End()
 
-	// Return early if no interested agent is connected
-	if !s.queues.HasQueuePair(outbound.Namespace) {
-		if err := s.queues.Create(outbound.Namespace); err != nil {
-			logCtx.WithError(err).Error("failed to create a queue pair for an existing agent namespace")
-			return
-		}
-		logCtx.Trace("Created a new queue pair for the existing namespace")
-	}
-
 	if s.metrics != nil {
 		s.metrics.AppProjectCreated.Inc()
 	}
@@ -400,13 +391,6 @@ func (s *Server) updateAppProjectCallback(old *v1alpha1.AppProject, new *v1alpha
 		logCtx.WithField("resource_version", new.ResourceVersion).Debugf("Resource version has already been seen")
 		return
 	}
-	if !s.queues.HasQueuePair(old.Namespace) {
-		if err := s.queues.Create(old.Namespace); err != nil {
-			logCtx.WithError(err).Error("failed to create a queue pair for an existing agent namespace")
-			return
-		}
-		logCtx.Trace("Created a new queue pair for the existing agent namespace")
-	}
 
 	s.syncAppProjectUpdatesToAgents(ctx, old, new, logCtx)
 
@@ -458,19 +442,6 @@ func (s *Server) deleteAppProjectCallback(outbound *v1alpha1.AppProject) {
 
 	ctx, span := s.startSpan(operationdelete, "AppProject", outbound)
 	defer span.End()
-
-	if !s.queues.HasQueuePair(outbound.Namespace) {
-		if err := s.queues.Create(outbound.Namespace); err != nil {
-			logCtx.WithError(err).Error("failed to create a queue pair for an existing agent namespace")
-			return
-		}
-		logCtx.Trace("Created a new queue pair for the existing agent namespace")
-	}
-	q := s.queues.SendQ(outbound.Namespace)
-	if q == nil {
-		logCtx.Error("Help! Queue pair has disappeared!")
-		return
-	}
 
 	agents := s.mapAppProjectToAgents(*outbound)
 	for agent := range agents {
@@ -761,26 +732,10 @@ func (s *Server) syncGPGKeyToManagedAgents(ctx context.Context, cm *corev1.Confi
 // deleteNamespaceCallback is called when the user deletes the agent namespace.
 // Since there is no namespace we can remove the queue associated with this agent.
 func (s *Server) deleteNamespaceCallback(outbound *corev1.Namespace) {
-	logCtx := log().WithFields(logrus.Fields{
-		"component":      "EventCallback",
-		"queue":          outbound.Name,
-		"event":          "namespace_delete",
-		"namespace_name": outbound.Name,
-	})
-
 	if !s.queues.HasQueuePair(outbound.Name) {
 		return
 	}
-
-	if err := s.queues.Delete(outbound.Name, true); err != nil {
-		logCtx.WithError(err).Error("failed to remove the queue pair for a deleted agent namespace")
-		return
-	}
-
-	// Remove eventwriter associated with this agent
-	s.eventWriters.Remove(outbound.Name)
-
-	logCtx.Tracef("Deleted the queue pair since the agent namespace is deleted")
+	s.cleanupAgentState(outbound.Name)
 }
 
 // mapAppProjectToAgents returns the set of managed agents that should receive this AppProject.
@@ -1145,4 +1100,15 @@ func (c *concurrentMap[K, V]) Delete(key K) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	delete(c.m, key)
+}
+
+// DeleteByValue removes all entries whose value equals the given value.
+func (c *concurrentMap[K, V]) DeleteByValue(value V, eq func(a, b V) bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for k, v := range c.m {
+		if eq(v, value) {
+			delete(c.m, k)
+		}
+	}
 }

--- a/principal/callbacks.go
+++ b/principal/callbacks.go
@@ -72,13 +72,15 @@ func (s *Server) newAppCallback(outbound *v1alpha1.Application) {
 		return
 	}
 
-	s.resources.Add(agentName, resources.NewResourceKeyFromApp(outbound))
-	s.trackAppToAgent(outbound, agentName)
-
 	ctx, span := s.startSpan(operationcreate, "Application", outbound)
 	defer span.End()
 
 	logCtx = logCtx.WithField("queue", agentName)
+
+	if s.clusterMgr != nil && !s.clusterMgr.HasMapping(agentName) {
+		logCtx.Error("Application is targeting an invalid agent, skipping creation")
+		return
+	}
 
 	if !s.queues.HasQueuePair(agentName) {
 		if err := s.queues.Create(agentName); err != nil {
@@ -92,6 +94,10 @@ func (s *Server) newAppCallback(outbound *v1alpha1.Application) {
 		logCtx.Errorf("Help! queue pair for agent %s disappeared!", agentName)
 		return
 	}
+
+	s.resources.Add(agentName, resources.NewResourceKeyFromApp(outbound))
+	s.trackAppToAgent(outbound, agentName)
+
 	ev := s.events.ApplicationEvent(event.Create, outbound)
 	// Inject trace context into the event for propagation to agent
 	s.stampEvent(ctx, ev)
@@ -165,6 +171,10 @@ func (s *Server) updateAppCallback(old *v1alpha1.Application, new *v1alpha1.Appl
 		return
 	}
 	if !s.queues.HasQueuePair(agentName) {
+		if s.clusterMgr != nil && !s.clusterMgr.HasMapping(agentName) {
+			logCtx.Warn("Application is targeting an invalid agent, skipping update")
+			return
+		}
 		if err := s.queues.Create(agentName); err != nil {
 			logCtx.WithError(err).Error("failed to create a queue pair for agent")
 			return
@@ -255,6 +265,10 @@ func (s *Server) deleteAppCallback(outbound *v1alpha1.Application) {
 	}
 
 	if !s.queues.HasQueuePair(agentName) {
+		if s.clusterMgr != nil && !s.clusterMgr.HasMapping(agentName) {
+			logCtx.Warn("Application is targeting an invalid agent, skipping deletion")
+			return
+		}
 		if err := s.queues.Create(agentName); err != nil {
 			logCtx.WithError(err).Error("failed to create a queue pair for agent")
 			return
@@ -748,6 +762,11 @@ func (s *Server) mapAppProjectToAgents(appProject v1alpha1.AppProject) map[strin
 			continue
 		}
 
+		// Skip agents that don't have a valid agent cluster secret
+		if s.clusterMgr != nil && !s.clusterMgr.HasMapping(agentName) {
+			continue
+		}
+
 		if appproject.DoesAgentMatchWithProject(agentName, appProject, s.destinationBasedMapping) {
 			agents[agentName] = true
 		}
@@ -1027,8 +1046,10 @@ func (s *Server) handleAppAgentChange(ctx context.Context, old, new *v1alpha1.Ap
 		s.resources.Remove(oldAgentName, resources.NewResourceKeyFromApp(old))
 
 		if !s.queues.HasQueuePair(oldAgentName) {
-			if err := s.queues.Create(oldAgentName); err != nil {
-				logCtx.WithError(err).Error("failed to create queue pair for old agent")
+			if s.clusterMgr == nil || s.clusterMgr.HasMapping(oldAgentName) {
+				if err := s.queues.Create(oldAgentName); err != nil {
+					logCtx.WithError(err).Error("failed to create queue pair for old agent")
+				}
 			}
 		}
 		if oldQ := s.queues.SendQ(oldAgentName); oldQ != nil {

--- a/principal/callbacks_test.go
+++ b/principal/callbacks_test.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/argoproj-labs/argocd-agent/internal/argocd/cluster"
 	"github.com/argoproj-labs/argocd-agent/internal/backend/mocks"
 	"github.com/argoproj-labs/argocd-agent/internal/cache"
 	"github.com/argoproj-labs/argocd-agent/internal/event"
@@ -1346,6 +1347,39 @@ func TestServer_deleteAppCallback(t *testing.T) {
 		agents := s.appToAgent.Get(app.QualifiedName())
 		assert.Empty(t, agents)
 	})
+
+	t.Run("skips queue creation for agent without cluster mapping", func(t *testing.T) {
+		mockBackend := &mocks.Application{}
+		appManager, err := application.NewApplicationManager(mockBackend, "argocd")
+		require.NoError(t, err)
+
+		clusterMgr := &cluster.Manager{}
+
+		s := &Server{
+			ctx:        context.Background(),
+			queues:     queue.NewSendRecvQueues(),
+			events:     event.NewEventSource("test"),
+			resources:  resources.NewAgentResources(),
+			appToAgent: newConcurrentStringMap(),
+			appManager: appManager,
+			clusterMgr: clusterMgr,
+		}
+
+		app := &v1alpha1.Application{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-app",
+				Namespace: "deregistered-agent",
+			},
+			Spec: v1alpha1.ApplicationSpec{
+				Project: "default",
+			},
+		}
+
+		s.deleteAppCallback(app)
+
+		// No queue should be created for deregistered agent
+		assert.False(t, s.queues.HasQueuePair("deregistered-agent"))
+	})
 }
 
 func TestServer_newAppCallback(t *testing.T) {
@@ -1467,6 +1501,73 @@ func TestServer_newAppCallback(t *testing.T) {
 
 		// Should not process the app
 		assert.Zero(t, s.queues.Len())
+	})
+
+	t.Run("skips app targeting agent without cluster mapping", func(t *testing.T) {
+		clusterMgr := &cluster.Manager{}
+
+		s := &Server{
+			ctx:        context.Background(),
+			queues:     queue.NewSendRecvQueues(),
+			events:     event.NewEventSource("test"),
+			resources:  resources.NewAgentResources(),
+			appToAgent: newConcurrentStringMap(),
+			clusterMgr: clusterMgr,
+		}
+
+		app := &v1alpha1.Application{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-app",
+				Namespace: "deregistered-agent",
+			},
+			Spec: v1alpha1.ApplicationSpec{
+				Project: "default",
+			},
+		}
+
+		s.newAppCallback(app)
+
+		// No queue should be created
+		assert.False(t, s.queues.HasQueuePair("deregistered-agent"))
+		// No resource tracking
+		assert.Empty(t, s.resources.GetAllResources("deregistered-agent"))
+		// No app-to-agent tracking
+		assert.Empty(t, s.appToAgent.Get("deregistered-agent/test-app"))
+	})
+
+	t.Run("processes app when cluster mapping exists", func(t *testing.T) {
+		clusterMgr, err := cluster.NewManager(context.Background(), "argocd", "", "", "", kubefake.NewSimpleClientset(), nil)
+		require.NoError(t, err)
+		require.NoError(t, clusterMgr.MapCluster("registered-agent", &v1alpha1.Cluster{Name: "registered-agent", Server: "https://registered.example.com"}))
+
+		s := &Server{
+			ctx:        context.Background(),
+			queues:     queue.NewSendRecvQueues(),
+			events:     event.NewEventSource("test"),
+			resources:  resources.NewAgentResources(),
+			appToAgent: newConcurrentStringMap(),
+			clusterMgr: clusterMgr,
+		}
+
+		app := &v1alpha1.Application{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-app",
+				Namespace: "registered-agent",
+			},
+			Spec: v1alpha1.ApplicationSpec{
+				Project: "default",
+			},
+		}
+
+		s.newAppCallback(app)
+
+		// Queue should be created and event added
+		assert.True(t, s.queues.HasQueuePair("registered-agent"))
+		sendQ := s.queues.SendQ("registered-agent")
+		require.NotNil(t, sendQ)
+		assert.Equal(t, 1, sendQ.Len())
+		// Resource tracking should be populated
+		assert.Len(t, s.resources.GetAllResources("registered-agent"), 1)
 	})
 }
 
@@ -2153,6 +2254,41 @@ func TestServer_updateAppCallback(t *testing.T) {
 		// Verify resource tracking was removed
 		agentResources1 := s.resources.GetAllResources("cluster-1")
 		assert.Len(t, agentResources1, 0, "Old cluster should have no resources")
+	})
+
+	t.Run("skips queue creation for agent without cluster mapping", func(t *testing.T) {
+		mockBackend := &mocks.Application{}
+		mockBackend.On("IsChangeIgnored", mock.Anything, mock.Anything).Return(false)
+
+		appManager, err := application.NewApplicationManager(mockBackend, "argocd")
+		require.NoError(t, err)
+
+		clusterMgr := &cluster.Manager{}
+
+		s := &Server{
+			ctx:        context.Background(),
+			queues:     queue.NewSendRecvQueues(),
+			events:     event.NewEventSource("test"),
+			resources:  resources.NewAgentResources(),
+			appToAgent: newConcurrentStringMap(),
+			appManager: appManager,
+			clusterMgr: clusterMgr,
+		}
+
+		app := &v1alpha1.Application{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-app",
+				Namespace: "deregistered-agent",
+			},
+			Spec: v1alpha1.ApplicationSpec{
+				Project: "default",
+			},
+		}
+
+		s.updateAppCallback(app, app)
+
+		// No queue should be created for deregistered agent
+		assert.False(t, s.queues.HasQueuePair("deregistered-agent"))
 	})
 }
 

--- a/principal/mapset.go
+++ b/principal/mapset.go
@@ -65,3 +65,16 @@ func (m *MapToSet) Delete(key string, value string) {
 		}
 	}
 }
+
+// DeleteFromAll removes the given value from every key's set.
+// Keys whose sets become empty are removed entirely.
+func (m *MapToSet) DeleteFromAll(value string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for key, s := range m.m {
+		delete(s, value)
+		if len(s) == 0 {
+			delete(m.m, key)
+		}
+	}
+}

--- a/principal/mapset_test.go
+++ b/principal/mapset_test.go
@@ -246,3 +246,44 @@ func Test_mapToSet_PanicPrevention(t *testing.T) {
 		})
 	})
 }
+
+func TestMapToSet_DeleteFromAll(t *testing.T) {
+	t.Run("removes value from all keys", func(t *testing.T) {
+		ms := NewMapToSet()
+		ms.Add("repo1", "agent1")
+		ms.Add("repo1", "agent2")
+		ms.Add("repo2", "agent1")
+		ms.Add("repo3", "agent3")
+
+		ms.DeleteFromAll("agent1")
+
+		repo1 := ms.Get("repo1")
+		require.NotNil(t, repo1)
+		assert.False(t, repo1["agent1"])
+		assert.True(t, repo1["agent2"])
+
+		assert.Nil(t, ms.Get("repo2"))
+
+		repo3 := ms.Get("repo3")
+		require.NotNil(t, repo3)
+		assert.True(t, repo3["agent3"])
+	})
+
+	t.Run("no-op for non-existent value", func(t *testing.T) {
+		ms := NewMapToSet()
+		ms.Add("key1", "value1")
+
+		assert.NotPanics(t, func() {
+			ms.DeleteFromAll("nonexistent")
+		})
+
+		assert.Equal(t, map[string]bool{"value1": true}, ms.Get("key1"))
+	})
+
+	t.Run("works on empty map", func(t *testing.T) {
+		ms := NewMapToSet()
+		assert.NotPanics(t, func() {
+			ms.DeleteFromAll("value")
+		})
+	})
+}

--- a/principal/server.go
+++ b/principal/server.go
@@ -597,6 +597,7 @@ func NewServer(ctx context.Context, kubeClient *kube.KubernetesClient, namespace
 	}
 
 	s.clusterMgr.SetOnClusterDeleted(s.cleanupAgentState)
+	s.clusterMgr.SetOnClusterAdded(s.resyncAppsForAgent)
 
 	s.resources = resources.NewAgentResources()
 	s.logStream = logstream.NewServer()
@@ -1479,6 +1480,38 @@ func (s *Server) cleanupAgentState(agentName string) {
 	s.repoToAgents.DeleteFromAll(agentName)
 
 	logCtx.Info("Agent state cleanup complete")
+}
+
+// resyncAppsForAgent reconciles all the applications for a given agent
+// This is called when a cluster secret is created and all applications for the agent are resynced.
+func (s *Server) resyncAppsForAgent(agentName string) {
+	logCtx := log().WithField("agent", agentName).WithField("component", "AgentResync")
+	logCtx.Info("Resyncing applications after cluster secret creation")
+
+	var selector backend.ApplicationSelector
+	if s.destinationBasedMapping {
+		// In destination-based mapping, apps can live in any namespace.
+		selector = backend.ApplicationSelector{}
+	} else {
+		// In namespace-based mapping, the agent name is the namespace.
+		selector = backend.ApplicationSelector{Namespaces: []string{agentName}}
+	}
+
+	appList, err := s.appManager.List(s.ctx, selector)
+	if err != nil {
+		logCtx.WithError(err).Error("Failed to list applications for resync")
+		return
+	}
+
+	count := 0
+	for _, app := range appList {
+		if s.getAgentNameForApp(&app) == agentName {
+			s.newAppCallback(&app)
+			count++
+		}
+	}
+
+	logCtx.Infof("Resynced %d applications for agent", count)
 }
 
 func (s *Server) isAgentConnected(agentName string) bool {

--- a/principal/server.go
+++ b/principal/server.go
@@ -1281,19 +1281,6 @@ func (s *Server) defaultAppFilterChain() *filter.Chain[*v1alpha1.Application] {
 			return name != "" && name != "in-cluster"
 		})
 	}
-
-	// Filter out apps that target an invalid agent i.e agents without cluster secret
-	c.AppendAdmitFilter(func(res *v1alpha1.Application) bool {
-		if s.clusterMgr == nil {
-			return true
-		}
-		agentName := s.getAgentNameForApp(res)
-		if agentName == "" {
-			return false
-		}
-		return s.clusterMgr.HasMapping(agentName)
-	})
-
 	return c
 }
 

--- a/principal/server.go
+++ b/principal/server.go
@@ -596,6 +596,8 @@ func NewServer(ctx context.Context, kubeClient *kube.KubernetesClient, namespace
 		return nil, err
 	}
 
+	s.clusterMgr.SetOnClusterDeleted(s.cleanupAgentState)
+
 	s.resources = resources.NewAgentResources()
 	s.logStream = logstream.NewServer()
 	s.terminalStreamServer = terminalstream.NewServer()
@@ -716,6 +718,15 @@ func (s *Server) Start(ctx context.Context, errch chan error) error {
 		}()
 	}
 
+	syncTimeout := s.options.informerSyncTimeout
+	if syncTimeout == 0 {
+		syncTimeout = waitForSyncedDuration
+	}
+
+	if err := s.clusterMgr.Start(); err != nil {
+		return fmt.Errorf("unable to start cluster manager with informer sync timeout %v: %w", syncTimeout, err)
+	}
+
 	go s.RunHandlersOnConnect(s.ctx)
 
 	if err = s.StartEventProcessor(s.ctx); err != nil {
@@ -790,11 +801,6 @@ func (s *Server) Start(ctx context.Context, errch chan error) error {
 		}
 	}()
 
-	syncTimeout := s.options.informerSyncTimeout
-	if syncTimeout == 0 {
-		syncTimeout = waitForSyncedDuration
-	}
-
 	if err := s.appManager.EnsureSynced(syncTimeout); err != nil {
 		return fmt.Errorf("unable to sync Application informer: %w", err)
 	}
@@ -833,9 +839,6 @@ func (s *Server) Start(ctx context.Context, errch chan error) error {
 		log().Infof("Resource proxy is disabled")
 	}
 
-	if err := s.clusterMgr.Start(); err != nil {
-		return fmt.Errorf("unable to start cluster manager with informer sync timeout %v: %w", syncTimeout, err)
-	}
 	if err := s.namespaceManager.EnsureSynced(syncTimeout); err != nil {
 		return fmt.Errorf("unable to sync Namespace informer: %w", err)
 	}
@@ -893,6 +896,13 @@ func (rs *resyncStatus) resynced(agentName string) {
 	defer rs.mu.Unlock()
 
 	rs.resync[agentName] = true
+}
+
+func (rs *resyncStatus) remove(agentName string) {
+	rs.mu.Lock()
+	defer rs.mu.Unlock()
+
+	delete(rs.resync, agentName)
 }
 
 // RunHandlersOnConnect runs the registered handlers when an agent connects to the principal
@@ -1271,6 +1281,19 @@ func (s *Server) defaultAppFilterChain() *filter.Chain[*v1alpha1.Application] {
 			return name != "" && name != "in-cluster"
 		})
 	}
+
+	// Filter out apps that target an invalid agent i.e agents without cluster secret
+	c.AppendAdmitFilter(func(res *v1alpha1.Application) bool {
+		if s.clusterMgr == nil {
+			return true
+		}
+		agentName := s.getAgentNameForApp(res)
+		if agentName == "" {
+			return false
+		}
+		return s.clusterMgr.HasMapping(agentName)
+	})
+
 	return c
 }
 
@@ -1423,6 +1446,52 @@ func (s *Server) GetHAStatus() *HAStatus {
 		return nil
 	}
 	return s.ha.GetHAStatus()
+}
+
+// cleanupAgentState removes all principal-side state for an agent whose cluster
+// secret has been deleted.
+func (s *Server) cleanupAgentState(agentName string) {
+	logCtx := log().WithField("agent", agentName).WithField("component", "AgentCleanup")
+	logCtx.Info("Cleaning up agent state after cluster secret deletion")
+
+	// 1. Disconnect the agent if it is still streaming
+	if s.eventStreamSrv != nil {
+		if s.eventStreamSrv.DisconnectAgent(agentName) {
+			logCtx.Info("Disconnected active agent stream")
+		}
+	}
+
+	// 2. Delete the queue pair
+	if s.queues.HasQueuePair(agentName) {
+		if err := s.queues.Delete(agentName, true); err != nil {
+			logCtx.WithError(err).Error("Failed to delete queue pair")
+		}
+	}
+
+	// 3. Remove event writer
+	s.eventWriters.Remove(agentName)
+
+	// 4. Remove from namespaceMap and agentNamespaces
+	s.clientLock.Lock()
+	delete(s.namespaceMap, agentName)
+	delete(s.agentNamespaces, agentName)
+	s.clientLock.Unlock()
+
+	// 5. Remove tracked resources
+	s.resources.RemoveAgent(agentName)
+
+	// 6. Remove resync status
+	s.resyncStatus.remove(agentName)
+
+	// 7. Clean up routing maps
+	// For destination-based mapping: remove all appToAgent entries pointing to this agent
+	if s.destinationBasedMapping && s.appToAgent != nil {
+		s.appToAgent.DeleteByValue(agentName, func(a, b string) bool { return a == b })
+	}
+	// Remove agent from repo-to-agents mapping (agent could be a value in any repo key)
+	s.repoToAgents.DeleteFromAll(agentName)
+
+	logCtx.Info("Agent state cleanup complete")
 }
 
 func (s *Server) isAgentConnected(agentName string) bool {

--- a/principal/server.go
+++ b/principal/server.go
@@ -1487,6 +1487,9 @@ func (s *Server) cleanupAgentState(agentName string) {
 		s.metrics.ResourceProxyErrors.DeletePartialMatch(agentLabel)
 		s.metrics.RedisProxyRequests.DeletePartialMatch(agentLabel)
 		s.metrics.RedisProxyErrors.DeletePartialMatch(agentLabel)
+		s.metrics.EventProcessingTime.DeletePartialMatch(agentLabel)
+		s.metrics.EventWriterSendErrors.DeletePartialMatch(agentLabel)
+		s.metrics.EventWriterEventsDiscarded.DeletePartialMatch(agentLabel)
 	}
 
 	logCtx.Info("Agent state cleanup complete")

--- a/principal/server.go
+++ b/principal/server.go
@@ -1442,42 +1442,52 @@ func (s *Server) cleanupAgentState(agentName string) {
 	logCtx := log().WithField("agent", agentName).WithField("component", "AgentCleanup")
 	logCtx.Info("Cleaning up agent state after cluster secret deletion")
 
-	// 1. Disconnect the agent if it is still streaming
+	// Disconnect the agent if it is still streaming
 	if s.eventStreamSrv != nil {
 		if s.eventStreamSrv.DisconnectAgent(agentName) {
 			logCtx.Info("Disconnected active agent stream")
 		}
 	}
 
-	// 2. Delete the queue pair
+	// Delete the queue pair
 	if s.queues.HasQueuePair(agentName) {
 		if err := s.queues.Delete(agentName, true); err != nil {
 			logCtx.WithError(err).Error("Failed to delete queue pair")
 		}
 	}
 
-	// 3. Remove event writer
+	// Remove event writer
 	s.eventWriters.Remove(agentName)
 
-	// 4. Remove from namespaceMap and agentNamespaces
+	// Remove from namespaceMap and agentNamespaces
 	s.clientLock.Lock()
 	delete(s.namespaceMap, agentName)
 	delete(s.agentNamespaces, agentName)
 	s.clientLock.Unlock()
 
-	// 5. Remove tracked resources
+	// Remove tracked resources
 	s.resources.RemoveAgent(agentName)
 
-	// 6. Remove resync status
+	// Remove resync status
 	s.resyncStatus.remove(agentName)
 
-	// 7. Clean up routing maps
+	// Clean up routing maps
 	// For destination-based mapping: remove all appToAgent entries pointing to this agent
 	if s.destinationBasedMapping && s.appToAgent != nil {
 		s.appToAgent.DeleteByValue(agentName, func(a, b string) bool { return a == b })
 	}
 	// Remove agent from repo-to-agents mapping (agent could be a value in any repo key)
 	s.repoToAgents.DeleteFromAll(agentName)
+
+	// Delete per-agent metric series to stop cardinality growth
+	if s.metrics != nil {
+		agentLabel := prometheus.Labels{"agent_name": agentName}
+		s.metrics.AgentConnectionCount.DeletePartialMatch(agentLabel)
+		s.metrics.ResourceProxyRequests.DeletePartialMatch(agentLabel)
+		s.metrics.ResourceProxyErrors.DeletePartialMatch(agentLabel)
+		s.metrics.RedisProxyRequests.DeletePartialMatch(agentLabel)
+		s.metrics.RedisProxyErrors.DeletePartialMatch(agentLabel)
+	}
 
 	logCtx.Info("Agent state cleanup complete")
 }

--- a/principal/server.go
+++ b/principal/server.go
@@ -724,6 +724,8 @@ func (s *Server) Start(ctx context.Context, errch chan error) error {
 		syncTimeout = waitForSyncedDuration
 	}
 
+	s.events = event.NewEventSource(s.options.serverName)
+
 	if err := s.clusterMgr.Start(); err != nil {
 		return fmt.Errorf("unable to start cluster manager with informer sync timeout %v: %w", syncTimeout, err)
 	}
@@ -733,8 +735,6 @@ func (s *Server) Start(ctx context.Context, errch chan error) error {
 	if err = s.StartEventProcessor(s.ctx); err != nil {
 		return err
 	}
-
-	s.events = event.NewEventSource(s.options.serverName)
 
 	if s.options.labelSelector != "" {
 		log().Infof("Principal informers are using the label selector: %s", s.options.labelSelector)

--- a/principal/server_test.go
+++ b/principal/server_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/argoproj-labs/argocd-agent/internal/event"
 	"github.com/argoproj-labs/argocd-agent/internal/event/targets"
 	"github.com/argoproj-labs/argocd-agent/internal/manager"
+	"github.com/argoproj-labs/argocd-agent/internal/manager/application"
 	"github.com/argoproj-labs/argocd-agent/internal/manager/appproject"
 	"github.com/argoproj-labs/argocd-agent/internal/manager/gpgkey"
 	"github.com/argoproj-labs/argocd-agent/internal/manager/repository"
@@ -49,6 +50,7 @@ import (
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	kubefake "k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/rest"
 )
 
@@ -831,6 +833,131 @@ func Test_cleanupAgentState(t *testing.T) {
 		assert.NotPanics(t, func() {
 			s.cleanupAgentState("nonexistent-agent")
 		})
+	})
+}
+
+func Test_resyncAppsForAgent(t *testing.T) {
+	t.Run("resyncs applications targeting the agent (namespace-based)", func(t *testing.T) {
+		mockAppBackend := &mocks.Application{}
+		appMgr, err := application.NewApplicationManager(mockAppBackend, "argocd")
+		require.NoError(t, err)
+
+		clusterMgr, err := cluster.NewManager(context.Background(), "argocd", "", "", "", kubefake.NewSimpleClientset(), nil)
+		require.NoError(t, err)
+		require.NoError(t, clusterMgr.MapCluster("agent1", &v1alpha1.Cluster{Name: "agent1", Server: "https://agent1.example.com"}))
+
+		s := &Server{
+			ctx:        context.Background(),
+			queues:     queue.NewSendRecvQueues(),
+			events:     event.NewEventSource("test"),
+			resources:  resources.NewAgentResources(),
+			appToAgent: newConcurrentStringMap(),
+			appManager: appMgr,
+			clusterMgr: clusterMgr,
+			options:    &ServerOptions{namespaces: []string{"agent1", "agent2"}},
+		}
+
+		apps := []v1alpha1.Application{
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "app1", Namespace: "agent1"},
+				Spec:       v1alpha1.ApplicationSpec{Project: "default"},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "app2", Namespace: "agent2"},
+				Spec:       v1alpha1.ApplicationSpec{Project: "default"},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "app3", Namespace: "agent1"},
+				Spec:       v1alpha1.ApplicationSpec{Project: "default"},
+			},
+		}
+		mockAppBackend.On("List", mock.Anything, mock.Anything).Return(apps, nil)
+
+		s.resyncAppsForAgent("agent1")
+
+		// Only apps targeting agent1 should be dispatched
+		assert.True(t, s.queues.HasQueuePair("agent1"))
+		sendQ := s.queues.SendQ("agent1")
+		require.NotNil(t, sendQ)
+		assert.Equal(t, 2, sendQ.Len())
+
+		// agent2 should have no queue
+		assert.False(t, s.queues.HasQueuePair("agent2"))
+	})
+
+	t.Run("resyncs applications targeting the agent (destination-based)", func(t *testing.T) {
+		mockAppBackend := &mocks.Application{}
+		appMgr, err := application.NewApplicationManager(mockAppBackend, "argocd")
+		require.NoError(t, err)
+
+		clusterMgr, err := cluster.NewManager(context.Background(), "argocd", "", "", "", kubefake.NewSimpleClientset(), nil)
+		require.NoError(t, err)
+		require.NoError(t, clusterMgr.MapCluster("target-cluster", &v1alpha1.Cluster{Name: "target-cluster", Server: "https://target.example.com"}))
+
+		s := &Server{
+			ctx:                     context.Background(),
+			queues:                  queue.NewSendRecvQueues(),
+			events:                  event.NewEventSource("test"),
+			resources:               resources.NewAgentResources(),
+			appToAgent:              newConcurrentStringMap(),
+			appManager:              appMgr,
+			clusterMgr:              clusterMgr,
+			destinationBasedMapping: true,
+			namespace:               "argocd",
+			options:                 &ServerOptions{namespaces: []string{}},
+		}
+
+		apps := []v1alpha1.Application{
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "app1", Namespace: "argocd"},
+				Spec:       v1alpha1.ApplicationSpec{Project: "default", Destination: v1alpha1.ApplicationDestination{Name: "target-cluster"}},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "app2", Namespace: "argocd"},
+				Spec:       v1alpha1.ApplicationSpec{Project: "default", Destination: v1alpha1.ApplicationDestination{Name: "other-cluster"}},
+			},
+		}
+		mockAppBackend.On("List", mock.Anything, mock.Anything).Return(apps, nil)
+
+		s.resyncAppsForAgent("target-cluster")
+
+		// Only app1 targets the agent
+		assert.True(t, s.queues.HasQueuePair("target-cluster"))
+		sendQ := s.queues.SendQ("target-cluster")
+		require.NotNil(t, sendQ)
+		assert.Equal(t, 1, sendQ.Len())
+
+		// Verify app-to-agent tracking was populated
+		assert.Equal(t, "target-cluster", s.appToAgent.Get("argocd/app1"))
+	})
+
+	t.Run("handles empty app list gracefully", func(t *testing.T) {
+		mockAppBackend := &mocks.Application{}
+		appMgr, err := application.NewApplicationManager(mockAppBackend, "argocd")
+		require.NoError(t, err)
+
+		clusterMgr, err := cluster.NewManager(context.Background(), "argocd", "", "", "", kubefake.NewSimpleClientset(), nil)
+		require.NoError(t, err)
+		require.NoError(t, clusterMgr.MapCluster("agent1", &v1alpha1.Cluster{Name: "agent1", Server: "https://agent1.example.com"}))
+
+		s := &Server{
+			ctx:        context.Background(),
+			queues:     queue.NewSendRecvQueues(),
+			events:     event.NewEventSource("test"),
+			resources:  resources.NewAgentResources(),
+			appToAgent: newConcurrentStringMap(),
+			appManager: appMgr,
+			clusterMgr: clusterMgr,
+			options:    &ServerOptions{namespaces: []string{"agent1"}},
+		}
+
+		mockAppBackend.On("List", mock.Anything, mock.Anything).Return([]v1alpha1.Application{}, nil)
+
+		assert.NotPanics(t, func() {
+			s.resyncAppsForAgent("agent1")
+		})
+
+		assert.False(t, s.queues.HasQueuePair("agent1"))
 	})
 }
 

--- a/principal/server_test.go
+++ b/principal/server_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/argoproj-labs/argocd-agent/internal/argocd/cluster"
 	"github.com/argoproj-labs/argocd-agent/internal/backend"
 	"github.com/argoproj-labs/argocd-agent/internal/backend/mocks"
 	"github.com/argoproj-labs/argocd-agent/internal/config"
@@ -33,7 +34,9 @@ import (
 	"github.com/argoproj-labs/argocd-agent/internal/manager/gpgkey"
 	"github.com/argoproj-labs/argocd-agent/internal/manager/repository"
 	"github.com/argoproj-labs/argocd-agent/internal/queue"
+	"github.com/argoproj-labs/argocd-agent/internal/resources"
 	"github.com/argoproj-labs/argocd-agent/pkg/types"
+	"github.com/argoproj-labs/argocd-agent/principal/apis/eventstream"
 	"github.com/argoproj-labs/argocd-agent/test/fake/kube"
 	fakecerts "github.com/argoproj-labs/argocd-agent/test/fake/testcerts"
 	"github.com/argoproj/argo-cd/v3/common"
@@ -693,6 +696,142 @@ func Test_SendCurrentStateToAgent(t *testing.T) {
 		assert.Equal(t, 2, sendQ.Len())
 	})
 
+}
+
+func Test_cleanupAgentState(t *testing.T) {
+	t.Run("cleans up all agent state for namespace-based mapping", func(t *testing.T) {
+		s := &Server{
+			queues:       queue.NewSendRecvQueues(),
+			eventWriters: event.NewEventWritersMap(),
+			namespaceMap: map[string]types.AgentMode{
+				"agent1": types.AgentModeManaged,
+				"agent2": types.AgentModeAutonomous,
+				"agent3": types.AgentModeManaged,
+			},
+			agentNamespaces: map[string]string{"agent1": "ns1", "agent2": "ns2"},
+			resources:       resources.NewAgentResources(),
+			resyncStatus:    newResyncStatus(),
+			appToAgent:      newConcurrentStringMap(),
+			repoToAgents:    NewMapToSet(),
+			projectToRepos:  NewMapToSet(),
+			eventStreamSrv:  eventstream.NewServer(queue.NewSendRecvQueues(), event.NewEventWritersMap(), nil, &cluster.Manager{}),
+		}
+
+		// Set up state for agent1
+		require.NoError(t, s.queues.Create("agent1"))
+		require.NoError(t, s.queues.Create("agent2"))
+		s.resources.Add("agent1", resources.ResourceKey{Name: "app1", Namespace: "agent1"})
+		s.resyncStatus.resynced("agent1")
+		s.repoToAgents.Add("repo-a", "agent1")
+		s.repoToAgents.Add("repo-a", "agent2")
+		s.repoToAgents.Add("repo-b", "agent1")
+
+		// Clean up agent1
+		s.cleanupAgentState("agent1")
+
+		// Verify agent1 state is removed
+		assert.False(t, s.queues.HasQueuePair("agent1"))
+		_, agent1Exists := s.namespaceMap["agent1"]
+		assert.False(t, agent1Exists)
+		_, agent1NsExists := s.agentNamespaces["agent1"]
+		assert.False(t, agent1NsExists)
+		assert.Empty(t, s.resources.GetAllResources("agent1"))
+		assert.False(t, s.resyncStatus.isResynced("agent1"))
+
+		// Verify agent1 removed from repo-to-agents mapping
+		repoAAgents := s.repoToAgents.Get("repo-a")
+		assert.False(t, repoAAgents["agent1"])
+		assert.True(t, repoAAgents["agent2"])
+		assert.Nil(t, s.repoToAgents.Get("repo-b"))
+
+		// Verify agent2 state is untouched
+		assert.True(t, s.queues.HasQueuePair("agent2"))
+		assert.Equal(t, types.AgentModeAutonomous, s.namespaceMap["agent2"])
+		assert.Equal(t, "ns2", s.agentNamespaces["agent2"])
+	})
+
+	t.Run("cleans up all state for destination-based mapping", func(t *testing.T) {
+		s := &Server{
+			queues:       queue.NewSendRecvQueues(),
+			eventWriters: event.NewEventWritersMap(),
+			namespaceMap: map[string]types.AgentMode{
+				"target-cluster": types.AgentModeManaged,
+				"other-cluster":  types.AgentModeAutonomous,
+				"agent3":         types.AgentModeManaged,
+			},
+			agentNamespaces: map[string]string{
+				"target-cluster": "target-ns",
+				"other-cluster":  "other-ns",
+				"agent3":         "agent3-ns",
+			},
+			resources:               resources.NewAgentResources(),
+			resyncStatus:            newResyncStatus(),
+			appToAgent:              newConcurrentStringMap(),
+			repoToAgents:            NewMapToSet(),
+			projectToRepos:          NewMapToSet(),
+			destinationBasedMapping: true,
+			eventStreamSrv:          eventstream.NewServer(queue.NewSendRecvQueues(), event.NewEventWritersMap(), nil, &cluster.Manager{}),
+		}
+
+		require.NoError(t, s.queues.Create("target-cluster"))
+		require.NoError(t, s.queues.Create("other-cluster"))
+		require.NoError(t, s.queues.Create("agent3"))
+		s.resources.Add("target-cluster", resources.ResourceKey{Name: "app1", Namespace: "argocd"})
+		s.resyncStatus.resynced("target-cluster")
+		s.repoToAgents.Add("repo1", "target-cluster")
+		s.repoToAgents.Add("repo1", "other-cluster")
+		s.repoToAgents.Add("repo1", "agent3")
+
+		// Simulate destination-based app-to-agent mappings
+		s.appToAgent.Set("argocd/app1", "target-cluster")
+		s.appToAgent.Set("argocd/app2", "target-cluster")
+		s.appToAgent.Set("argocd/app3", "other-cluster")
+
+		s.cleanupAgentState("target-cluster")
+
+		// Verify target-cluster state is fully removed
+		assert.False(t, s.queues.HasQueuePair("target-cluster"))
+		_, targetExists := s.namespaceMap["target-cluster"]
+		assert.False(t, targetExists)
+		_, targetNsExists := s.agentNamespaces["target-cluster"]
+		assert.False(t, targetNsExists)
+		assert.Empty(t, s.resources.GetAllResources("target-cluster"))
+		assert.False(t, s.resyncStatus.isResynced("target-cluster"))
+		assert.Empty(t, s.appToAgent.Get("argocd/app1"))
+		assert.Empty(t, s.appToAgent.Get("argocd/app2"))
+		repo1Agents := s.repoToAgents.Get("repo1")
+		assert.False(t, repo1Agents["target-cluster"])
+
+		// Verify other-cluster state is untouched
+		assert.True(t, s.queues.HasQueuePair("other-cluster"))
+		assert.True(t, s.queues.HasQueuePair("agent3"))
+		assert.Equal(t, types.AgentModeAutonomous, s.namespaceMap["other-cluster"])
+		assert.Equal(t, types.AgentModeManaged, s.namespaceMap["agent3"])
+		assert.Equal(t, "other-ns", s.agentNamespaces["other-cluster"])
+		assert.Equal(t, "agent3-ns", s.agentNamespaces["agent3"])
+		assert.Equal(t, "other-cluster", s.appToAgent.Get("argocd/app3"))
+		assert.True(t, repo1Agents["other-cluster"])
+		assert.True(t, repo1Agents["agent3"])
+	})
+
+	t.Run("handles non-existent agent gracefully", func(t *testing.T) {
+		s := &Server{
+			queues:          queue.NewSendRecvQueues(),
+			eventWriters:    event.NewEventWritersMap(),
+			namespaceMap:    map[string]types.AgentMode{},
+			agentNamespaces: map[string]string{},
+			resources:       resources.NewAgentResources(),
+			resyncStatus:    newResyncStatus(),
+			appToAgent:      newConcurrentStringMap(),
+			repoToAgents:    NewMapToSet(),
+			projectToRepos:  NewMapToSet(),
+			eventStreamSrv:  eventstream.NewServer(queue.NewSendRecvQueues(), event.NewEventWritersMap(), nil, &cluster.Manager{}),
+		}
+
+		assert.NotPanics(t, func() {
+			s.cleanupAgentState("nonexistent-agent")
+		})
+	})
 }
 
 func init() {

--- a/principal/server_test.go
+++ b/principal/server_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/argoproj-labs/argocd-agent/internal/manager/appproject"
 	"github.com/argoproj-labs/argocd-agent/internal/manager/gpgkey"
 	"github.com/argoproj-labs/argocd-agent/internal/manager/repository"
+	"github.com/argoproj-labs/argocd-agent/internal/metrics"
 	"github.com/argoproj-labs/argocd-agent/internal/queue"
 	"github.com/argoproj-labs/argocd-agent/internal/resources"
 	"github.com/argoproj-labs/argocd-agent/pkg/types"
@@ -42,6 +43,8 @@ import (
 	fakecerts "github.com/argoproj-labs/argocd-agent/test/fake/testcerts"
 	"github.com/argoproj/argo-cd/v3/common"
 	"github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
+	"github.com/prometheus/client_golang/prometheus"
+	io_prometheus_client "github.com/prometheus/client_model/go"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -834,6 +837,48 @@ func Test_cleanupAgentState(t *testing.T) {
 			s.cleanupAgentState("nonexistent-agent")
 		})
 	})
+
+	t.Run("deletes per-agent metric series", func(t *testing.T) {
+		m := metrics.NewPrincipalMetrics()
+		s := &Server{
+			queues:          queue.NewSendRecvQueues(),
+			eventWriters:    event.NewEventWritersMap(),
+			namespaceMap:    map[string]types.AgentMode{},
+			agentNamespaces: map[string]string{},
+			resources:       resources.NewAgentResources(),
+			resyncStatus:    newResyncStatus(),
+			appToAgent:      newConcurrentStringMap(),
+			repoToAgents:    NewMapToSet(),
+			projectToRepos:  NewMapToSet(),
+			eventStreamSrv:  eventstream.NewServer(queue.NewSendRecvQueues(), event.NewEventWritersMap(), nil, &cluster.Manager{}),
+			metrics:         m,
+		}
+
+		// Simulate metric activity for two agents
+		for _, agent := range []string{"ephemeral-agent", "persistent-agent"} {
+			m.AgentConnectionCount.WithLabelValues(agent).Inc()
+			m.ResourceProxyRequests.WithLabelValues(agent).Inc()
+			m.ResourceProxyErrors.WithLabelValues(agent, "timeout").Inc()
+			m.ResourceProxyErrors.WithLabelValues(agent, "not_connected").Inc()
+			m.RedisProxyRequests.WithLabelValues(agent, "GET").Inc()
+			m.RedisProxyRequests.WithLabelValues(agent, "SET").Inc()
+			m.RedisProxyErrors.WithLabelValues(agent, "GET").Inc()
+		}
+
+		s.cleanupAgentState("ephemeral-agent")
+
+		allMetrics := []*prometheus.CounterVec{
+			m.AgentConnectionCount,
+			m.ResourceProxyRequests,
+			m.ResourceProxyErrors,
+			m.RedisProxyRequests,
+			m.RedisProxyErrors,
+		}
+		for _, cv := range allMetrics {
+			assert.Equal(t, 0, collectAgentMetrics(cv, "ephemeral-agent"))
+			assert.Greater(t, collectAgentMetrics(cv, "persistent-agent"), 0)
+		}
+	})
 }
 
 func Test_resyncAppsForAgent(t *testing.T) {
@@ -963,4 +1008,26 @@ func Test_resyncAppsForAgent(t *testing.T) {
 
 func init() {
 	logrus.SetLevel(logrus.TraceLevel)
+}
+
+// collectAgentMetrics returns the number of series in the CounterVec that have
+// agent_name matching the given value.
+func collectAgentMetrics(cv *prometheus.CounterVec, agentName string) int {
+	ch := make(chan prometheus.Metric, 100)
+	go func() {
+		cv.Collect(ch)
+		close(ch)
+	}()
+	count := 0
+	for m := range ch {
+		dto := &io_prometheus_client.Metric{}
+		_ = m.Write(dto)
+		for _, lp := range dto.GetLabel() {
+			if lp.GetName() == "agent_name" && lp.GetValue() == agentName {
+				count++
+				break
+			}
+		}
+	}
+	return count
 }


### PR DESCRIPTION
**What does this PR do / why we need it**:

Currently, when an agent is deleted, the principal still retains the state (work queues, metadata, etc.) for that agent. This slowly adds up in an environment with ephemeral agents, where agents are deleted frequently. In this PR, we remove the agent state on the removal of the agent cluster secret. We also add a check to prevent reconciling applications that target agents without a cluster secret. Once the cluster secret is created, the principal should reconcile all the apps targetting that agent.

**Which issue(s) this PR fixes**:

Fixes https://github.com/argoproj-labs/argocd-agent/issues/1026

**How to test changes / Special notes to the reviewer**:

**Checklist**

* [ ] Documentation update is required by this PR (and has been updated) OR no documentation update is required.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Automatic per-agent cleanup when a cluster is deleted (streams, queues, routing data, tracked resources, and metrics).
  - Added agent disconnect support and a registerable cluster-deleted callback.
  - Added removal helpers for tracked resources/mappings (agent resource removal, map-to-set and map deletion utilities).

- **Bug Fixes**
  - Improved cluster informer concurrency so callbacks run safely outside locks.
  - Prevented queue/resource/event processing for apps targeting agents without valid cluster mappings.

- **Tests**
  - Expanded unit coverage for cluster add/delete callbacks, cleanup behavior, removal helpers, and mapping-eligibility gating.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->