### PR TITLE
chore(rbac): add examples for agent clusterroles that enhance permissions for the resource proxy

### DIFF
--- a/examples/agent-rbac/README.md
+++ b/examples/agent-rbac/README.md
@@ -1,0 +1,10 @@
+This directory contains examples for RBAC for the Agent's Resource Proxy to allow for different levels of CRUD operations on resources.
+Argo CD Agent's resource proxy started with more strict permissions only allowing for operation on Secrets, ConfigMaps, Namespaces, and Argo CD resources (Applications, ApplicationSets, and AppProjects).
+
+There are two examples that are taken from the [live resources](https://argocd-agent.readthedocs.io/latest/user-guide/live-resources/#rbac-requirements) docs page.
+For more information about the resource proxy's permissions see that docs page.
+
+The first example is a ClusterRole for that allows for permissions on common core Kubernetes resources that would be deployed by applications from all categories like workloads,
+configuration, and RBAC, and networking.
+
+The second example ClusterRole shows how RBAC could be configured for CustomResources that an application might deploy. Examples are shown for cert-manager, istio, and the monitoring stack.

--- a/examples/agent-rbac/README.md
+++ b/examples/agent-rbac/README.md
@@ -8,3 +8,5 @@ The first example is a ClusterRole for that allows for permissions on common cor
 configuration, and RBAC, and networking.
 
 The second example ClusterRole shows how RBAC could be configured for CustomResources that an application might deploy. Examples are shown for cert-manager, istio, and the monitoring stack.
+
+Both examples provide a `ClusterRoleBinding` that must be edited with the namespace the agent lives in to be applied.

--- a/examples/agent-rbac/common-application-resources-binding.yaml
+++ b/examples/agent-rbac/common-application-resources-binding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: argocd-agent-common-application-resources
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: argocd-agent-common-application-resources
+subjects:
+- kind: ServiceAccount
+  name: argocd-agent-agent
+  namespace: default  # Replace with the namespace the agent is in

--- a/examples/agent-rbac/common-application-resources.yaml
+++ b/examples/agent-rbac/common-application-resources.yaml
@@ -1,0 +1,82 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: argocd-agent-common-application-resources
+rules:
+  # Core Kubernetes resources
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+      - services
+      - endpoints
+      - persistentvolumeclaims
+      - configmaps
+      - secrets
+      - serviceaccounts
+      - namespaces
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+
+  # Apps resources
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+      - replicasets
+      - statefulsets
+      - daemonsets
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+
+  # Networking resources
+  - apiGroups: 
+      - "networking.k8s.io"
+    resources:
+      - ingresses
+      - networkpolicies
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+
+  # RBAC resources
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - roles
+      - rolebindings
+      - clusterroles
+      - clusterrolebindings
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+
+  # Argo CD resources
+  - apiGroups:
+      - argoproj.io
+    resources:
+      - "*"
+    verbs:
+      - "*"

--- a/examples/agent-rbac/cr-example-binding.yaml
+++ b/examples/agent-rbac/cr-example-binding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: argocd-agent-cr-examples
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: argocd-agent-cr-examples
+subjects:
+- kind: ServiceAccount
+  name: argocd-agent-agent
+  namespace: default  # Replace with the namespace the agent is in

--- a/examples/agent-rbac/cr-example.yaml
+++ b/examples/agent-rbac/cr-example.yaml
@@ -1,0 +1,51 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: argocd-agent-cr-examples
+rules:
+  # Example: For applications using cert-manager
+  - apiGroups:
+      - cert-manager.io
+    resources:
+      - certificates
+      - issuers
+      - clusterissuers
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+
+  # Example: For applications using Istio
+  - apiGroups:
+      - networking.istio.io
+    resources:
+      - virtualservices
+      - destinationrules
+      - gateways
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+
+  # Example: For applications using monitoring stack
+  - apiGroups:
+      - monitoring.coreos.com
+    resources:
+      - servicemonitors
+      - prometheusrules
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete


### PR DESCRIPTION
**What does this PR do / why we need it**:

At the current moment, the agent's cluster role is minimal and does not allow for reading every resource. This leads to the resource proxy not being able to get resources when interacting with something like the UI. This can lead to confusion for users due to getting resources from the UI being a more common use case.

This PR adds the examples from the [live resources](https://argocd-agent.readthedocs.io/latest/user-guide/live-resources/#rbac-requirements) docs page to the `examples/` directory with ClusterRoleBindings so they can be applied/edited easier.

**Which issue(s) this PR fixes**:

N/A

**How to test changes / Special notes to the reviewer**:

Deploy an Agent with the updated RBAC to ensure that it can read resources in the UI.

**Checklist**

* [X] Documentation update is required by this PR (and has been updated) OR no documentation update is required.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Kubernetes RBAC examples for configuring the Argo CD Agent Resource Proxy.
  * Added permissions for common application resources, including workloads, networking, configuration, and RBAC objects.
  * Added a Custom Resource example covering cert-manager, Istio, and monitoring resources.
  * Added bindings connecting these permissions to the Argo CD Agent service account.

* **Documentation**
  * Added guidance describing the proxy’s default permission scope and available RBAC examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->