### PR TITLE
fix(principal): fall back to full update when granular status patch is rejected

### DIFF
--- a/internal/manager/application/application.go
+++ b/internal/manager/application/application.go
@@ -589,12 +589,13 @@ func (m *ApplicationManager) UpdateStatus(ctx context.Context, namespace string,
 		return nil, fmt.Errorf("UpdateStatus should only be called on principal")
 	}
 
-	updated, err = m.update(ctx, false, incoming, func(existing, incoming *v1alpha1.Application) {
+	updateFn := func(existing, incoming *v1alpha1.Application) {
 		existing.Annotations = incoming.Annotations
 		existing.Labels = incoming.Labels
 		existing.Status = *incoming.Status.DeepCopy()
 		existing.Operation = incoming.Operation
-	}, func(existing, incoming *v1alpha1.Application) (jsondiff.Patch, error) {
+	}
+	patchFn := func(existing, incoming *v1alpha1.Application) (jsondiff.Patch, error) {
 		refresh, incomingRefresh := incoming.Annotations["argocd.argoproj.io/refresh"]
 		_, existingRefresh := existing.Annotations["argocd.argoproj.io/refresh"]
 		target := &v1alpha1.Application{
@@ -627,7 +628,22 @@ func (m *ApplicationManager) UpdateStatus(ctx context.Context, namespace string,
 		}
 
 		return patch, err
-	})
+	}
+	updated, err = m.update(ctx, false, incoming, updateFn, patchFn)
+	// The granular patch built above can be rejected by the API server with
+	// 400/422 when the diff source carries zero-valued non-pointer structs that
+	// the sparse live status doesn't have (encoding/json ignores omitempty on
+	// non-pointer structs, e.g. SyncStatus.ComparedTo) — the resulting patch
+	// operations then target parents that don't exist on the live object.
+	// Without a fallback, the same patch is rebuilt and rejected on every
+	// retry, and status updates for the application stop flowing. When that
+	// happens, retry via the full-update path (patchFn=nil), which replaces
+	// status/annotations/labels/operation wholesale and involves no JSON
+	// diffing.
+	if err != nil && (errors.IsInvalid(err) || errors.IsBadRequest(err)) {
+		logCtx.WithError(err).Warn("granular status patch rejected by API server, falling back to full update")
+		updated, err = m.update(ctx, false, incoming, updateFn, nil)
+	}
 	if err == nil {
 		if err := m.IgnoreChange(updated.QualifiedName(), updated.ResourceVersion); err != nil {
 			logCtx.Warnf("Could not ignore change %s for app %s: %v", updated.ResourceVersion, updated.QualifiedName(), err)

--- a/internal/manager/application/application_test.go
+++ b/internal/manager/application/application_test.go
@@ -1199,3 +1199,63 @@ func Test_ClearOperationState(t *testing.T) {
 		mockedBackend.AssertExpectations(t)
 	})
 }
+
+// Test_UpdateStatus_FallbackOnPatchRejection verifies that UpdateStatus falls
+// back to the full-update path when the API server rejects the granular status
+// patch with 400 or 422. Such rejections can occur when the diff source
+// carries zero-valued non-pointer structs (encoding/json ignores omitempty on
+// e.g. SyncStatus.ComparedTo), producing patch operations that target parents
+// absent on the sparse live status. Without the fallback, the same patch is
+// rebuilt and rejected on every retry and status updates for the application
+// stop flowing.
+func Test_UpdateStatus_FallbackOnPatchRejection(t *testing.T) {
+	newInvalid := func() error {
+		return errors.NewInvalid(schema.GroupKind{Group: "argoproj.io", Kind: "Application"}, "foobar", nil)
+	}
+	newBadRequest := func() error { return errors.NewBadRequest("the request is invalid") }
+	for name, rejection := range map[string]error{"422-invalid": newInvalid(), "400-bad-request": newBadRequest()} {
+		t.Run("granular patch rejected with "+name+" falls back to full update", func(t *testing.T) {
+			mockedBackend := appmock.NewApplication(t)
+			existing := &v1alpha1.Application{
+				ObjectMeta: v1.ObjectMeta{Name: "foobar", Namespace: "argocd"},
+			}
+			incoming := existing.DeepCopy()
+			incoming.Status = v1alpha1.ApplicationStatus{
+				Sync: v1alpha1.SyncStatus{Status: v1alpha1.SyncStatusCodeSynced},
+			}
+			updatedApp := incoming.DeepCopy()
+
+			mockedBackend.On("SupportsPatch").Return(true)
+			mockedBackend.On("Get", mock.Anything, "foobar", "argocd").Return(existing, nil)
+			mockedBackend.On("Patch", mock.Anything, "foobar", "argocd", mock.Anything).Return(nil, rejection)
+			mockedBackend.On("Update", mock.Anything, mock.Anything).Return(updatedApp, nil)
+
+			mgr, err := NewApplicationManager(mockedBackend, "argocd",
+				WithRole(manager.ManagerRolePrincipal))
+			require.NoError(t, err)
+
+			updated, err := mgr.UpdateStatus(context.TODO(), "argocd", incoming)
+			require.NoError(t, err)
+			require.NotNil(t, updated)
+			require.Equal(t, v1alpha1.SyncStatusCodeSynced, updated.Status.Sync.Status)
+			mockedBackend.AssertCalled(t, "Update", mock.Anything, mock.Anything)
+		})
+	}
+	t.Run("non-4xx patch errors do NOT fall back", func(t *testing.T) {
+		mockedBackend := appmock.NewApplication(t)
+		existing := &v1alpha1.Application{ObjectMeta: v1.ObjectMeta{Name: "foobar", Namespace: "argocd"}}
+		incoming := existing.DeepCopy()
+		mockedBackend.On("SupportsPatch").Return(true)
+		mockedBackend.On("Get", mock.Anything, "foobar", "argocd").Return(existing, nil)
+		mockedBackend.On("Patch", mock.Anything, "foobar", "argocd", mock.Anything).
+			Return(nil, errors.NewInternalError(fmt.Errorf("boom")))
+
+		mgr, err := NewApplicationManager(mockedBackend, "argocd",
+			WithRole(manager.ManagerRolePrincipal))
+		require.NoError(t, err)
+
+		_, err = mgr.UpdateStatus(context.TODO(), "argocd", incoming)
+		require.Error(t, err)
+		mockedBackend.AssertNotCalled(t, "Update", mock.Anything, mock.Anything)
+	})
+}


### PR DESCRIPTION
**What does this PR do / why we need it**:

The principal's `UpdateStatus` builds a granular JSON patch (via jsondiff) to update an application's status. That patch can be rejected by the API server with 400 or 422: when the diff source carries zero-valued non-pointer structs that the sparse live status doesn't have (Go's `encoding/json` ignores `omitempty` on non-pointer structs, e.g. `SyncStatus.ComparedTo`), the generated patch operations target parents that don't exist on the live object.

