### PR TITLE
feat: translate AppProject roles in autonomous agent mode

### DIFF
--- a/agent/inbound.go
+++ b/agent/inbound.go
@@ -707,7 +707,7 @@ func (a *Agent) processIncomingResourceResyncEvent(ev *event.Event) error {
 			}
 		}
 
-		return resyncHandler.ProcessRequestUpdateEvent(a.context, agentName, incoming)
+		return resyncHandler.ProcessRequestUpdateEvent(a.context, agentName, a.mode, incoming)
 	case event.EventRequestResourceResync:
 		if a.mode != types.AgentModeManaged {
 			return fmt.Errorf("agent can only handle ResourceResync request in the managed mode")

--- a/docs/user-guide/appprojects.md
+++ b/docs/user-guide/appprojects.md
@@ -133,6 +133,11 @@ spec:
   - argocd
   sourceRepos:
   - "*"
+  roles:
+  - name: read-only
+    policies:
+    - "p, proj:my-project:read-only, applications, get, my-project/*, allow"
+  # (...)
 ```
 
 When this AppProject is created on an autonomous agent named `agent-production`, it will be transformed and appear on the principal as:
@@ -155,6 +160,11 @@ spec:
   - agent-production                 # Agent's namespace on principal
   sourceRepos:
   - "*"
+  roles:
+  - name: read-only
+    policies:
+    - "p, proj:agent-production-my-project:read-only, applications, get, agent-production-my-project/agent-production/*, allow" # Since the project '.name' was prefixed with the agent name above, the agent logic performs the same translation here. We also update the 5th field, including updating the namespace to principal cluster namespace.
+  # (...)
 ```
 
 ### Principal-Side Transformation
@@ -189,6 +199,17 @@ When an AppProject is received from an autonomous agent, the principal applies t
 
 4. **Namespace Mapping**: The project is placed in the Argo CD namespace on the principal (same as where other AppProjects reside)
 
+5. **Roles**: Role policies are translated so that RBAC references remain valid on the principal. For each policy line in `.spec.roles[].policies[]`:
+   - The `proj:<project>:<role>` subject is updated to use the prefixed project name
+   - The object field is transformed from `<project>/<app>` to `<project>/<agent-namespace>/<app>` (since Application-in-any-namespace is enabled on the principal for autonomous agents)
+   - Only policies targeting supported resource types (`applications`, `applicationsets`, `logs`, `exec`) are transformed; others are preserved as-is
+```
+   # Original (on agent):
+   p, proj:my-project:read-only, applications, get, my-project/*, allow
+   # Transformed (on principal):
+   p, proj:agent-production-my-project:read-only, applications, get, agent-production-my-project/agent-production/*, allow
+```
+
 ## Key Transformation Differences
 
 The transformation logic differs significantly between managed and autonomous agents:
@@ -206,6 +227,7 @@ The transformation logic differs significantly between managed and autonomous ag
 - **Destinations**: All destinations are transformed to point to the agent cluster (name = agent name, server = "*")
 - **Source Namespaces**: Replaced with the agent's namespace on the principal
 - **Name**: Prefixed with agent name to avoid conflicts
+- **Roles**: Policy lines are translated — project references are prefixed and object fields gain the agent namespace (`<project>/<app>` → `<project>/<agent-ns>/<app>`)
 
 ### Lifecycle Management
 

--- a/internal/manager/appproject/appproject.go
+++ b/internal/manager/appproject/appproject.go
@@ -27,13 +27,14 @@ import (
 	"github.com/argoproj-labs/argocd-agent/internal/cache"
 	"github.com/argoproj-labs/argocd-agent/internal/logging"
 	"github.com/argoproj-labs/argocd-agent/internal/manager"
+	"github.com/argoproj-labs/argocd-agent/pkg/types"
 	"github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
 	"github.com/argoproj/argo-cd/v3/util/glob"
 	"github.com/sirupsen/logrus"
 	"github.com/wI2L/jsondiff"
 	"k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
+	ktypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/retry"
 )
 
@@ -437,7 +438,7 @@ func (m *AppProjectManager) RevertAppProjectChanges(ctx context.Context, project
 		return false, fmt.Errorf("source UID annotation not found for resource")
 	}
 
-	if cachedSpec, ok := projectCache.Get(types.UID(sourceUID)); ok {
+	if cachedSpec, ok := projectCache.Get(ktypes.UID(sourceUID)); ok {
 		logCtx.Debugf("AppProject %s is available in agent cache", project.Name)
 
 		if isEqual := reflect.DeepEqual(cachedSpec, project.Spec); !isEqual {
@@ -519,7 +520,8 @@ func isDenyPattern(pattern string) bool {
 // AgentSpecificAppProject returns an agent specific version of the given AppProject
 // We don't have to check for deny patterns because we only construct the agent specific AppProject
 // if the agent name matches the AppProject's destinations.
-func AgentSpecificAppProject(appProject v1alpha1.AppProject, agent string, dstMapping bool) v1alpha1.AppProject {
+func AgentSpecificAppProject(appProject v1alpha1.AppProject, agent string, dstMapping bool, mode types.AgentMode) v1alpha1.AppProject {
+
 	// Only keep the destinations that are relevant to the given agent
 	filteredDst := []v1alpha1.ApplicationDestination{}
 	for _, dst := range appProject.Spec.Destinations {
@@ -553,8 +555,10 @@ func AgentSpecificAppProject(appProject v1alpha1.AppProject, agent string, dstMa
 		appProject.Spec.SourceNamespaces = nil
 	}
 
-	// Remove the roles since they are not relevant on the workload cluster
-	appProject.Spec.Roles = []v1alpha1.ProjectRole{}
+	if !mode.IsAutonomous() {
+		// Remove the roles since they are not relevant on the workload cluster
+		appProject.Spec.Roles = []v1alpha1.ProjectRole{}
+	}
 
 	return appProject
 }

--- a/internal/manager/appproject/appproject_test.go
+++ b/internal/manager/appproject/appproject_test.go
@@ -23,6 +23,7 @@ import (
 	appmock "github.com/argoproj-labs/argocd-agent/internal/backend/mocks"
 	"github.com/argoproj-labs/argocd-agent/internal/informer"
 	"github.com/argoproj-labs/argocd-agent/internal/manager"
+	"github.com/argoproj-labs/argocd-agent/pkg/types"
 	"github.com/sirupsen/logrus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -557,10 +558,12 @@ func TestAgentSpecificAppProject(t *testing.T) {
 		agent      string
 		want       v1alpha1.AppProject
 		dstMapping bool
+		mode       types.AgentMode
 	}{
 		{
 			name:       "filters destinations for matching agent",
 			dstMapping: false,
+			mode:       types.AgentModeManaged,
 			appProject: v1alpha1.AppProject{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-project",
@@ -612,6 +615,7 @@ func TestAgentSpecificAppProject(t *testing.T) {
 		{
 			name:       "matches multiple destinations with glob pattern",
 			dstMapping: false,
+			mode:       types.AgentModeManaged,
 			appProject: v1alpha1.AppProject{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "multi-dest-project",
@@ -669,6 +673,7 @@ func TestAgentSpecificAppProject(t *testing.T) {
 		{
 			name:       "no matching destinations",
 			dstMapping: false,
+			mode:       types.AgentModeManaged,
 			appProject: v1alpha1.AppProject{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "no-match-project",
@@ -714,6 +719,7 @@ func TestAgentSpecificAppProject(t *testing.T) {
 		{
 			name:       "empty destinations and roles",
 			dstMapping: false,
+			mode:       types.AgentModeManaged,
 			appProject: v1alpha1.AppProject{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "empty-project",
@@ -741,6 +747,7 @@ func TestAgentSpecificAppProject(t *testing.T) {
 		{
 			name:       "agent name matches wildcard destination",
 			dstMapping: false,
+			mode:       types.AgentModeManaged,
 			appProject: v1alpha1.AppProject{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "wildcard-project",
@@ -779,6 +786,7 @@ func TestAgentSpecificAppProject(t *testing.T) {
 		{
 			name:       "preserves source namespaces for destination-based mapping",
 			dstMapping: true,
+			mode:       types.AgentModeManaged,
 			appProject: v1alpha1.AppProject{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "wildcard-project",
@@ -814,11 +822,65 @@ func TestAgentSpecificAppProject(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:       "autonomous mode preserves source namespaces and roles",
+			dstMapping: false,
+			mode:       types.AgentModeAutonomous,
+			appProject: v1alpha1.AppProject{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "auto-project",
+					Namespace: "argocd",
+				},
+				Spec: v1alpha1.AppProjectSpec{
+					Destinations: []v1alpha1.ApplicationDestination{
+						{
+							Name:      "cluster-prod",
+							Namespace: "default",
+							Server:    "https://prod-cluster.example.com",
+						},
+					},
+					SourceNamespaces: []string{"argocd", "apps"},
+					Roles: []v1alpha1.ProjectRole{
+						{
+							Name: "admin",
+							Policies: []string{
+								"p, proj:auto-project:admin, applications, *, auto-project/*, allow",
+							},
+						},
+					},
+				},
+			},
+			agent: "cluster-prod",
+			want: v1alpha1.AppProject{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "auto-project",
+					Namespace: "argocd",
+				},
+				Spec: v1alpha1.AppProjectSpec{
+					Destinations: []v1alpha1.ApplicationDestination{
+						{
+							Name:      "in-cluster",
+							Namespace: "default",
+							Server:    "https://kubernetes.default.svc",
+						},
+					},
+					SourceNamespaces: nil,
+					Roles: []v1alpha1.ProjectRole{
+						{
+							Name: "admin",
+							Policies: []string{
+								"p, proj:auto-project:admin, applications, *, auto-project/*, allow",
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := AgentSpecificAppProject(tt.appProject, tt.agent, tt.dstMapping)
+			got := AgentSpecificAppProject(tt.appProject, tt.agent, tt.dstMapping, tt.mode)
 			assert.Equal(t, tt.want, got)
 		})
 	}

--- a/internal/resync/resync.go
+++ b/internal/resync/resync.go
@@ -27,6 +27,7 @@ import (
 	"github.com/argoproj-labs/argocd-agent/internal/manager"
 	"github.com/argoproj-labs/argocd-agent/internal/manager/appproject"
 	"github.com/argoproj-labs/argocd-agent/internal/resources"
+	"github.com/argoproj-labs/argocd-agent/pkg/types"
 	"github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
 	cloudevent "github.com/cloudevents/sdk-go/v2/event"
 	"github.com/sirupsen/logrus"
@@ -57,6 +58,7 @@ type RequestHandler struct {
 
 	log *logrus.Entry
 
+	// role refers to the role of the current process, either 'principal'/'agent'
 	role manager.ManagerRole
 
 	namespace string
@@ -280,10 +282,23 @@ func (r *RequestHandler) sendRequestUpdate(ctx context.Context, resource resourc
 	return nil
 }
 
-func (r *RequestHandler) ProcessRequestUpdateEvent(ctx context.Context, agentName string, reqUpdate *event.RequestUpdate) error {
+func (r *RequestHandler) ProcessRequestUpdateEvent(ctx context.Context, agentName string, agentMode types.AgentMode, reqUpdate *event.RequestUpdate) error {
 	logCtx := logCtxForRequestUpdate(r.log, reqUpdate)
 
 	logCtx.Trace("Received a request for the resource update event")
+
+	// Sanity test:
+	// Principal should only accept 'request-update' events from managed agent
+	// Autonomous agent can accept request-update events
+	// Managed agent should never accept request-update events
+	// Agent mode should be set
+	if r.role == manager.ManagerRolePrincipal && agentMode != types.AgentModeManaged {
+		return fmt.Errorf("principal should only process requestUpdate events from managed mode agents")
+	} else if r.role == manager.ManagerRoleAgent && agentMode != types.AgentModeAutonomous {
+		return fmt.Errorf("managed mode agents should not process requestUpdate events; only autonomous agents should process them")
+	} else if agentMode == types.AgentModeUnknown {
+		return fmt.Errorf("agent mode is unknown")
+	}
 
 	gvr, err := getGroupVersionResource(reqUpdate.Kind)
 	if err != nil {
@@ -356,10 +371,20 @@ func (r *RequestHandler) ProcessRequestUpdateEvent(ctx context.Context, agentNam
 
 	logCtx.Trace("Checksums do not match. Sending a specUpdate event")
 
-	return r.handleUpdatedResource(logCtx, reqUpdate, res, agentName)
+	return r.handleUpdatedResource(logCtx, reqUpdate, res, agentName, agentMode)
 }
 
-func (r *RequestHandler) handleUpdatedResource(logCtx *logrus.Entry, reqUpdate *event.RequestUpdate, res *unstructured.Unstructured, agentName string) error {
+func (r *RequestHandler) handleUpdatedResource(logCtx *logrus.Entry, reqUpdate *event.RequestUpdate, res *unstructured.Unstructured, agentName string, agentMode types.AgentMode) error {
+
+	// Sanity test the context of this function call
+	if r.role == manager.ManagerRolePrincipal && agentMode != types.AgentModeManaged {
+		return fmt.Errorf("principal should only send specupdates to managed mode agents, not autonomous")
+	} else if r.role == manager.ManagerRoleAgent && agentMode != types.AgentModeAutonomous {
+		return fmt.Errorf("managed mode agents should not send specupdates; only autonomous agents")
+	} else if agentMode == types.AgentModeUnknown {
+		return fmt.Errorf("agent mode is unknown")
+	}
+
 	resBytes, err := res.MarshalJSON()
 	if err != nil {
 		return err
@@ -385,7 +410,7 @@ func (r *RequestHandler) handleUpdatedResource(logCtx *logrus.Entry, reqUpdate *
 			return err
 		}
 
-		agentAppProject := appproject.AgentSpecificAppProject(*appProject, agentName, r.destinationBasedMapping)
+		agentAppProject := appproject.AgentSpecificAppProject(*appProject, agentName, r.destinationBasedMapping, agentMode)
 		ev := r.events.AppProjectEvent(event.SpecUpdate, &agentAppProject)
 		logCtx.Trace("Sending a request to update the appProject")
 		r.sendQ.Add(ev)

--- a/internal/resync/resync_test.go
+++ b/internal/resync/resync_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/argoproj-labs/argocd-agent/internal/manager"
 	"github.com/argoproj-labs/argocd-agent/internal/queue"
 	"github.com/argoproj-labs/argocd-agent/internal/resources"
+	"github.com/argoproj-labs/argocd-agent/pkg/types"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -571,7 +572,7 @@ func Test_ProcessRequestUpdateEvent(t *testing.T) {
 			Checksum:  checksum,
 		}
 
-		err = handler.ProcessRequestUpdateEvent(ctx, testAgentName, reqUpdate)
+		err = handler.ProcessRequestUpdateEvent(ctx, testAgentName, types.AgentModeAutonomous, reqUpdate)
 		assert.Nil(t, err)
 		assert.Zero(t, handler.sendQ.Len())
 
@@ -586,7 +587,7 @@ func Test_ProcessRequestUpdateEvent(t *testing.T) {
 			Kind:      "Application",
 		}
 
-		err := handler.ProcessRequestUpdateEvent(ctx, testAgentName, reqUpdate)
+		err := handler.ProcessRequestUpdateEvent(ctx, testAgentName, types.AgentModeAutonomous, reqUpdate)
 		assert.Nil(t, err)
 
 		ev, shutdown := handler.sendQ.Get()
@@ -610,7 +611,7 @@ func Test_ProcessRequestUpdateEvent(t *testing.T) {
 			Checksum:  []byte("invalid-checksum"),
 		}
 
-		err = handler.ProcessRequestUpdateEvent(ctx, testAgentName, reqUpdate)
+		err = handler.ProcessRequestUpdateEvent(ctx, testAgentName, types.AgentModeAutonomous, reqUpdate)
 		assert.Nil(t, err)
 
 		ev, shutdown := handler.sendQ.Get()
@@ -713,7 +714,7 @@ func Test_ProcessRequestUpdateEvent_GPGKey(t *testing.T) {
 			Checksum:  checksum,
 		}
 
-		err = handler.ProcessRequestUpdateEvent(ctx, testAgentName, reqUpdate)
+		err = handler.ProcessRequestUpdateEvent(ctx, testAgentName, types.AgentModeAutonomous, reqUpdate)
 		assert.Nil(t, err)
 		assert.Zero(t, handler.sendQ.Len())
 	})
@@ -728,7 +729,7 @@ func Test_ProcessRequestUpdateEvent_GPGKey(t *testing.T) {
 			Kind:      "GPGKey",
 		}
 
-		err := handler.ProcessRequestUpdateEvent(ctx, testAgentName, reqUpdate)
+		err := handler.ProcessRequestUpdateEvent(ctx, testAgentName, types.AgentModeAutonomous, reqUpdate)
 		assert.Nil(t, err)
 
 		ev, shutdown := handler.sendQ.Get()
@@ -755,7 +756,7 @@ func Test_ProcessRequestUpdateEvent_GPGKey(t *testing.T) {
 			Checksum:  []byte("invalid-checksum"),
 		}
 
-		err = handler.ProcessRequestUpdateEvent(ctx, testAgentName, reqUpdate)
+		err = handler.ProcessRequestUpdateEvent(ctx, testAgentName, types.AgentModeAutonomous, reqUpdate)
 		assert.Nil(t, err)
 
 		ev, shutdown := handler.sendQ.Get()
@@ -796,7 +797,7 @@ func Test_ProcessRequestUpdateEvent_PeerNamespaceRemap(t *testing.T) {
 			Checksum:  checksum,
 		}
 
-		err = handler.ProcessRequestUpdateEvent(ctx, testAgentName, reqUpdate)
+		err = handler.ProcessRequestUpdateEvent(ctx, testAgentName, types.AgentModeManaged, reqUpdate)
 		assert.Nil(t, err)
 		assert.Zero(t, handler.sendQ.Len(), "checksum matches, nothing to send")
 	})
@@ -817,7 +818,7 @@ func Test_ProcessRequestUpdateEvent_PeerNamespaceRemap(t *testing.T) {
 			Kind:      "Application",
 		}
 
-		err := handler.ProcessRequestUpdateEvent(ctx, testAgentName, reqUpdate)
+		err := handler.ProcessRequestUpdateEvent(ctx, testAgentName, types.AgentModeManaged, reqUpdate)
 		assert.Nil(t, err)
 
 		ev, shutdown := handler.sendQ.Get()
@@ -850,7 +851,7 @@ func Test_ProcessRequestUpdateEvent_PeerNamespaceRemap(t *testing.T) {
 			Checksum:  checksum,
 		}
 
-		err = handler.ProcessRequestUpdateEvent(ctx, testAgentName, reqUpdate)
+		err = handler.ProcessRequestUpdateEvent(ctx, testAgentName, types.AgentModeManaged, reqUpdate)
 		assert.Nil(t, err)
 		assert.Zero(t, handler.sendQ.Len(), "checksum matches in tenant namespace, nothing to send")
 	})
@@ -883,7 +884,7 @@ func Test_ProcessRequestUpdateEvent_PeerNamespaceRemap(t *testing.T) {
 			Checksum:  checksum,
 		}
 
-		err = handler.ProcessRequestUpdateEvent(ctx, testAgentName, reqUpdate)
+		err = handler.ProcessRequestUpdateEvent(ctx, testAgentName, types.AgentModeManaged, reqUpdate)
 		assert.Nil(t, err)
 		assert.Zero(t, handler.sendQ.Len(), "checksum matches in agent namespace, nothing to send")
 	})

--- a/principal/callbacks.go
+++ b/principal/callbacks.go
@@ -331,7 +331,7 @@ func (s *Server) newAppProjectCallback(outbound *v1alpha1.AppProject) {
 			continue
 		}
 
-		agentAppProject := appproject.AgentSpecificAppProject(*outbound, agent, s.destinationBasedMapping)
+		agentAppProject := appproject.AgentSpecificAppProject(*outbound, agent, s.destinationBasedMapping, types.AgentModeManaged)
 		ev := s.events.AppProjectEvent(event.Create, &agentAppProject)
 		// Inject trace context into the event for propagation to agent
 		s.stampEvent(ctx, ev)
@@ -408,7 +408,9 @@ func (s *Server) updateAppProjectCallback(old *v1alpha1.AppProject, new *v1alpha
 		logCtx.Trace("Created a new queue pair for the existing agent namespace")
 	}
 
-	s.syncAppProjectUpdatesToAgents(ctx, old, new, logCtx)
+	if !s.isAppProjectFromAutonomousAgent(new) {
+		s.syncAppProjectUpdatesToAgents(ctx, old, new, logCtx)
+	} // For the autonomous case, on principal, there is no need to send AppProject updates to autonomous agents.
 
 	ev := s.events.AppProjectEvent(event.SpecUpdate, new)
 	s.ha.ForwardEventForReplication(event.New(ev, targets.AppProject), new.Namespace, replication.DirectionOutbound)
@@ -480,7 +482,7 @@ func (s *Server) deleteAppProjectCallback(outbound *v1alpha1.AppProject) {
 			continue
 		}
 
-		agentAppProject := appproject.AgentSpecificAppProject(*outbound, agent, s.destinationBasedMapping)
+		agentAppProject := appproject.AgentSpecificAppProject(*outbound, agent, s.destinationBasedMapping, types.AgentModeManaged)
 		ev := s.events.AppProjectEvent(event.Delete, &agentAppProject)
 		// Inject trace context into the event for propagation to agent
 		s.stampEvent(ctx, ev)
@@ -804,6 +806,11 @@ func (s *Server) mapAppProjectToAgents(appProject v1alpha1.AppProject) map[strin
 // syncAppProjectUpdatesToAgents sends the AppProject update events to the relevant clusters.
 // It sends delete events to the clusters that no longer match the given AppProject.
 func (s *Server) syncAppProjectUpdatesToAgents(ctx context.Context, old, new *v1alpha1.AppProject, logCtx *logrus.Entry) {
+
+	if s.isAppProjectFromAutonomousAgent(new) || s.isAppProjectFromAutonomousAgent(old) {
+		return
+	}
+
 	oldAgents := s.mapAppProjectToAgents(*old)
 	newAgents := s.mapAppProjectToAgents(*new)
 
@@ -821,7 +828,7 @@ func (s *Server) syncAppProjectUpdatesToAgents(ctx context.Context, old, new *v1
 			continue
 		}
 
-		agentAppProject := appproject.AgentSpecificAppProject(*new, agent, s.destinationBasedMapping)
+		agentAppProject := appproject.AgentSpecificAppProject(*new, agent, s.destinationBasedMapping, types.AgentModeManaged)
 		ev := s.events.AppProjectEvent(event.Delete, &agentAppProject)
 		// Inject trace context into the event for propagation to agent
 		s.stampEvent(ctx, ev)
@@ -842,7 +849,7 @@ func (s *Server) syncAppProjectUpdatesToAgents(ctx context.Context, old, new *v1
 			continue
 		}
 
-		agentAppProject := appproject.AgentSpecificAppProject(*new, agent, s.destinationBasedMapping)
+		agentAppProject := appproject.AgentSpecificAppProject(*new, agent, s.destinationBasedMapping, types.AgentModeManaged)
 		ev := s.events.AppProjectEvent(event.SpecUpdate, &agentAppProject)
 		// Inject trace context into the event for propagation to agent
 		s.stampEvent(ctx, ev)

--- a/principal/event.go
+++ b/principal/event.go
@@ -17,6 +17,7 @@ package principal
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/argoproj-labs/argocd-agent/internal/backend"
@@ -423,6 +424,83 @@ func (s *Server) processApplicationEvent(ctx context.Context, agentName string, 
 	return nil
 }
 
+// processAppProjectEventRoleLine processes Argo CD RBAC line from AppProject resource of 'spec.roles[].policies[]', and returns a version of that line that has been translated for the target environment (for example, translating an autonomous agent AppProject to principal Argo CD)
+// - If we can't translate the line (for example, it's not applicable or doesn't have the expected format), it is returned as-is
+// - Only used for translating AppProjects from autonomous mode agents.
+// params:
+// - policyLineInputParam - As above
+// - roleName - Value from .spec.roles[x].name
+// - newAppprojectName - translated AppProject resource name
+// - oldAppprojectName - untranslated AppProject resource name
+// - autonomousAgentApplicationNamespace is the namespace (on principal cluster) within which Applications from autonomous agent cluster are stored.
+// For reference:
+// - https://argo-cd.readthedocs.io/en/stable/user-guide/projects/#configuring-rbac-with-projects
+// - https://argo-cd.readthedocs.io/en/stable/operator-manual/rbac/
+func processAppProjectEventRoleLine(policyLineInputParam string, roleName string, newAppprojectName string, oldAppprojectName string, autonomousAgentApplicationNamespace string) string {
+	// Example policy line:
+	// p, proj:my-project:read-only, applications, get, my-project/*, allow
+	fields := strings.Split(policyLineInputParam, ",")
+	if len(fields) != 6 {
+		return policyLineInputParam
+	}
+
+	if strings.TrimSpace(fields[0]) != "p" { // Sanity test
+		return policyLineInputParam
+	}
+
+	// We only attempt to transform these resources, return for any other resource
+	resourceType := strings.TrimSpace(fields[2])
+	switch resourceType {
+	case "applications", "applicationsets", "logs", "exec":
+	default:
+		return policyLineInputParam
+	}
+
+	// Only process 'proj:' prefixed lines
+	roleNameScopedToProject := strings.TrimSpace(fields[1])
+	if !strings.HasPrefix(roleNameScopedToProject, "proj:") {
+		return policyLineInputParam // This function doesn't touch non-'proj:' lines, so just return
+	}
+
+	// Replace field 1 if it's targeting a project (has 'proj:' prefix), AND that project matches oldAppprojectName, AND the role matches rolename
+	parts := strings.SplitN(roleNameScopedToProject, ":", 3)
+	if len(parts) == 3 {
+		if parts[1] != oldAppprojectName {
+			return policyLineInputParam // Unexpected value, return the line unmodified
+		}
+		if parts[2] != roleName {
+			return policyLineInputParam // Unexpected value, return the line unmodified
+		}
+		// We've verified it matches 'proj:(proj name):(role name)', so we are safe to replace the proj value.
+		parts[1] = newAppprojectName
+		fields[1] = strings.Replace(fields[1], roleNameScopedToProject, strings.Join(parts, ":"), 1)
+	}
+
+	// Since Application in any namespace is enabled on principal in the autonomous case, the field must have this form:
+	// <app-project>/<app-ns>/<app-name>
+	// e.g. example-project/app-namespace/my-app
+	//
+	// We expect it will have this value pre-transform:
+	// <app-project>/<app-name>
+	objectValue := strings.TrimSpace(fields[4])
+
+	// Replace field 4, from <app-project>/<app-name> -> <app-project>/<app-ns>/<app-name>, where app-ns is 'autonomousAgentApplicationNamespace'
+	if parts := strings.Split(objectValue, "/"); len(parts) == 2 {
+		projPart := parts[0]
+
+		if projPart == oldAppprojectName { // Update appProject only value only if it matches
+			projPart = newAppprojectName // appproject name on autonomous cluster -> appproject name on principal cluster
+		} else {
+			return policyLineInputParam // No match, so return the line unmodified
+		}
+
+		fields[4] = " " + projPart + "/" + autonomousAgentApplicationNamespace + "/" + parts[1]
+	}
+
+	return strings.Join(fields, ",")
+
+}
+
 func (s *Server) processAppProjectEvent(ctx context.Context, agentName string, ev *cloudevents.Event) error {
 	incoming := &v1alpha1.AppProject{}
 	err := ev.DataAs(incoming)
@@ -440,6 +518,8 @@ func (s *Server) processAppProjectEvent(ctx context.Context, agentName string, e
 		"resource_id": event.ResourceID(ev),
 		"event_id":    event.EventID(ev),
 	})
+
+	eventAppProjectIncomingName := incoming.Name
 
 	// AppProjects coming from different autonomous agents could have the same name,
 	// so we prefix the project name with the agent name
@@ -460,6 +540,22 @@ func (s *Server) processAppProjectEvent(ctx context.Context, agentName string, e
 			incoming.Spec.Destinations[i].Name = agentName
 			incoming.Spec.Destinations[i].Server = "*"
 		}
+
+		// Translate ProjectRole policies from autonomous context to principal context (see processAppProjectEventRoleLine for details)
+		newRoles := make([]v1alpha1.ProjectRole, 0)
+		for _, role := range incoming.Spec.Roles {
+
+			newPolicies := make([]string, 0)
+			for _, policy := range role.Policies {
+
+				policy = processAppProjectEventRoleLine(policy, role.Name, incoming.Name, eventAppProjectIncomingName, agentName)
+				newPolicies = append(newPolicies, policy)
+			}
+			role.Policies = newPolicies
+
+			newRoles = append(newRoles, role)
+		}
+		incoming.Spec.Roles = newRoles
 	}
 
 	switch ev.Type() {
@@ -768,7 +864,7 @@ func (s *Server) processIncomingResourceResyncEvent(ctx context.Context, agentNa
 			incoming.Name = prefixedName
 		}
 
-		return resyncHandler.ProcessRequestUpdateEvent(ctx, agentName, incoming)
+		return resyncHandler.ProcessRequestUpdateEvent(ctx, agentName, agentMode, incoming)
 	case event.EventRequestResourceResync.String():
 		if agentMode != types.AgentModeAutonomous {
 			return fmt.Errorf("principal can only handle ResourceResync request in autonomous mode")

--- a/principal/event_test.go
+++ b/principal/event_test.go
@@ -16,6 +16,7 @@ package principal
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -1416,6 +1417,134 @@ func Test_processAppProjectEvent(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, principalNamespace, createdProject.Namespace, "Project should be created in principal namespace, not agent namespace")
 	})
+
+	t.Run("Create AppProject in autonomous mode translates role policies", func(t *testing.T) {
+		agentName := "agent-auto"
+
+		project := &v1alpha1.AppProject{
+			ObjectMeta: v1.ObjectMeta{
+				Name:      "my-project",
+				Namespace: "argocd",
+			},
+			Spec: v1alpha1.AppProjectSpec{
+				SourceRepos: []string{"*"},
+				Destinations: []v1alpha1.ApplicationDestination{
+					{Name: "cluster", Server: "https://cluster.example.com"},
+				},
+				Roles: []v1alpha1.ProjectRole{
+					{
+						Name: "read-only",
+						Policies: []string{
+							"p, proj:my-project:read-only, applications, get, my-project/*, allow",
+							"p, proj:my-project:read-only, logs, get, my-project/*, allow",
+						},
+					},
+					{
+						Name: "deployer",
+						Policies: []string{
+							"p, proj:my-project:deployer, applications, sync, my-project/my-app, allow",
+						},
+					},
+				},
+			},
+		}
+
+		fac := kube.NewKubernetesFakeClientWithApps("argocd")
+		s, err := NewServer(context.Background(), fac, "argocd", WithGeneratedTokenSigningKey(), WithRedisProxyDisabled())
+		require.NoError(t, err)
+		s.setAgentMode(agentName, types.AgentModeAutonomous)
+
+		ev := cloudevents.NewEvent()
+		ev.SetDataSchema("appproject")
+		ev.SetType(event.Create.String())
+		err = ev.SetData(cloudevents.ApplicationJSON, project)
+		require.NoError(t, err)
+
+		err = s.processAppProjectEvent(context.Background(), agentName, &ev)
+		assert.NoError(t, err)
+
+		prefixedName, err := agentPrefixedProjectName("my-project", agentName)
+		require.NoError(t, err)
+
+		created, err := fac.ApplicationsClientset.ArgoprojV1alpha1().AppProjects("argocd").Get(context.Background(), prefixedName, v1.GetOptions{})
+		require.NoError(t, err)
+
+		require.Len(t, created.Spec.Roles, 2)
+
+		readOnly := created.Spec.Roles[0]
+		assert.Equal(t, "read-only", readOnly.Name)
+		require.Len(t, readOnly.Policies, 2)
+		assert.Equal(t, "p, proj:"+prefixedName+":read-only, applications, get, agent-auto-my-project/"+agentName+"/*, allow", readOnly.Policies[0])
+		assert.Equal(t, "p, proj:"+prefixedName+":read-only, logs, get, agent-auto-my-project/"+agentName+"/*, allow", readOnly.Policies[1])
+
+		deployer := created.Spec.Roles[1]
+		assert.Equal(t, "deployer", deployer.Name)
+		require.Len(t, deployer.Policies, 1)
+		assert.Equal(t, "p, proj:"+prefixedName+":deployer, applications, sync, agent-auto-my-project/"+agentName+"/my-app, allow", deployer.Policies[0])
+	})
+
+	t.Run("Update AppProject in autonomous mode translates role policies", func(t *testing.T) {
+		agentName := "agent-auto"
+		prefixedName, err := agentPrefixedProjectName("my-project", agentName)
+		require.NoError(t, err)
+
+		existingProject := &v1alpha1.AppProject{
+			ObjectMeta: v1.ObjectMeta{
+				Name:      prefixedName,
+				Namespace: "argocd",
+			},
+			Spec: v1alpha1.AppProjectSpec{
+				SourceRepos:      []string{"*"},
+				SourceNamespaces: []string{agentName},
+				Destinations: []v1alpha1.ApplicationDestination{
+					{Name: agentName, Server: "*"},
+				},
+			},
+		}
+
+		fac := kube.NewKubernetesFakeClientWithApps("argocd", existingProject)
+		s, err := NewServer(context.Background(), fac, "argocd", WithGeneratedTokenSigningKey(), WithRedisProxyDisabled())
+		require.NoError(t, err)
+		s.setAgentMode(agentName, types.AgentModeAutonomous)
+
+		updatedProject := &v1alpha1.AppProject{
+			ObjectMeta: v1.ObjectMeta{
+				Name:      "my-project",
+				Namespace: "argocd",
+			},
+			Spec: v1alpha1.AppProjectSpec{
+				SourceRepos: []string{"*"},
+				Destinations: []v1alpha1.ApplicationDestination{
+					{Name: "cluster", Server: "https://cluster.example.com"},
+				},
+				Roles: []v1alpha1.ProjectRole{
+					{
+						Name: "admin",
+						Policies: []string{
+							"p, proj:my-project:admin, applications, *, my-project/*, allow",
+						},
+					},
+				},
+			},
+		}
+
+		ev := cloudevents.NewEvent()
+		ev.SetDataSchema("appproject")
+		ev.SetType(event.SpecUpdate.String())
+		err = ev.SetData(cloudevents.ApplicationJSON, updatedProject)
+		require.NoError(t, err)
+
+		err = s.processAppProjectEvent(context.Background(), agentName, &ev)
+		assert.NoError(t, err)
+
+		got, err := fac.ApplicationsClientset.ArgoprojV1alpha1().AppProjects("argocd").Get(context.Background(), prefixedName, v1.GetOptions{})
+		require.NoError(t, err)
+
+		require.Len(t, got.Spec.Roles, 1)
+		assert.Equal(t, "admin", got.Spec.Roles[0].Name)
+		require.Len(t, got.Spec.Roles[0].Policies, 1)
+		assert.Equal(t, "p, proj:"+prefixedName+":admin, applications, *, agent-auto-my-project/"+agentName+"/*, allow", got.Spec.Roles[0].Policies[0])
+	})
 }
 
 func Test_processResourceEventResponse(t *testing.T) {
@@ -1583,6 +1712,79 @@ func Test_processIncomingResourceResyncEvent(t *testing.T) {
 		err = s.processIncomingResourceResyncEvent(ctx, agentName, ev)
 		assert.Equal(t, expected, err.Error())
 	})
+}
+
+func Test_processAppProjectEventRoleLine(t *testing.T) {
+
+	for _, resourceType := range []string{"applications", "applicationsets", "logs", "exec"} {
+		t.Run(fmt.Sprintf("Supported resource type %s is translated", resourceType), func(t *testing.T) {
+			input := fmt.Sprintf("p, proj:my-project:read-only, %s, get, my-project/*, allow", resourceType)
+			expected := fmt.Sprintf("p, proj:agent-my-project:read-only, %s, get, agent-my-project/agent-ns/*, allow", resourceType)
+			result := processAppProjectEventRoleLine(input, "read-only", "agent-my-project", "my-project", "agent-ns")
+			assert.Equal(t, expected, result)
+		})
+	}
+
+	t.Run("Unsupported resource type is returned as-is", func(t *testing.T) {
+		input := "p, proj:my-project:read-only, repositories, get, my-project/*, allow"
+		result := processAppProjectEventRoleLine(input, "read-only", "agent-my-project", "my-project", "agent-ns")
+		assert.Equal(t, input, result)
+	})
+
+	t.Run("Wrong number of fields returns input as-is", func(t *testing.T) {
+		input := "p, proj:my-project:read-only, applications, get, my-project/*"
+		result := processAppProjectEventRoleLine(input, "read-only", "agent-my-project", "my-project", "agent-ns")
+		assert.Equal(t, input, result)
+	})
+
+	t.Run("Non-p policy type returns input as-is", func(t *testing.T) {
+		input := "g, admin, role:admin"
+		result := processAppProjectEventRoleLine(input, "read-only", "agent-my-project", "my-project", "agent-ns")
+		assert.Equal(t, input, result)
+	})
+
+	t.Run("Project name mismatch in field 1 returns input as-is", func(t *testing.T) {
+		input := "p, proj:other-project:read-only, applications, get, my-project/*, allow"
+		result := processAppProjectEventRoleLine(input, "read-only", "agent-my-project", "my-project", "agent-ns")
+		assert.Equal(t, input, result)
+	})
+
+	t.Run("Role name mismatch in field 1 returns input as-is", func(t *testing.T) {
+		input := "p, proj:my-project:admin, applications, get, my-project/*, allow"
+		result := processAppProjectEventRoleLine(input, "read-only", "agent-my-project", "my-project", "agent-ns")
+		assert.Equal(t, input, result)
+	})
+
+	t.Run("Non-proj prefix in field 1 leaves it unchanged", func(t *testing.T) {
+		input := "p, role:my-role, applications, get, my-project/*, allow"
+		result := processAppProjectEventRoleLine(input, "read-only", "agent-my-project", "my-project", "agent-ns")
+		assert.Equal(t, "p, role:my-role, applications, get, my-project/*, allow", result)
+	})
+
+	t.Run("Field 4 with three parts is not transformed", func(t *testing.T) {
+		input := "p, proj:my-project:read-only, applications, get, my-project/ns/app, allow"
+		result := processAppProjectEventRoleLine(input, "read-only", "agent-my-project", "my-project", "agent-ns")
+		assert.Equal(t, "p, proj:agent-my-project:read-only, applications, get, my-project/ns/app, allow", result)
+	})
+
+	t.Run("Field 4 with single value is not transformed", func(t *testing.T) {
+		input := "p, proj:my-project:read-only, applications, get, *, allow"
+		result := processAppProjectEventRoleLine(input, "read-only", "agent-my-project", "my-project", "agent-ns")
+		assert.Equal(t, "p, proj:agent-my-project:read-only, applications, get, *, allow", result)
+	})
+
+	t.Run("Deny action is preserved", func(t *testing.T) {
+		input := "p, proj:my-project:read-only, applications, get, my-project/*, deny"
+		result := processAppProjectEventRoleLine(input, "read-only", "agent-my-project", "my-project", "agent-ns")
+		assert.Equal(t, "p, proj:agent-my-project:read-only, applications, get, agent-my-project/agent-ns/*, deny", result)
+	})
+
+	t.Run("Specific app name in field 4 is preserved", func(t *testing.T) {
+		input := "p, proj:my-project:deployer, applications, sync, my-project/my-app, allow"
+		result := processAppProjectEventRoleLine(input, "deployer", "agent-my-project", "my-project", "agent-ns")
+		assert.Equal(t, "p, proj:agent-my-project:deployer, applications, sync, agent-my-project/agent-ns/my-app, allow", result)
+	})
+
 }
 
 func Test_agentPrefixedProjectName(t *testing.T) {

--- a/principal/server.go
+++ b/principal/server.go
@@ -941,7 +941,7 @@ func (s *Server) handleResyncOnConnect(agent types.Agent) error {
 			// When the agent is down, the informer could've dropped events since it doesn't know anything about the agent.
 			// So, we send the current state of AppProjects/Repositories to the agent after it reconnects.
 			logCtx.Trace("Sending current state of AppProjects and Repositories to the agent")
-			if err := s.sendCurrentStateToAgent(agent.Name()); err != nil {
+			if err := s.sendCurrentStateToAgent(agent); err != nil {
 				return fmt.Errorf("failed to send current state to agent: %w", err)
 			}
 		}
@@ -984,11 +984,11 @@ func (s *Server) handleResyncOnConnect(agent types.Agent) error {
 		sendQ.Add(ev)
 		logCtx.Trace("Sent a request for SyncedResourceList")
 	} else {
-		// When the principal restarts, the infomer might start processing the events before the agent is connected.
+		// When the principal restarts, the informer might start processing the events before the agent is connected.
 		// This may lead to principal dropping those events since it doesn't know anything about the agent yet.
 		// So, we send the current state of AppProjects and Repositories to the agent. This ensures that the agent is in sync with the principal.
 		logCtx.Trace("Sending current state of AppProjects and Repositories to the agent")
-		if err := s.sendCurrentStateToAgent(agent.Name()); err != nil {
+		if err := s.sendCurrentStateToAgent(agent); err != nil {
 			return fmt.Errorf("failed to send current state to agent: %w", err)
 		}
 
@@ -1008,15 +1008,22 @@ func (s *Server) handleResyncOnConnect(agent types.Agent) error {
 	return nil
 }
 
-func (s *Server) sendCurrentStateToAgent(agent string) error {
+func (s *Server) sendCurrentStateToAgent(agentParam types.Agent) error {
+
+	if agentParam.Mode() == types.AgentModeAutonomous.String() {
+		return fmt.Errorf("sending current state to autonomous agent is not supported")
+	}
+
+	agentName := agentParam.Name()
+
 	ctx, span := tracing.Tracer().Start(s.ctx, "sendCurrentStateToAgent", trace.WithAttributes(
-		tracing.AttrAgentName.String(agent),
+		tracing.AttrAgentName.String(agentName),
 		tracing.AttrComponentType.String("principal"),
 		tracing.AttrEventType.String(event.SpecUpdate.String()),
 	))
 	defer span.End()
 
-	sendQ := s.queues.SendQ(agent)
+	sendQ := s.queues.SendQ(agentName)
 	// Send all the AppProjects to the agent
 	appProjects, err := s.projectManager.List(s.ctx, backend.AppProjectSelector{Namespace: s.namespace})
 	if err != nil {
@@ -1031,7 +1038,7 @@ func (s *Server) sendCurrentStateToAgent(agent string) error {
 			}
 		}
 
-		if !appproject.DoesAgentMatchWithProject(agent, appProject, s.destinationBasedMapping) {
+		if !appproject.DoesAgentMatchWithProject(agentName, appProject, s.destinationBasedMapping) {
 			continue
 		}
 
@@ -1040,7 +1047,7 @@ func (s *Server) sendCurrentStateToAgent(agent string) error {
 			continue
 		}
 
-		agentAppProject := appproject.AgentSpecificAppProject(appProject, agent, s.destinationBasedMapping)
+		agentAppProject := appproject.AgentSpecificAppProject(appProject, agentName, s.destinationBasedMapping, types.AgentModeManaged)
 		ev := s.events.AppProjectEvent(event.SpecUpdate, &agentAppProject)
 		tracing.PopulateSpanFromObject(span, &appProject)
 		tracing.InjectTraceContext(ctx, ev)
@@ -1077,12 +1084,12 @@ func (s *Server) sendCurrentStateToAgent(agent string) error {
 				continue
 			}
 
-			if !appproject.DoesAgentMatchWithProject(agent, project, s.destinationBasedMapping) {
+			if !appproject.DoesAgentMatchWithProject(agentName, project, s.destinationBasedMapping) {
 				continue
 			}
 
 			s.projectToRepos.Add(projectName, repository.Name)
-			s.repoToAgents.Add(repository.Name, agent)
+			s.repoToAgents.Add(repository.Name, agentName)
 
 			ev := s.events.RepositoryEvent(event.SpecUpdate, &repository)
 			tracing.PopulateSpanFromObject(span, &repository)

--- a/principal/server_test.go
+++ b/principal/server_test.go
@@ -356,7 +356,7 @@ func Test_SendCurrentStateToAgent(t *testing.T) {
 		mockRepoBackend.On("List", mock.Anything, mock.Anything).Return([]corev1.Secret{}, nil)
 
 		s := newServer(t, mockProjBackend, mockRepoBackend)
-		err := s.sendCurrentStateToAgent(agentName)
+		err := s.sendCurrentStateToAgent(types.NewAgent(agentName, types.AgentModeManaged.String()))
 		require.NoError(t, err)
 
 		sendQ := s.queues.SendQ(agentName)
@@ -385,7 +385,7 @@ func Test_SendCurrentStateToAgent(t *testing.T) {
 		mockRepoBackend.On("List", mock.Anything, mock.Anything).Return([]corev1.Secret{}, nil)
 
 		s := newServer(t, mockProjBackend, mockRepoBackend)
-		err := s.sendCurrentStateToAgent(agentName)
+		err := s.sendCurrentStateToAgent(types.NewAgent(agentName, types.AgentModeManaged.String()))
 		require.NoError(t, err)
 
 		sendQ := s.queues.SendQ(agentName)
@@ -402,7 +402,7 @@ func Test_SendCurrentStateToAgent(t *testing.T) {
 		mockRepoBackend.On("List", mock.Anything, mock.Anything).Return([]corev1.Secret{}, nil)
 
 		s := newServer(t, mockProjBackend, mockRepoBackend)
-		err := s.sendCurrentStateToAgent(agentName)
+		err := s.sendCurrentStateToAgent(types.NewAgent(agentName, types.AgentModeManaged.String()))
 		require.NoError(t, err)
 
 		sendQ := s.queues.SendQ(agentName)
@@ -419,7 +419,7 @@ func Test_SendCurrentStateToAgent(t *testing.T) {
 		mockRepoBackend.On("List", mock.Anything, mock.Anything).Return([]corev1.Secret{}, nil)
 
 		s := newServer(t, mockProjBackend, mockRepoBackend)
-		err := s.sendCurrentStateToAgent(agentName)
+		err := s.sendCurrentStateToAgent(types.NewAgent(agentName, types.AgentModeManaged.String()))
 		require.NoError(t, err)
 
 		sendQ := s.queues.SendQ(agentName)
@@ -436,7 +436,7 @@ func Test_SendCurrentStateToAgent(t *testing.T) {
 		mockRepoBackend.On("List", mock.Anything, mock.Anything).Return([]corev1.Secret{}, nil)
 
 		s := newServer(t, mockProjBackend, mockRepoBackend)
-		err := s.sendCurrentStateToAgent(agentName)
+		err := s.sendCurrentStateToAgent(types.NewAgent(agentName, types.AgentModeManaged.String()))
 		require.NoError(t, err)
 
 		sendQ := s.queues.SendQ(agentName)
@@ -460,7 +460,7 @@ func Test_SendCurrentStateToAgent(t *testing.T) {
 		}).Return([]corev1.Secret{}, nil)
 
 		s := newServer(t, mockProjBackend, mockRepoBackend)
-		err := s.sendCurrentStateToAgent(agentName)
+		err := s.sendCurrentStateToAgent(types.NewAgent(agentName, types.AgentModeManaged.String()))
 		require.NoError(t, err)
 
 		// 1 project event + 1 repository event
@@ -499,7 +499,7 @@ func Test_SendCurrentStateToAgent(t *testing.T) {
 		}).Return([]corev1.Secret{repoCreds}, nil)
 
 		s := newServer(t, mockProjBackend, mockRepoBackend)
-		err := s.sendCurrentStateToAgent(agentName)
+		err := s.sendCurrentStateToAgent(types.NewAgent(agentName, types.AgentModeManaged.String()))
 		require.NoError(t, err)
 
 		// 1 project event + 1 repo-creds event
@@ -527,7 +527,7 @@ func Test_SendCurrentStateToAgent(t *testing.T) {
 		}).Return([]corev1.Secret{}, nil)
 
 		s := newServer(t, mockProjBackend, mockRepoBackend)
-		err := s.sendCurrentStateToAgent(agentName)
+		err := s.sendCurrentStateToAgent(types.NewAgent(agentName, types.AgentModeManaged.String()))
 		require.NoError(t, err)
 
 		// Only 1 project event, no repository event
@@ -560,7 +560,7 @@ func Test_SendCurrentStateToAgent(t *testing.T) {
 		}).Return([]corev1.Secret{}, nil)
 
 		s := newServer(t, mockProjBackend, mockRepoBackend)
-		err := s.sendCurrentStateToAgent(agentName)
+		err := s.sendCurrentStateToAgent(types.NewAgent(agentName, types.AgentModeManaged.String()))
 		require.NoError(t, err)
 
 		sendQ := s.queues.SendQ(agentName)
@@ -585,7 +585,7 @@ func Test_SendCurrentStateToAgent(t *testing.T) {
 		}).Return([]corev1.Secret{}, nil)
 
 		s := newServer(t, mockProjBackend, mockRepoBackend)
-		err := s.sendCurrentStateToAgent(agentName)
+		err := s.sendCurrentStateToAgent(types.NewAgent(agentName, types.AgentModeManaged.String()))
 		require.NoError(t, err)
 
 		sendQ := s.queues.SendQ(agentName)
@@ -611,7 +611,7 @@ func Test_SendCurrentStateToAgent(t *testing.T) {
 		}).Return([]corev1.Secret{}, nil)
 
 		s := newServer(t, mockProjBackend, mockRepoBackend)
-		err := s.sendCurrentStateToAgent(agentName)
+		err := s.sendCurrentStateToAgent(types.NewAgent(agentName, types.AgentModeManaged.String()))
 		require.NoError(t, err)
 
 		sendQ := s.queues.SendQ(agentName)
@@ -648,7 +648,7 @@ func Test_SendCurrentStateToAgent(t *testing.T) {
 
 		s := newServer(t, mockProjBackend, mockRepoBackend)
 		s.gpgKeyManager = gpgkey.NewManager(mockGPGBackend, ns)
-		err := s.sendCurrentStateToAgent(agentName)
+		err := s.sendCurrentStateToAgent(types.NewAgent(agentName, types.AgentModeManaged.String()))
 		require.NoError(t, err)
 
 		// 1 project + 1 repo + 1 GPG key
@@ -685,7 +685,7 @@ func Test_SendCurrentStateToAgent(t *testing.T) {
 
 		s := newServer(t, mockProjBackend, mockRepoBackend)
 		s.gpgKeyManager = gpgkey.NewManager(mockGPGBackend, ns)
-		err := s.sendCurrentStateToAgent(agentName)
+		err := s.sendCurrentStateToAgent(types.NewAgent(agentName, types.AgentModeManaged.String()))
 		require.NoError(t, err)
 
 		// 1 project + 1 repo, GPG key skipped

--- a/test/e2e/appproject_test.go
+++ b/test/e2e/appproject_test.go
@@ -15,6 +15,7 @@
 package e2e
 
 import (
+	"strings"
 	"testing"
 	"time"
 
@@ -110,11 +111,113 @@ func (suite *AppProjectTestSuite) Test_AppProject_Managed() {
 	}, 30*time.Second, 1*time.Second)
 }
 
+// Ensure that when an (autonomous) AppProject is created with roles already defined, that these are correctly to principal
+func (suite *AppProjectTestSuite) Test_AppProject_Autonomous_CreateWithProjectRole() {
+	requires := suite.Require()
+
+	// Create an autonomousAppProject on the autonomous-agent's cluster with project roles included from creation
+	autonomousAppProject := argoapp.AppProject{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "sample",
+			Namespace: fixture.AutonomousAgentNamespace,
+		},
+		Spec: argoapp.AppProjectSpec{
+			Destinations: []argoapp.ApplicationDestination{
+				{
+					Namespace: "*",
+					Name:      "agent-*",
+				},
+			},
+			SourceNamespaces: []string{"agent-*"},
+			Roles: []argoapp.ProjectRole{
+				{
+					Name:        "read-only",
+					Description: "Read-only access",
+					Policies: []string{
+						// 1) we expect proj: field and object field to be modified
+						"p, proj:sample:read-only, applications, get, sample/*, allow",
+						// 2) Since 'extensions' is not one of the resource we touch, this should not be modified.
+						"p, example-user, extensions, invoke, httpbin, allow",
+						// 3) Since 'differentrole' doesn't match the name of the Role field, this should not be modified. (In real world this would be user config error)
+						"p, proj:sample:differentrole, applications, get, sample/*, allow",
+						// 4) Since 'diffproject' does match the name of the AppProject, this should not be modified.  (In real world this would be user config error)
+						"p, proj:diffproject:read-only, applications, get, sample/*, allow",
+					},
+				},
+			},
+		},
+	}
+
+	err := suite.AutonomousAgentClient.Create(suite.Ctx, &autonomousAppProject, metav1.CreateOptions{})
+	requires.NoError(err)
+
+	principalKey := types.NamespacedName{
+		Name:      "agent-autonomous-sample",
+		Namespace: fixture.PrincipalNamespace,
+	}
+
+	// Verify that roles are synced to the corresponding AppProject on principal, with policies transformed for the autonomous agent context:
+	requires.Eventually(func() bool {
+		principalAppProject := argoapp.AppProject{}
+		err := suite.PrincipalClient.Get(suite.Ctx, principalKey, &principalAppProject, metav1.GetOptions{})
+		if err != nil {
+			suite.T().Logf("failed to get appProject from principal: %v", err)
+			return false
+		}
+		if len(principalAppProject.Spec.Roles) != 1 {
+			suite.T().Logf("expected 1 role, got %d", len(principalAppProject.Spec.Roles))
+			return false
+		}
+		role := principalAppProject.Spec.Roles[0]
+		if role.Name != "read-only" {
+			suite.T().Logf("expected role name 'read-only', got %q", role.Name)
+			return false
+		}
+		if len(role.Policies) != 4 {
+			suite.T().Logf("expected 4 policies, got %d", len(role.Policies))
+			return false
+		}
+		expectedPolicy := "p, proj:agent-autonomous-sample:read-only, applications, get, agent-autonomous-sample/agent-autonomous/*, allow"
+		if role.Policies[0] != expectedPolicy {
+			suite.T().Logf("policy[0] mismatch: got %q, expected %q", role.Policies[0], expectedPolicy)
+			return false
+		}
+		expectedPolicy = "p, example-user, extensions, invoke, httpbin, allow"
+		if role.Policies[1] != expectedPolicy {
+			suite.T().Logf("policy[1] mismatch: got %q, expected %q", role.Policies[1], expectedPolicy)
+			return false
+		}
+		expectedPolicy = "p, proj:sample:differentrole, applications, get, " + autonomousAppProject.Name + "/*, allow"
+		if role.Policies[2] != expectedPolicy {
+			suite.T().Logf("policy[2] mismatch: got %q, expected %q", role.Policies[2], expectedPolicy)
+			return false
+		}
+		expectedPolicy = "p, proj:diffproject:read-only, applications, get, " + autonomousAppProject.Name + "/*, allow"
+		if role.Policies[3] != expectedPolicy {
+			suite.T().Logf("policy[3] mismatch: got %q, expected %q", role.Policies[3], expectedPolicy)
+			return false
+		}
+		suite.T().Logf("policies match: %v", strings.Join(role.Policies, "  |  "))
+		return true
+	}, 30*time.Second, 1*time.Second)
+
+	// Delete the appProject from the autonomous-agent
+	err = suite.AutonomousAgentClient.Delete(suite.Ctx, &autonomousAppProject, metav1.DeleteOptions{})
+	requires.NoError(err)
+
+	// Ensure the appProject has been deleted from the principal
+	requires.Eventually(func() bool {
+		appProject := argoapp.AppProject{}
+		err := suite.PrincipalClient.Get(suite.Ctx, principalKey, &appProject, metav1.GetOptions{})
+		return errors.IsNotFound(err)
+	}, 30*time.Second, 1*time.Second)
+}
+
 func (suite *AppProjectTestSuite) Test_AppProject_Autonomous() {
 	requires := suite.Require()
 
-	// Create an appProject on the autonomous-agent's cluster
-	appProject := argoapp.AppProject{
+	// Create an autonomousAppProject on the autonomous-agent's cluster
+	autonomousAppProject := argoapp.AppProject{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "sample",
 			Namespace: fixture.AutonomousAgentNamespace,
@@ -130,7 +233,7 @@ func (suite *AppProjectTestSuite) Test_AppProject_Autonomous() {
 		},
 	}
 
-	err := suite.AutonomousAgentClient.Create(suite.Ctx, &appProject, metav1.CreateOptions{})
+	err := suite.AutonomousAgentClient.Create(suite.Ctx, &autonomousAppProject, metav1.CreateOptions{})
 	requires.NoError(err)
 
 	principalKey := types.NamespacedName{
@@ -138,34 +241,106 @@ func (suite *AppProjectTestSuite) Test_AppProject_Autonomous() {
 		Namespace: fixture.PrincipalNamespace,
 	}
 	agentKey := types.NamespacedName{
-		Name:      appProject.Name,
+		Name:      autonomousAppProject.Name,
 		Namespace: fixture.AutonomousAgentNamespace,
 	}
 
 	// Ensure the appProject has been pushed to the principal
 	requires.Eventually(func() bool {
-		appProject := argoapp.AppProject{}
-		err := suite.PrincipalClient.Get(suite.Ctx, principalKey, &appProject, metav1.GetOptions{})
+		principalAppProject := argoapp.AppProject{}
+		err := suite.PrincipalClient.Get(suite.Ctx, principalKey, &principalAppProject, metav1.GetOptions{})
 		return err == nil
 	}, 30*time.Second, 1*time.Second)
 
 	// Modify the appProject on the autonomous-agent and ensure the change is
 	// propagated to the principal
-	err = suite.AutonomousAgentClient.EnsureAppProjectUpdate(suite.Ctx, agentKey, func(appProject *argoapp.AppProject) error {
-		appProject.Spec.Description = "sample description"
+	err = suite.AutonomousAgentClient.EnsureAppProjectUpdate(suite.Ctx, agentKey, func(appProjectParam *argoapp.AppProject) error {
+		appProjectParam.Spec.Description = "sample description"
 		return nil
 	}, metav1.UpdateOptions{})
 	requires.NoError(err)
 
 	requires.Eventually(func() bool {
-		appProject := argoapp.AppProject{}
-		err := suite.PrincipalClient.Get(suite.Ctx, principalKey, &appProject, metav1.GetOptions{})
+		principalAppProject := argoapp.AppProject{}
+		err := suite.PrincipalClient.Get(suite.Ctx, principalKey, &principalAppProject, metav1.GetOptions{})
 		return err == nil &&
-			appProject.Spec.Description == "sample description"
+			principalAppProject.Spec.Description == "sample description"
+	}, 30*time.Second, 1*time.Second)
+
+	// Update autonomous agent AppProject .spec.roles to add a new role with policies
+	err = suite.AutonomousAgentClient.EnsureAppProjectUpdate(suite.Ctx, agentKey, func(appProjectParam *argoapp.AppProject) error {
+		appProjectParam.Spec.Roles = []argoapp.ProjectRole{
+			{
+				Name:        "read-only",
+				Description: "Read-only access",
+				Policies: []string{
+					// 1) we expect proj: field and object field to be modified
+					"p, proj:sample:read-only, applications, get, " + appProjectParam.Name + "/*, allow",
+					// 2) Since 'extensions' is not one of the resource we touch, this should not be modified.
+					"p, example-user, extensions, invoke, httpbin, allow",
+					// 3) Since 'differentrole' doesn't match the name of the Role field, this should not be modified. (In real world this would be user config error)
+					"p, proj:sample:differentrole, applications, get, " + appProjectParam.Name + "/*, allow",
+					// 4) Since 'diffproject' does match the name of the AppProject, this should not be modified.  (In real world this would be user config error)
+					"p, proj:diffproject:read-only, applications, get, " + appProjectParam.Name + "/*, allow",
+				},
+			},
+		}
+		return nil
+	}, metav1.UpdateOptions{})
+	requires.NoError(err)
+
+	// Verify that roles are synced to the corresponding AppProject on principal, with policies transformed for the autonomous agent context:
+	// policy at 0:
+	// - Role project reference is prefixed: proj:sample:read-only -> proj:agent-autonomous-sample:read-only
+	// - Object field gains agent namespace: sample/* -> sample/agent-autonomous/*
+	// policy at 1:
+	// - unchanged
+	requires.Eventually(func() bool {
+		principalAppProject := argoapp.AppProject{}
+		err := suite.PrincipalClient.Get(suite.Ctx, principalKey, &principalAppProject, metav1.GetOptions{})
+		if err != nil {
+			suite.T().Logf("failed to get appProject from principal: %v", err)
+			return false
+		}
+		if len(principalAppProject.Spec.Roles) != 1 {
+			suite.T().Logf("expected 1 role, got %d", len(principalAppProject.Spec.Roles))
+			return false
+		}
+		role := principalAppProject.Spec.Roles[0]
+		if role.Name != "read-only" {
+			suite.T().Logf("expected role name 'read-only', got %q", role.Name)
+			return false
+		}
+		if len(role.Policies) != 4 {
+			suite.T().Logf("expected 4 policies, got %d", len(role.Policies))
+			return false
+		}
+		expectedPolicy := "p, proj:agent-autonomous-sample:read-only, applications, get, agent-autonomous-sample/agent-autonomous/*, allow"
+		if role.Policies[0] != expectedPolicy {
+			suite.T().Logf("policy[0] mismatch: got %q, expected %q", role.Policies[0], expectedPolicy)
+			return false
+		}
+		expectedPolicy = "p, example-user, extensions, invoke, httpbin, allow"
+		if role.Policies[1] != expectedPolicy {
+			suite.T().Logf("policy[1] mismatch: got %q, expected %q", role.Policies[1], expectedPolicy)
+			return false
+		}
+		expectedPolicy = "p, proj:sample:differentrole, applications, get, " + autonomousAppProject.Name + "/*, allow"
+		if role.Policies[2] != expectedPolicy {
+			suite.T().Logf("policy[2] mismatch: got %q, expected %q", role.Policies[2], expectedPolicy)
+			return false
+		}
+		expectedPolicy = "p, proj:diffproject:read-only, applications, get, " + autonomousAppProject.Name + "/*, allow"
+		if role.Policies[3] != expectedPolicy {
+			suite.T().Logf("policy[3] mismatch: got %q, expected %q", role.Policies[3], expectedPolicy)
+			return false
+		}
+		suite.T().Logf("policies match: %v", strings.Join(role.Policies, "  |  "))
+		return true
 	}, 30*time.Second, 1*time.Second)
 
 	// Delete the appProject from the autonomous-agent
-	err = suite.AutonomousAgentClient.Delete(suite.Ctx, &appProject, metav1.DeleteOptions{})
+	err = suite.AutonomousAgentClient.Delete(suite.Ctx, &autonomousAppProject, metav1.DeleteOptions{})
 	requires.NoError(err)
 
 	// Ensure the appProject has been deleted from the principal

--- a/test/e2e/resync_test.go
+++ b/test/e2e/resync_test.go
@@ -17,6 +17,7 @@ package e2e
 import (
 	"fmt"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 
@@ -823,6 +824,273 @@ func (suite *ResyncTestSuite) Test_AppProjectResync_CreateOnAgentDelete() {
 		err := suite.ManagedAgentClient.Get(suite.Ctx, projKeyManaged, &appProject, metav1.GetOptions{})
 		return err == nil
 	}, 30*time.Second, 1*time.Second)
+}
+
+// Ensure that when an (autonomous) AppProject is created without roles, synced to the principal,
+// then the principal is stopped, roles are added on the agent side, and the principal is restarted,
+// the role policies are correctly translated on the principal.
+func (suite *ResyncTestSuite) Test_AppProjectResyncOnPrincipalRestartWithRoleUpdatedOnAgent_Autonomous() {
+	requires := suite.Require()
+
+	// Create an autonomous AppProject WITHOUT roles
+	autonomousAppProject := argoapp.AppProject{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "sample",
+			Namespace: fixture.AutonomousAgentNamespace,
+		},
+		Spec: argoapp.AppProjectSpec{
+			Destinations: []argoapp.ApplicationDestination{
+				{
+					Namespace: "*",
+					Name:      "agent-*",
+				},
+			},
+			SourceNamespaces: []string{"agent-*"},
+		},
+	}
+
+	err := suite.AutonomousAgentClient.Create(suite.Ctx, &autonomousAppProject, metav1.CreateOptions{})
+	requires.NoError(err)
+
+	principalKey := types.NamespacedName{
+		Name:      "agent-autonomous-sample",
+		Namespace: fixture.PrincipalNamespace,
+	}
+	agentKey := types.NamespacedName{
+		Name:      autonomousAppProject.Name,
+		Namespace: fixture.AutonomousAgentNamespace,
+	}
+
+	// Wait for the appProject to sync to the principal
+	requires.Eventually(func() bool {
+		principalAppProject := argoapp.AppProject{}
+		err := suite.PrincipalClient.Get(suite.Ctx, principalKey, &principalAppProject, metav1.GetOptions{})
+		return err == nil
+	}, 30*time.Second, 1*time.Second)
+
+	// Stop the principal
+	err = fixture.StopProcess("principal", suite.T())
+	requires.NoError(err)
+
+	requires.Eventually(func() bool {
+		return !fixture.IsProcessRunning("principal", suite.T())
+	}, 30*time.Second, 1*time.Second)
+
+	// While principal is stopped, add project roles on the autonomous agent
+	err = suite.AutonomousAgentClient.EnsureAppProjectUpdate(suite.Ctx, agentKey, func(appProjectParam *argoapp.AppProject) error {
+		appProjectParam.Spec.Roles = []argoapp.ProjectRole{
+			{
+				Name:        "read-only",
+				Description: "Read-only access",
+				Policies: []string{
+					// 1) we expect proj: field and object field to be modified
+					"p, proj:sample:read-only, applications, get, sample/*, allow",
+					// 2) Since 'extensions' is not one of the resource we touch, this should not be modified.
+					"p, example-user, extensions, invoke, httpbin, allow",
+					// 3) Since 'differentrole' doesn't match the name of the Role field, this should not be modified. (In real world this would be user config error)
+					"p, proj:sample:differentrole, applications, get, sample/*, allow",
+					// 4) Since 'diffproject' does match the name of the AppProject, this should not be modified.  (In real world this would be user config error)
+					"p, proj:diffproject:read-only, applications, get, sample/*, allow",
+				},
+			},
+		}
+		return nil
+	}, metav1.UpdateOptions{})
+	requires.NoError(err)
+
+	// Start the principal and wait for readiness
+	err = fixture.StartProcess("principal", suite.T())
+	requires.NoError(err)
+
+	fixture.CheckReadiness(suite.T(), "principal")
+
+	// Verify that roles are synced to the corresponding AppProject on principal, with policies transformed for the autonomous agent context
+	requires.Eventually(func() bool {
+		principalAppProject := argoapp.AppProject{}
+		err := suite.PrincipalClient.Get(suite.Ctx, principalKey, &principalAppProject, metav1.GetOptions{})
+		if err != nil {
+			suite.T().Logf("failed to get appProject from principal: %v", err)
+			return false
+		}
+		if len(principalAppProject.Spec.Roles) != 1 {
+			suite.T().Logf("expected 1 role, got %d", len(principalAppProject.Spec.Roles))
+			return false
+		}
+		role := principalAppProject.Spec.Roles[0]
+		if role.Name != "read-only" {
+			suite.T().Logf("expected role name 'read-only', got %q", role.Name)
+			return false
+		}
+		if len(role.Policies) != 4 {
+			suite.T().Logf("expected 4 policies, got %d", len(role.Policies))
+			return false
+		}
+		expectedPolicy := "p, proj:agent-autonomous-sample:read-only, applications, get, agent-autonomous-sample/agent-autonomous/*, allow"
+		if role.Policies[0] != expectedPolicy {
+			suite.T().Logf("policy[0] mismatch: got %q, expected %q", role.Policies[0], expectedPolicy)
+			return false
+		}
+		expectedPolicy = "p, example-user, extensions, invoke, httpbin, allow"
+		if role.Policies[1] != expectedPolicy {
+			suite.T().Logf("policy[1] mismatch: got %q, expected %q", role.Policies[1], expectedPolicy)
+			return false
+		}
+		expectedPolicy = "p, proj:sample:differentrole, applications, get, " + autonomousAppProject.Name + "/*, allow"
+		if role.Policies[2] != expectedPolicy {
+			suite.T().Logf("policy[2] mismatch: got %q, expected %q", role.Policies[2], expectedPolicy)
+			return false
+		}
+		expectedPolicy = "p, proj:diffproject:read-only, applications, get, " + autonomousAppProject.Name + "/*, allow"
+		if role.Policies[3] != expectedPolicy {
+			suite.T().Logf("policy[3] mismatch: got %q, expected %q", role.Policies[3], expectedPolicy)
+			return false
+		}
+		suite.T().Logf("policies match: %v", strings.Join(role.Policies, "  |  "))
+		return true
+	}, 30*time.Second, 1*time.Second)
+
+	// Ensure the roles remain consistently correct over time
+	expectedPoliciesConsistent := []string{
+		"p, proj:agent-autonomous-sample:read-only, applications, get, agent-autonomous-sample/agent-autonomous/*, allow",
+		"p, example-user, extensions, invoke, httpbin, allow",
+		"p, proj:sample:differentrole, applications, get, " + autonomousAppProject.Name + "/*, allow",
+		"p, proj:diffproject:read-only, applications, get, " + autonomousAppProject.Name + "/*, allow",
+	}
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		principalAppProject := argoapp.AppProject{}
+		err = suite.PrincipalClient.Get(suite.Ctx, principalKey, &principalAppProject, metav1.GetOptions{})
+		requires.NoError(err, "AppProject should still exist on principal")
+		requires.Len(principalAppProject.Spec.Roles, 1, "should still have exactly 1 role")
+		role := principalAppProject.Spec.Roles[0]
+		requires.Equal("read-only", role.Name)
+		requires.Equal(expectedPoliciesConsistent, role.Policies, "policies should remain correctly transformed")
+		time.Sleep(1 * time.Second)
+	}
+
+	// Delete the appProject from the autonomous-agent
+	err = suite.AutonomousAgentClient.Delete(suite.Ctx, &autonomousAppProject, metav1.DeleteOptions{})
+	requires.NoError(err)
+
+	// Ensure the appProject has been deleted from the principal
+	requires.Eventually(func() bool {
+		appProject := argoapp.AppProject{}
+		err := suite.PrincipalClient.Get(suite.Ctx, principalKey, &appProject, metav1.GetOptions{})
+		return errors.IsNotFound(err)
+	}, 30*time.Second, 1*time.Second)
+}
+
+// Autonomous: Create an AppProject with roles on the agent while the principal is down,
+// then verify roles are correctly synced after principal restart
+func (suite *ResyncTestSuite) Test_AppProjectResyncOnPrincipalRestartWithRoleCreatedOnAgent_Autonomous() {
+	requires := suite.Require()
+
+	// Stop the principal
+	err := fixture.StopProcess("principal", suite.T())
+	requires.NoError(err)
+
+	requires.Eventually(func() bool {
+		return !fixture.IsProcessRunning("principal", suite.T())
+	}, 30*time.Second, 1*time.Second)
+
+	// Create an AppProject with roles on the autonomous-agent's cluster while principal is offline
+	agentAppProject := &argoapp.AppProject{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "sample-with-roles",
+			Namespace: fixture.AutonomousAgentNamespace,
+		},
+		Spec: argoapp.AppProjectSpec{
+			Destinations: []argoapp.ApplicationDestination{
+				{
+					Namespace: "*",
+					Name:      "agent-*",
+				},
+			},
+			SourceNamespaces: []string{"agent-*"},
+			Roles: []argoapp.ProjectRole{
+				{
+					Name:        "read-only",
+					Description: "Read-only access",
+					Policies: []string{
+						"p, proj:sample-with-roles:read-only, applications, get, sample-with-roles/*, allow",
+						"p, example-user, extensions, invoke, httpbin, allow",
+						"p, proj:sample-with-roles:differentrole, applications, get, sample-with-roles/*, allow",
+						"p, proj:diffproject:read-only, applications, get, sample-with-roles/*, allow",
+					},
+				},
+			},
+		},
+	}
+
+	err = suite.AutonomousAgentClient.Create(suite.Ctx, agentAppProject, metav1.CreateOptions{})
+	requires.NoError(err)
+
+	principalKey := types.NamespacedName{
+		Name:      "agent-autonomous-" + agentAppProject.Name,
+		Namespace: fixture.PrincipalNamespace,
+	}
+
+	// Start the principal
+	err = fixture.StartProcess("principal", suite.T())
+	requires.NoError(err)
+
+	fixture.CheckReadiness(suite.T(), "principal")
+
+	// Verify that roles are synced with correctly transformed policies
+	requires.Eventually(func() bool {
+		principalAppProject := argoapp.AppProject{}
+		err := suite.PrincipalClient.Get(suite.Ctx, principalKey, &principalAppProject, metav1.GetOptions{})
+		if err != nil {
+			suite.T().Logf("failed to get appProject from principal: %v", err)
+			return false
+		}
+		if len(principalAppProject.Spec.Roles) != 1 {
+			suite.T().Logf("expected 1 role, got %d", len(principalAppProject.Spec.Roles))
+			return false
+		}
+		role := principalAppProject.Spec.Roles[0]
+		if role.Name != "read-only" {
+			suite.T().Logf("expected role name 'read-only', got %q", role.Name)
+			return false
+		}
+		if len(role.Policies) != 4 {
+			suite.T().Logf("expected 4 policies, got %d", len(role.Policies))
+			return false
+		}
+
+		expectedPolicies := []string{
+			"p, proj:agent-autonomous-sample-with-roles:read-only, applications, get, agent-autonomous-sample-with-roles/agent-autonomous/*, allow",
+			"p, example-user, extensions, invoke, httpbin, allow",
+			"p, proj:sample-with-roles:differentrole, applications, get, " + agentAppProject.Name + "/*, allow",
+			"p, proj:diffproject:read-only, applications, get, " + agentAppProject.Name + "/*, allow",
+		}
+		for i, expected := range expectedPolicies {
+			if role.Policies[i] != expected {
+				suite.T().Logf("policy[%d] mismatch: got %q, expected %q", i, role.Policies[i], expected)
+				return false
+			}
+		}
+		return true
+	}, 60*time.Second, 1*time.Second)
+
+	// Ensure the roles remain consistently correct over time
+	expectedPoliciesConsistent := []string{
+		"p, proj:agent-autonomous-sample-with-roles:read-only, applications, get, agent-autonomous-sample-with-roles/agent-autonomous/*, allow",
+		"p, example-user, extensions, invoke, httpbin, allow",
+		"p, proj:sample-with-roles:differentrole, applications, get, " + agentAppProject.Name + "/*, allow",
+		"p, proj:diffproject:read-only, applications, get, " + agentAppProject.Name + "/*, allow",
+	}
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		principalAppProject := argoapp.AppProject{}
+		err = suite.PrincipalClient.Get(suite.Ctx, principalKey, &principalAppProject, metav1.GetOptions{})
+		requires.NoError(err, "AppProject should still exist on principal")
+		requires.Len(principalAppProject.Spec.Roles, 1, "should still have exactly 1 role")
+		role := principalAppProject.Spec.Roles[0]
+		requires.Equal("read-only", role.Name)
+		requires.Equal(expectedPoliciesConsistent, role.Policies, "policies should remain correctly transformed")
+		time.Sleep(1 * time.Second)
+	}
 }
 
 // AppProjects on both the agent and the principal must be synchronized when the principal is restarted

--- a/test/e2e/resync_test.go
+++ b/test/e2e/resync_test.go
@@ -956,17 +956,19 @@ func (suite *ResyncTestSuite) Test_AppProjectResyncOnPrincipalRestartWithRoleUpd
 		"p, proj:sample:differentrole, applications, get, " + autonomousAppProject.Name + "/*, allow",
 		"p, proj:diffproject:read-only, applications, get, " + autonomousAppProject.Name + "/*, allow",
 	}
-	deadline := time.Now().Add(10 * time.Second)
-	for time.Now().Before(deadline) {
+
+	requires.Never(func() bool {
 		principalAppProject := argoapp.AppProject{}
-		err = suite.PrincipalClient.Get(suite.Ctx, principalKey, &principalAppProject, metav1.GetOptions{})
-		requires.NoError(err, "AppProject should still exist on principal")
-		requires.Len(principalAppProject.Spec.Roles, 1, "should still have exactly 1 role")
+		err := suite.PrincipalClient.Get(suite.Ctx, principalKey, &principalAppProject, metav1.GetOptions{})
+		if err != nil {
+			return true
+		}
+		if len(principalAppProject.Spec.Roles) != 1 {
+			return true
+		}
 		role := principalAppProject.Spec.Roles[0]
-		requires.Equal("read-only", role.Name)
-		requires.Equal(expectedPoliciesConsistent, role.Policies, "policies should remain correctly transformed")
-		time.Sleep(1 * time.Second)
-	}
+		return role.Name != "read-only" || !reflect.DeepEqual(expectedPoliciesConsistent, role.Policies)
+	}, 10*time.Second, 1*time.Second, "policies should remain correctly transformed")
 
 	// Delete the appProject from the autonomous-agent
 	err = suite.AutonomousAgentClient.Delete(suite.Ctx, &autonomousAppProject, metav1.DeleteOptions{})
@@ -1080,17 +1082,18 @@ func (suite *ResyncTestSuite) Test_AppProjectResyncOnPrincipalRestartWithRoleCre
 		"p, proj:sample-with-roles:differentrole, applications, get, " + agentAppProject.Name + "/*, allow",
 		"p, proj:diffproject:read-only, applications, get, " + agentAppProject.Name + "/*, allow",
 	}
-	deadline := time.Now().Add(10 * time.Second)
-	for time.Now().Before(deadline) {
+	requires.Never(func() bool {
 		principalAppProject := argoapp.AppProject{}
-		err = suite.PrincipalClient.Get(suite.Ctx, principalKey, &principalAppProject, metav1.GetOptions{})
-		requires.NoError(err, "AppProject should still exist on principal")
-		requires.Len(principalAppProject.Spec.Roles, 1, "should still have exactly 1 role")
+		err := suite.PrincipalClient.Get(suite.Ctx, principalKey, &principalAppProject, metav1.GetOptions{})
+		if err != nil {
+			return true
+		}
+		if len(principalAppProject.Spec.Roles) != 1 {
+			return true
+		}
 		role := principalAppProject.Spec.Roles[0]
-		requires.Equal("read-only", role.Name)
-		requires.Equal(expectedPoliciesConsistent, role.Policies, "policies should remain correctly transformed")
-		time.Sleep(1 * time.Second)
-	}
+		return role.Name != "read-only" || !reflect.DeepEqual(expectedPoliciesConsistent, role.Policies)
+	}, 10*time.Second, 1*time.Second, "policies should remain correctly transformed")
 }
 
 // AppProjects on both the agent and the principal must be synchronized when the principal is restarted


### PR DESCRIPTION
**What does this PR do / why we need it**:
- When an AppProject is synced from an autonomous agent to the principal, RBAC policy lines in .spec.roles[].policies[] are now translated so that project references and object fields remain valid on the principal
- Only policies targeting supported resource types (applications, applicationsets, logs, exec) are transformed; others are preserved as-is
- Additional sanity tests added to code to ensure we are not processing events in wrong mode.
- E2E/Unit tests
- Doc updated to describe new behaviour

**Checklist**

* [X] Documentation update is required by this PR (and has been updated) OR no documentation update is required.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Autonomous AppProjects now synchronize RBAC role policies with translated project and namespace references.
  * Resynchronization now accounts for agent mode and validates event direction.
* **Bug Fixes**
  * Roles are preserved when synchronizing autonomous AppProjects.
  * Improved consistency during restarts and resynchronization.
* **Documentation**
  * Added autonomous-mode RBAC policy translation examples to the AppProject guide.
* **Tests**
  * Expanded coverage for autonomous role synchronization and restart recovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->