### PR TITLE
fix: rewrite ApplicationSet/Application namespace in cached resource tree for agent-owned apps

### DIFF
--- a/principal/redisproxy/redisproxy.go
+++ b/principal/redisproxy/redisproxy.go
@@ -575,12 +575,6 @@ func (rp *RedisProxy) handleAgentGet(connState *connectionState, key string, arg
 
 		responseBytes := response.Get.Bytes
 
-		// The resource tree cache is built by the agent using its own (local) namespace
-		// for every Application-kind node, since that's genuinely where those objects
-		// live on the agent's cluster. The UI uses this data verbatim to build links in
-		// the resource tree, so for agent-owned Application nodes we rewrite Namespace to
-		// the agent's namespace on the principal, mirroring the same rewrite that's
-		// already applied to Application.status.resources in event.go.
 		if strings.HasPrefix(key, "app|resources-tree|") {
 			if rewritten, err := rewriteResourcesTreeNamespace(responseBytes, agentName); err != nil {
 				logCtx.WithError(err).Warn("unable to rewrite namespace in cached resource tree, forwarding as-is")
@@ -601,22 +595,9 @@ func (rp *RedisProxy) handleAgentGet(connState *connectionState, key string, arg
 	}
 }
 
-// rewriteResourcesTreeNamespace rewrites the Namespace field of every Application- and
-// ApplicationSet-kind node in a cached resource tree to the agent's namespace on the
-// principal. The cached tree is built by the agent using its own local namespace for
-// these nodes, which is correct on the agent's cluster but not where the mirrored
-// Application actually lives on the principal, so links built from this data in the UI
-// need it rewritten the same way Application.status.resources already is (see
-// principal/event.go).
-//
-// ApplicationSet nodes are included alongside Application nodes (not just the latter,
-// which is all Application.status.resources itself needs) because the UI's resource-tree
-// renderer only draws a connecting edge between a parent and child node when their
-// Namespace fields are equal (see ui/.../application-resource-tree.tsx). Rewriting only
-// the Application-kind children of an ApplicationSet, and not the ApplicationSet itself,
-// leaves them with mismatched namespaces and visually disconnected from their parent,
-// even though the grouping itself (keyed by UID, not namespace) and the per-node links
-// are both already correct.
+// rewriteResourcesTreeNamespace rewrites Namespace on Application/ApplicationSet nodes
+// in a cached resource tree to the agent's namespace, mirroring the same rewrite already
+// done for Application.status.resources in principal/event.go.
 func rewriteResourcesTreeNamespace(data []byte, agentName string) ([]byte, error) {
 	gzipped := len(data) >= 2 && data[0] == 0x1f && data[1] == 0x8b
 

--- a/principal/redisproxy/redisproxy.go
+++ b/principal/redisproxy/redisproxy.go
@@ -620,12 +620,16 @@ func rewriteResourcesTreeNamespace(data []byte, agentName string) ([]byte, error
 	}
 
 	rewritten := false
-	for i, node := range tree.Nodes {
-		if node.Group == "argoproj.io" && (node.Kind == "Application" || node.Kind == "ApplicationSet") && node.Namespace != agentName {
-			tree.Nodes[i].Namespace = agentName
-			rewritten = true
+	rewriteNodes := func(nodes []v1alpha1.ResourceNode) {
+		for i, node := range nodes {
+			if node.Group == "argoproj.io" && (node.Kind == "Application" || node.Kind == "ApplicationSet") && node.Namespace != agentName {
+				nodes[i].Namespace = agentName
+				rewritten = true
+			}
 		}
 	}
+	rewriteNodes(tree.Nodes)
+	rewriteNodes(tree.OrphanedNodes)
 	if !rewritten {
 		// Nothing to change: forward the original bytes untouched.
 		return data, nil

--- a/principal/redisproxy/redisproxy.go
+++ b/principal/redisproxy/redisproxy.go
@@ -17,10 +17,12 @@ package redisproxy
 import (
 	"bufio"
 	"bytes"
+	"compress/gzip"
 	"context"
 	"crypto"
 	"crypto/tls"
 	"crypto/x509"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net"
@@ -33,6 +35,7 @@ import (
 	"github.com/argoproj-labs/argocd-agent/internal/logging"
 	"github.com/argoproj-labs/argocd-agent/internal/tlsutil"
 	"github.com/argoproj-labs/argocd-agent/principal/tracker"
+	"github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
 	cloudevents "github.com/cloudevents/sdk-go/v2"
 	"github.com/google/uuid"
 	"github.com/sirupsen/logrus"
@@ -570,16 +573,92 @@ func (rp *RedisProxy) handleAgentGet(connState *connectionState, key string, arg
 
 		// Cache hit: there was data for that key in agent redis, so forward back to principal Argo CD
 
+		responseBytes := response.Get.Bytes
+
+		// The resource tree cache is built by the agent using its own (local) namespace
+		// for every Application-kind node, since that's genuinely where those objects
+		// live on the agent's cluster. The UI uses this data verbatim to build links in
+		// the resource tree, so for agent-owned Application nodes we rewrite Namespace to
+		// the agent's namespace on the principal, mirroring the same rewrite that's
+		// already applied to Application.status.resources in event.go.
+		if strings.HasPrefix(key, "app|resources-tree|") {
+			if rewritten, err := rewriteResourcesTreeNamespace(responseBytes, agentName); err != nil {
+				logCtx.WithError(err).Warn("unable to rewrite namespace in cached resource tree, forwarding as-is")
+			} else {
+				responseBytes = rewritten
+			}
+		}
+
 		// We sanitize the log string because it may contain confidential data, which we don't want to log.
-		logCtx.Tracef("Wrote GET response to argo cd: '%s' '%s'", key, sanitizeStringIfNonASCII(string(response.Get.Bytes)))
+		logCtx.Tracef("Wrote GET response to argo cd: '%s' '%s'", key, sanitizeStringIfNonASCII(string(responseBytes)))
 
 		// Get response format is as described above
-		if err := argocdWriter.writeToArgoCDRedisSocket(logCtx, fmt.Appendf(nil, "$%d\r\n%s\r\n", len(response.Get.Bytes), response.Get.Bytes)); err != nil {
+		if err := argocdWriter.writeToArgoCDRedisSocket(logCtx, fmt.Appendf(nil, "$%d\r\n%s\r\n", len(responseBytes), responseBytes)); err != nil {
 			return err
 		}
 
 		return nil
 	}
+}
+
+// rewriteResourcesTreeNamespace rewrites the Namespace field of every Application-kind
+// node in a cached resource tree to the agent's namespace on the principal. The cached
+// tree is built by the agent using its own local namespace for these nodes, which is
+// correct on the agent's cluster but not where the mirrored Application actually lives
+// on the principal, so links built from this data in the UI need it rewritten the same
+// way Application.status.resources already is (see principal/event.go).
+func rewriteResourcesTreeNamespace(data []byte, agentName string) ([]byte, error) {
+	gzipped := len(data) >= 2 && data[0] == 0x1f && data[1] == 0x8b
+
+	raw := data
+	if gzipped {
+		gzipReader, err := gzip.NewReader(bytes.NewReader(data))
+		if err != nil {
+			return nil, fmt.Errorf("unable to create gzip reader: %w", err)
+		}
+		defer gzipReader.Close()
+		raw, err = io.ReadAll(gzipReader)
+		if err != nil {
+			return nil, fmt.Errorf("unable to decompress cached resource tree: %w", err)
+		}
+	}
+
+	var tree v1alpha1.ApplicationTree
+	if err := json.Unmarshal(raw, &tree); err != nil {
+		return nil, fmt.Errorf("unable to unmarshal cached resource tree: %w", err)
+	}
+
+	rewritten := false
+	for i, node := range tree.Nodes {
+		if node.Group == "argoproj.io" && node.Kind == "Application" && node.Namespace != agentName {
+			tree.Nodes[i].Namespace = agentName
+			rewritten = true
+		}
+	}
+	if !rewritten {
+		// Nothing to change: forward the original bytes untouched.
+		return data, nil
+	}
+
+	newRaw, err := json.Marshal(&tree)
+	if err != nil {
+		return nil, fmt.Errorf("unable to marshal rewritten resource tree: %w", err)
+	}
+
+	if !gzipped {
+		return newRaw, nil
+	}
+
+	buf := &bytes.Buffer{}
+	gzipWriter := gzip.NewWriter(buf)
+	if _, err := gzipWriter.Write(newRaw); err != nil {
+		return nil, fmt.Errorf("unable to compress rewritten resource tree: %w", err)
+	}
+	if err := gzipWriter.Close(); err != nil {
+		return nil, fmt.Errorf("unable to close gzip writer: %w", err)
+	}
+
+	return buf.Bytes(), nil
 }
 
 // handleAgentSubscribe handles a subscription request from Argo CD to be forwarded to agent redis

--- a/principal/redisproxy/redisproxy.go
+++ b/principal/redisproxy/redisproxy.go
@@ -601,12 +601,22 @@ func (rp *RedisProxy) handleAgentGet(connState *connectionState, key string, arg
 	}
 }
 
-// rewriteResourcesTreeNamespace rewrites the Namespace field of every Application-kind
-// node in a cached resource tree to the agent's namespace on the principal. The cached
-// tree is built by the agent using its own local namespace for these nodes, which is
-// correct on the agent's cluster but not where the mirrored Application actually lives
-// on the principal, so links built from this data in the UI need it rewritten the same
-// way Application.status.resources already is (see principal/event.go).
+// rewriteResourcesTreeNamespace rewrites the Namespace field of every Application- and
+// ApplicationSet-kind node in a cached resource tree to the agent's namespace on the
+// principal. The cached tree is built by the agent using its own local namespace for
+// these nodes, which is correct on the agent's cluster but not where the mirrored
+// Application actually lives on the principal, so links built from this data in the UI
+// need it rewritten the same way Application.status.resources already is (see
+// principal/event.go).
+//
+// ApplicationSet nodes are included alongside Application nodes (not just the latter,
+// which is all Application.status.resources itself needs) because the UI's resource-tree
+// renderer only draws a connecting edge between a parent and child node when their
+// Namespace fields are equal (see ui/.../application-resource-tree.tsx). Rewriting only
+// the Application-kind children of an ApplicationSet, and not the ApplicationSet itself,
+// leaves them with mismatched namespaces and visually disconnected from their parent,
+// even though the grouping itself (keyed by UID, not namespace) and the per-node links
+// are both already correct.
 func rewriteResourcesTreeNamespace(data []byte, agentName string) ([]byte, error) {
 	gzipped := len(data) >= 2 && data[0] == 0x1f && data[1] == 0x8b
 
@@ -630,7 +640,7 @@ func rewriteResourcesTreeNamespace(data []byte, agentName string) ([]byte, error
 
 	rewritten := false
 	for i, node := range tree.Nodes {
-		if node.Group == "argoproj.io" && node.Kind == "Application" && node.Namespace != agentName {
+		if node.Group == "argoproj.io" && (node.Kind == "Application" || node.Kind == "ApplicationSet") && node.Namespace != agentName {
 			tree.Nodes[i].Namespace = agentName
 			rewritten = true
 		}

--- a/principal/redisproxy/redisproxy_test.go
+++ b/principal/redisproxy/redisproxy_test.go
@@ -15,12 +15,17 @@
 package redisproxy
 
 import (
+	"bytes"
+	"compress/gzip"
 	"context"
+	"encoding/json"
 	"fmt"
+	"io"
 	"testing"
 
 	"github.com/argoproj-labs/argocd-agent/internal/event"
 	"github.com/argoproj-labs/argocd-agent/internal/logging"
+	"github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
 	cloudevents "github.com/cloudevents/sdk-go/v2"
 	"github.com/google/uuid"
 	"github.com/sirupsen/logrus"
@@ -454,5 +459,90 @@ func Test_handleAgentSubscribe(t *testing.T) {
 
 		// Check that ping routine was started
 		require.True(t, connState.pingRoutineStarted[agentName])
+	})
+}
+
+func Test_rewriteResourcesTreeNamespace(t *testing.T) {
+	t.Run("rewrites namespace for Application-kind nodes, gzip'd", func(t *testing.T) {
+		tree := &v1alpha1.ApplicationTree{
+			Nodes: []v1alpha1.ResourceNode{
+				{
+					ResourceRef: v1alpha1.ResourceRef{
+						Group: "argoproj.io", Kind: "Application", Namespace: "argocd", Name: "child-app",
+					},
+				},
+				{
+					ResourceRef: v1alpha1.ResourceRef{
+						Group: "apps", Kind: "Deployment", Namespace: "default", Name: "some-deployment",
+					},
+				},
+			},
+		}
+		raw, err := json.Marshal(tree)
+		require.NoError(t, err)
+
+		buf := &bytes.Buffer{}
+		gzipWriter := gzip.NewWriter(buf)
+		_, err = gzipWriter.Write(raw)
+		require.NoError(t, err)
+		require.NoError(t, gzipWriter.Close())
+
+		rewritten, err := rewriteResourcesTreeNamespace(buf.Bytes(), "agent-staging")
+		require.NoError(t, err)
+
+		gzipReader, err := gzip.NewReader(bytes.NewReader(rewritten))
+		require.NoError(t, err)
+		decompressed, err := io.ReadAll(gzipReader)
+		require.NoError(t, err)
+
+		var got v1alpha1.ApplicationTree
+		require.NoError(t, json.Unmarshal(decompressed, &got))
+
+		require.Equal(t, "agent-staging", got.Nodes[0].Namespace, "Application node namespace should be rewritten")
+		require.Equal(t, "default", got.Nodes[1].Namespace, "non-Application node namespace should be untouched")
+	})
+
+	t.Run("rewrites namespace for Application-kind nodes, uncompressed", func(t *testing.T) {
+		tree := &v1alpha1.ApplicationTree{
+			Nodes: []v1alpha1.ResourceNode{
+				{
+					ResourceRef: v1alpha1.ResourceRef{
+						Group: "argoproj.io", Kind: "Application", Namespace: "argocd", Name: "child-app",
+					},
+				},
+			},
+		}
+		raw, err := json.Marshal(tree)
+		require.NoError(t, err)
+
+		rewritten, err := rewriteResourcesTreeNamespace(raw, "agent-staging")
+		require.NoError(t, err)
+
+		var got v1alpha1.ApplicationTree
+		require.NoError(t, json.Unmarshal(rewritten, &got))
+		require.Equal(t, "agent-staging", got.Nodes[0].Namespace)
+	})
+
+	t.Run("no Application nodes: returns original bytes untouched", func(t *testing.T) {
+		tree := &v1alpha1.ApplicationTree{
+			Nodes: []v1alpha1.ResourceNode{
+				{
+					ResourceRef: v1alpha1.ResourceRef{
+						Group: "apps", Kind: "Deployment", Namespace: "default", Name: "some-deployment",
+					},
+				},
+			},
+		}
+		raw, err := json.Marshal(tree)
+		require.NoError(t, err)
+
+		rewritten, err := rewriteResourcesTreeNamespace(raw, "agent-staging")
+		require.NoError(t, err)
+		require.Equal(t, raw, rewritten)
+	})
+
+	t.Run("invalid data: returns an error", func(t *testing.T) {
+		_, err := rewriteResourcesTreeNamespace([]byte("not json"), "agent-staging")
+		require.Error(t, err)
 	})
 }

--- a/principal/redisproxy/redisproxy_test.go
+++ b/principal/redisproxy/redisproxy_test.go
@@ -558,6 +558,33 @@ func Test_rewriteResourcesTreeNamespace(t *testing.T) {
 		require.Equal(t, got.Nodes[0].Namespace, got.Nodes[1].Namespace, "ApplicationSet and its generated child must end up with matching namespaces so the UI draws the connecting edge between them")
 	})
 
+	t.Run("rewrites namespace for orphaned Application/ApplicationSet nodes", func(t *testing.T) {
+		tree := &v1alpha1.ApplicationTree{
+			OrphanedNodes: []v1alpha1.ResourceNode{
+				{
+					ResourceRef: v1alpha1.ResourceRef{
+						Group: "argoproj.io", Kind: "Application", Namespace: "argocd", Name: "orphaned-app",
+					},
+				},
+				{
+					ResourceRef: v1alpha1.ResourceRef{
+						Group: "apps", Kind: "Deployment", Namespace: "default", Name: "orphaned-deployment",
+					},
+				},
+			},
+		}
+		raw, err := json.Marshal(tree)
+		require.NoError(t, err)
+
+		rewritten, err := rewriteResourcesTreeNamespace(raw, "agent-staging")
+		require.NoError(t, err)
+
+		var got v1alpha1.ApplicationTree
+		require.NoError(t, json.Unmarshal(rewritten, &got))
+		require.Equal(t, "agent-staging", got.OrphanedNodes[0].Namespace, "orphaned Application node namespace should be rewritten")
+		require.Equal(t, "default", got.OrphanedNodes[1].Namespace, "non-argoproj.io orphaned node namespace should be untouched")
+	})
+
 	t.Run("no Application/ApplicationSet nodes: returns original bytes untouched", func(t *testing.T) {
 		tree := &v1alpha1.ApplicationTree{
 			Nodes: []v1alpha1.ResourceNode{

--- a/principal/redisproxy/redisproxy_test.go
+++ b/principal/redisproxy/redisproxy_test.go
@@ -463,12 +463,17 @@ func Test_handleAgentSubscribe(t *testing.T) {
 }
 
 func Test_rewriteResourcesTreeNamespace(t *testing.T) {
-	t.Run("rewrites namespace for Application-kind nodes, gzip'd", func(t *testing.T) {
+	t.Run("rewrites namespace for Application- and ApplicationSet-kind nodes, gzip'd", func(t *testing.T) {
 		tree := &v1alpha1.ApplicationTree{
 			Nodes: []v1alpha1.ResourceNode{
 				{
 					ResourceRef: v1alpha1.ResourceRef{
 						Group: "argoproj.io", Kind: "Application", Namespace: "argocd", Name: "child-app",
+					},
+				},
+				{
+					ResourceRef: v1alpha1.ResourceRef{
+						Group: "argoproj.io", Kind: "ApplicationSet", Namespace: "argocd", Name: "generator",
 					},
 				},
 				{
@@ -499,7 +504,8 @@ func Test_rewriteResourcesTreeNamespace(t *testing.T) {
 		require.NoError(t, json.Unmarshal(decompressed, &got))
 
 		require.Equal(t, "agent-staging", got.Nodes[0].Namespace, "Application node namespace should be rewritten")
-		require.Equal(t, "default", got.Nodes[1].Namespace, "non-Application node namespace should be untouched")
+		require.Equal(t, "agent-staging", got.Nodes[1].Namespace, "ApplicationSet node namespace should be rewritten")
+		require.Equal(t, "default", got.Nodes[2].Namespace, "non-argoproj.io node namespace should be untouched")
 	})
 
 	t.Run("rewrites namespace for Application-kind nodes, uncompressed", func(t *testing.T) {
@@ -523,7 +529,36 @@ func Test_rewriteResourcesTreeNamespace(t *testing.T) {
 		require.Equal(t, "agent-staging", got.Nodes[0].Namespace)
 	})
 
-	t.Run("no Application nodes: returns original bytes untouched", func(t *testing.T) {
+	t.Run("ApplicationSet-generated child ends up with the same namespace as its ApplicationSet parent", func(t *testing.T) {
+		tree := &v1alpha1.ApplicationTree{
+			Nodes: []v1alpha1.ResourceNode{
+				{
+					ResourceRef: v1alpha1.ResourceRef{
+						Group: "argoproj.io", Kind: "ApplicationSet", Namespace: "argocd", Name: "generator", UID: "appset-uid",
+					},
+				},
+				{
+					ResourceRef: v1alpha1.ResourceRef{
+						Group: "argoproj.io", Kind: "Application", Namespace: "argocd", Name: "generated-app",
+					},
+					ParentRefs: []v1alpha1.ResourceRef{
+						{Group: "argoproj.io", Kind: "ApplicationSet", Namespace: "argocd", Name: "generator", UID: "appset-uid"},
+					},
+				},
+			},
+		}
+		raw, err := json.Marshal(tree)
+		require.NoError(t, err)
+
+		rewritten, err := rewriteResourcesTreeNamespace(raw, "agent-staging")
+		require.NoError(t, err)
+
+		var got v1alpha1.ApplicationTree
+		require.NoError(t, json.Unmarshal(rewritten, &got))
+		require.Equal(t, got.Nodes[0].Namespace, got.Nodes[1].Namespace, "ApplicationSet and its generated child must end up with matching namespaces so the UI draws the connecting edge between them")
+	})
+
+	t.Run("no Application/ApplicationSet nodes: returns original bytes untouched", func(t *testing.T) {
 		tree := &v1alpha1.ApplicationTree{
 			Nodes: []v1alpha1.ResourceNode{
 				{


### PR DESCRIPTION
**What does this PR do / why we need it**:

For hybrid setups with an autonomous agent, the resource tree cache for an agent-owned Application is built by the agent using its own local namespace. That's correct on the agent's cluster, but not where the mirrored Application lives on the principal, so links built from this data in the UI point at the wrong namespace and 404/permission-deny for every child in the tree, direct children and ApplicationSet-generated grandchildren alike.

`Application.status.resources` already gets this rewrite in `principal/event.go` (#949, #962), but that only covers the flat status field, not the interactive resource tree served via `ResourceTree`/`WatchResourceTree` and cached in Redis, which is what the UI actually uses to render the graph and build links.

This adds the same rewrite for `Application`- and `ApplicationSet`-kind nodes in that cached tree, applied in `principal/redisproxy` where the cached bytes are forwarded back to the principal's Argo CD. Both kinds need it: the UI only draws a connecting edge between a parent and child node when their `Namespace` fields are equal, so rewriting only `Application` nodes left ApplicationSet-generated children with a mismatched namespace against their (unrewritten) ApplicationSet parent, visually disconnecting them from the tree even though their links were already correct.

**Which issue(s) this PR fixes**:

Fixes #1040

**How to test changes / Special notes to the reviewer**:

Verified against a live hub/autonomous-spoke setup: built this fix into a test image, deployed it to the principal, and confirmed both the previously-broken child links now resolve to the correct namespace and ApplicationSet-generated children are visually connected to their parent in the resource tree again.

**Checklist**

* [x] Documentation update is required by this PR (and has been updated) OR no documentation update is required.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected cached resource-tree responses so `Application` and `ApplicationSet` namespaces are aligned with the target agent.
  * Maintained support for both gzipped and uncompressed cached payloads when applying the namespace update.
  * Confirmed that non-`argoproj.io` namespaces (including orphaned nodes) are left unchanged, and malformed cached payloads fail safely.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->