When this happens there is currently no recovery path — the same patch is rebuilt and rejected on every retry, and status updates for the affected application stop flowing until manual intervention. We hit this in production, with one application's status wedged for about 90 minutes.

This PR adds a fallback: when the patch is rejected with 422 (`IsInvalid`) or 400 (`IsBadRequest`), the update is retried once through the existing full-update path (`patchFn = nil`), which replaces status/annotations/labels/operation wholesale and involves no JSON diffing. All other error classes keep their existing behavior, and the happy path is unchanged.

**Which issue(s) this PR fixes**:

No existing issue — happy to file one first if that's preferred.

**How to test changes / Special notes to the reviewer**:

Three new unit tests in `internal/manager/application` cover the behavior:
- a 422 (`IsInvalid`) patch rejection falls back to the full update
- a 400 (`IsBadRequest`) patch rejection falls back to the full update
- non-4xx errors (e.g. an internal error) do not trigger the fallback

The two anonymous update/patch callbacks in `UpdateStatus` are extracted into named variables (`updateFn`, `patchFn`) so the fallback can reuse them — no functional change to either.

**Checklist**

* [x] Documentation update is required by this PR (and has been updated) OR no documentation update is required.

Note: this re-submits #1042, which was auto-closed when the source fork was accidentally deleted; content is unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved application status updates when granular API patches are rejected.
  * Automatically retries with a full update for client-side validation or bad-request errors, helping status changes complete successfully.
  * Preserves existing error behavior for unrelated server or internal failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->