### PR TITLE
chore: run 'go fix' and audit changes

### DIFF
--- a/agent/inbound_redis.go
+++ b/agent/inbound_redis.go
@@ -358,14 +358,14 @@ func stripNamespaceFromRedisKey(key string, logCtx *logrus.Entry) (string, error
 
 	appName := components[2]
 
-	underscoreIndex := strings.Index(appName, "_")
-	if underscoreIndex == -1 {
+	_, after, ok := strings.Cut(appName, "_")
+	if !ok {
 		err := fmt.Errorf("unexpected key format, missing '_': '%s'", key)
 		logCtx.WithError(err).Error("Unable to reply to redis get request")
 		return "", err
 
 	}
-	components[2] = appName[underscoreIndex+1:]
+	components[2] = after
 
 	key = strings.Join(components, "|")
 

--- a/agent/log_test.go
+++ b/agent/log_test.go
@@ -75,11 +75,11 @@ func (m *MockLogStreamClient) Trailer() metadata.MD {
 	return metadata.New(nil)
 }
 
-func (m *MockLogStreamClient) SendMsg(msg interface{}) error {
+func (m *MockLogStreamClient) SendMsg(msg any) error {
 	return nil
 }
 
-func (m *MockLogStreamClient) RecvMsg(msg interface{}) error {
+func (m *MockLogStreamClient) RecvMsg(msg any) error {
 	return nil
 }
 
@@ -179,17 +179,17 @@ func TestExtractTimestamp(t *testing.T) {
 		{
 			name:     "RFC3339 with nanoseconds",
 			input:    "2025-12-07T10:30:45.123456789Z some log message",
-			expected: timePtr(time.Date(2025, 12, 7, 10, 30, 45, 123456789, time.UTC)),
+			expected: new(time.Date(2025, 12, 7, 10, 30, 45, 123456789, time.UTC)),
 		},
 		{
 			name:     "RFC3339 without nanoseconds",
 			input:    "2025-12-07T10:30:45Z some log message",
-			expected: timePtr(time.Date(2025, 12, 7, 10, 30, 45, 0, time.UTC)),
+			expected: new(time.Date(2025, 12, 7, 10, 30, 45, 0, time.UTC)),
 		},
 		{
 			name:     "RFC3339 with milliseconds",
 			input:    "2025-12-07T10:30:45.123Z some log message",
-			expected: timePtr(time.Date(2025, 12, 7, 10, 30, 45, 123000000, time.UTC)),
+			expected: new(time.Date(2025, 12, 7, 10, 30, 45, 123000000, time.UTC)),
 		},
 		{
 			name:     "no timestamp",
@@ -199,7 +199,7 @@ func TestExtractTimestamp(t *testing.T) {
 		{
 			name:     "timestamp with tab separator",
 			input:    "2025-12-07T10:30:45Z\tsome log message",
-			expected: timePtr(time.Date(2025, 12, 7, 10, 30, 45, 0, time.UTC)),
+			expected: new(time.Date(2025, 12, 7, 10, 30, 45, 0, time.UTC)),
 		},
 	}
 
@@ -362,9 +362,4 @@ func TestStreamLogs(t *testing.T) {
 		require.Greater(t, len(sentData), 0, "expected a send attempt before failure")
 		assert.Equal(t, testData, string(sentData[0].Data))
 	})
-}
-
-// Helper function to create time pointer
-func timePtr(t time.Time) *time.Time {
-	return &t
 }

--- a/agent/resource_test.go
+++ b/agent/resource_test.go
@@ -1345,12 +1345,12 @@ func Test_getAvailableAPIs(t *testing.T) {
 		// Check that resources array exists and has content
 		resources, exists := result.Object["resources"]
 		assert.True(t, exists)
-		resourcesList, ok := resources.([]interface{})
+		resourcesList, ok := resources.([]any)
 		assert.True(t, ok)
 		assert.Greater(t, len(resourcesList), 0)
 
 		// Check that the first resource has the expected fields
-		firstResource, ok := resourcesList[0].(map[string]interface{})
+		firstResource, ok := resourcesList[0].(map[string]any)
 		assert.True(t, ok)
 		assert.Contains(t, firstResource, "name")
 		assert.Contains(t, firstResource, "kind")
@@ -1378,12 +1378,12 @@ func Test_getAvailableAPIs(t *testing.T) {
 		// Check that resources array exists and has content
 		resources, exists := result.Object["resources"]
 		assert.True(t, exists)
-		resourcesList, ok := resources.([]interface{})
+		resourcesList, ok := resources.([]any)
 		assert.True(t, ok)
 		assert.Greater(t, len(resourcesList), 0)
 
 		// Check that the first resource has the expected fields
-		firstResource, ok := resourcesList[0].(map[string]interface{})
+		firstResource, ok := resourcesList[0].(map[string]any)
 		assert.True(t, ok)
 		assert.Contains(t, firstResource, "name")
 		assert.Contains(t, firstResource, "kind")
@@ -1406,12 +1406,12 @@ func Test_getAvailableAPIs(t *testing.T) {
 		// Check that groups array exists and has content
 		groups, exists := result.Object["groups"]
 		assert.True(t, exists)
-		groupsList, ok := groups.([]interface{})
+		groupsList, ok := groups.([]any)
 		assert.True(t, ok)
 		assert.Greater(t, len(groupsList), 0)
 
 		// Check that the first group has the expected fields
-		firstGroup, ok := groupsList[0].(map[string]interface{})
+		firstGroup, ok := groupsList[0].(map[string]any)
 		assert.True(t, ok)
 		assert.Contains(t, firstGroup, "name")
 		assert.Contains(t, firstGroup, "versions")
@@ -1420,12 +1420,12 @@ func Test_getAvailableAPIs(t *testing.T) {
 		// Check that versions array exists and has content
 		versions, exists := firstGroup["versions"]
 		assert.True(t, exists)
-		versionsList, ok := versions.([]interface{})
+		versionsList, ok := versions.([]any)
 		assert.True(t, ok)
 		assert.Greater(t, len(versionsList), 0)
 
 		// Check that the first version has the expected fields
-		firstVersion, ok := versionsList[0].(map[string]interface{})
+		firstVersion, ok := versionsList[0].(map[string]any)
 		assert.True(t, ok)
 		assert.Contains(t, firstVersion, "groupVersion")
 		assert.Contains(t, firstVersion, "version")

--- a/agent/terminal_test.go
+++ b/agent/terminal_test.go
@@ -599,7 +599,7 @@ func TestConcurrentTerminalOperations(t *testing.T) {
 		numGoroutines := 50
 
 		// Concurrent adds
-		for i := 0; i < numGoroutines; i++ {
+		for i := range numGoroutines {
 			wg.Add(1)
 			go func(id int) {
 				defer wg.Done()

--- a/cmd/argocd-agent/principal.go
+++ b/cmd/argocd-agent/principal.go
@@ -820,11 +820,11 @@ func parseHeaderAuth(config string) (string, *regexp.Regexp, error) {
 //
 // Example: "uri:spiffe://ea1t\\.us\\.a/ns/argocd-agent/sa/(.+)"
 func parseMTLSConfig(config string) (mtls.IdentitySource, string) {
-	if strings.HasPrefix(config, "subject:") {
-		return mtls.IdentitySourceSubject, strings.TrimPrefix(config, "subject:")
+	if after, ok := strings.CutPrefix(config, "subject:"); ok {
+		return mtls.IdentitySourceSubject, after
 	}
-	if strings.HasPrefix(config, "uri:") {
-		return mtls.IdentitySourceURI, strings.TrimPrefix(config, "uri:")
+	if after, ok := strings.CutPrefix(config, "uri:"); ok {
+		return mtls.IdentitySourceURI, after
 	}
 	logrus.Warn("DEPRECATED: mTLS auth config without explicit source (subject: or uri:). Please update to use 'mtls:subject:<regex>' or 'mtls:uri:<regex>'")
 	return mtls.IdentitySourceSubject, config

--- a/cmd/cmdutil/fatal.go
+++ b/cmd/cmdutil/fatal.go
@@ -19,14 +19,14 @@ import (
 	"os"
 )
 
-func Error(msg string, args ...interface{}) {
+func Error(msg string, args ...any) {
 }
 
-func Fatal(msg string, args ...interface{}) {
+func Fatal(msg string, args ...any) {
 	FatalWithExitCode(1, msg, args...)
 }
 
-func FatalWithExitCode(code int, msg string, args ...interface{}) {
+func FatalWithExitCode(code int, msg string, args ...any) {
 	fmt.Fprintf(os.Stderr, "[FATAL]: ")
 	fmt.Fprintf(os.Stderr, msg, args...)
 	fmt.Fprintf(os.Stderr, "\n")

--- a/cmd/cmdutil/warn.go
+++ b/cmd/cmdutil/warn.go
@@ -19,7 +19,7 @@ import (
 	"os"
 )
 
-func Warn(msg string, args ...interface{}) {
+func Warn(msg string, args ...any) {
 	fmt.Fprintf(os.Stderr, "[WARN]: ")
 	fmt.Fprintf(os.Stderr, msg, args...)
 	fmt.Fprintf(os.Stderr, "\n")

--- a/cmd/ctl/validate_test.go
+++ b/cmd/ctl/validate_test.go
@@ -174,15 +174,15 @@ func createCertWithEmptyCN(t *testing.T, signerCert *x509.Certificate, signerKey
 // Helper that returns an unstructured that represents a fake application
 func createFakeApp() *unstructured.Unstructured {
 	return &unstructured.Unstructured{
-		Object: map[string]interface{}{
+		Object: map[string]any{
 			"apiVersion": "argoproj.io/v1alpha1",
 			"kind":       "Application",
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"name":      "fake-app",
 				"namespace": "argocd",
 			},
-			"spec": map[string]interface{}{
-				"destination": map[string]interface{}{
+			"spec": map[string]any{
+				"destination": map[string]any{
 					"server":    "https://kubernetes.default.svc",
 					"namespace": "default",
 				},
@@ -383,7 +383,7 @@ func TestCheckConfigPrincipal(t *testing.T) {
 		route.SetKind("Route")
 		route.SetName("argocd-server")
 		route.SetNamespace(principalNS)
-		route.Object["spec"] = map[string]interface{}{
+		route.Object["spec"] = map[string]any{
 			"host": "localhost", // matches the cert IPS/DNS
 		}
 		_, err = dynCl.Resource(schema.GroupVersionResource{Group: "route.openshift.io", Version: "v1", Resource: "routes"}).Namespace(principalNS).Create(context.TODO(), route, metav1.CreateOptions{})
@@ -885,7 +885,7 @@ func TestCheckConfigPrincipal(t *testing.T) {
 		route.SetKind("Route")
 		route.SetName("argocd-server")
 		route.SetNamespace(principalNS)
-		route.Object["spec"] = map[string]interface{}{
+		route.Object["spec"] = map[string]any{
 			"host": "mismatched-host.example.com", // Doesn't match cert DNS
 		}
 		_, err = dynCl.Resource(schema.GroupVersionResource{Group: "route.openshift.io", Version: "v1", Resource: "routes"}).Namespace(principalNS).Create(context.TODO(), route, metav1.CreateOptions{})

--- a/internal/env/env.go
+++ b/internal/env/env.go
@@ -129,7 +129,7 @@ func StringSlice(key string, validator func(string) error) ([]string, error) {
 		return []string{}, os.ErrNotExist //fmt.Errorf("environment '%s' not set", key)
 	}
 	ret := []string{}
-	for _, s := range strings.Split(ev, ",") {
+	for s := range strings.SplitSeq(ev, ",") {
 		s = strings.TrimSpace(s)
 		if validator != nil {
 			if err := validator(s); err != nil {

--- a/internal/event/event_writer_test.go
+++ b/internal/event/event_writer_test.go
@@ -193,11 +193,11 @@ func TestEventWriter(t *testing.T) {
 		numOpsPerGoroutine := 100
 
 		// Concurrent adds
-		for i := 0; i < numGoroutines; i++ {
+		for i := range numGoroutines {
 			wg.Add(1)
 			go func(id int) {
 				defer wg.Done()
-				for j := 0; j < numOpsPerGoroutine; j++ {
+				for j := range numOpsPerGoroutine {
 					app := &v1alpha1.Application{
 						ObjectMeta: metav1.ObjectMeta{
 							Name:            fmt.Sprintf("app-%d", id),
@@ -338,7 +338,7 @@ func TestEventWriter(t *testing.T) {
 		evSender := NewEventWriter("test", fs, eventWriterLogger)
 
 		// Simulate multiple heartbeats being sent (like a real heartbeat interval)
-		for i := 0; i < 10; i++ {
+		for range 10 {
 			heartbeatEv := es.HeartbeatEvent(Ping)
 			resID := ResourceID(heartbeatEv)
 			evSender.Add(heartbeatEv)

--- a/internal/grpcutil/msgsize.go
+++ b/internal/grpcutil/msgsize.go
@@ -43,7 +43,7 @@ type messageSizeLoggerClientStream struct {
 
 // protoSize returns the serialized size of a message if it implements
 // proto.Message, or -1 if the size cannot be determined.
-func protoSize(msg interface{}) int {
+func protoSize(msg any) int {
 	if pm, ok := msg.(proto.Message); ok {
 		return proto.Size(pm)
 	}
@@ -52,7 +52,7 @@ func protoSize(msg interface{}) int {
 
 // warnIfExceedsThreshold logs a warning when the serialized size of msg meets
 // or exceeds x% of maxSize.
-func warnIfExceedsThreshold(method string, msg interface{}, maxSize int, direction string) {
+func warnIfExceedsThreshold(method string, msg any, maxSize int, direction string) {
 	if maxSize <= 0 {
 		return
 	}
@@ -78,12 +78,12 @@ func warnIfExceedsThreshold(method string, msg interface{}, maxSize int, directi
 	logrus.WithFields(fields).Warnf("gRPC message size (%d bytes) is %d%% of max (%d bytes)", size, pct, maxSize)
 }
 
-func (s *messageSizeLoggerStream) SendMsg(m interface{}) error {
+func (s *messageSizeLoggerStream) SendMsg(m any) error {
 	warnIfExceedsThreshold(s.method, m, s.maxSize, "send")
 	return s.ServerStream.SendMsg(m)
 }
 
-func (s *messageSizeLoggerStream) RecvMsg(m interface{}) error {
+func (s *messageSizeLoggerStream) RecvMsg(m any) error {
 	err := s.ServerStream.RecvMsg(m)
 	if err != nil {
 		return err
@@ -92,12 +92,12 @@ func (s *messageSizeLoggerStream) RecvMsg(m interface{}) error {
 	return nil
 }
 
-func (s *messageSizeLoggerClientStream) SendMsg(m interface{}) error {
+func (s *messageSizeLoggerClientStream) SendMsg(m any) error {
 	warnIfExceedsThreshold(s.method, m, s.maxSize, "send")
 	return s.ClientStream.SendMsg(m)
 }
 
-func (s *messageSizeLoggerClientStream) RecvMsg(m interface{}) error {
+func (s *messageSizeLoggerClientStream) RecvMsg(m any) error {
 	err := s.ClientStream.RecvMsg(m)
 	if err != nil {
 		return err
@@ -110,7 +110,7 @@ func (s *messageSizeLoggerClientStream) RecvMsg(m interface{}) error {
 // logs a warning when any message sent or received on a stream exceeds x% of
 // maxGRPCMessageSize.
 func StreamServerMsgSizeInterceptor(maxGRPCMessageSize int) grpc.StreamServerInterceptor {
-	return func(srv interface{}, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+	return func(srv any, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
 		wrapped := &messageSizeLoggerStream{
 			ServerStream: ss,
 			maxSize:      maxGRPCMessageSize,
@@ -141,7 +141,7 @@ func StreamClientMsgSizeInterceptor(maxGRPCMessageSize int) grpc.StreamClientInt
 // logs a warning when the request or response message exceeds x% of
 // maxGRPCMessageSize.
 func UnaryServerMsgSizeInterceptor(maxGRPCMessageSize int) grpc.UnaryServerInterceptor {
-	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
+	return func(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
 		warnIfExceedsThreshold(info.FullMethod, req, maxGRPCMessageSize, "recv")
 		resp, err := handler(ctx, req)
 		if err != nil {
@@ -156,7 +156,7 @@ func UnaryServerMsgSizeInterceptor(maxGRPCMessageSize int) grpc.UnaryServerInter
 // logs a warning when the request or response message exceeds x% of
 // maxGRPCMessageSize.
 func UnaryClientMsgSizeInterceptor(maxGRPCMessageSize int) grpc.UnaryClientInterceptor {
-	return func(ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
+	return func(ctx context.Context, method string, req, reply any, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
 		warnIfExceedsThreshold(method, req, maxGRPCMessageSize, "send")
 		err := invoker(ctx, method, req, reply, cc, opts...)
 		if err != nil {

--- a/internal/informer/informer.go
+++ b/internal/informer/informer.go
@@ -208,7 +208,7 @@ func (i *Informer[T]) installEventHandlers() error {
 					i.onAdd(res)
 				}
 			},
-			UpdateFunc: func(oldObj, newObj interface{}) {
+			UpdateFunc: func(oldObj, newObj any) {
 				oldRes, oldOk := oldObj.(T)
 				newRes, newOk := newObj.(T)
 				if !oldOk || !newOk {
@@ -219,7 +219,7 @@ func (i *Informer[T]) installEventHandlers() error {
 					i.onUpdate(oldRes, newRes)
 				}
 			},
-			DeleteFunc: func(obj interface{}) {
+			DeleteFunc: func(obj any) {
 				res, ok := obj.(T)
 				if !ok {
 					return

--- a/internal/issuer/jwt.go
+++ b/internal/issuer/jwt.go
@@ -125,7 +125,7 @@ func NewIssuer(name string, opts ...JwtIssuerOption) (*JwtIssuer, error) {
 	return iss, nil
 }
 
-func (i *JwtIssuer) validationKey(t *jwt.Token) (interface{}, error) {
+func (i *JwtIssuer) validationKey(t *jwt.Token) (any, error) {
 	var pubKey crypto.PublicKey
 	switch t.Method {
 	case jwt.SigningMethodRS512:

--- a/internal/issuer/jwt_test.go
+++ b/internal/issuer/jwt_test.go
@@ -30,7 +30,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func signedTokenWithClaims(method jwt.SigningMethod, key interface{}, claims jwt.Claims) (string, error) {
+func signedTokenWithClaims(method jwt.SigningMethod, key any, claims jwt.Claims) (string, error) {
 	tok := jwt.NewWithClaims(method, claims)
 	return tok.SignedString(key)
 }

--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -24,6 +24,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"maps"
 	"reflect"
 	"strings"
 
@@ -322,11 +323,9 @@ func (l *CentralizedLogger) GetLogLevel() logrus.Level {
 }
 
 // WithContext creates a logger entry with common context fields
-func (l *CentralizedLogger) WithContext(module string, fields map[string]interface{}) *logrus.Entry {
+func (l *CentralizedLogger) WithContext(module string, fields map[string]any) *logrus.Entry {
 	logFields := logrus.Fields{logfields.Module: module}
-	for k, v := range fields {
-		logFields[k] = v
-	}
+	maps.Copy(logFields, fields)
 	return l.logger.WithFields(logFields)
 }
 

--- a/internal/logging/logging_test.go
+++ b/internal/logging/logging_test.go
@@ -115,7 +115,7 @@ func TestComponentLogger(t *testing.T) {
 	logger := defaultLogger.ComponentLogger("TestComponent")
 	logger.Info("test message")
 
-	var logEntry map[string]interface{}
+	var logEntry map[string]any
 	err = json.Unmarshal(buf.Bytes(), &logEntry)
 	require.NoError(t, err)
 
@@ -132,7 +132,7 @@ func TestModuleLogger(t *testing.T) {
 	logger := defaultLogger.ModuleLogger("TestModule")
 	logger.Info("test message")
 
-	var logEntry map[string]interface{}
+	var logEntry map[string]any
 	err = json.Unmarshal(buf.Bytes(), &logEntry)
 	require.NoError(t, err)
 
@@ -148,7 +148,7 @@ func TestMethodLogger(t *testing.T) {
 	logger := defaultLogger.MethodLogger("TestModule", "TestMethod")
 	logger.Info("test message")
 
-	var logEntry map[string]interface{}
+	var logEntry map[string]any
 	err = json.Unmarshal(buf.Bytes(), &logEntry)
 	require.NoError(t, err)
 
@@ -164,7 +164,7 @@ func TestRequestLogger(t *testing.T) {
 	logger := defaultLogger.RequestLogger("TestModule", "TestMethod", "test-request-id")
 	logger.Info("test message")
 
-	var logEntry map[string]interface{}
+	var logEntry map[string]any
 	err = json.Unmarshal(buf.Bytes(), &logEntry)
 	require.NoError(t, err)
 
@@ -181,7 +181,7 @@ func TestApplicationLogger(t *testing.T) {
 	logger := defaultLogger.ApplicationLogger("TestModule", "test-app")
 	logger.Info("test message")
 
-	var logEntry map[string]interface{}
+	var logEntry map[string]any
 	err = json.Unmarshal(buf.Bytes(), &logEntry)
 	require.NoError(t, err)
 
@@ -197,7 +197,7 @@ func TestKubernetesResourceLogger(t *testing.T) {
 	logger := defaultLogger.KubernetesResourceLogger("TestModule", "Pod", "default", "test-pod")
 	logger.Info("test message")
 
-	var logEntry map[string]interface{}
+	var logEntry map[string]any
 	err = json.Unmarshal(buf.Bytes(), &logEntry)
 	require.NoError(t, err)
 
@@ -215,7 +215,7 @@ func TestRedisLogger(t *testing.T) {
 	logger := defaultLogger.RedisLogger("TestModule", "GET", "test-key")
 	logger.Info("test message")
 
-	var logEntry map[string]interface{}
+	var logEntry map[string]any
 	err = json.Unmarshal(buf.Bytes(), &logEntry)
 	require.NoError(t, err)
 
@@ -232,7 +232,7 @@ func TestGRPCLogger(t *testing.T) {
 	logger := defaultLogger.GRPCLogger("TestModule", "/test.Service/Method")
 	logger.Info("test message")
 
-	var logEntry map[string]interface{}
+	var logEntry map[string]any
 	err = json.Unmarshal(buf.Bytes(), &logEntry)
 	require.NoError(t, err)
 
@@ -248,7 +248,7 @@ func TestHTTPLogger(t *testing.T) {
 	logger := defaultLogger.HTTPLogger("TestModule", "GET", "/api/v1/test")
 	logger.Info("test message")
 
-	var logEntry map[string]interface{}
+	var logEntry map[string]any
 	err = json.Unmarshal(buf.Bytes(), &logEntry)
 	require.NoError(t, err)
 
@@ -282,7 +282,7 @@ func TestJSONFormat(t *testing.T) {
 	// Should contain the debug message since we set level to debug
 	assert.NotEmpty(t, buf.String())
 
-	var logEntry map[string]interface{}
+	var logEntry map[string]any
 	err = json.Unmarshal(buf.Bytes(), &logEntry)
 	require.NoError(t, err)
 
@@ -355,7 +355,7 @@ func TestWithContext(t *testing.T) {
 	err := defaultLogger.SetupLogging(LogLevelInfo, LogFormatJSON, &buf)
 	require.NoError(t, err)
 
-	fields := map[string]interface{}{
+	fields := map[string]any{
 		logfields.Username:  "testuser",
 		logfields.RequestID: "req-123",
 	}
@@ -363,7 +363,7 @@ func TestWithContext(t *testing.T) {
 	logger := defaultLogger.WithContext("TestModule", fields)
 	logger.Info("test message")
 
-	var logEntry map[string]interface{}
+	var logEntry map[string]any
 	err = json.Unmarshal(buf.Bytes(), &logEntry)
 	require.NoError(t, err)
 
@@ -464,9 +464,9 @@ func newTestEntry(buf *bytes.Buffer) *logrus.Entry {
 	return logrus.NewEntry(logger)
 }
 
-func parseLogLine(t *testing.T, buf *bytes.Buffer) map[string]interface{} {
+func parseLogLine(t *testing.T, buf *bytes.Buffer) map[string]any {
 	t.Helper()
-	var entry map[string]interface{}
+	var entry map[string]any
 	require.NoError(t, json.Unmarshal(buf.Bytes(), &entry))
 	return entry
 }

--- a/internal/resources/resources_test.go
+++ b/internal/resources/resources_test.go
@@ -135,7 +135,7 @@ func Test_AgentResources(t *testing.T) {
 	res := NewAgentResources()
 
 	resKeys := make([]ResourceKey, 10)
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		app := &v1alpha1.Application{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      fmt.Sprintf("test-%d", i),
@@ -162,11 +162,11 @@ func Test_AgentResources(t *testing.T) {
 		}
 
 		freq := map[ResourceKey]int{}
-		for i := 0; i < len(a); i++ {
+		for i := range a {
 			freq[a[i]]++
 		}
 
-		for i := 0; i < len(b); i++ {
+		for i := range b {
 			if freq[b[i]] == 0 {
 				return false
 			}

--- a/internal/resync/resync.go
+++ b/internal/resync/resync.go
@@ -599,14 +599,14 @@ func getGroupVersionResource(kind string) (schema.GroupVersionResource, error) {
 func generateSpecChecksum(resObj *unstructured.Unstructured) ([]byte, error) {
 	res := resObj.DeepCopy()
 
-	var resSpec interface{}
+	var resSpec any
 	var ok bool
 	if res.GetKind() == "Secret" || res.GetKind() == "ConfigMap" {
 		resSpec, ok = res.Object["data"]
 		if !ok {
 			if res.GetKind() == "ConfigMap" {
 				logrus.Debugf("ConfigMap %s has no data field, using empty map for checksum", res.GetName())
-				resSpec = map[string]interface{}{}
+				resSpec = map[string]any{}
 			} else {
 				return nil, fmt.Errorf("data field not found for resource: %s", res.GetName())
 			}
@@ -618,7 +618,7 @@ func generateSpecChecksum(resObj *unstructured.Unstructured) ([]byte, error) {
 		}
 	}
 
-	specMap, ok := resSpec.(map[string]interface{})
+	specMap, ok := resSpec.(map[string]any)
 	if !ok {
 		return nil, fmt.Errorf("unable to convert the spec object of %s:%s to a map", res.GetKind(), res.GetName())
 	}

--- a/internal/resync/resync_test.go
+++ b/internal/resync/resync_test.go
@@ -51,7 +51,7 @@ func Test_ProcessIncomingSyncedResourceList(t *testing.T) {
 	})
 
 	t.Run("return nil if checksum matches", func(t *testing.T) {
-		for i := 0; i < resNum; i++ {
+		for i := range resNum {
 			name := fmt.Sprintf("test-%d", i)
 			testResource := resources.ResourceKey{
 				Name:      name,
@@ -76,7 +76,7 @@ func Test_ProcessIncomingSyncedResourceList(t *testing.T) {
 
 	t.Run("send SyncedResource event for all resources if the checksum doesn't match", func(t *testing.T) {
 		testResources := make([]resources.ResourceKey, resNum)
-		for i := 0; i < resNum; i++ {
+		for i := range resNum {
 			name := fmt.Sprintf("test-%d", i)
 			testResource := resources.ResourceKey{
 				Name:      name,
@@ -97,7 +97,7 @@ func Test_ProcessIncomingSyncedResourceList(t *testing.T) {
 
 		assert.Equal(t, handler.sendQ.Len(), resNum)
 
-		for i := 0; i < resNum; i++ {
+		for range resNum {
 			ev, shutdown := handler.sendQ.Get()
 			assert.False(t, shutdown)
 			assert.Equal(t, event.ResponseSyncedResource.String(), ev.Type())
@@ -289,7 +289,7 @@ func Test_generateSpecChecksum(t *testing.T) {
 
 	t.Run("generate checksum for resource with destination field", func(t *testing.T) {
 		resource := fakeUnresApp()
-		resource.Object["spec"] = map[string]interface{}{
+		resource.Object["spec"] = map[string]any{
 			"project":     "default",
 			"destination": "in-cluster",
 		}
@@ -526,7 +526,7 @@ func Test_SendRequestUpdates(t *testing.T) {
 		gvr, err := getGroupVersionResource("Application")
 		assert.Nil(t, err)
 
-		for i := 0; i < 3; i++ {
+		for i := range 3 {
 			resource := fakeUnresApp()
 			resource.SetName(fmt.Sprintf("unmanaged-app-%d", i))
 			_, err = handler.dynClient.Resource(gvr).Namespace("default").
@@ -1029,7 +1029,7 @@ func fakeUnresApp() *unstructured.Unstructured {
 	resource.SetName("test-app")
 	resource.SetNamespace("default")
 	resource.SetUID("test-uid")
-	resource.Object["spec"] = map[string]interface{}{
+	resource.Object["spec"] = map[string]any{
 		"project": "default",
 	}
 	return resource
@@ -1045,7 +1045,7 @@ func fakeUnresGPGKey() *unstructured.Unstructured {
 	resource.SetName("argocd-gpg-keys-cm")
 	resource.SetNamespace("argocd")
 	resource.SetUID("gpg-uid")
-	resource.Object["data"] = map[string]interface{}{
+	resource.Object["data"] = map[string]any{
 		"7AEE18F83AFDEB23": "test-gpg-key-data",
 	}
 	return resource

--- a/internal/tlsutil/tlsutil.go
+++ b/internal/tlsutil/tlsutil.go
@@ -26,6 +26,7 @@ import (
 	"encoding/pem"
 	"fmt"
 	"os"
+	"slices"
 	"time"
 )
 
@@ -202,13 +203,7 @@ func ValidateTLSConfig(minVersion, maxVersion uint16, cipherSuites []uint16) err
 			for _, cs := range availableCiphers {
 				if cs.ID == cipherID {
 					// Check if this cipher supports the minimum TLS version
-					supported := false
-					for _, v := range cs.SupportedVersions {
-						if v == minVersion {
-							supported = true
-							break
-						}
-					}
+					supported := slices.Contains(cs.SupportedVersions, minVersion)
 					if !supported {
 						return fmt.Errorf("cipher suite %s is not supported by minimum TLS version %s",
 							cs.Name, TLSVersionName(minVersion))

--- a/internal/tlsutil/tlsutil_test.go
+++ b/internal/tlsutil/tlsutil_test.go
@@ -21,6 +21,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"path"
+	"slices"
 	"testing"
 
 	"github.com/argoproj-labs/argocd-agent/test/fake/testcerts"
@@ -222,11 +223,8 @@ func Test_ValidateTLSConfig(t *testing.T) {
 		// Find a cipher that supports TLS 1.2
 		var tls12Cipher *tls.CipherSuite
 		for _, cs := range tls.CipherSuites() {
-			for _, v := range cs.SupportedVersions {
-				if v == tls.VersionTLS12 {
-					tls12Cipher = cs
-					break
-				}
+			if slices.Contains(cs.SupportedVersions, tls.VersionTLS12) {
+				tls12Cipher = cs
 			}
 			if tls12Cipher != nil {
 				break
@@ -242,13 +240,7 @@ func Test_ValidateTLSConfig(t *testing.T) {
 		// Find a cipher that does NOT support TLS 1.3 (TLS 1.2 only ciphers)
 		var tls12OnlyCipher *tls.CipherSuite
 		for _, cs := range tls.CipherSuites() {
-			supportsTLS13 := false
-			for _, v := range cs.SupportedVersions {
-				if v == tls.VersionTLS13 {
-					supportsTLS13 = true
-					break
-				}
-			}
+			supportsTLS13 := slices.Contains(cs.SupportedVersions, tls.VersionTLS13)
 			if !supportsTLS13 {
 				tls12OnlyCipher = cs
 				break
@@ -357,12 +349,9 @@ func Test_SetTLSConfigFromFlags(t *testing.T) {
 		var cipherName string
 		var cipherID uint16
 		for _, cs := range ciphers {
-			for _, v := range cs.SupportedVersions {
-				if v == tls.VersionTLS12 {
-					cipherName = cs.Name
-					cipherID = cs.ID
-					break
-				}
+			if slices.Contains(cs.SupportedVersions, tls.VersionTLS12) {
+				cipherName = cs.Name
+				cipherID = cs.ID
 			}
 			if cipherName != "" {
 				break

--- a/pkg/client/remote.go
+++ b/pkg/client/remote.go
@@ -430,7 +430,7 @@ func (r *Remote) retriable(err error) bool {
 	return true
 }
 
-func (r *Remote) unaryAuthInterceptor(ctx context.Context, method string, req interface{}, reply interface{}, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
+func (r *Remote) unaryAuthInterceptor(ctx context.Context, method string, req any, reply any, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
 	log().Infof("Outgoing unary call to %s", method)
 
 	// Auth methods do not need token refresh, so we can call the invoker directly

--- a/pkg/client/remote_test.go
+++ b/pkg/client/remote_test.go
@@ -23,6 +23,7 @@ import (
 	"math/big"
 	"net"
 	"path"
+	"slices"
 	"strconv"
 	"sync/atomic"
 	"testing"
@@ -322,13 +323,7 @@ func Test_validateTLSConfig(t *testing.T) {
 		// Find a cipher that does NOT support TLS 1.3 (TLS 1.2 only ciphers)
 		var tls12OnlyCipher *tls.CipherSuite
 		for _, cs := range tls.CipherSuites() {
-			supportsTLS13 := false
-			for _, v := range cs.SupportedVersions {
-				if v == tls.VersionTLS13 {
-					supportsTLS13 = true
-					break
-				}
-			}
+			supportsTLS13 := slices.Contains(cs.SupportedVersions, tls.VersionTLS13)
 			if !supportsTLS13 {
 				tls12OnlyCipher = cs
 				break

--- a/pkg/ha/state.go
+++ b/pkg/ha/state.go
@@ -14,7 +14,10 @@
 
 package ha
 
-import "fmt"
+import (
+	"fmt"
+	"slices"
+)
 
 // State represents the current HA state of a principal
 type State string
@@ -99,10 +102,5 @@ func ValidTransition(from, to State) bool {
 		return false
 	}
 
-	for _, s := range allowed {
-		if s == to {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(allowed, to)
 }

--- a/pkg/replication/client.go
+++ b/pkg/replication/client.go
@@ -641,17 +641,13 @@ func (c *Client) runEventStream(ctx context.Context) error {
 
 	var wg sync.WaitGroup
 
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		c.sendAcks(streamCtx, stream, ackCh)
-	}()
+	})
 
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		c.runReconcileLoop(streamCtx)
-	}()
+	})
 
 	err = c.receiveEvents(streamCtx, stream, ackCh)
 

--- a/principal/apis/eventstream/eventstream_test.go
+++ b/principal/apis/eventstream/eventstream_test.go
@@ -260,7 +260,6 @@ func TestDisconnectAll(t *testing.T) {
 		gate := make(chan struct{})
 
 		for _, name := range []string{"agent-a", "agent-b"} {
-			name := name
 			st := &mock.MockEventServer{AgentName: name}
 			st.AddRecvHook(func(_ *mock.MockEventServer) error {
 				<-gate

--- a/principal/apis/logstreamapi/logstream_test.go
+++ b/principal/apis/logstreamapi/logstream_test.go
@@ -543,7 +543,7 @@ func TestConcurrentAccess(t *testing.T) {
 	var wg sync.WaitGroup
 	numGoroutines := 10
 
-	for i := 0; i < numGoroutines; i++ {
+	for i := range numGoroutines {
 		wg.Add(1)
 		go func(id int) {
 			defer wg.Done()
@@ -565,7 +565,7 @@ func TestConcurrentAccess(t *testing.T) {
 }
 
 func TestWaitForCompletion_RaceWithFinalizeSession(t *testing.T) {
-	for i := 0; i < 100; i++ {
+	for range 100 {
 		server := NewServer()
 		reqID := "race-test"
 

--- a/principal/apis/replication/server.go
+++ b/principal/apis/replication/server.go
@@ -206,11 +206,9 @@ func (s *Server) Subscribe(stream replicationapi.Replication_SubscribeServer) er
 		return fmt.Errorf("flushing buffered events: %w", err)
 	}
 
-	client.wg.Add(1)
-	go func() {
-		defer client.wg.Done()
+	client.wg.Go(func() {
 		s.receiveAcks(client)
-	}()
+	})
 
 	<-ctx.Done()
 

--- a/principal/apis/terminalstream/mock/mock.go
+++ b/principal/apis/terminalstream/mock/mock.go
@@ -248,11 +248,11 @@ func (m *MockTerminalStreamClient) Context() context.Context {
 	return m.ctx
 }
 
-func (m *MockTerminalStreamClient) SendMsg(msg interface{}) error {
+func (m *MockTerminalStreamClient) SendMsg(msg any) error {
 	return nil
 }
 
-func (m *MockTerminalStreamClient) RecvMsg(msg interface{}) error {
+func (m *MockTerminalStreamClient) RecvMsg(msg any) error {
 	return nil
 }
 

--- a/principal/apis/terminalstream/terminalstream_test.go
+++ b/principal/apis/terminalstream/terminalstream_test.go
@@ -425,7 +425,7 @@ func TestConcurrentSessionOperations(t *testing.T) {
 		numSessions := 100
 
 		// Add sessions concurrently
-		for i := 0; i < numSessions; i++ {
+		for i := range numSessions {
 			wg.Add(1)
 			go func(idx int) {
 				defer wg.Done()
@@ -439,7 +439,7 @@ func TestConcurrentSessionOperations(t *testing.T) {
 		}
 
 		// Get sessions concurrently
-		for i := 0; i < numSessions; i++ {
+		for i := range numSessions {
 			wg.Add(1)
 			go func(idx int) {
 				defer wg.Done()
@@ -459,7 +459,7 @@ func TestConcurrentSessionOperations(t *testing.T) {
 		numSessions := 100
 
 		// Add sessions
-		for i := 0; i < numSessions; i++ {
+		for i := range numSessions {
 			session := &TerminalSession{
 				UUID:      fmt.Sprintf("uuid-%d", i),
 				AgentName: "agent",
@@ -469,7 +469,7 @@ func TestConcurrentSessionOperations(t *testing.T) {
 		}
 
 		// Remove sessions concurrently
-		for i := 0; i < numSessions; i++ {
+		for i := range numSessions {
 			wg.Add(1)
 			go func(idx int) {
 				defer wg.Done()

--- a/principal/auth.go
+++ b/principal/auth.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/argoproj-labs/argocd-agent/internal/auth"
@@ -173,10 +174,8 @@ func (s *Server) authenticateReplication(ctx context.Context) error {
 
 	allowed := s.ha.Controller.Options().AllowedReplicationClients
 	if len(allowed) > 0 {
-		for _, c := range allowed {
-			if identity == c {
-				return nil
-			}
+		if slices.Contains(allowed, identity) {
+			return nil
 		}
 		log().WithField("identity", identity).Warn("Replication request rejected: identity not in allowed clients")
 		return status.Errorf(codes.PermissionDenied, "identity %q not in allowed replication clients", identity)

--- a/principal/event_test.go
+++ b/principal/event_test.go
@@ -35,7 +35,6 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/rest"
-	"k8s.io/utils/ptr"
 )
 
 func Test_EventProcessorRoutesACKToMatchingQueue(t *testing.T) {
@@ -947,7 +946,7 @@ func Test_DeleteEvents_ManagedMode(t *testing.T) {
 			}
 
 			if test.deletionTimestampSetOnPrincipal {
-				delApp.DeletionTimestamp = ptr.To(v1.Time{Time: time.Now()})
+				delApp.DeletionTimestamp = new(v1.Time{Time: time.Now()})
 			}
 
 			// Create fake client with the application already in it
@@ -979,7 +978,7 @@ func Test_DeleteEvents_ManagedMode(t *testing.T) {
 			s.setAgentMode("foo", types.AgentModeManaged)
 
 			var cachedApp *v1alpha1.Application
-			for i := 0; i < 20; i++ {
+			for range 20 {
 				cachedApp, err = s.appManager.Get(ctx, delApp.Name, delApp.Namespace)
 				if err == nil {
 					break

--- a/principal/logging.go
+++ b/principal/logging.go
@@ -50,7 +50,7 @@ func InterceptorLogger(l logrus.FieldLogger) logging.Logger {
 }
 
 func (s *Server) unaryRequestLogger() grpc.UnaryServerInterceptor {
-	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (resp interface{}, err error) {
+	return func(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (resp any, err error) {
 		s.logGrpcEvent().WithFields(logrus.Fields{
 			"method":      info.FullMethod,
 			"client_addr": grpcutil.AddressFromContext(ctx),
@@ -60,7 +60,7 @@ func (s *Server) unaryRequestLogger() grpc.UnaryServerInterceptor {
 }
 
 func (s *Server) streamRequestLogger() grpc.StreamServerInterceptor {
-	return func(srv interface{}, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+	return func(srv any, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
 		s.logGrpcEvent().WithFields(logrus.Fields{
 			"method":      info.FullMethod,
 			"client_addr": grpcutil.AddressFromContext(ss.Context()),

--- a/principal/mapset.go
+++ b/principal/mapset.go
@@ -14,7 +14,10 @@
 
 package principal
 
-import "sync"
+import (
+	"maps"
+	"sync"
+)
 
 // MapToSet is a map of keys to a set of unique values.
 type MapToSet struct {
@@ -36,9 +39,7 @@ func (m *MapToSet) Get(key string) map[string]bool {
 		return nil
 	}
 	cp := make(map[string]bool, len(s))
-	for k, v := range s {
-		cp[k] = v
-	}
+	maps.Copy(cp, s)
 	return cp
 }
 

--- a/principal/mapset_test.go
+++ b/principal/mapset_test.go
@@ -239,7 +239,7 @@ func Test_mapToSet_PanicPrevention(t *testing.T) {
 	t.Run("Rapid add/delete cycles do not panic", func(t *testing.T) {
 		ms := NewMapToSet()
 		assert.NotPanics(t, func() {
-			for i := 0; i < 100; i++ {
+			for range 100 {
 				ms.Add("key", "value")
 				ms.Delete("key", "value")
 			}

--- a/principal/redisproxy/redisproxy.go
+++ b/principal/redisproxy/redisproxy.go
@@ -742,12 +742,13 @@ func (prc *parsedRedisCommand) generateParsedCommandDebugString() string {
 		return fmt.Sprintf("internal message: %v", prc.internalMsg)
 	}
 
-	res := "(a->r) "
+	var res strings.Builder
+	res.WriteString("(a->r) ")
 	for _, str := range prc.parsedReceived {
-		res += fmt.Sprintf("'%s' | ", sanitizeStringIfNonASCII(str))
+		fmt.Fprintf(&res, "'%s' | ", sanitizeStringIfNonASCII(str))
 	}
 
-	return res
+	return res.String()
 }
 
 // sanitizeStringIfNonASCII: if the string is non-ascii (likely because it includes binary data), then only return the number of bytes of the string rather than the string itself

--- a/principal/resource_test.go
+++ b/principal/resource_test.go
@@ -55,7 +55,7 @@ func Test_resourceRequester(t *testing.T) {
 			PeerCertificates: []*x509.Certificate{cert},
 		}
 		w := httptest.NewRecorder()
-		ch := make(chan interface{})
+		ch := make(chan any)
 		go func() {
 			s.processResourceRequest(w, r, resourceproxy.NewParams())
 			ch <- 1
@@ -86,7 +86,7 @@ func Test_resourceRequester(t *testing.T) {
 		s := newResourceTestServer(t)
 		r := httptest.NewRequest("GET", "/", nil)
 		w := httptest.NewRecorder()
-		ch := make(chan interface{})
+		ch := make(chan any)
 		go func() {
 			s.processResourceRequest(w, r, resourceproxy.NewParams())
 			ch <- 1
@@ -108,7 +108,7 @@ func Test_resourceRequester(t *testing.T) {
 			PeerCertificates: []*x509.Certificate{{}},
 		}
 		w := httptest.NewRecorder()
-		ch := make(chan interface{})
+		ch := make(chan any)
 		go func() {
 			s.processResourceRequest(w, r, resourceproxy.NewParams())
 			ch <- 1
@@ -135,7 +135,7 @@ func Test_resourceRequester(t *testing.T) {
 			PeerCertificates: []*x509.Certificate{cert},
 		}
 		w := httptest.NewRecorder()
-		ch := make(chan interface{})
+		ch := make(chan any)
 		go func() {
 			s.processResourceRequest(w, r, resourceproxy.NewParams())
 			ch <- 1
@@ -163,7 +163,7 @@ func Test_resourceRequester(t *testing.T) {
 			PeerCertificates: []*x509.Certificate{cert},
 		}
 		w := httptest.NewRecorder()
-		ch := make(chan interface{})
+		ch := make(chan any)
 		go func() {
 			s.processResourceRequest(w, r, resourceproxy.NewParams())
 			ch <- 1
@@ -188,7 +188,7 @@ func Test_resourceRequester(t *testing.T) {
 			PeerCertificates: []*x509.Certificate{cert},
 		}
 		w := httptest.NewRecorder()
-		ch := make(chan interface{})
+		ch := make(chan any)
 		go func() {
 			s.processResourceRequest(w, r, resourceproxy.NewParams())
 			ch <- 1
@@ -227,7 +227,7 @@ func Test_resourceRequester(t *testing.T) {
 			PeerCertificates: []*x509.Certificate{cert},
 		}
 		w := httptest.NewRecorder()
-		ch := make(chan interface{})
+		ch := make(chan any)
 		go func() {
 			s.processResourceRequest(w, r, resourceproxy.NewParams())
 			ch <- 1

--- a/principal/terminal_test.go
+++ b/principal/terminal_test.go
@@ -622,7 +622,7 @@ func TestHandleJSONResizeMessage(t *testing.T) {
 			Done:    make(chan struct{}),
 		}
 
-		resizeMsg := map[string]interface{}{
+		resizeMsg := map[string]any{
 			"operation": "resize",
 			"cols":      float64(100),
 			"rows":      float64(30),
@@ -649,7 +649,7 @@ func TestHandleJSONResizeMessage(t *testing.T) {
 			Done:    make(chan struct{}),
 		}
 
-		msg := map[string]interface{}{
+		msg := map[string]any{
 			"operation": "other",
 			"cols":      float64(100),
 			"rows":      float64(30),

--- a/test/e2e/fixture/argoclient.go
+++ b/test/e2e/fixture/argoclient.go
@@ -193,7 +193,7 @@ func (c *ArgoRestClient) RunResourceAction(app *v1alpha1.Application, action, gr
 	reqURL.Path = fmt.Sprintf("/api/v1/applications/%s/resource/actions/v2", app.Name)
 
 	// Based on Argo CD Swagger: https://cd.apps.argoproj.io/swagger-ui#tag/ApplicationService/operation/ApplicationService_RunResourceActionV2
-	requestBody := map[string]interface{}{
+	requestBody := map[string]any{
 		"action":       action,
 		"appNamespace": app.Namespace,
 		"group":        group,
@@ -305,11 +305,11 @@ func (c *ArgoRestClient) GetApplicationLogs(app *v1alpha1.Application, namespace
 	}
 
 	type logResult struct {
-		Content      string      `json:"content"`
-		TimeStamp    interface{} `json:"timeStamp"`
-		Last         bool        `json:"last"`
-		TimeStampStr string      `json:"timeStampStr"`
-		PodName      string      `json:"podName"`
+		Content      string `json:"content"`
+		TimeStamp    any    `json:"timeStamp"`
+		Last         bool   `json:"last"`
+		TimeStampStr string `json:"timeStampStr"`
+		PodName      string `json:"podName"`
 	}
 	type logError struct {
 		GRPCCode   int    `json:"grpc_code"`

--- a/test/e2e/fixture/fixture.go
+++ b/test/e2e/fixture/fixture.go
@@ -17,8 +17,10 @@ package fixture
 import (
 	"context"
 	"fmt"
+	"maps"
 	"os"
 	"reflect"
+	"slices"
 	"strings"
 	"sync"
 	"testing"
@@ -132,9 +134,7 @@ func WriteEnvVarsToFile(vars map[string]string) error {
 		allVars["ARGOCD_AGENT_CREATE_NAMESPACE"] = "true"
 		allVars["ARGOCD_PRINCIPAL_DESTINATION_BASED_MAPPING"] = "true"
 	}
-	for k, v := range vars {
-		allVars[k] = v
-	}
+	maps.Copy(allVars, vars)
 	if len(allVars) == 0 {
 		os.Remove(EnvVariablesFromE2EFile)
 		return nil
@@ -254,12 +254,7 @@ func (suite *BaseSuite) setupDestinationBasedMapping() {
 		if err != nil {
 			return false
 		}
-		for _, ns := range proj.Spec.SourceNamespaces {
-			if ns == "*" {
-				return true
-			}
-		}
-		return false
+		return slices.Contains(proj.Spec.SourceNamespaces, "*")
 	}, 30*time.Second, 1*time.Second, "SourceNamespaces should propagate to managed agent")
 
 	// Update argocd-cmd-params-cm to allow applications in any namespace.
@@ -359,7 +354,7 @@ func EnsureDeletion(ctx context.Context, kclient KubeClient, obj KubeObject) err
 	// Wait for the object to be deleted for 180 seconds
 	// - Primarily this will be waiting for the finalizer to be removed, so that the object is deleted
 	key := types.NamespacedName{Name: obj.GetName(), Namespace: obj.GetNamespace()}
-	for count := 0; count < 180; count++ {
+	for range 180 {
 		err := kclient.Delete(ctx, obj, metav1.DeleteOptions{})
 		if errors.IsNotFound(err) {
 			// object is already deleted
@@ -390,7 +385,7 @@ func EnsureDeletion(ctx context.Context, kclient KubeClient, obj KubeObject) err
 
 	// Continue waiting for object to be deleted, now that finalizers have been removed.
 	key = types.NamespacedName{Name: obj.GetName(), Namespace: obj.GetNamespace()}
-	for count := 0; count < 180; count++ {
+	for range 180 {
 		err := kclient.Get(ctx, key, obj, metav1.GetOptions{})
 		if errors.IsNotFound(err) {
 			return nil
@@ -407,7 +402,7 @@ func EnsureDeletion(ctx context.Context, kclient KubeClient, obj KubeObject) err
 // WaitForDeletion will wait for a resource to be deleted
 func WaitForDeletion(ctx context.Context, kclient KubeClient, obj KubeObject, debugContext string) error {
 	key := types.NamespacedName{Name: obj.GetName(), Namespace: obj.GetNamespace()}
-	for count := 0; count < 180; count++ {
+	for range 180 {
 		err := kclient.Get(ctx, key, obj, metav1.GetOptions{})
 		if err != nil {
 			if errors.IsNotFound(err) {

--- a/test/e2e/fixture/kubeclient.go
+++ b/test/e2e/fixture/kubeclient.go
@@ -245,7 +245,7 @@ func (c KubeClient) Update(ctx context.Context, object KubeObject, options metav
 // Patch patches the given object in the cluster using the JSONPatch patch type.
 // object must be a struct pointer so that it can be updated with the result
 // returned by the server.
-func (c KubeClient) Patch(ctx context.Context, object KubeObject, jsonPatch []interface{}, options metav1.PatchOptions) error {
+func (c KubeClient) Patch(ctx context.Context, object KubeObject, jsonPatch []any, options metav1.PatchOptions) error {
 	resource, err := c.resourceFor(object)
 	if err != nil {
 		return err

--- a/test/e2e/fixture_test.go
+++ b/test/e2e/fixture_test.go
@@ -484,8 +484,8 @@ func (suite *FixtureTestSuite) Test_Patch_Application() {
 			Namespace: "test-argocd-agent",
 		},
 	}
-	err = kclient.Patch(ctx, &app, []interface{}{
-		map[string]interface{}{
+	err = kclient.Patch(ctx, &app, []any{
+		map[string]any{
 			"op":    "replace",
 			"path":  "/spec/source/targetRevision",
 			"value": "TAIL",

--- a/test/e2e/redis_proxy_test.go
+++ b/test/e2e/redis_proxy_test.go
@@ -589,8 +589,8 @@ func streamFromEventSourceNew(ctx context.Context, eventSourceAPIURL string, ses
 					return strings.Contains(err.Error(), "context canceled")
 				}
 
-				if strings.HasPrefix(line, "data:") {
-					data := strings.TrimSpace(strings.TrimPrefix(line, "data:"))
+				if after, ok := strings.CutPrefix(line, "data:"); ok {
+					data := strings.TrimSpace(after)
 					select {
 					case <-ctx.Done():
 						t.Log("Context is complete")

--- a/test/e2e/resource_tracking_test.go
+++ b/test/e2e/resource_tracking_test.go
@@ -28,7 +28,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/utils/ptr"
 )
 
 // ResourceTrackingTestSuite tests that the argocd-agent correctly identifies
@@ -165,8 +164,8 @@ func (suite *ResourceTrackingTestSuite) runTrackingTest(
 			},
 			SyncPolicy: &argoapp.SyncPolicy{
 				Automated: &argoapp.SyncPolicyAutomated{
-					Prune:    ptr.To(true),
-					SelfHeal: ptr.To(true),
+					Prune:    new(true),
+					SelfHeal: new(true),
 				},
 			},
 		},

--- a/test/e2e/rp_test.go
+++ b/test/e2e/rp_test.go
@@ -23,6 +23,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -460,12 +461,7 @@ func (suite *ResourceProxyTestSuite) Test_ResourceProxy_ResourceActions() {
 		actions, err := argoClient.ListResourceActions(&app, "apps", "v1", "Deployment", "guestbook", "kustomize-guestbook-ui")
 		requires.NoError(err)
 
-		for _, action := range actions {
-			if action == "Test" {
-				return true
-			}
-		}
-		return false
+		return slices.Contains(actions, "Test")
 	}, 30*time.Second, 1*time.Second)
 
 	argocdCM := &corev1.ConfigMap{}
@@ -593,7 +589,7 @@ func (suite *ResourceProxyTestSuite) Test_ResourceProxy_Subresources() {
 	resp.Body.Close()
 	requires.NoError(err)
 	// The scale response should be a Scale object, not a Deployment
-	var scale map[string]interface{}
+	var scale map[string]any
 	err = json.Unmarshal(resource, &scale)
 	requires.NoError(err)
 	requires.Contains(scale, "kind")
@@ -611,7 +607,7 @@ func (suite *ResourceProxyTestSuite) Test_ResourceProxy_Subresources() {
 	// This test verifies that POST requests to subresources work correctly
 	// We'll test with a pod eviction endpoint - it should fail with 404 since the pod doesn't exist,
 	// but this proves the subresource routing works
-	postData := []byte(fmt.Sprintf(`{"apiVersion":"policy/v1","kind":"Eviction","metadata":{"name":"test-pod","namespace":"%s"}}`, fixture.ManagedAgentNamespace))
+	postData := fmt.Appendf(nil, `{"apiVersion":"policy/v1","kind":"Eviction","metadata":{"name":"test-pod","namespace":"%s"}}`, fixture.ManagedAgentNamespace)
 	req, err := http.NewRequest(http.MethodPost, fmt.Sprintf("https://127.0.0.1:9090/api/v1/namespaces/%s/pods/test-pod/eviction", fixture.ManagedAgentNamespace),
 		io.NopCloser(strings.NewReader(string(postData))))
 	requires.NoError(err)


### PR DESCRIPTION
**What does this PR do / why we need it**:
Go 1.26 includes a new  'go fix' implementation which modernizes Go codebases. See [go fix](https://go.dev/blog/gofix) blog for details.

This PR:
- I ran 'go fix' from `go version go1.26.3 linux/amd64`.
- I manually verified all the changes.
    - I left out about 5 suggestions as I could not immediately verify their correctness (all were related to context cancellation)
    - After this PR is merged, another `go fix` would reveal those for further consideration.
-  Finally, I asked Claude to review for correctness:
```
● Code review(high · 0 findings)

● No correctness bugs found. The commit is a clean Go 1.26 modernization pass. All 8 review angles (3 correctness, 3 cleanup, altitude, conventions) converged on the same conclusion. I
  verified independently that the code compiles (go build ./...), passes go vet, and the tests that exercise the most semantically significant change (new(value) replacing ptr.To/timePtr)
  pass.
```




**How to test changes / Special notes to the reviewer**:


**Checklist**

* [X] Documentation update is required by this PR (and has been updated) OR no documentation update is required.

