### PR TITLE
fix(ctl): correct flag name in jwt create-key error message

### DIFF
--- a/cmd/ctl/jwt.go
+++ b/cmd/ctl/jwt.go
@@ -75,7 +75,7 @@ The secret will be created in the principal's namespace on the principal's conte
 				if err != nil {
 					cmdutil.Fatal("Error getting JWT secret: %v", err)
 				} else if !upsert {
-					cmdutil.Fatal("JWT secret already exists. Use --force to recreate it.")
+					cmdutil.Fatal("JWT secret already exists. Use --upsert to recreate it.")
 				}
 				exists = true
 			}


### PR DESCRIPTION
**What does this PR do / why we need it**:

When `argocd-agentctl jwt create-key` is run and the JWT secret already exists, the error message instructs the user to re-run with `--force`. However, `create-key` does not define a `--force` flag — the flag it defines for recreating the key is `--upsert` (see `cmd/ctl/jwt.go`). Following the suggested instruction fails with `unknown flag: --force`.

The message appears to have been carried over from the `pki`/`ca` commands, which use `--force` for this purpose. This PR updates the message to point to the flag the command actually defines.

**Which issue(s) this PR fixes**:

None

**How to test changes / Special notes to the reviewer**:

1. Run `argocd-agentctl jwt create-key` against a cluster where the `argocd-agent-jwt` secret already exists.
2. The command fails with "JWT secret already exists. Use --upsert to recreate it." — and re-running with `--upsert` succeeds, whereas the previously suggested `--force` is rejected by the CLI.

**Checklist**

* [x] Documentation update is required by this PR (and has been updated) OR no documentation update is required.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the JWT secret creation error message to correctly instruct users to use `--upsert` when recreating an existing secret.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->