### PR TITLE
feat: add SPIFFE/SPIRE integration for automated mTLS authentication

### DIFF
--- a/cmd/argocd-agent/agent.go
+++ b/cmd/argocd-agent/agent.go
@@ -210,6 +210,15 @@ func NewAgentRunCommand() *cobra.Command {
 			if spireAuthMethod != "" && spireAuthMethod != "jwt" && spireAuthMethod != "mtls" {
 				cmdutil.Fatal("--spire-auth-method must be 'jwt' or 'mtls', got %q", spireAuthMethod)
 			}
+			if spireAgentSocket != "" && insecurePlaintext {
+				cmdutil.Fatal("--spire-agent-socket cannot be used with --insecure-plaintext; SPIRE provides TLS credentials")
+			}
+			if spireAgentSocket != "" && insecure {
+				cmdutil.Fatal("--spire-agent-socket cannot be used with --insecure-tls; SPIRE handles certificate verification")
+			}
+			if spireAgentSocket != "" && creds != "" {
+				cmdutil.Fatal("--creds cannot be used with --spire-agent-socket; SPIRE derives credentials from --spire-auth-method")
+			}
 
 			// Configure TLS: SPIRE, plaintext, or static certs
 			if spireAgentSocket != "" {

--- a/cmd/argocd-agent/agent.go
+++ b/cmd/argocd-agent/agent.go
@@ -216,9 +216,6 @@ func NewAgentRunCommand() *cobra.Command {
 			if spireAgentSocket != "" && insecure {
 				cmdutil.Fatal("--spire-agent-socket cannot be used with --insecure-tls; SPIRE handles certificate verification")
 			}
-			if spireAgentSocket != "" && creds != "" {
-				cmdutil.Fatal("--creds cannot be used with --spire-agent-socket; SPIRE derives credentials from --spire-auth-method")
-			}
 
 			// Configure TLS: SPIRE, plaintext, or static certs
 			if spireAgentSocket != "" {

--- a/cmd/argocd-agent/agent.go
+++ b/cmd/argocd-agent/agent.go
@@ -34,6 +34,7 @@ import (
 	"github.com/argoproj-labs/argocd-agent/internal/env"
 	"github.com/argoproj-labs/argocd-agent/internal/grpcutil"
 	"github.com/argoproj-labs/argocd-agent/internal/metrics"
+	"github.com/argoproj-labs/argocd-agent/internal/spire"
 	"github.com/argoproj-labs/argocd-agent/internal/tracing"
 	"github.com/argoproj-labs/argocd-agent/pkg/client"
 	"github.com/argoproj-labs/argocd-agent/pkg/types"
@@ -118,6 +119,10 @@ func NewAgentRunCommand() *cobra.Command {
 
 		// Adoption options
 		adoptionPolicy string
+
+		// SPIRE integration
+		spireAgentSocket string
+		spireAuthMethod  string
 	)
 	command := &cobra.Command{
 		Use:   "agent",
@@ -195,8 +200,40 @@ func NewAgentRunCommand() *cobra.Command {
 			}
 			var remote *client.Remote
 
-			// Configure TLS or plaintext mode
-			if insecurePlaintext {
+			// Validate SPIRE flags
+			if spireAgentSocket != "" && spireAuthMethod == "" {
+				cmdutil.Fatal("--spire-auth-method is required when --spire-agent-socket is set (use 'jwt' or 'mtls')")
+			}
+			if spireAuthMethod != "" && spireAgentSocket == "" {
+				cmdutil.Fatal("--spire-auth-method requires --spire-agent-socket to be set")
+			}
+			if spireAuthMethod != "" && spireAuthMethod != "jwt" && spireAuthMethod != "mtls" {
+				cmdutil.Fatal("--spire-auth-method must be 'jwt' or 'mtls', got %q", spireAuthMethod)
+			}
+
+			// Configure TLS: SPIRE, plaintext, or static certs
+			if spireAgentSocket != "" {
+				logrus.Infof("Using SPIRE for TLS credentials (socket: %s)", spireAgentSocket)
+				spireSource, err := spire.New(ctx, spireAgentSocket)
+				if err != nil {
+					cmdutil.Fatal("Failed to connect to SPIRE Agent: %v", err)
+				}
+				defer spireSource.Close()
+				remoteOpts = append(remoteOpts, client.WithSPIRE(spireSource, spireAuthMethod == "mtls"))
+				if creds == "" {
+					switch spireAuthMethod {
+					case "mtls":
+						creds = "mtls:"
+					case "jwt":
+						creds = "spiffe-jwt:"
+					}
+					authMethod, authCreds, err := parseCreds(creds)
+					if err != nil {
+						cmdutil.Fatal("Error setting up creds: %v", err)
+					}
+					remoteOpts = append(remoteOpts, client.WithAuth(authMethod, authCreds))
+				}
+			} else if insecurePlaintext {
 				// Plaintext mode - skip all TLS configuration (e.g., when behind Istio)
 				logrus.Warn("INSECURE: Connecting without TLS - ensure Istio or similar service mesh provides mTLS")
 				remoteOpts = append(remoteOpts, client.WithInsecurePlaintext())
@@ -503,6 +540,14 @@ func NewAgentRunCommand() *cobra.Command {
 		env.StringWithDefault("ARGOCD_AGENT_ADOPTION_POLICY", nil, "always"),
 		"Set the adoption policy for applications that already exist on a managed agent (always or never)")
 
+	command.Flags().StringVar(&spireAgentSocket, "spire-agent-socket",
+		env.StringWithDefault("ARGOCD_AGENT_SPIRE_AGENT_SOCKET", nil, ""),
+		"SPIRE Agent socket URI (e.g., unix:///run/spire/sockets/agent.sock). When set, TLS credentials are obtained from SPIRE instead of static certs")
+
+	command.Flags().StringVar(&spireAuthMethod, "spire-auth-method",
+		env.StringWithDefault("ARGOCD_AGENT_SPIRE_AUTH_METHOD", nil, ""),
+		"SPIFFE authentication method (required when --spire-agent-socket is set): 'jwt' uses JWT-SVIDs (for federated SPIRE), 'mtls' uses X.509-SVIDs (for centralized SPIRE)")
+
 	command.Flags().StringVar(&kubeConfig, "kubeconfig", "", "Path to a kubeconfig file to use")
 	command.Flags().StringVar(&kubeContext, "kubecontext", "", "Override the default kube context")
 	return command
@@ -524,6 +569,8 @@ func parseCreds(credStr string) (string, auth.Credentials, error) {
 		return auth.MethodUserPass, creds, nil
 	case auth.MethodMTLS:
 		return auth.MethodMTLS, auth.Credentials{}, nil
+	case auth.MethodSPIFFEJWT:
+		return auth.MethodSPIFFEJWT, auth.Credentials{}, nil
 	case auth.MethodHeader:
 		// Header-based auth doesn't require credentials - the sidecar/proxy injects the header
 		return auth.MethodHeader, auth.Credentials{}, nil

--- a/cmd/argocd-agent/agent.go
+++ b/cmd/argocd-agent/agent.go
@@ -34,6 +34,7 @@ import (
 	"github.com/argoproj-labs/argocd-agent/internal/env"
 	"github.com/argoproj-labs/argocd-agent/internal/grpcutil"
 	"github.com/argoproj-labs/argocd-agent/internal/metrics"
+	"github.com/argoproj-labs/argocd-agent/internal/spire"
 	"github.com/argoproj-labs/argocd-agent/internal/tracing"
 	"github.com/argoproj-labs/argocd-agent/pkg/client"
 	"github.com/argoproj-labs/argocd-agent/pkg/types"
@@ -118,6 +119,10 @@ func NewAgentRunCommand() *cobra.Command {
 
 		// Adoption options
 		adoptionPolicy string
+
+		// SPIRE integration
+		spireAgentSocket string
+		spireAuthMethod  string
 	)
 	command := &cobra.Command{
 		Use:   "agent",
@@ -195,8 +200,40 @@ func NewAgentRunCommand() *cobra.Command {
 			}
 			var remote *client.Remote
 
-			// Configure TLS or plaintext mode
-			if insecurePlaintext {
+			// Validate SPIRE flags
+			if spireAgentSocket != "" && spireAuthMethod == "" {
+				cmdutil.Fatal("--spire-auth-method is required when --spire-agent-socket is set (use 'jwt' or 'mtls')")
+			}
+			if spireAuthMethod != "" && spireAgentSocket == "" {
+				cmdutil.Fatal("--spire-auth-method requires --spire-agent-socket to be set")
+			}
+			if spireAuthMethod != "" && spireAuthMethod != "jwt" && spireAuthMethod != "mtls" {
+				cmdutil.Fatal("--spire-auth-method must be 'jwt' or 'mtls', got %q", spireAuthMethod)
+			}
+
+			// Configure TLS: SPIRE, plaintext, or static certs
+			if spireAgentSocket != "" {
+				logrus.Infof("Using SPIRE for TLS credentials (socket: %s)", spireAgentSocket)
+				spireSource, err := spire.New(ctx, spireAgentSocket)
+				if err != nil {
+					cmdutil.Fatal("Failed to connect to SPIRE Agent: %v", err)
+				}
+				defer spireSource.Close()
+				remoteOpts = append(remoteOpts, client.WithSPIRE(spireSource, spireAuthMethod == "mtls"))
+				if creds == "" {
+					switch spireAuthMethod {
+					case "mtls":
+						creds = "mtls:"
+					case "jwt":
+						creds = "spiffe-jwt:"
+					}
+					authMethod, authCreds, err := parseCreds(creds)
+					if err != nil {
+						cmdutil.Fatal("Error setting up creds: %v", err)
+					}
+					remoteOpts = append(remoteOpts, client.WithAuth(authMethod, authCreds))
+				}
+			} else if insecurePlaintext {
 				// Plaintext mode - skip all TLS configuration (e.g., when behind Istio)
 				logrus.Warn("INSECURE: Connecting without TLS - ensure Istio or similar service mesh provides mTLS")
 				remoteOpts = append(remoteOpts, client.WithInsecurePlaintext())
@@ -503,6 +540,14 @@ func NewAgentRunCommand() *cobra.Command {
 		env.StringWithDefault("ARGOCD_AGENT_ADOPTION_POLICY", nil, "always"),
 		"Set the adoption policy for applications that already exist on a managed agent (always or never)")
 
+	command.Flags().StringVar(&spireAgentSocket, "spire-agent-socket",
+		env.StringWithDefault("ARGOCD_AGENT_SPIRE_AGENT_SOCKET", nil, ""),
+		"SPIRE Agent socket URI (e.g., unix:///run/spire/sockets/agent.sock). When set, TLS credentials are obtained from SPIRE instead of static certs")
+
+	command.Flags().StringVar(&spireAuthMethod, "spire-auth-method",
+		env.StringWithDefault("ARGOCD_AGENT_SPIRE_AUTH_METHOD", nil, ""),
+		"SPIFFE authentication method (required when --spire-agent-socket is set): 'jwt' uses JWT-SVIDs (for federated SPIRE), 'mtls' uses X.509-SVIDs (for centralized SPIRE)")
+
 	command.Flags().StringVar(&kubeConfig, "kubeconfig", "", "Path to a kubeconfig file to use")
 	command.Flags().StringVar(&kubeContext, "kubecontext", "", "Override the default kube context")
 	return command
@@ -524,6 +569,8 @@ func parseCreds(credStr string) (string, auth.Credentials, error) {
 		return "userpass", creds, nil
 	case "mtls":
 		return "mtls", auth.Credentials{}, nil
+	case "spiffe-jwt":
+		return "spiffe-jwt", auth.Credentials{}, nil
 	case "header":
 		// Header-based auth doesn't require credentials - the sidecar/proxy injects the header
 		return "header", auth.Credentials{}, nil

--- a/cmd/argocd-agent/principal.go
+++ b/cmd/argocd-agent/principal.go
@@ -29,6 +29,7 @@ import (
 	"github.com/argoproj-labs/argocd-agent/internal/auth"
 	"github.com/argoproj-labs/argocd-agent/internal/auth/header"
 	"github.com/argoproj-labs/argocd-agent/internal/auth/mtls"
+	"github.com/argoproj-labs/argocd-agent/internal/auth/spiffejwt"
 	"github.com/argoproj-labs/argocd-agent/internal/auth/userpass"
 	"github.com/argoproj-labs/argocd-agent/internal/blocklist"
 	"github.com/argoproj-labs/argocd-agent/internal/config"
@@ -36,6 +37,7 @@ import (
 	"github.com/argoproj-labs/argocd-agent/internal/grpcutil"
 	"github.com/argoproj-labs/argocd-agent/internal/kube"
 	"github.com/argoproj-labs/argocd-agent/internal/labels"
+	"github.com/argoproj-labs/argocd-agent/internal/spire"
 	"github.com/argoproj-labs/argocd-agent/internal/tlsutil"
 	"github.com/argoproj-labs/argocd-agent/internal/tracing"
 	"github.com/argoproj-labs/argocd-agent/pkg/ha"
@@ -44,6 +46,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+	"github.com/spiffe/go-spiffe/v2/bundle/jwtbundle"
 )
 
 // NewPrincipalRunCommand returns a new principal run command.
@@ -131,6 +134,10 @@ func NewPrincipalRunCommand() *cobra.Command {
 		haAdminPort                    int
 		haAllowedReplClients           []string
 		haReplicationInitialAckTimeout time.Duration
+
+		// SPIRE integration
+		spireAgentSocket string
+		spireAuthMethod  string
 	)
 	command := &cobra.Command{
 		Use:   "principal",
@@ -213,8 +220,36 @@ func NewPrincipalRunCommand() *cobra.Command {
 
 			opts = append(opts, principal.WithNamespaces(allowedNamespaces...))
 
-			// Configure TLS or plaintext mode
-			if insecurePlaintext {
+			// Validate SPIRE flags
+			if spireAgentSocket != "" && spireAuthMethod == "" {
+				cmdutil.Fatal("--spire-auth-method is required when --spire-agent-socket is set (use 'jwt' or 'mtls')")
+			}
+			if spireAuthMethod != "" && spireAgentSocket == "" {
+				cmdutil.Fatal("--spire-auth-method requires --spire-agent-socket to be set")
+			}
+			if spireAuthMethod != "" && spireAuthMethod != "jwt" && spireAuthMethod != "mtls" {
+				cmdutil.Fatal("--spire-auth-method must be 'jwt' or 'mtls', got %q", spireAuthMethod)
+			}
+
+			// Configure TLS: SPIRE, plaintext, or static certs
+			var spireSource *spire.Source
+			if spireAgentSocket != "" {
+				logrus.Infof("Using SPIRE for TLS credentials (socket: %s)", spireAgentSocket)
+				spireSource, err = spire.New(ctx, spireAgentSocket)
+				if err != nil {
+					cmdutil.Fatal("Failed to connect to SPIRE Agent: %v", err)
+				}
+				defer spireSource.Close()
+				opts = append(opts, principal.WithSPIRESource(spireSource))
+				if authMethod == "" {
+					switch spireAuthMethod {
+					case "mtls":
+						authMethod = `mtls:uri:spiffe://[^/]+/(.+)`
+					case "jwt":
+						authMethod = `spiffe-jwt:spiffe://[^/]+/(.+)`
+					}
+				}
+			} else if insecurePlaintext {
 				logrus.Warn("INSECURE: Running in plaintext mode - ensure Istio or similar service mesh provides mTLS")
 				opts = append(opts, principal.WithInsecurePlaintext())
 			} else if allowTLSGenerate {
@@ -230,8 +265,8 @@ func NewPrincipalRunCommand() *cobra.Command {
 				opts = append(opts, principal.WithTLSKeyPairFromSecret(kubeConfig.Clientset, namespace, tlsSecretName))
 			}
 
-			// Only load root CA if not in plaintext mode
-			if !insecurePlaintext {
+			// Only load root CA if not in plaintext or SPIRE mode
+			if !insecurePlaintext && spireAgentSocket == "" {
 				if rootCaPath != "" {
 					logrus.Infof("Loading root CA certificate from file %s", rootCaPath)
 					opts = append(opts, principal.WithTLSRootCaFromFile(rootCaPath))
@@ -345,6 +380,24 @@ func NewPrincipalRunCommand() *cobra.Command {
 				err = authMethods.RegisterMethod(auth.MethodUserPass, userauth)
 				if err != nil {
 					cmdutil.Fatal("Could not register userpass auth method: %v", err)
+				}
+			case auth.MethodSPIFFEJWT:
+				var regex *regexp.Regexp
+				if authConfig != "" {
+					regex, err = regexp.Compile(authConfig)
+					if err != nil {
+						cmdutil.Fatal("Error compiling spiffe-jwt agent id regex: %v", err)
+					}
+				}
+				var jwtBundleSource jwtbundle.Source
+				if spireSource != nil {
+					jwtBundleSource = spireSource.JWTSource()
+				}
+				jwtAuth := spiffejwt.NewSPIFFEJWTAuthentication(regex, config.SPIREJWTAudience, jwtBundleSource)
+				logrus.Infof("Using SPIFFE JWT authentication (pattern: %s, audience: %s)", authConfig, config.SPIREJWTAudience)
+				err = authMethods.RegisterMethod(auth.MethodSPIFFEJWT, jwtAuth)
+				if err != nil {
+					cmdutil.Fatal("Could not register spiffe-jwt auth method: %v", err)
 				}
 			case auth.MethodHeader:
 				// Generic header-based authentication extracts agent ID from any HTTP header
@@ -673,6 +726,14 @@ func NewPrincipalRunCommand() *cobra.Command {
 		env.StringWithDefault("ARGOCD_PRINCIPAL_LABEL_SELECTOR", nil, ""),
 		"Kubernetes label selector to restrict which resources the principal watches")
 
+	command.Flags().StringVar(&spireAgentSocket, "spire-agent-socket",
+		env.StringWithDefault("ARGOCD_PRINCIPAL_SPIRE_AGENT_SOCKET", nil, ""),
+		"SPIRE Agent socket URI (e.g., unix:///run/spire/sockets/agent.sock). When set, TLS credentials are obtained from SPIRE instead of static certs")
+
+	command.Flags().StringVar(&spireAuthMethod, "spire-auth-method",
+		env.StringWithDefault("ARGOCD_PRINCIPAL_SPIRE_AUTH_METHOD", nil, ""),
+		"SPIFFE authentication method (required when --spire-agent-socket is set): 'jwt' uses JWT-SVIDs (for federated SPIRE), 'mtls' uses X.509-SVIDs (for centralized SPIRE)")
+
 	command.Flags().StringVar(&kubeConfig, "kubeconfig", "", "Path to a kubeconfig file to use")
 	command.Flags().StringVar(&kubeContext, "kubecontext", "", "Override the default kube context")
 
@@ -791,6 +852,8 @@ func parseAuth(authStr string) (string, string, error) {
 		return auth.MethodMTLS, p[1], nil
 	case auth.MethodHeader:
 		return auth.MethodHeader, p[1], nil
+	case auth.MethodSPIFFEJWT:
+		return auth.MethodSPIFFEJWT, p[1], nil
 	default:
 		return "", "", fmt.Errorf("unknown auth method: %s", p[0])
 	}

--- a/cmd/argocd-agent/principal.go
+++ b/cmd/argocd-agent/principal.go
@@ -230,6 +230,9 @@ func NewPrincipalRunCommand() *cobra.Command {
 			if spireAuthMethod != "" && spireAuthMethod != "jwt" && spireAuthMethod != "mtls" {
 				cmdutil.Fatal("--spire-auth-method must be 'jwt' or 'mtls', got %q", spireAuthMethod)
 			}
+			if spireAgentSocket != "" && insecurePlaintext {
+				cmdutil.Fatal("--spire-agent-socket cannot be used with --insecure-plaintext; SPIRE provides TLS credentials")
+			}
 
 			// Configure TLS: SPIRE, plaintext, or static certs
 			var spireSource *spire.Source
@@ -927,6 +930,12 @@ func validateAuthTLSPairing(authMethod string, insecurePlaintext bool) error {
 				"  Either:\n" +
 				"  - Remove --insecure-plaintext flag to enable TLS for mTLS authentication\n" +
 				"  - Use --auth=header:<header>:<regex> for service mesh environments with plaintext mode")
+		}
+	case auth.MethodSPIFFEJWT:
+		if insecurePlaintext {
+			return fmt.Errorf("invalid configuration: spiffe-jwt authentication cannot be used with --insecure-plaintext\n" +
+				"  JWT-SVIDs sent over an unencrypted channel can be intercepted and replayed.\n" +
+				"  Remove --insecure-plaintext flag to enable TLS for SPIFFE JWT authentication")
 		}
 	}
 	return nil

--- a/cmd/argocd-agent/principal.go
+++ b/cmd/argocd-agent/principal.go
@@ -29,12 +29,14 @@ import (
 	"github.com/argoproj-labs/argocd-agent/internal/auth"
 	"github.com/argoproj-labs/argocd-agent/internal/auth/header"
 	"github.com/argoproj-labs/argocd-agent/internal/auth/mtls"
+	"github.com/argoproj-labs/argocd-agent/internal/auth/spiffejwt"
 	"github.com/argoproj-labs/argocd-agent/internal/auth/userpass"
 	"github.com/argoproj-labs/argocd-agent/internal/config"
 	"github.com/argoproj-labs/argocd-agent/internal/env"
 	"github.com/argoproj-labs/argocd-agent/internal/grpcutil"
 	"github.com/argoproj-labs/argocd-agent/internal/kube"
 	"github.com/argoproj-labs/argocd-agent/internal/labels"
+	"github.com/argoproj-labs/argocd-agent/internal/spire"
 	"github.com/argoproj-labs/argocd-agent/internal/tlsutil"
 	"github.com/argoproj-labs/argocd-agent/internal/tracing"
 	"github.com/argoproj-labs/argocd-agent/pkg/ha"
@@ -43,6 +45,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+	"github.com/spiffe/go-spiffe/v2/bundle/jwtbundle"
 )
 
 // NewPrincipalRunCommand returns a new principal run command.
@@ -130,6 +133,10 @@ func NewPrincipalRunCommand() *cobra.Command {
 		haAdminPort                    int
 		haAllowedReplClients           []string
 		haReplicationInitialAckTimeout time.Duration
+
+		// SPIRE integration
+		spireAgentSocket string
+		spireAuthMethod  string
 	)
 	command := &cobra.Command{
 		Use:   "principal",
@@ -212,8 +219,36 @@ func NewPrincipalRunCommand() *cobra.Command {
 
 			opts = append(opts, principal.WithNamespaces(allowedNamespaces...))
 
-			// Configure TLS or plaintext mode
-			if insecurePlaintext {
+			// Validate SPIRE flags
+			if spireAgentSocket != "" && spireAuthMethod == "" {
+				cmdutil.Fatal("--spire-auth-method is required when --spire-agent-socket is set (use 'jwt' or 'mtls')")
+			}
+			if spireAuthMethod != "" && spireAgentSocket == "" {
+				cmdutil.Fatal("--spire-auth-method requires --spire-agent-socket to be set")
+			}
+			if spireAuthMethod != "" && spireAuthMethod != "jwt" && spireAuthMethod != "mtls" {
+				cmdutil.Fatal("--spire-auth-method must be 'jwt' or 'mtls', got %q", spireAuthMethod)
+			}
+
+			// Configure TLS: SPIRE, plaintext, or static certs
+			var spireSource *spire.Source
+			if spireAgentSocket != "" {
+				logrus.Infof("Using SPIRE for TLS credentials (socket: %s)", spireAgentSocket)
+				spireSource, err = spire.New(ctx, spireAgentSocket)
+				if err != nil {
+					cmdutil.Fatal("Failed to connect to SPIRE Agent: %v", err)
+				}
+				defer spireSource.Close()
+				opts = append(opts, principal.WithSPIRESource(spireSource))
+				if authMethod == "" {
+					switch spireAuthMethod {
+					case "mtls":
+						authMethod = `mtls:uri:spiffe://[^/]+/(.+)`
+					case "jwt":
+						authMethod = `spiffe-jwt:spiffe://[^/]+/(.+)`
+					}
+				}
+			} else if insecurePlaintext {
 				logrus.Warn("INSECURE: Running in plaintext mode - ensure Istio or similar service mesh provides mTLS")
 				opts = append(opts, principal.WithInsecurePlaintext())
 			} else if allowTLSGenerate {
@@ -229,8 +264,8 @@ func NewPrincipalRunCommand() *cobra.Command {
 				opts = append(opts, principal.WithTLSKeyPairFromSecret(kubeConfig.Clientset, namespace, tlsSecretName))
 			}
 
-			// Only load root CA if not in plaintext mode
-			if !insecurePlaintext {
+			// Only load root CA if not in plaintext or SPIRE mode
+			if !insecurePlaintext && spireAgentSocket == "" {
 				if rootCaPath != "" {
 					logrus.Infof("Loading root CA certificate from file %s", rootCaPath)
 					opts = append(opts, principal.WithTLSRootCaFromFile(rootCaPath))
@@ -333,6 +368,24 @@ func NewPrincipalRunCommand() *cobra.Command {
 				err = authMethods.RegisterMethod("userpass", userauth)
 				if err != nil {
 					cmdutil.Fatal("Could not register userpass auth method: %v", err)
+				}
+			case "spiffe-jwt":
+				var regex *regexp.Regexp
+				if authConfig != "" {
+					regex, err = regexp.Compile(authConfig)
+					if err != nil {
+						cmdutil.Fatal("Error compiling spiffe-jwt agent id regex: %v", err)
+					}
+				}
+				var jwtBundleSource jwtbundle.Source
+				if spireSource != nil {
+					jwtBundleSource = spireSource.JWTSource()
+				}
+				jwtAuth := spiffejwt.NewSPIFFEJWTAuthentication(regex, config.SPIREJWTAudience, jwtBundleSource)
+				logrus.Infof("Using SPIFFE JWT authentication (pattern: %s, audience: %s)", authConfig, config.SPIREJWTAudience)
+				err = authMethods.RegisterMethod("spiffe-jwt", jwtAuth)
+				if err != nil {
+					cmdutil.Fatal("Could not register spiffe-jwt auth method: %v", err)
 				}
 			case "header":
 				// Generic header-based authentication extracts agent ID from any HTTP header
@@ -661,6 +714,14 @@ func NewPrincipalRunCommand() *cobra.Command {
 		env.StringWithDefault("ARGOCD_PRINCIPAL_LABEL_SELECTOR", nil, ""),
 		"Kubernetes label selector to restrict which resources the principal watches")
 
+	command.Flags().StringVar(&spireAgentSocket, "spire-agent-socket",
+		env.StringWithDefault("ARGOCD_PRINCIPAL_SPIRE_AGENT_SOCKET", nil, ""),
+		"SPIRE Agent socket URI (e.g., unix:///run/spire/sockets/agent.sock). When set, TLS credentials are obtained from SPIRE instead of static certs")
+
+	command.Flags().StringVar(&spireAuthMethod, "spire-auth-method",
+		env.StringWithDefault("ARGOCD_PRINCIPAL_SPIRE_AUTH_METHOD", nil, ""),
+		"SPIFFE authentication method (required when --spire-agent-socket is set): 'jwt' uses JWT-SVIDs (for federated SPIRE), 'mtls' uses X.509-SVIDs (for centralized SPIRE)")
+
 	command.Flags().StringVar(&kubeConfig, "kubeconfig", "", "Path to a kubeconfig file to use")
 	command.Flags().StringVar(&kubeContext, "kubecontext", "", "Override the default kube context")
 
@@ -779,6 +840,8 @@ func parseAuth(authStr string) (string, string, error) {
 		return "mtls", p[1], nil
 	case "header":
 		return "header", p[1], nil
+	case "spiffe-jwt":
+		return "spiffe-jwt", p[1], nil
 	default:
 		return "", "", fmt.Errorf("unknown auth method: %s", p[0])
 	}

--- a/cmd/ctl/ca.go
+++ b/cmd/ctl/ca.go
@@ -532,7 +532,7 @@ func NewPKIIssueSharedClientCert() *cobra.Command {
 	)
 	command := &cobra.Command{
 		Use:   "shared-client",
-		Short: "Issue a shared client certificate for self-registration",
+		Short: "NON-PROD!! Issue a shared client certificate for self-registration",
 		Long: `Issues a TLS client certificate and stores it in the principal namespace.
 This certificate is used by self-registration: when an agent self-registers,
 the principal copies this shared cert into the agent's cluster secret so that

--- a/cmd/ctl/ca.go
+++ b/cmd/ctl/ca.go
@@ -369,6 +369,7 @@ func NewPKIIssueCommand() *cobra.Command {
 	command.AddCommand(NewPKIIssuePrincipalCommand())
 	command.AddCommand(NewPKIIssueResourceProxyCommand())
 	command.AddCommand(NewPKIIssueAgentClientCert())
+	command.AddCommand(NewPKIIssueSharedClientCert())
 	return command
 }
 
@@ -515,6 +516,40 @@ func NewPKIIssueAgentClientCert() *cobra.Command {
 	command.Flags().BoolVarP(&upsert, "upsert", "u", false, "Whether to update an existing certificate if it exists")
 	command.Flags().BoolVar(&sameContext, "same-context", false, "Use when the PKI and agent use the same context")
 	command.Flags().StringVar(&agentNamespace, "agent-namespace", "argocd", "The namespace the agent is installed to")
+	command.Flags().IntVar(&days, "days", tlsutil.DefaultLeafCertValidityDays, "Number of days the certificate is valid for")
+	addKeyGenFlags(command, &keyAlgorithm, &keySize)
+	return command
+}
+
+// NewPKIIssueSharedClientCert returns a command to issue a shared TLS client
+// certificate for self-registration and store it in the principal namespace.
+func NewPKIIssueSharedClientCert() *cobra.Command {
+	var (
+		upsert       bool
+		days         int
+		keyAlgorithm string
+		keySize      int
+	)
+	command := &cobra.Command{
+		Use:   "shared-client",
+		Short: "Issue a shared client certificate for self-registration",
+		Long: `Issues a TLS client certificate and stores it in the principal namespace.
+This certificate is used by self-registration: when an agent self-registers,
+the principal copies this shared cert into the agent's cluster secret so that
+ArgoCD's application controller can authenticate to the resource proxy.
+
+Only the principal context is required. No agent context needed.`,
+		Run: func(cmd *cobra.Command, args []string) {
+			if principalCfg.KubeContext == "" {
+				cmdutil.Fatal("Principal kubecontext must be set.")
+			}
+			keyOpts := parseKeyGenFlags(keyAlgorithm, keySize)
+			issueAndSaveSecret(principalCfg.KubeContext, config.SecretNameSharedClientCert, principalCfg.Namespace, upsert, days, keyOpts, func(c *x509.Certificate, pk crypto.PrivateKey) (string, string, error) {
+				return tlsutil.GenerateClientCertificate("argocd-agent-shared-client", c, pk, days, keyOpts)
+			})
+		},
+	}
+	command.Flags().BoolVarP(&upsert, "upsert", "u", false, "Whether to update an existing certificate if it exists")
 	command.Flags().IntVar(&days, "days", tlsutil.DefaultLeafCertValidityDays, "Number of days the certificate is valid for")
 	addKeyGenFlags(command, &keyAlgorithm, &keySize)
 	return command

--- a/docs/configuration/authentication.md
+++ b/docs/configuration/authentication.md
@@ -230,7 +230,9 @@ argocd-agent agent --creds="header:"
 |-----------------|--------------|-------|-------|
 | `--insecure-plaintext=true` + `--auth=header:...` | `--creds=header:` | Yes | Service mesh handles mTLS |
 | `--insecure-plaintext=false` + `--auth=mtls:...` | `--creds=mtls:` | Yes | Direct mTLS to principal |
-| `--spire-agent-socket=...` | `--spire-agent-socket=...` | Yes | SPIRE provides mTLS credentials |
+| `--spire-agent-socket=...` + `--spire-auth-method=jwt` | `--spire-agent-socket=...` + `--spire-auth-method=jwt` | Yes | SPIRE JWT-SVID authentication |
+| `--spire-agent-socket=...` + `--spire-auth-method=mtls` | `--spire-agent-socket=...` + `--spire-auth-method=mtls` | Yes | SPIRE X.509-SVID mTLS authentication |
+| `--spire-agent-socket=...` (no `--spire-auth-method`) | Any | **No** | `--spire-auth-method` is required when SPIRE is enabled |
 | `--insecure-plaintext=true` + `--auth=mtls:...` | Any | **No** | No client certs in plaintext mode |
 | `--insecure-plaintext=false` + `--auth=header:...` | Any | **No** | Headers not injected without mesh |
 

--- a/docs/configuration/authentication.md
+++ b/docs/configuration/authentication.md
@@ -296,7 +296,7 @@ ARGOCD_PRINCIPAL_SELF_REGISTRATION_CLIENT_CERT_SECRET: "argocd-agent-shared-clie
 
 The shared client certificate must be created beforehand using `argocd-agentctl pki issue shared-client`. See [TLS & Certificates](tls-certificates.md#using-spire-automated-certificate-management) for the complete setup steps.
 
-No static certificate secrets are needed on the agent cluster — SPIRE provides all credentials automatically.
+No static certificate secrets are needed on the agent cluster. SPIRE provides all credentials automatically.
 
 ## UserPass Authentication (Deprecated)
 

--- a/docs/configuration/authentication.md
+++ b/docs/configuration/authentication.md
@@ -9,6 +9,7 @@ argocd-agent supports three authentication methods:
 | Method | Security Level | Use Case | Status |
 |--------|---------------|----------|--------|
 | **mTLS** | High | Direct agent-to-principal connections | Recommended |
+| **mTLS + SPIRE** | High | Multi-cluster with automated cert management | Recommended for SPIRE environments |
 | **Header-based** | High | Service mesh deployments (Istio, Linkerd) | Recommended for mesh |
 | **UserPass** | Low | Development only | **Deprecated** |
 
@@ -229,8 +230,71 @@ argocd-agent agent --creds="header:"
 |-----------------|--------------|-------|-------|
 | `--insecure-plaintext=true` + `--auth=header:...` | `--creds=header:` | Yes | Service mesh handles mTLS |
 | `--insecure-plaintext=false` + `--auth=mtls:...` | `--creds=mtls:` | Yes | Direct mTLS to principal |
+| `--spire-agent-socket=...` | `--spire-agent-socket=...` | Yes | SPIRE provides mTLS credentials |
 | `--insecure-plaintext=true` + `--auth=mtls:...` | Any | **No** | No client certs in plaintext mode |
 | `--insecure-plaintext=false` + `--auth=header:...` | Any | **No** | Headers not injected without mesh |
+
+## Authentication with SPIRE
+
+When SPIRE is enabled (`--spire-agent-socket`), TLS is handled by SPIRE-issued X.509 SVIDs. The `--spire-auth-method` flag controls how agents authenticate to the principal. Two methods are supported:
+
+### JWT mode (`--spire-auth-method jwt`)
+
+Agent fetches a JWT-SVID from its local SPIRE Agent and sends it as a bearer token. Principal validates the JWT using its SPIRE JWT bundle source. Use this when each cluster has its own SPIRE Server and trust domain (federated setup).
+
+**Principal Configuration:**
+
+```yaml
+# ConfigMap (argocd-agent-params)
+principal.spire.socket-path: "unix:///run/spire/agent-sockets/spire-agent.sock"
+principal.spire.auth-method: "jwt"
+# Auth defaults to spiffe-jwt:spiffe://[^/]+/(.+)
+```
+
+**Agent Configuration:**
+
+```yaml
+# ConfigMap (argocd-agent-params)
+agent.spire.socket-path: "unix:///run/spire/agent-sockets/spire-agent.sock"
+agent.spire.auth-method: "jwt"
+# Creds defaults to spiffe-jwt:
+```
+
+### mTLS mode (`--spire-auth-method mtls`)
+
+Agent presents its X.509-SVID as a TLS client certificate. Principal verifies the cert against the SPIRE trust bundle and extracts identity from the SPIFFE URI in the certificate SAN. Use this when all clusters share a single SPIRE Server (centralized setup), or when your SPIFFE provider doesn't support JWT-SVIDs.
+
+**Principal Configuration:**
+
+```yaml
+# ConfigMap (argocd-agent-params)
+principal.spire.socket-path: "unix:///run/spire/agent-sockets/spire-agent.sock"
+principal.spire.auth-method: "mtls"
+# Auth defaults to mtls:uri:spiffe://[^/]+/(.+)
+```
+
+**Agent Configuration:**
+
+```yaml
+# ConfigMap (argocd-agent-params)
+agent.spire.socket-path: "unix:///run/spire/agent-sockets/spire-agent.sock"
+agent.spire.auth-method: "mtls"
+# Creds defaults to mtls:
+```
+
+### Self-registration (required with SPIRE)
+
+With static certificates, agent registration happens when you run `argocd-agentctl pki issue agent <name>` — this creates the agent's cluster secret on the principal. With SPIRE, there are no per-agent certificate steps, so **self-registration must be enabled** on the principal. When an agent connects for the first time, the principal automatically creates the cluster secret.
+
+```yaml
+# Environment variables on the principal
+ARGOCD_PRINCIPAL_ENABLE_SELF_CLUSTER_REGISTRATION: "true"
+ARGOCD_PRINCIPAL_SELF_REGISTRATION_CLIENT_CERT_SECRET: "argocd-agent-shared-client-tls"
+```
+
+The shared client certificate must be created beforehand using `argocd-agentctl pki issue shared-client`. See [TLS & Certificates](tls-certificates.md#using-spire-automated-certificate-management) for the complete setup steps.
+
+No static certificate secrets are needed on the agent cluster — SPIRE provides all credentials automatically.
 
 ## UserPass Authentication (Deprecated)
 

--- a/docs/configuration/tls-certificates.md
+++ b/docs/configuration/tls-certificates.md
@@ -175,13 +175,15 @@ Register the principal and each agent with the SPIRE Server. The SPIFFE IDs must
 spire-server entry create \
   -spiffeID spiffe://example.org/argocd/principal \
   -parentID <spire-agent-spiffe-id> \
-  -selector k8s:ns:<principal-namespace>
+  -selector k8s:ns:<principal-namespace> \
+  -selector k8s:sa:<principal-service-account>
 
 # Register an agent (on the SPIRE Server that serves the agent's cluster)
 spire-server entry create \
   -spiffeID spiffe://example.org/argocd/agent/cluster-01 \
   -parentID <spire-agent-spiffe-id> \
-  -selector k8s:ns:<agent-namespace>
+  -selector k8s:ns:<agent-namespace> \
+  -selector k8s:sa:<agent-service-account>
 ```
 
 **Agent name extraction:** The principal's auth regex extracts the agent name from the SPIFFE ID. With the default regex `spiffe://[^/]+/(.+)`, the agent name from `spiffe://example.org/argocd/agent/cluster-01` would be `argocd/agent/cluster-01`. A namespace with this name must exist on the principal's cluster for Applications to be routed to this agent.
@@ -199,7 +201,7 @@ kubectl logs deploy/argocd-agent-principal -n argocd | grep -iE "spire|mtls|jwt|
 
 Expected output (JWT mode):
 
-```
+```text
 Using SPIRE for TLS credentials (socket: unix:///run/spire/agent-sockets/spire-agent.sock)
 Connected to SPIRE Agent, X.509 and JWT sources ready
 Using SPIRE for server TLS credentials
@@ -209,7 +211,7 @@ Now listening on [::]:8443
 
 Expected output (mTLS mode):
 
-```
+```text
 Using SPIRE for TLS credentials (socket: unix:///run/spire/agent-sockets/spire-agent.sock)
 Connected to SPIRE Agent, X.509 and JWT sources ready
 Using SPIRE for server TLS credentials

--- a/docs/configuration/tls-certificates.md
+++ b/docs/configuration/tls-certificates.md
@@ -48,7 +48,7 @@ graph TB
 
 ## Using SPIRE (Automated Certificate Management)
 
-[SPIRE](https://spiffe.io/docs/latest/spire-about/) can replace static certificate management for agent-to-principal communication. When enabled, TLS credentials are obtained automatically from the SPIRE Workload API — no per-agent certificate generation, no secret copying between clusters.
+[SPIRE](https://spiffe.io/docs/latest/spire-about/) can replace static certificate management for agent-to-principal communication. When enabled, TLS credentials are obtained automatically from the SPIRE Workload API. There is no per-agent certificate generation, and no secret copying between clusters.
 
 !!! note "What SPIRE replaces and what it does not"
     SPIRE replaces the **agent-to-principal gRPC TLS** certificates (principal server cert, agent client certs, and CA certs) and **agent authentication** (identity comes from SPIFFE IDs instead of certificate CNs). The resource proxy TLS, JWT signing key, and CA secret on the principal are still managed via static secrets.
@@ -74,7 +74,10 @@ Two authentication methods are supported. Choose based on what your SPIRE setup 
 
 ### Step 2: Create one-time secrets on the principal
 
-These static secrets are still required because the resource proxy and JWT signing use static TLS, and self-registration needs a shared client certificate:
+These static secrets are still required because the resource proxy and JWT signing use static TLS, and self-registration needs a shared client certificate.
+
+!!! warning "Non-production PKI"
+    The `argocd-agentctl pki` commands below use a built-in CA intended for development and testing only. For production environments, use certificates issued by your organization's PKI or certificate authority.
 
 ```bash
 # Initialize the CA

--- a/docs/configuration/tls-certificates.md
+++ b/docs/configuration/tls-certificates.md
@@ -46,6 +46,206 @@ graph TB
     ProxyCert --> ArgoCD[Argo CD Server]
 ```
 
+## Using SPIRE (Automated Certificate Management)
+
+[SPIRE](https://spiffe.io/docs/latest/spire-about/) can replace static certificate management for agent-to-principal communication. When enabled, TLS credentials are obtained automatically from the SPIRE Workload API — no per-agent certificate generation, no secret copying between clusters.
+
+!!! note "What SPIRE replaces and what it does not"
+    SPIRE replaces the **agent-to-principal gRPC TLS** certificates (principal server cert, agent client certs, and CA certs) and **agent authentication** (identity comes from SPIFFE IDs instead of certificate CNs). The resource proxy TLS, JWT signing key, and CA secret on the principal are still managed via static secrets.
+
+### Prerequisites
+
+- A SPIFFE-compatible Workload API (e.g., SPIRE) deployed on your clusters
+- A SPIRE Agent socket accessible to principal and agent pods (via hostPath or CSI driver)
+- argocd-agent is **not responsible** for SPIRE infrastructure setup — it only consumes the Workload API
+
+### Step 1: Choose the authentication method
+
+Two authentication methods are supported. Choose based on what your SPIRE setup provides:
+
+| Method | `--spire-auth-method` | How it works | Use when |
+|---|---|---|---|
+| **JWT** | `jwt` | Agent fetches a JWT-SVID from its local SPIRE Agent and sends it as a bearer token. Principal validates the JWT using its SPIRE JWT bundle source. | Each cluster has its own SPIRE Server (separate trust domains). Both sides need JWT-SVID support. This is the most common setup with federated SPIRE. |
+| **mTLS** | `mtls` | Agent presents its X.509-SVID as a TLS client certificate. Principal verifies the cert chain against the SPIRE trust bundle and extracts identity from the SPIFFE URI in the certificate SAN. | All clusters share a single SPIRE Server (same trust domain). Uses only X.509-SVIDs, which are the core SPIFFE standard — works with any SPIFFE-compatible provider, even those that don't support JWT-SVIDs. |
+
+!!! tip "Which method should I choose?"
+    - If your clusters each have their own SPIRE Server and trust domain → use **JWT**
+    - If all clusters share a single SPIRE Server → use **mTLS**
+
+### Step 2: Create one-time secrets on the principal
+
+These static secrets are still required because the resource proxy and JWT signing use static TLS, and self-registration needs a shared client certificate:
+
+```bash
+# Initialize the CA
+argocd-agentctl pki init \
+  --principal-context <control-plane-context> \
+  --principal-namespace argocd
+
+# Issue the resource proxy server certificate
+argocd-agentctl pki issue resource-proxy \
+  --principal-context <control-plane-context> \
+  --principal-namespace argocd \
+  --dns argocd-agent-resource-proxy.argocd.svc.cluster.local \
+  --upsert
+
+# Issue a shared client certificate for self-registration
+argocd-agentctl pki issue shared-client \
+  --principal-context <control-plane-context> \
+  --principal-namespace argocd \
+  --upsert
+
+# Create the JWT signing key
+argocd-agentctl jwt create-key \
+  --principal-context <control-plane-context> \
+  --principal-namespace argocd \
+  --upsert
+```
+
+### Step 3: Enable self-registration on the principal
+
+!!! important "Self-registration is required with SPIRE"
+    With static certificates, you manually run `argocd-agentctl pki issue agent <name>` for each agent — this creates the agent's cluster secret on the principal. With SPIRE, there are no per-agent certificate steps. Instead, **self-registration** must be enabled so the principal automatically creates the agent's cluster secret when the agent connects for the first time.
+
+Enable self-registration by setting these environment variables (or CLI flags) on the principal:
+
+| Environment Variable | Value | Description |
+|---|---|---|
+| `ARGOCD_PRINCIPAL_ENABLE_SELF_CLUSTER_REGISTRATION` | `true` | Enables automatic cluster secret creation when a new agent connects |
+| `ARGOCD_PRINCIPAL_SELF_REGISTRATION_CLIENT_CERT_SECRET` | `argocd-agent-shared-client-tls` | Name of the shared client cert secret (created in Step 2). The principal copies this into the agent's cluster secret so the ArgoCD application controller can authenticate to the resource proxy. |
+
+### Step 4: Configure the principal
+
+```yaml
+# ConfigMap (argocd-agent-params)
+principal.spire.socket-path: "unix:///run/spire/agent-sockets/spire-agent.sock"
+principal.spire.auth-method: "jwt"   # or "mtls"
+```
+
+When SPIRE is enabled, the principal automatically:
+
+- Uses SPIRE X.509-SVIDs for its server TLS certificate (replaces `argocd-agent-principal-tls`)
+- Skips loading the static principal TLS secret and root CA
+- With `jwt`: validates agent JWT-SVIDs, defaults `--auth` to `spiffe-jwt:spiffe://[^/]+/(.+)`
+- With `mtls`: requires client X.509-SVIDs verified against SPIRE trust bundle, defaults `--auth` to `mtls:uri:spiffe://[^/]+/(.+)`
+
+**Helm values:**
+
+```yaml
+principal:
+  spire:
+    enabled: true
+    authMethod: "jwt"   # or "mtls"
+    mountMethod: hostPath  # or "csi" for the SPIFFE CSI driver
+```
+
+### Step 5: Configure the agent
+
+```yaml
+# ConfigMap (argocd-agent-params)
+agent.spire.socket-path: "unix:///run/spire/agent-sockets/spire-agent.sock"
+agent.spire.auth-method: "jwt"   # or "mtls"
+```
+
+When SPIRE is enabled, the agent automatically:
+
+- Uses SPIRE X.509-SVIDs for TLS (replaces `argocd-agent-client-tls`)
+- Skips loading static CA and client cert secrets — **no secrets needed on the agent cluster**
+- With `jwt`: fetches a JWT-SVID and sends it as a bearer token, defaults `--creds` to `spiffe-jwt:`
+- With `mtls`: presents X.509-SVID as a client certificate, defaults `--creds` to `mtls:`
+
+**Helm values:**
+
+```yaml
+spire:
+  enabled: true
+  authMethod: "jwt"   # or "mtls"
+  mountMethod: hostPath  # or "csi" for the SPIFFE CSI driver
+```
+
+### Step 6: Create SPIRE registration entries
+
+Register the principal and each agent with the SPIRE Server. The SPIFFE IDs must follow the pattern that matches the principal's auth regex.
+
+!!! warning "One entry per SPIRE Agent (per node)"
+    Each node runs its own SPIRE Agent with a unique SPIFFE ID. A registration entry only applies to workloads attested by the specific agent in its `parentID`. Since pods can be scheduled on any node, create one entry **per SPIRE Agent** in the cluster.
+
+```bash
+# Register the principal (on the SPIRE Server that serves the principal's cluster)
+spire-server entry create \
+  -spiffeID spiffe://example.org/argocd/principal \
+  -parentID <spire-agent-spiffe-id> \
+  -selector k8s:ns:<principal-namespace>
+
+# Register an agent (on the SPIRE Server that serves the agent's cluster)
+spire-server entry create \
+  -spiffeID spiffe://example.org/argocd/agent/cluster-01 \
+  -parentID <spire-agent-spiffe-id> \
+  -selector k8s:ns:<agent-namespace>
+```
+
+**Agent name extraction:** The principal's auth regex extracts the agent name from the SPIFFE ID. With the default regex `spiffe://[^/]+/(.+)`, the agent name from `spiffe://example.org/argocd/agent/cluster-01` would be `argocd/agent/cluster-01`. A namespace with this name must exist on the principal's cluster for Applications to be routed to this agent.
+
+!!! note "Federated entries (JWT mode with separate trust domains)"
+    If hub and spoke have different trust domains, add `-federatesWith spiffe://<other-trust-domain>` to each entry so the SVID includes the federated trust bundle.
+
+### Verification
+
+Check the principal logs:
+
+```bash
+kubectl logs deploy/argocd-agent-principal -n argocd | grep -iE "spire|mtls|jwt|listen"
+```
+
+Expected output (JWT mode):
+
+```
+Using SPIRE for TLS credentials (socket: unix:///run/spire/agent-sockets/spire-agent.sock)
+Connected to SPIRE Agent, X.509 and JWT sources ready
+Using SPIRE for server TLS credentials
+Using SPIFFE JWT authentication
+Now listening on [::]:8443
+```
+
+Expected output (mTLS mode):
+
+```
+Using SPIRE for TLS credentials (socket: unix:///run/spire/agent-sockets/spire-agent.sock)
+Connected to SPIRE Agent, X.509 and JWT sources ready
+Using SPIRE for server TLS credentials
+SPIRE mTLS: requiring client certificates verified against SPIRE trust bundle
+Using mTLS authentication (source: uri, pattern: spiffe://[^/]+/(.+))
+Now listening on [::]:8443
+```
+
+Check agent logs:
+
+```bash
+kubectl logs deploy/argocd-agent-agent -n argocd | grep -iE "spire|auth|jwt|svid"
+```
+
+### Configuration Reference
+
+| Parameter | Environment Variable | Description |
+|-----------|---------------------|-------------|
+| `principal.spire.socket-path` | `ARGOCD_PRINCIPAL_SPIRE_AGENT_SOCKET` | SPIRE Workload API socket URI on the principal |
+| `principal.spire.auth-method` | `ARGOCD_PRINCIPAL_SPIRE_AUTH_METHOD` | Authentication method: `jwt` or `mtls` |
+| `agent.spire.socket-path` | `ARGOCD_AGENT_SPIRE_AGENT_SOCKET` | SPIRE Workload API socket URI on the agent |
+| `agent.spire.auth-method` | `ARGOCD_AGENT_SPIRE_AUTH_METHOD` | Authentication method: `jwt` or `mtls` |
+| — | `ARGOCD_PRINCIPAL_ENABLE_SELF_CLUSTER_REGISTRATION` | Enable self-registration (required for SPIRE) |
+| — | `ARGOCD_PRINCIPAL_SELF_REGISTRATION_CLIENT_CERT_SECRET` | Shared client cert secret name for self-registration |
+
+### Comparison with Static Certificates
+
+| | Static Certs | SPIRE |
+|---|---|---|
+| **Per-agent setup** | `pki issue agent`, copy CA, copy cert | Create SPIRE registration entry only |
+| **Certificate rotation** | Manual (re-issue and redistribute) | Automatic (SPIRE rotates SVIDs) |
+| **Agent registration** | Manual (`pki issue agent` creates cluster secret) | Automatic (self-registration on first connect) |
+| **Secrets on agent cluster** | `argocd-agent-ca`, `argocd-agent-client-tls` | None (SPIRE provides all credentials) |
+| **Secrets on principal cluster** | CA, principal TLS, resource proxy, JWT | CA, resource proxy, shared client cert, JWT |
+| **Self-registration** | Optional | Required |
+
 ## Using argocd-agentctl CLI (Recommended)
 
 The `argocd-agentctl` CLI provides the simplest way to manage the entire PKI lifecycle.
@@ -621,6 +821,7 @@ kubectl get secret argocd-agent-client-tls -n argocd -o jsonpath='{.data.tls\.cr
 5. **Monitor Expiration**: Set up alerts for certificate expiration
 6. **Restrict CA Access**: Only the principal cluster should have the CA private key
 7. **Use Strong TLS Settings**: Enable TLS 1.3 and disable weak cipher suites
+8. **Consider SPIRE for multi-cluster**: For deployments with many clusters, SPIRE eliminates per-agent certificate management
 
 ## Related Documentation
 

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/cenkalti/backoff/v4 v4.3.0
 	github.com/cloudevents/sdk-go/binding/format/protobuf/v2 v2.16.2
 	github.com/cloudevents/sdk-go/v2 v2.16.2
+	github.com/go-jose/go-jose/v4 v4.1.4
 	github.com/go-redis/cache/v9 v9.0.0
 	github.com/go-redis/redismock/v9 v9.2.0
 	github.com/golang-jwt/jwt/v5 v5.3.1
@@ -24,6 +25,7 @@ require (
 	github.com/rs/zerolog v1.35.1
 	github.com/sirupsen/logrus v1.10.0
 	github.com/spf13/cobra v1.10.2
+	github.com/spiffe/go-spiffe/v2 v2.7.0
 	github.com/stretchr/testify v1.12.1
 	github.com/wI2L/jsondiff v0.7.0
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.70.0
@@ -97,7 +99,6 @@ require (
 	github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376 // indirect
 	github.com/go-git/go-billy/v5 v5.9.0 // indirect
 	github.com/go-git/go-git/v5 v5.19.2 // indirect
-	github.com/go-jose/go-jose/v4 v4.1.4 // indirect
 	github.com/go-logr/logr v1.4.4 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-openapi/jsonpointer v0.23.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/cenkalti/backoff/v4 v4.3.0
 	github.com/cloudevents/sdk-go/binding/format/protobuf/v2 v2.16.2
 	github.com/cloudevents/sdk-go/v2 v2.16.2
+	github.com/go-jose/go-jose/v4 v4.1.4
 	github.com/go-redis/cache/v9 v9.0.0
 	github.com/go-redis/redismock/v9 v9.2.0
 	github.com/golang-jwt/jwt/v5 v5.3.1
@@ -24,6 +25,7 @@ require (
 	github.com/rs/zerolog v1.35.1
 	github.com/sirupsen/logrus v1.9.4
 	github.com/spf13/cobra v1.10.2
+	github.com/spiffe/go-spiffe/v2 v2.8.1
 	github.com/stretchr/testify v1.11.1
 	github.com/wI2L/jsondiff v0.7.0
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.69.0
@@ -98,7 +100,6 @@ require (
 	github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376 // indirect
 	github.com/go-git/go-billy/v5 v5.6.2 // indirect
 	github.com/go-git/go-git/v5 v5.14.0 // indirect
-	github.com/go-jose/go-jose/v4 v4.1.4 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-openapi/jsonpointer v0.22.5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -407,6 +407,8 @@ github.com/spf13/cobra v1.10.2/go.mod h1:7C1pvHqHw5A4vrJfjNwvOdzYu0Gml16OCs2GRiT
 github.com/spf13/pflag v1.0.9/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/spf13/pflag v1.0.10 h1:4EBh2KAYBwaONj6b2Ye1GiHfwjqyROoF4RwYO+vPwFk=
 github.com/spf13/pflag v1.0.10/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+github.com/spiffe/go-spiffe/v2 v2.8.1 h1:eXZMLsu+3MLEPJyGJkolqtVrteZfQdUpOWj6LTiDl/E=
+github.com/spiffe/go-spiffe/v2 v2.8.1/go.mod h1:47Q0Q9/AqGha8QLHp+kxpH4Wca7X7EnOtlIJy3mxZ3U=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=

--- a/go.sum
+++ b/go.sum
@@ -401,6 +401,8 @@ github.com/spf13/cobra v1.10.2/go.mod h1:7C1pvHqHw5A4vrJfjNwvOdzYu0Gml16OCs2GRiT
 github.com/spf13/pflag v1.0.9/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/spf13/pflag v1.0.10 h1:4EBh2KAYBwaONj6b2Ye1GiHfwjqyROoF4RwYO+vPwFk=
 github.com/spf13/pflag v1.0.10/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+github.com/spiffe/go-spiffe/v2 v2.7.0 h1:uXe1MflJoHw58wAUvxVlcM7WpKtijWG7I1UidcGh6g4=
+github.com/spiffe/go-spiffe/v2 v2.7.0/go.mod h1:47Q0Q9/AqGha8QLHp+kxpH4Wca7X7EnOtlIJy3mxZ3U=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=

--- a/hack/dev-env/start-agent-autonomous.sh
+++ b/hack/dev-env/start-agent-autonomous.sh
@@ -33,7 +33,18 @@ fi
 E2E_ENV_FILE="/tmp/argocd-agent-e2e"
 if [ -f "$E2E_ENV_FILE" ]; then
     source "$E2E_ENV_FILE"
+    if [ -n "$ARGOCD_AUTONOMOUS_AGENT_SPIRE_AGENT_SOCKET" ]; then
+        export ARGOCD_AGENT_SPIRE_AGENT_SOCKET="$ARGOCD_AUTONOMOUS_AGENT_SPIRE_AGENT_SOCKET"
+        export ARGOCD_AGENT_SPIRE_AUTH_METHOD="${ARGOCD_AGENT_SPIRE_AUTH_METHOD:-jwt}"
+        if [ "$ARGOCD_AGENT_SPIRE_AUTH_METHOD" = "mtls" ]; then
+            AGENT_CREDS="mtls:"
+        else
+            AGENT_CREDS="spiffe-jwt:"
+        fi
+    fi
 fi
+
+AGENT_CREDS="${AGENT_CREDS:-mtls:any}"
 
 RACE_FLAG=""
 if [ "${ENABLE_DATA_RACE_DETECTOR}" = "true" ]; then
@@ -42,7 +53,7 @@ fi
 
 go run ${RACE_FLAG} github.com/argoproj-labs/argocd-agent/cmd/argocd-agent agent \
     --agent-mode autonomous \
-    --creds mtls:any \
+    --creds "${AGENT_CREDS}" \
     --server-address 127.0.0.1 \
     --kubecontext vcluster-agent-autonomous \
     --namespace ${ARGOCD_AUTONOMOUS_NAMESPACE} \

--- a/hack/dev-env/start-agent-managed.sh
+++ b/hack/dev-env/start-agent-managed.sh
@@ -36,7 +36,18 @@ if [ -f "$E2E_ENV_FILE" ]; then
     export ARGOCD_AGENT_DESTINATION_BASED_MAPPING=${ARGOCD_AGENT_DESTINATION_BASED_MAPPING:-false}
     export ARGOCD_AGENT_CREATE_NAMESPACE=${ARGOCD_AGENT_CREATE_NAMESPACE:-false}
     export ARGOCD_AGENT_ON_APPLICATION_RECREATE=${ARGOCD_AGENT_ON_APPLICATION_RECREATE:-ignore}
+    if [ -n "$ARGOCD_AGENT_SPIRE_AGENT_SOCKET" ]; then
+        export ARGOCD_AGENT_SPIRE_AGENT_SOCKET
+        export ARGOCD_AGENT_SPIRE_AUTH_METHOD="${ARGOCD_AGENT_SPIRE_AUTH_METHOD:-jwt}"
+        if [ "$ARGOCD_AGENT_SPIRE_AUTH_METHOD" = "mtls" ]; then
+            AGENT_CREDS="mtls:"
+        else
+            AGENT_CREDS="spiffe-jwt:"
+        fi
+    fi
 fi
+
+AGENT_CREDS="${AGENT_CREDS:-mtls:any}"
 
 RACE_FLAG=""
 if [ "${ENABLE_DATA_RACE_DETECTOR}" = "true" ]; then
@@ -46,7 +57,7 @@ fi
 go run ${RACE_FLAG} github.com/argoproj-labs/argocd-agent/cmd/argocd-agent agent \
     --agent-mode managed \
     --allowed-namespaces '*' \
-    --creds "mtls:any" \
+    --creds "${AGENT_CREDS}" \
     --server-address 127.0.0.1 \
     --kubecontext vcluster-agent-managed \
     --namespace ${ARGOCD_MANAGED_NAMESPACE} \

--- a/hack/dev-env/start-principal.sh
+++ b/hack/dev-env/start-principal.sh
@@ -43,6 +43,7 @@ fi
 
 # Point the principal to the e2e test configuration if it exists
 E2E_ENV_FILE="/tmp/argocd-agent-e2e"
+PRINCIPAL_AUTH='mtls:CN=([^,]+)'
 if [ -f "$E2E_ENV_FILE" ]; then
     source "$E2E_ENV_FILE"
     export ARGOCD_PRINCIPAL_ENABLE_WEBSOCKET=${ARGOCD_PRINCIPAL_ENABLE_WEBSOCKET:-false}
@@ -50,6 +51,15 @@ if [ -f "$E2E_ENV_FILE" ]; then
     export ARGOCD_PRINCIPAL_ENABLE_SELF_CLUSTER_REGISTRATION=${ARGOCD_PRINCIPAL_ENABLE_SELF_CLUSTER_REGISTRATION:-false}
     if [ -n "$ARGOCD_PRINCIPAL_SELF_REGISTRATION_CLIENT_CERT_SECRET" ]; then
         export ARGOCD_PRINCIPAL_SELF_REGISTRATION_CLIENT_CERT_SECRET
+    fi
+    if [ -n "$ARGOCD_PRINCIPAL_SPIRE_AGENT_SOCKET" ]; then
+        export ARGOCD_PRINCIPAL_SPIRE_AGENT_SOCKET
+        export ARGOCD_PRINCIPAL_SPIRE_AUTH_METHOD="${ARGOCD_PRINCIPAL_SPIRE_AUTH_METHOD:-jwt}"
+        if [ "$ARGOCD_PRINCIPAL_SPIRE_AUTH_METHOD" = "mtls" ]; then
+            PRINCIPAL_AUTH='mtls:uri:spiffe://[^/]+/(.+)'
+        else
+            PRINCIPAL_AUTH='spiffe-jwt:spiffe://[^/]+/(.+)'
+        fi
     fi
 fi
 
@@ -67,6 +77,6 @@ go run ${RACE_FLAG} github.com/argoproj-labs/argocd-agent/cmd/argocd-agent princ
 	--log-level ${ARGOCD_AGENT_LOG_LEVEL:-trace} \
 	--namespace ${ARGOCD_PRINCIPAL_NAMESPACE} \
     --destination-based-mapping=${ARGOCD_PRINCIPAL_DESTINATION_BASED_MAPPING:-false}\
-	--auth "mtls:CN=([^,]+)" \
+	--auth "${PRINCIPAL_AUTH}" \
     --resource-proxy-address "${ARGOCD_AGENT_RESOURCE_PROXY}:9090" \
 	$ARGS

--- a/install/helm-repo/argocd-agent-agent/Chart.yaml
+++ b/install/helm-repo/argocd-agent-agent/Chart.yaml
@@ -5,7 +5,7 @@ description: Argo CD Agent for connecting managed clusters to a Principal
 type: application
 
 # chart version
-version: 0.2.6
+version: 0.2.7
 
 # application version, ArgoCD Agent version
 appVersion: v0.8.1

--- a/install/helm-repo/argocd-agent-agent/README.md
+++ b/install/helm-repo/argocd-agent-agent/README.md
@@ -1,6 +1,6 @@
 # argocd-agent-agent
 
-![Version: 0.2.6](https://img.shields.io/badge/Version-0.2.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.8.1](https://img.shields.io/badge/AppVersion-v0.8.1-informational?style=flat-square)
+![Version: 0.2.7](https://img.shields.io/badge/Version-0.2.7-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.8.1](https://img.shields.io/badge/AppVersion-v0.8.1-informational?style=flat-square)
 
 Argo CD Agent for connecting managed clusters to a Principal
 
@@ -112,6 +112,11 @@ Kubernetes: `>=1.24.0-0`
 | serviceMonitor.scheme | string | `""` | Prometheus ServiceMonitor scheme |
 | serviceMonitor.scrapeTimeout | string | `"10s"` | Prometheus scrape timeout. Must be a valid duration string (e.g. "10s"). |
 | serviceMonitor.tlsConfig | object | `{}` | Prometheus ServiceMonitor tlsConfig |
+| spire | object | `{"authMethod":"","enabled":false,"hostSocketDir":"/run/spire/agent-sockets","mountMethod":"hostPath","socketPath":"unix:///run/spire/agent-sockets/spire-agent.sock"}` | SPIRE integration for automatic certificate and identity provisioning. |
+| spire.authMethod | string | `""` | SPIFFE authentication method. Required when SPIRE is enabled. "jwt" uses JWT-SVIDs (for federated SPIRE with multiple trust domains). "mtls" uses X.509-SVIDs (for centralized SPIRE with a single trust domain). |
+| spire.enabled | bool | `false` | Enable SPIRE-based TLS. When enabled, TLS credentials are obtained from the SPIRE Workload API instead of static Kubernetes secrets. |
+| spire.hostSocketDir | string | `"/run/spire/agent-sockets"` | Path to the SPIRE Agent socket directory. Used as the container mountPath and host path. |
+| spire.mountMethod | string | `"hostPath"` | How to mount the SPIRE Agent socket into the pod. "hostPath" mounts the socket directory from the host. |
 | terminationGracePeriodSeconds | int | `30` | Grace period for Pod termination (seconds). |
 | tests | object | `{"enabled":false,"image":"bitnamilegacy/kubectl","tag":"1.33.4"}` | Configuration for helm-chart tests. |
 | tests.enabled | bool | `false` | By default, chart tests are disabled. |

--- a/install/helm-repo/argocd-agent-agent/templates/agent-deployment.yaml
+++ b/install/helm-repo/argocd-agent-agent/templates/agent-deployment.yaml
@@ -281,6 +281,18 @@ spec:
                 name: {{ include "argocd-agent-agent.paramsConfigMapName" . }}
                 key: agent.label-selector
                 optional: true
+          - name: ARGOCD_AGENT_SPIRE_AGENT_SOCKET
+            valueFrom:
+              configMapKeyRef:
+                name: {{ include "argocd-agent-agent.paramsConfigMapName" . }}
+                key: agent.spire.socket-path
+                optional: true
+          - name: ARGOCD_AGENT_SPIRE_AUTH_METHOD
+            valueFrom:
+              configMapKeyRef:
+                name: {{ include "argocd-agent-agent.paramsConfigMapName" . }}
+                key: agent.spire.auth-method
+                optional: true
           ports:
             - name: metrics
               containerPort: {{ .Values.metricsPort }}
@@ -318,6 +330,11 @@ spec:
             - name: userpass-passwd
               mountPath: /app/config/creds
               readOnly: true
+            {{- if .Values.spire.enabled }}
+            - name: spire-agent-socket
+              mountPath: {{ .Values.spire.hostSocketDir }}
+              readOnly: true
+            {{- end }}
       volumes:
         - name: userpass-passwd
           secret:
@@ -326,6 +343,18 @@ spec:
               - key: credentials
                 path: userpass.creds
             optional: true
+        {{- if .Values.spire.enabled }}
+        - name: spire-agent-socket
+          {{- if eq .Values.spire.mountMethod "csi" }}
+          csi:
+            driver: "csi.spiffe.io"
+            readOnly: true
+          {{- else }}
+          hostPath:
+            path: {{ .Values.spire.hostSocketDir }}
+            type: DirectoryOrCreate
+          {{- end }}
+        {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/install/helm-repo/argocd-agent-agent/templates/agent-deployment.yaml
+++ b/install/helm-repo/argocd-agent-agent/templates/agent-deployment.yaml
@@ -352,7 +352,7 @@ spec:
           {{- else }}
           hostPath:
             path: {{ .Values.spire.hostSocketDir }}
-            type: DirectoryOrCreate
+            type: Directory
           {{- end }}
         {{- end }}
       {{- with .Values.nodeSelector }}

--- a/install/helm-repo/argocd-agent-agent/templates/agent-params-cm.yaml
+++ b/install/helm-repo/argocd-agent-agent/templates/agent-params-cm.yaml
@@ -135,3 +135,7 @@ data:
   # agent.redis.tls.insecure: INSECURE: Do not verify Redis TLS certificate.
   # Default: false
   agent.redis.tls.insecure: {{ .Values.redisTLS.insecure | quote }}
+  # agent.spire.socket-path: SPIRE Agent socket URI for obtaining TLS credentials.
+  # Default: ""
+  agent.spire.socket-path: {{ ternary .Values.spire.socketPath "" .Values.spire.enabled | quote }}
+  agent.spire.auth-method: {{ ternary .Values.spire.authMethod "" .Values.spire.enabled | quote }}

--- a/install/helm-repo/argocd-agent-agent/templates/agent-params-cm.yaml
+++ b/install/helm-repo/argocd-agent-agent/templates/agent-params-cm.yaml
@@ -17,7 +17,9 @@ data:
   # - "mtls:_agent_id_regex_" where _agent_id_regex_ is the regex pattern for
   #   extracting the agent ID from client cert subject.
   # Default: ""
-  agent.creds: {{ .Values.auth | quote }}
+  # When SPIRE is enabled, creds is left empty so the runtime auto-derives
+  # "mtls:" or "spiffe-jwt:" from agent.spire.auth-method.
+  agent.creds: {{ if .Values.spire.enabled }}""{{ else }}{{ .Values.auth | quote }}{{ end }}
   # agent.tls.secret-name: Name of the secret containing the TLS certificate.
   # Default: "argocd-agent-client-tls"
   agent.tls.secret-name: {{ .Values.tlsSecretName | quote }}

--- a/install/helm-repo/argocd-agent-agent/values.schema.json
+++ b/install/helm-repo/argocd-agent-agent/values.schema.json
@@ -1068,6 +1068,12 @@
         }
       },
       "required": ["enabled", "authMethod", "socketPath", "mountMethod", "hostSocketDir"],
+      "if": {
+        "properties": { "enabled": { "const": true } }
+      },
+      "then": {
+        "properties": { "authMethod": { "enum": ["jwt", "mtls"] } }
+      },
       "title": "spire",
       "type": "object"
     }

--- a/install/helm-repo/argocd-agent-agent/values.schema.json
+++ b/install/helm-repo/argocd-agent-agent/values.schema.json
@@ -1029,6 +1029,47 @@
       "description": "Name of the Secret containing agent username/password (if used).",
       "title": "userPasswordSecretName",
       "type": "string"
+    },
+    "spire": {
+      "additionalProperties": false,
+      "description": "SPIRE integration for automatic mTLS certificate provisioning.",
+      "properties": {
+        "enabled": {
+          "default": false,
+          "description": "Enable SPIRE-based TLS. When enabled, TLS credentials are obtained from the SPIRE Workload API instead of static Kubernetes secrets.",
+          "title": "enabled",
+          "type": "boolean"
+        },
+        "authMethod": {
+          "default": "",
+          "description": "SPIFFE authentication method. Required when SPIRE is enabled. 'jwt' uses JWT-SVIDs (for federated SPIRE), 'mtls' uses X.509-SVIDs (for centralized SPIRE).",
+          "title": "authMethod",
+          "type": "string",
+          "enum": ["", "jwt", "mtls"]
+        },
+        "socketPath": {
+          "default": "unix:///run/spire/agent-sockets/spire-agent.sock",
+          "description": "SPIRE Agent socket URI passed to --spire-agent-socket.",
+          "title": "socketPath",
+          "type": "string"
+        },
+        "mountMethod": {
+          "default": "hostPath",
+          "description": "How to mount the SPIRE Agent socket into the pod.",
+          "title": "mountMethod",
+          "type": "string",
+          "enum": ["hostPath", "csi"]
+        },
+        "hostSocketDir": {
+          "default": "/run/spire/agent-sockets",
+          "description": "Path to the SPIRE Agent socket directory. Used as the container mountPath and host path.",
+          "title": "hostSocketDir",
+          "type": "string"
+        }
+      },
+      "required": ["enabled", "authMethod", "socketPath", "mountMethod", "hostSocketDir"],
+      "title": "spire",
+      "type": "object"
     }
   },
   "required": [

--- a/install/helm-repo/argocd-agent-agent/values.yaml
+++ b/install/helm-repo/argocd-agent-agent/values.yaml
@@ -236,6 +236,24 @@ createNamespace: false
 # Only matching resources will be listed, watched, and processed.
 labelSelector: ""
 
+## @section SPIRE Integration
+# -- SPIRE integration for automatic certificate and identity provisioning.
+spire:
+  # -- Enable SPIRE-based TLS. When enabled, TLS credentials are obtained from
+  # the SPIRE Workload API instead of static Kubernetes secrets.
+  enabled: false
+  # -- SPIFFE authentication method. Required when SPIRE is enabled.
+  # "jwt" uses JWT-SVIDs (for federated SPIRE with multiple trust domains).
+  # "mtls" uses X.509-SVIDs (for centralized SPIRE with a single trust domain).
+  authMethod: ""
+  # -- SPIRE Agent socket URI passed to --spire-agent-socket.
+  socketPath: "unix:///run/spire/agent-sockets/spire-agent.sock"
+  # -- How to mount the SPIRE Agent socket into the pod.
+  # "hostPath" mounts the socket directory from the host.
+  mountMethod: "hostPath"
+  # -- Path to the SPIRE Agent socket directory. Used as the container mountPath and host path.
+  hostSocketDir: "/run/spire/agent-sockets"
+
 ## @section Redis TLS
 # -- Redis TLS configuration.
 redisTLS:

--- a/install/helm-repo/argocd-agent-principal/Chart.yaml
+++ b/install/helm-repo/argocd-agent-principal/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: argocd-agent-principal
 description: Argo CD Agent Principal component for multi-cluster application management
 type: application
-version: 0.3.2
+version: 0.3.3
 appVersion: "v0.8.1"
 home: https://github.com/argoproj-labs/argocd-agent
 sources:

--- a/install/helm-repo/argocd-agent-principal/README.md
+++ b/install/helm-repo/argocd-agent-principal/README.md
@@ -1,6 +1,6 @@
 # argocd-agent-principal
 
-![Version: 0.3.2](https://img.shields.io/badge/Version-0.3.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.8.1](https://img.shields.io/badge/AppVersion-v0.8.1-informational?style=flat-square)
+![Version: 0.3.3](https://img.shields.io/badge/Version-0.3.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.8.1](https://img.shields.io/badge/AppVersion-v0.8.1-informational?style=flat-square)
 
 Argo CD Agent Principal component for multi-cluster application management
 
@@ -59,7 +59,7 @@ Kubernetes: `>=1.24.0-0`
 | podSecurityContext | object | `{"fsGroup":999,"fsGroupChangePolicy":"OnRootMismatch","runAsGroup":999,"runAsNonRoot":true,"runAsUser":999,"seccompProfile":{"type":"RuntimeDefault"}}` | Pod-level securityContext. Applied to the Pod spec. |
 | principal.additionalArgs | list | `[]` | Extra CLI arguments to pass to the principal binary. |
 | principal.allowedNamespaces | string | `""` | Comma-separated list of additional namespaces the principal watches. Supports glob patterns. |
-| principal.auth | string | `"mtls:CN=([^,]+)"` | Authentication method. Formats: "mtls:CN=([^,]+)", "userpass:/path/to/creds", "header:x-forwarded-client-cert:^.*URI=spiffe://...". |
+| principal.auth | string | `"mtls:CN=([^,]+)"` | Authentication method. Formats: "mtls:CN=([^,]+)", "userpass:/path/to/creds", "spiffe-jwt:spiffe://...". |
 | principal.destinationBasedMapping | bool | `false` | Enable destination-based mapping (deploys apps into their declared namespace instead of the agent namespace). |
 | principal.eventProcessors | string | `"10"` | Number of concurrent event processors. |
 | principal.healthz.port | int | `8003` | Health check server port. |
@@ -95,6 +95,15 @@ Kubernetes: `>=1.24.0-0`
 | principal.resourceProxy.secretName | string | `"argocd-agent-resource-proxy-tls"` | Name of the Secret containing the resource proxy TLS cert/key. |
 | principal.resourceProxy.tls.certPath | string | `""` | Path to the resource proxy TLS certificate inside the container. |
 | principal.resourceProxy.tls.keyPath | string | `""` | Path to the resource proxy TLS key inside the container. |
+| principal.resourceProxyAddress | string | `"argocd-agent-resource-proxy:9090"` | Address of the resource proxy as seen by ArgoCD's application controller. |
+| principal.selfRegistration | object | `{"clientCertSecretName":"","enabled":false}` | Self-registration allows agents to auto-create their cluster secret on the principal when they first connect with valid credentials. |
+| principal.selfRegistration.clientCertSecretName | string | `""` | Name of a Secret (in the principal namespace) containing a shared TLS client cert that gets copied into every self-registered cluster secret. |
+| principal.selfRegistration.enabled | bool | `false` | Enable self-registration. Requires resourceProxy.enabled=true. |
+| principal.spire | object | `{"authMethod":"","enabled":false,"hostSocketDir":"/run/spire/agent-sockets","mountMethod":"hostPath","socketPath":"unix:///run/spire/agent-sockets/spire-agent.sock"}` | SPIRE integration for automatic certificate and identity provisioning. |
+| principal.spire.authMethod | string | `""` | SPIFFE authentication method. Required when SPIRE is enabled. "jwt" uses JWT-SVIDs (for federated SPIRE with multiple trust domains). "mtls" uses X.509-SVIDs (for centralized SPIRE with a single trust domain). |
+| principal.spire.enabled | bool | `false` | Enable SPIRE-based TLS. When enabled, TLS credentials are obtained from the SPIRE Workload API instead of static Kubernetes secrets. |
+| principal.spire.hostSocketDir | string | `"/run/spire/agent-sockets"` | Path to the SPIRE Agent socket directory. Used as the container mountPath and host path. |
+| principal.spire.mountMethod | string | `"hostPath"` | How to mount the SPIRE Agent socket into the pod. "hostPath" mounts the socket directory from the host. |
 | principal.tls.ciphersuites | string | `""` | Comma-separated list of TLS cipher suites. Empty uses Go defaults. |
 | principal.tls.clientCert.matchSubject | bool | `false` | Match the subject field in the client certificate to the agent's registered name. |
 | principal.tls.clientCert.require | bool | `false` | Require agents to present a client certificate upon connection. |

--- a/install/helm-repo/argocd-agent-principal/templates/principal-deployment.yaml
+++ b/install/helm-repo/argocd-agent-principal/templates/principal-deployment.yaml
@@ -351,6 +351,36 @@ spec:
                 name: {{ include "argocd-agent-principal.configMapName" . }}
                 key: principal.event-processors
                 optional: true
+          - name: ARGOCD_PRINCIPAL_ENABLE_SELF_CLUSTER_REGISTRATION
+            valueFrom:
+              configMapKeyRef:
+                name: {{ include "argocd-agent-principal.configMapName" . }}
+                key: principal.self-registration.enabled
+                optional: true
+          - name: ARGOCD_PRINCIPAL_SELF_REGISTRATION_CLIENT_CERT_SECRET
+            valueFrom:
+              configMapKeyRef:
+                name: {{ include "argocd-agent-principal.configMapName" . }}
+                key: principal.self-registration.client-cert-secret
+                optional: true
+          - name: ARGOCD_PRINCIPAL_RESOURCE_PROXY_ADDRESS
+            valueFrom:
+              configMapKeyRef:
+                name: {{ include "argocd-agent-principal.configMapName" . }}
+                key: principal.resource-proxy.address
+                optional: true
+          - name: ARGOCD_PRINCIPAL_SPIRE_AGENT_SOCKET
+            valueFrom:
+              configMapKeyRef:
+                name: {{ include "argocd-agent-principal.configMapName" . }}
+                key: principal.spire.socket-path
+                optional: true
+          - name: ARGOCD_PRINCIPAL_SPIRE_AUTH_METHOD
+            valueFrom:
+              configMapKeyRef:
+                name: {{ include "argocd-agent-principal.configMapName" . }}
+                key: principal.spire.auth-method
+                optional: true
           - name: REDIS_PASSWORD
             valueFrom:
               secretKeyRef:
@@ -412,6 +442,11 @@ spec:
             - name: redis-tls-ca
               mountPath: /app/config/redis-tls
               readOnly: true
+            {{- if .Values.principal.spire.enabled }}
+            - name: spire-agent-socket
+              mountPath: {{ .Values.principal.spire.hostSocketDir }}
+              readOnly: true
+            {{- end }}
       volumes:
       - name: userpass-passwd
         secret:
@@ -445,6 +480,18 @@ spec:
           - key: ca.crt
             path: ca.crt
           optional: true
+      {{- if .Values.principal.spire.enabled }}
+      - name: spire-agent-socket
+        {{- if eq .Values.principal.spire.mountMethod "csi" }}
+        csi:
+          driver: "csi.spiffe.io"
+          readOnly: true
+        {{- else }}
+        hostPath:
+          path: {{ .Values.principal.spire.hostSocketDir }}
+          type: DirectoryOrCreate
+        {{- end }}
+      {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/install/helm-repo/argocd-agent-principal/templates/principal-deployment.yaml
+++ b/install/helm-repo/argocd-agent-principal/templates/principal-deployment.yaml
@@ -489,7 +489,7 @@ spec:
         {{- else }}
         hostPath:
           path: {{ .Values.principal.spire.hostSocketDir }}
-          type: DirectoryOrCreate
+          type: Directory
         {{- end }}
       {{- end }}
       {{- with .Values.nodeSelector }}

--- a/install/helm-repo/argocd-agent-principal/templates/principal-params-cm.yaml
+++ b/install/helm-repo/argocd-agent-principal/templates/principal-params-cm.yaml
@@ -146,6 +146,11 @@ data:
   principal.redis.proxy.server.tls.cert-path: {{ .Values.principal.redis.proxy.server.tls.certPath | quote }}
   principal.redis.proxy.server.tls.key-path: {{ .Values.principal.redis.proxy.server.tls.keyPath | quote }}
   principal.redis.proxy.server.tls.secret-name: {{ .Values.principal.redis.proxy.server.tls.secretName | quote }}
+  principal.spire.socket-path: {{ ternary .Values.principal.spire.socketPath "" .Values.principal.spire.enabled | quote }}
+  principal.spire.auth-method: {{ ternary .Values.principal.spire.authMethod "" .Values.principal.spire.enabled | quote }}
+  principal.self-registration.enabled: {{ .Values.principal.selfRegistration.enabled | quote }}
+  principal.self-registration.client-cert-secret: {{ .Values.principal.selfRegistration.clientCertSecretName | quote }}
+  principal.resource-proxy.address: {{ .Values.principal.resourceProxyAddress | quote }}
   {{- range $key, $value := .Values.configMapData }}
   {{ $key }}: {{ $value | quote }}
   {{- end }}

--- a/install/helm-repo/argocd-agent-principal/templates/principal-params-cm.yaml
+++ b/install/helm-repo/argocd-agent-principal/templates/principal-params-cm.yaml
@@ -10,7 +10,7 @@ data:
   # for all interfaces.
   # Default: ""
   # When SPIRE is enabled, listen on all interfaces since agents connect remotely.
-  principal.listen.host: {{ if .Values.spire.enabled }}""{{ else }}{{ .Values.principal.listen.host | quote }}{{ end }}
+  principal.listen.host: {{ if .Values.principal.spire.enabled }}""{{ else }}{{ .Values.principal.listen.host | quote }}{{ end }}
   # principal.listen.port: The port the gRPC server should listen on.
   # Default: 8443
   principal.listen.port: {{ .Values.principal.listen.port | quote }}
@@ -125,7 +125,7 @@ data:
   # Default: userpass:_path_to_encrypted_creds_
   # When SPIRE is enabled, auth is left empty so the runtime auto-derives
   # "spiffe-jwt:..." or "mtls:uri:..." from principal.spire.auth-method.
-  principal.auth: {{ if .Values.spire.enabled }}""{{ else }}{{ .Values.principal.auth | quote }}{{ end }}
+  principal.auth: {{ if .Values.principal.spire.enabled }}""{{ else }}{{ .Values.principal.auth | quote }}{{ end }}
   # principal.websocket.enable: Whether to use the websocket to stream events to the
   # agent.
   # Default: false

--- a/install/helm-repo/argocd-agent-principal/templates/principal-params-cm.yaml
+++ b/install/helm-repo/argocd-agent-principal/templates/principal-params-cm.yaml
@@ -9,7 +9,8 @@ data:
   # principal.listen.host: The interface address to listen on. Leave empty
   # for all interfaces.
   # Default: ""
-  principal.listen.host: {{ .Values.principal.listen.host | quote }}
+  # When SPIRE is enabled, listen on all interfaces since agents connect remotely.
+  principal.listen.host: {{ if .Values.spire.enabled }}""{{ else }}{{ .Values.principal.listen.host | quote }}{{ end }}
   # principal.listen.port: The port the gRPC server should listen on.
   # Default: 8443
   principal.listen.port: {{ .Values.principal.listen.port | quote }}
@@ -122,7 +123,9 @@ data:
   #   extracting the agent ID from client cert subject. Use "mtls:any" to
   #   accept any client cert.
   # Default: userpass:_path_to_encrypted_creds_
-  principal.auth: {{ .Values.principal.auth | quote }}
+  # When SPIRE is enabled, auth is left empty so the runtime auto-derives
+  # "spiffe-jwt:..." or "mtls:uri:..." from principal.spire.auth-method.
+  principal.auth: {{ if .Values.spire.enabled }}""{{ else }}{{ .Values.principal.auth | quote }}{{ end }}
   # principal.websocket.enable: Whether to use the websocket to stream events to the
   # agent.
   # Default: false

--- a/install/helm-repo/argocd-agent-principal/values.schema.json
+++ b/install/helm-repo/argocd-agent-principal/values.schema.json
@@ -464,6 +464,74 @@
           },
           "title": "resourceProxy",
           "type": "object"
+        },
+        "resourceProxyAddress": {
+          "default": "argocd-agent-resource-proxy:9090",
+          "description": "Address of the resource proxy as seen by ArgoCD's application controller.",
+          "title": "resourceProxyAddress",
+          "type": "string"
+        },
+        "spire": {
+          "additionalProperties": false,
+          "description": "SPIRE integration for automatic mTLS certificate provisioning.",
+          "properties": {
+            "enabled": {
+              "default": false,
+              "description": "Enable SPIRE-based TLS. When enabled, TLS credentials are obtained from the SPIRE Workload API instead of static Kubernetes secrets.",
+              "title": "enabled",
+              "type": "boolean"
+            },
+            "authMethod": {
+              "default": "",
+              "description": "SPIFFE authentication method. Required when SPIRE is enabled. 'jwt' uses JWT-SVIDs (for federated SPIRE), 'mtls' uses X.509-SVIDs (for centralized SPIRE).",
+              "title": "authMethod",
+              "type": "string",
+              "enum": ["", "jwt", "mtls"]
+            },
+            "socketPath": {
+              "default": "unix:///run/spire/agent-sockets/spire-agent.sock",
+              "description": "SPIRE Agent socket URI passed to --spire-agent-socket.",
+              "title": "socketPath",
+              "type": "string"
+            },
+            "mountMethod": {
+              "default": "hostPath",
+              "description": "How to mount the SPIRE Agent socket into the pod.",
+              "title": "mountMethod",
+              "type": "string",
+              "enum": ["hostPath", "csi"]
+            },
+            "hostSocketDir": {
+              "default": "/run/spire/agent-sockets",
+              "description": "Path to the SPIRE Agent socket directory. Used as the container mountPath and host path.",
+              "title": "hostSocketDir",
+              "type": "string"
+            }
+          },
+          "required": ["enabled", "authMethod", "socketPath", "mountMethod", "hostSocketDir"],
+          "title": "spire",
+          "type": "object"
+        },
+        "selfRegistration": {
+          "additionalProperties": false,
+          "description": "Self-registration allows agents to auto-create their cluster secret on the principal when they first connect with valid credentials.",
+          "properties": {
+            "enabled": {
+              "default": false,
+              "description": "Enable self-registration. Requires resourceProxy.enabled=true.",
+              "title": "enabled",
+              "type": "boolean"
+            },
+            "clientCertSecretName": {
+              "default": "",
+              "description": "Name of a Secret (in the principal namespace) containing a shared TLS client cert that gets copied into every self-registered cluster secret.",
+              "title": "clientCertSecretName",
+              "type": "string"
+            }
+          },
+          "required": ["enabled", "clientCertSecretName"],
+          "title": "selfRegistration",
+          "type": "object"
         }
       },
       "required": ["listen", "log", "tls", "jwt", "namespaceCreate", "websocket", "redisProxy", "resourceProxy"],

--- a/install/helm-repo/argocd-agent-principal/values.schema.json
+++ b/install/helm-repo/argocd-agent-principal/values.schema.json
@@ -509,6 +509,12 @@
             }
           },
           "required": ["enabled", "authMethod", "socketPath", "mountMethod", "hostSocketDir"],
+          "if": {
+            "properties": { "enabled": { "const": true } }
+          },
+          "then": {
+            "properties": { "authMethod": { "enum": ["jwt", "mtls"] } }
+          },
           "title": "spire",
           "type": "object"
         },
@@ -535,6 +541,12 @@
         }
       },
       "required": ["listen", "log", "tls", "jwt", "namespaceCreate", "websocket", "redisProxy", "resourceProxy"],
+      "if": {
+        "properties": { "selfRegistration": { "properties": { "enabled": { "const": true } } } }
+      },
+      "then": {
+        "properties": { "resourceProxy": { "properties": { "enabled": { "const": true } } } }
+      },
       "title": "principal",
       "type": "object"
     },

--- a/install/helm-repo/argocd-agent-principal/values.yaml
+++ b/install/helm-repo/argocd-agent-principal/values.yaml
@@ -279,8 +279,24 @@ principal:
     # -- Path to the JWT private key file inside the container.
     keyPath: ""
 
-  # -- Authentication method. Formats: "mtls:CN=([^,]+)", "userpass:/path/to/creds",
-  # "header:x-forwarded-client-cert:^.*URI=spiffe://...".
+  # -- SPIRE integration for automatic certificate and identity provisioning.
+  spire:
+    # -- Enable SPIRE-based TLS. When enabled, TLS credentials are obtained from
+    # the SPIRE Workload API instead of static Kubernetes secrets.
+    enabled: false
+    # -- SPIFFE authentication method. Required when SPIRE is enabled.
+    # "jwt" uses JWT-SVIDs (for federated SPIRE with multiple trust domains).
+    # "mtls" uses X.509-SVIDs (for centralized SPIRE with a single trust domain).
+    authMethod: ""
+    # -- SPIRE Agent socket URI passed to --spire-agent-socket.
+    socketPath: "unix:///run/spire/agent-sockets/spire-agent.sock"
+    # -- How to mount the SPIRE Agent socket into the pod.
+    # "hostPath" mounts the socket directory from the host.
+    mountMethod: "hostPath"
+    # -- Path to the SPIRE Agent socket directory. Used as the container mountPath and host path.
+    hostSocketDir: "/run/spire/agent-sockets"
+
+  # -- Authentication method. Formats: "mtls:CN=([^,]+)", "userpass:/path/to/creds", "spiffe-jwt:spiffe://...".
   auth: "mtls:CN=([^,]+)"
 
   websocket:
@@ -300,6 +316,17 @@ principal:
     # Only required when principal.auth is set to userpass mode.
     # The secret must have a key "passwd" with the encrypted credentials file contents.
     secretName: "argocd-agent-principal-userpass"
+
+  # -- Self-registration allows agents to auto-create their cluster secret on the
+  # principal when they first connect with valid credentials.
+  selfRegistration:
+    # -- Enable self-registration. Requires resourceProxy.enabled=true.
+    enabled: false
+    # -- Name of a Secret (in the principal namespace) containing a shared TLS
+    # client cert that gets copied into every self-registered cluster secret.
+    clientCertSecretName: ""
+  # -- Address of the resource proxy as seen by ArgoCD's application controller.
+  resourceProxyAddress: "argocd-agent-resource-proxy:9090"
 
   # -- Enable destination-based mapping (deploys apps into their declared namespace instead of the agent namespace).
   destinationBasedMapping: false

--- a/internal/argocd/cluster/cluster.go
+++ b/internal/argocd/cluster/cluster.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/argoproj-labs/argocd-agent/internal/config"
 	"github.com/argoproj-labs/argocd-agent/internal/event"
 	"github.com/argoproj-labs/argocd-agent/internal/issuer"
 	"github.com/redis/go-redis/v9"
@@ -347,7 +348,8 @@ func UpdateClusterTLSFromSecret(ctx context.Context, kubeclient kubernetes.Inter
 }
 
 // readClientCertFromSecret reads TLS credentials from an existing Kubernetes TLS secret.
-// The secret should contain tls.crt, tls.key, and ca.crt keys.
+// If secret contains tls.crt and tls.key, it returns the credentials. If ca.crt is not present in the
+// secret, it is read from the principal CA secret in the same namespace.
 func readClientCertFromSecret(ctx context.Context, kubeclient kubernetes.Interface, namespace, secretName string) (clientCert, clientKey, caData string, err error) {
 	secret, err := kubeclient.CoreV1().Secrets(namespace).Get(ctx, secretName, metav1.GetOptions{})
 	if err != nil {
@@ -366,7 +368,14 @@ func readClientCertFromSecret(ctx context.Context, kubeclient kubernetes.Interfa
 
 	caBytes, ok := secret.Data["ca.crt"]
 	if !ok {
-		return "", "", "", fmt.Errorf("secret %s/%s missing ca.crt", namespace, secretName)
+		caSecret, err := kubeclient.CoreV1().Secrets(namespace).Get(ctx, config.SecretNamePrincipalCA, metav1.GetOptions{})
+		if err != nil {
+			return "", "", "", fmt.Errorf("secret %s/%s missing ca.crt and could not read CA from %s: %w", namespace, secretName, config.SecretNamePrincipalCA, err)
+		}
+		caBytes, ok = caSecret.Data["tls.crt"]
+		if !ok {
+			return "", "", "", fmt.Errorf("CA secret %s/%s missing tls.crt", namespace, config.SecretNamePrincipalCA)
+		}
 	}
 
 	return string(certData), string(keyData), string(caBytes), nil

--- a/internal/argocd/cluster/cluster.go
+++ b/internal/argocd/cluster/cluster.go
@@ -367,14 +367,14 @@ func readClientCertFromSecret(ctx context.Context, kubeclient kubernetes.Interfa
 	}
 
 	caBytes, ok := secret.Data["ca.crt"]
-	if !ok {
+	if !ok || len(caBytes) == 0 {
 		caSecret, err := kubeclient.CoreV1().Secrets(namespace).Get(ctx, config.SecretNamePrincipalCA, metav1.GetOptions{})
 		if err != nil {
 			return "", "", "", fmt.Errorf("secret %s/%s missing ca.crt and could not read CA from %s: %w", namespace, secretName, config.SecretNamePrincipalCA, err)
 		}
 		caBytes, ok = caSecret.Data["tls.crt"]
-		if !ok {
-			return "", "", "", fmt.Errorf("CA secret %s/%s missing tls.crt", namespace, config.SecretNamePrincipalCA)
+		if !ok || len(caBytes) == 0 {
+			return "", "", "", fmt.Errorf("CA secret %s/%s has missing or empty tls.crt", namespace, config.SecretNamePrincipalCA)
 		}
 	}
 

--- a/internal/argocd/cluster/cluster_test.go
+++ b/internal/argocd/cluster/cluster_test.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/alicebob/miniredis/v2"
+	"github.com/argoproj-labs/argocd-agent/internal/config"
 	"github.com/argoproj-labs/argocd-agent/internal/event"
 	issuermocks "github.com/argoproj-labs/argocd-agent/internal/issuer/mocks"
 	"github.com/argoproj-labs/argocd-agent/test/fake/kube"
@@ -503,7 +504,36 @@ func Test_readClientCertFromSecret(t *testing.T) {
 		require.Contains(t, err.Error(), "missing tls.key")
 	})
 
-	t.Run("Returns error when ca.crt is missing", func(t *testing.T) {
+	t.Run("Falls back to principal CA when ca.crt is missing", func(t *testing.T) {
+		secret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-client-cert",
+				Namespace: testNamespace,
+			},
+			Data: map[string][]byte{
+				"tls.crt": []byte("test-cert-data"),
+				"tls.key": []byte("test-key-data"),
+			},
+		}
+		caSecret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      config.SecretNamePrincipalCA,
+				Namespace: testNamespace,
+			},
+			Data: map[string][]byte{
+				"tls.crt": []byte("principal-ca-data"),
+			},
+		}
+		kubeclient := kube.NewFakeClientsetWithResources(secret, caSecret)
+
+		clientCert, clientKey, caData, err := readClientCertFromSecret(context.Background(), kubeclient, testNamespace, "test-client-cert")
+		require.NoError(t, err)
+		require.Equal(t, "test-cert-data", clientCert)
+		require.Equal(t, "test-key-data", clientKey)
+		require.Equal(t, "principal-ca-data", caData)
+	})
+
+	t.Run("Returns error when ca.crt missing and principal CA secret not found", func(t *testing.T) {
 		secret := &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test-client-cert",
@@ -519,6 +549,33 @@ func Test_readClientCertFromSecret(t *testing.T) {
 		_, _, _, err := readClientCertFromSecret(context.Background(), kubeclient, testNamespace, "test-client-cert")
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "missing ca.crt")
+		require.Contains(t, err.Error(), "could not read CA from")
+	})
+
+	t.Run("Returns error when ca.crt missing and principal CA secret has no tls.crt", func(t *testing.T) {
+		secret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-client-cert",
+				Namespace: testNamespace,
+			},
+			Data: map[string][]byte{
+				"tls.crt": []byte("test-cert-data"),
+				"tls.key": []byte("test-key-data"),
+			},
+		}
+		caSecret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      config.SecretNamePrincipalCA,
+				Namespace: testNamespace,
+			},
+			Data: map[string][]byte{},
+		}
+		kubeclient := kube.NewFakeClientsetWithResources(secret, caSecret)
+
+		_, _, _, err := readClientCertFromSecret(context.Background(), kubeclient, testNamespace, "test-client-cert")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "CA secret")
+		require.Contains(t, err.Error(), "missing tls.crt")
 	})
 }
 

--- a/internal/argocd/cluster/cluster_test.go
+++ b/internal/argocd/cluster/cluster_test.go
@@ -575,7 +575,65 @@ func Test_readClientCertFromSecret(t *testing.T) {
 		_, _, _, err := readClientCertFromSecret(context.Background(), kubeclient, testNamespace, "test-client-cert")
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "CA secret")
-		require.Contains(t, err.Error(), "missing tls.crt")
+		require.Contains(t, err.Error(), "missing or empty tls.crt")
+	})
+
+	t.Run("Returns error when ca.crt missing and principal CA secret has empty tls.crt", func(t *testing.T) {
+		secret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-client-cert",
+				Namespace: testNamespace,
+			},
+			Data: map[string][]byte{
+				"tls.crt": []byte("test-cert-data"),
+				"tls.key": []byte("test-key-data"),
+			},
+		}
+		caSecret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      config.SecretNamePrincipalCA,
+				Namespace: testNamespace,
+			},
+			Data: map[string][]byte{
+				"tls.crt": []byte(""),
+			},
+		}
+		kubeclient := kube.NewFakeClientsetWithResources(secret, caSecret)
+
+		_, _, _, err := readClientCertFromSecret(context.Background(), kubeclient, testNamespace, "test-client-cert")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "CA secret")
+		require.Contains(t, err.Error(), "missing or empty tls.crt")
+	})
+
+	t.Run("Falls back to principal CA when ca.crt is present but empty", func(t *testing.T) {
+		secret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-client-cert",
+				Namespace: testNamespace,
+			},
+			Data: map[string][]byte{
+				"tls.crt": []byte("test-cert-data"),
+				"tls.key": []byte("test-key-data"),
+				"ca.crt":  []byte(""),
+			},
+		}
+		caSecret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      config.SecretNamePrincipalCA,
+				Namespace: testNamespace,
+			},
+			Data: map[string][]byte{
+				"tls.crt": []byte("principal-ca-data"),
+			},
+		}
+		kubeclient := kube.NewFakeClientsetWithResources(secret, caSecret)
+
+		clientCert, clientKey, caData, err := readClientCertFromSecret(context.Background(), kubeclient, testNamespace, "test-client-cert")
+		require.NoError(t, err)
+		require.Equal(t, "test-cert-data", clientCert)
+		require.Equal(t, "test-key-data", clientKey)
+		require.Equal(t, "principal-ca-data", caData)
 	})
 }
 

--- a/internal/auth/methods.go
+++ b/internal/auth/methods.go
@@ -26,6 +26,8 @@ const (
 	MethodUserPass = "userpass"
 	// MethodHeader is the name of the header-based authentication method.
 	MethodHeader = "header"
+	// MethodSPIFFEJWT is the name of the SPIFFE JWT-SVID authentication method.
+	MethodSPIFFEJWT = "spiffe-jwt"
 )
 
 // Methods provide a thread-safe way to register and look up available auth

--- a/internal/auth/spiffejwt/spiffejwt.go
+++ b/internal/auth/spiffejwt/spiffejwt.go
@@ -1,0 +1,103 @@
+// Copyright 2026 The argocd-agent Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spiffejwt
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+
+	"github.com/argoproj-labs/argocd-agent/internal/auth"
+	"github.com/argoproj-labs/argocd-agent/internal/logging"
+	"github.com/spiffe/go-spiffe/v2/bundle/jwtbundle"
+	"github.com/spiffe/go-spiffe/v2/svid/jwtsvid"
+)
+
+var log = logging.GetDefaultLogger().ComponentLogger("spiffejwt")
+
+// SPIFFEJWTAuthentication validates SPIFFE JWT-SVIDs and
+// extracts agent identity from the SPIFFE ID.
+type SPIFFEJWTAuthentication struct {
+	// AgentIDRegex extracts the agent name from the SPIFFE ID.
+	// The first capture group becomes the agent ID.
+	// Example: spiffe://[^/]+/(.+) extracts the full path after the trust domain.
+	AgentIDRegex *regexp.Regexp
+
+	// BundleSource provides JWT bundles for validating JWT-SVID signatures.
+	// When set, ParseAndValidate is used for cryptographic verification.
+	// When nil, ParseInsecure is used (not recommended for production).
+	BundleSource jwtbundle.Source
+
+	// Audience is the expected audience in the JWT-SVID.
+	Audience string
+}
+
+// NewSPIFFEJWTAuthentication creates a new SPIFFE JWT authentication method.
+func NewSPIFFEJWTAuthentication(agentIDRegex *regexp.Regexp, audience string, bundleSource jwtbundle.Source) *SPIFFEJWTAuthentication {
+	return &SPIFFEJWTAuthentication{
+		AgentIDRegex: agentIDRegex,
+		Audience:     audience,
+		BundleSource: bundleSource,
+	}
+}
+
+// Init initializes the authentication method.
+func (a *SPIFFEJWTAuthentication) Init() error {
+	return nil
+}
+
+// Authenticate validates the SPIFFE JWT-SVID from the agent's credentials and returns
+// the agent name extracted from the SPIFFE ID.
+func (a *SPIFFEJWTAuthentication) Authenticate(_ context.Context, creds auth.Credentials) (string, error) {
+	token, ok := creds["token"]
+	if !ok || token == "" {
+		return "", fmt.Errorf("no SPIFFE JWT token provided in credentials")
+	}
+
+	var svid *jwtsvid.SVID
+	var err error
+
+	audiences := []string{a.Audience}
+
+	if a.BundleSource != nil {
+		svid, err = jwtsvid.ParseAndValidate(token, a.BundleSource, audiences)
+	} else {
+		log.Warn("No SPIFFE JWT bundle source configured, using insecure JWT parsing")
+		svid, err = jwtsvid.ParseInsecure(token, audiences)
+	}
+	if err != nil {
+		return "", fmt.Errorf("SPIFFE JWT-SVID validation failed: %w", err)
+	}
+
+	spiffeID := svid.ID.String()
+	log.Debugf("Validated SPIFFE JWT-SVID, SPIFFE ID: %s", spiffeID)
+
+	if a.AgentIDRegex == nil {
+		return spiffeID, nil
+	}
+
+	matches := a.AgentIDRegex.FindStringSubmatch(spiffeID)
+	if len(matches) < 2 {
+		return "", fmt.Errorf("SPIFFE ID %q did not match agent ID regex %q", spiffeID, a.AgentIDRegex.String())
+	}
+
+	agentID := matches[1]
+	if agentID == "" {
+		return "", fmt.Errorf("agent ID extracted from SPIFFE ID %q is empty", spiffeID)
+	}
+
+	log.Debugf("Extracted agent ID %q from SPIFFE ID %q", agentID, spiffeID)
+	return agentID, nil
+}

--- a/internal/auth/spiffejwt/spiffejwt.go
+++ b/internal/auth/spiffejwt/spiffejwt.go
@@ -36,8 +36,7 @@ type SPIFFEJWTAuthentication struct {
 	AgentIDRegex *regexp.Regexp
 
 	// BundleSource provides JWT bundles for validating JWT-SVID signatures.
-	// When set, ParseAndValidate is used for cryptographic verification.
-	// When nil, ParseInsecure is used (not recommended for production).
+	// Must be set; authentication fails if nil.
 	BundleSource jwtbundle.Source
 
 	// Audience is the expected audience in the JWT-SVID.
@@ -71,12 +70,10 @@ func (a *SPIFFEJWTAuthentication) Authenticate(_ context.Context, creds auth.Cre
 
 	audiences := []string{a.Audience}
 
-	if a.BundleSource != nil {
-		svid, err = jwtsvid.ParseAndValidate(token, a.BundleSource, audiences)
-	} else {
-		log.Warn("No SPIFFE JWT bundle source configured, using insecure JWT parsing")
-		svid, err = jwtsvid.ParseInsecure(token, audiences)
+	if a.BundleSource == nil {
+		return "", fmt.Errorf("no SPIFFE JWT bundle source configured; cannot validate JWT-SVID signature")
 	}
+	svid, err = jwtsvid.ParseAndValidate(token, a.BundleSource, audiences)
 	if err != nil {
 		return "", fmt.Errorf("SPIFFE JWT-SVID validation failed: %w", err)
 	}
@@ -85,7 +82,7 @@ func (a *SPIFFEJWTAuthentication) Authenticate(_ context.Context, creds auth.Cre
 	log.Debugf("Validated SPIFFE JWT-SVID, SPIFFE ID: %s", spiffeID)
 
 	if a.AgentIDRegex == nil {
-		return spiffeID, nil
+		return "", fmt.Errorf("no agent ID regex configured; cannot extract agent identity from SPIFFE ID %q", spiffeID)
 	}
 
 	matches := a.AgentIDRegex.FindStringSubmatch(spiffeID)

--- a/internal/auth/spiffejwt/spiffejwt_test.go
+++ b/internal/auth/spiffejwt/spiffejwt_test.go
@@ -86,11 +86,23 @@ func TestAuthenticate_Success(t *testing.T) {
 }
 
 func TestAuthenticate_NoToken(t *testing.T) {
-	a := NewSPIFFEJWTAuthentication(nil, "aud", nil)
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	bundleSource := setupBundleSource(t, key, "example.org")
 
-	_, err := a.Authenticate(context.Background(), auth.Credentials{})
+	a := NewSPIFFEJWTAuthentication(nil, "aud", bundleSource)
+
+	_, err = a.Authenticate(context.Background(), auth.Credentials{})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "no SPIFFE JWT token provided")
+}
+
+func TestAuthenticate_NilBundleSource(t *testing.T) {
+	a := NewSPIFFEJWTAuthentication(nil, "aud", nil)
+
+	_, err := a.Authenticate(context.Background(), auth.Credentials{"token": "some.jwt.token"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no SPIFFE JWT bundle source configured")
 }
 
 func TestAuthenticate_InvalidToken(t *testing.T) {
@@ -123,7 +135,7 @@ func TestAuthenticate_RegexNoMatch(t *testing.T) {
 	assert.Contains(t, err.Error(), "did not match agent ID regex")
 }
 
-func TestAuthenticate_NoRegex_ReturnsFullSPIFFEID(t *testing.T) {
+func TestAuthenticate_NoRegex_ReturnsError(t *testing.T) {
 	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	require.NoError(t, err)
 
@@ -135,9 +147,9 @@ func TestAuthenticate_NoRegex_ReturnsFullSPIFFEID(t *testing.T) {
 
 	a := NewSPIFFEJWTAuthentication(nil, audience, bundleSource)
 
-	agentID, err := a.Authenticate(context.Background(), auth.Credentials{"token": token})
-	require.NoError(t, err)
-	assert.Equal(t, spiffeID, agentID)
+	_, err = a.Authenticate(context.Background(), auth.Credentials{"token": token})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no agent ID regex configured")
 }
 
 func TestAuthenticate_WrongAudience(t *testing.T) {

--- a/internal/auth/spiffejwt/spiffejwt_test.go
+++ b/internal/auth/spiffejwt/spiffejwt_test.go
@@ -1,0 +1,155 @@
+// Copyright 2026 The argocd-agent Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spiffejwt
+
+import (
+	"context"
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/argoproj-labs/argocd-agent/internal/auth"
+	"github.com/go-jose/go-jose/v4"
+	josejwt "github.com/go-jose/go-jose/v4/jwt"
+	"github.com/spiffe/go-spiffe/v2/bundle/jwtbundle"
+	"github.com/spiffe/go-spiffe/v2/spiffeid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func generateTestJWT(t *testing.T, key *ecdsa.PrivateKey, spiffeID string, audience []string) string {
+	t.Helper()
+	signer, err := jose.NewSigner(
+		jose.SigningKey{Algorithm: jose.ES256, Key: key},
+		(&jose.SignerOptions{}).WithType("JWT").WithHeader("kid", "test-key"),
+	)
+	require.NoError(t, err)
+
+	now := time.Now()
+	claims := josejwt.Claims{
+		Subject:  spiffeID,
+		Audience: audience,
+		IssuedAt: josejwt.NewNumericDate(now),
+		Expiry:   josejwt.NewNumericDate(now.Add(1 * time.Hour)),
+	}
+	token, err := josejwt.Signed(signer).Claims(claims).Serialize()
+	require.NoError(t, err)
+	return token
+}
+
+func setupBundleSource(t *testing.T, key *ecdsa.PrivateKey, trustDomainStr string) jwtbundle.Source {
+	t.Helper()
+	td, err := spiffeid.TrustDomainFromString(trustDomainStr)
+	require.NoError(t, err)
+
+	authorities := map[string]crypto.PublicKey{
+		"test-key": &key.PublicKey,
+	}
+	bundle := jwtbundle.FromJWTAuthorities(td, authorities)
+
+	set := jwtbundle.NewSet(bundle)
+	return set
+}
+
+func TestAuthenticate_Success(t *testing.T) {
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	spiffeID := "spiffe://example.org/argocd/agent/spoke-1"
+	audience := "argocd-agent-principal"
+	token := generateTestJWT(t, key, spiffeID, []string{audience})
+
+	bundleSource := setupBundleSource(t, key, "example.org")
+
+	regex := regexp.MustCompile(`spiffe://[^/]+/(.+)`)
+	a := NewSPIFFEJWTAuthentication(regex, audience, bundleSource)
+
+	agentID, err := a.Authenticate(context.Background(), auth.Credentials{"token": token})
+	require.NoError(t, err)
+	assert.Equal(t, "argocd/agent/spoke-1", agentID)
+}
+
+func TestAuthenticate_NoToken(t *testing.T) {
+	a := NewSPIFFEJWTAuthentication(nil, "aud", nil)
+
+	_, err := a.Authenticate(context.Background(), auth.Credentials{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no SPIFFE JWT token provided")
+}
+
+func TestAuthenticate_InvalidToken(t *testing.T) {
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	bundleSource := setupBundleSource(t, key, "example.org")
+	a := NewSPIFFEJWTAuthentication(nil, "aud", bundleSource)
+
+	_, err = a.Authenticate(context.Background(), auth.Credentials{"token": "invalid.jwt.token"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "JWT-SVID validation failed")
+}
+
+func TestAuthenticate_RegexNoMatch(t *testing.T) {
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	spiffeID := "spiffe://example.org/other-service"
+	audience := "aud"
+	token := generateTestJWT(t, key, spiffeID, []string{audience})
+
+	bundleSource := setupBundleSource(t, key, "example.org")
+
+	regex := regexp.MustCompile(`spiffe://[^/]+/argocd/agent/(.+)`)
+	a := NewSPIFFEJWTAuthentication(regex, audience, bundleSource)
+
+	_, err = a.Authenticate(context.Background(), auth.Credentials{"token": token})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "did not match agent ID regex")
+}
+
+func TestAuthenticate_NoRegex_ReturnsFullSPIFFEID(t *testing.T) {
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	spiffeID := "spiffe://example.org/argocd/agent/spoke-1"
+	audience := "aud"
+	token := generateTestJWT(t, key, spiffeID, []string{audience})
+
+	bundleSource := setupBundleSource(t, key, "example.org")
+
+	a := NewSPIFFEJWTAuthentication(nil, audience, bundleSource)
+
+	agentID, err := a.Authenticate(context.Background(), auth.Credentials{"token": token})
+	require.NoError(t, err)
+	assert.Equal(t, spiffeID, agentID)
+}
+
+func TestAuthenticate_WrongAudience(t *testing.T) {
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	token := generateTestJWT(t, key, "spiffe://example.org/agent", []string{"other-audience"})
+	bundleSource := setupBundleSource(t, key, "example.org")
+
+	a := NewSPIFFEJWTAuthentication(nil, "expected-audience", bundleSource)
+
+	_, err = a.Authenticate(context.Background(), auth.Credentials{"token": token})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "JWT-SVID validation failed")
+}

--- a/internal/config/constants.go
+++ b/internal/config/constants.go
@@ -24,6 +24,10 @@ const SecretNameProxyTLS = "argocd-agent-resource-proxy-tls"
 // client certificate + key for an agent.
 const SecretNameAgentClientCert = "argocd-agent-client-tls"
 
+// SecretNameSharedClientCert is the name of the secret containing the shared
+// TLS client certificate for the agent.
+const SecretNameSharedClientCert = "argocd-agent-shared-client-tls"
+
 // SecretNameJWT is the name of the secret containing the JWT signing key
 // for the principal.
 const SecretNameJWT = "argocd-agent-jwt"
@@ -31,6 +35,10 @@ const SecretNameJWT = "argocd-agent-jwt"
 // ConfigMapNameTLSBlocklist is the name of the ConfigMap containing the
 // TLS certificate blocklist for the principal.
 const ConfigMapNameTLSBlocklist = "argocd-agent-tls-blocklist"
+
+// SPIREJWTAudience is the expected audience in SPIFFE JWT-SVIDs from agents
+// to the principal.
+const SPIREJWTAudience = "argocd-agent-principal"
 
 // SkipSyncLabel is the label used to skip sync for an application.
 const SkipSyncLabel = "argocd-agent.argoproj-labs.io/ignore-sync"

--- a/internal/config/constants.go
+++ b/internal/config/constants.go
@@ -24,9 +24,17 @@ const SecretNameProxyTLS = "argocd-agent-resource-proxy-tls"
 // client certificate + key for an agent.
 const SecretNameAgentClientCert = "argocd-agent-client-tls"
 
+// SecretNameSharedClientCert is the name of the secret containing the shared
+// TLS client certificate for the agent.
+const SecretNameSharedClientCert = "argocd-agent-shared-client-tls"
+
 // SecretNameJWT is the name of the secret containing the JWT signing key
 // for the principal.
 const SecretNameJWT = "argocd-agent-jwt"
+
+// SPIREJWTAudience is the expected audience in SPIFFE JWT-SVIDs from agents
+// to the principal.
+const SPIREJWTAudience = "argocd-agent-principal"
 
 // SkipSyncLabel is the label used to skip sync for an application.
 const SkipSyncLabel = "argocd-agent.argoproj-labs.io/ignore-sync"

--- a/internal/spire/source.go
+++ b/internal/spire/source.go
@@ -50,7 +50,9 @@ func New(ctx context.Context, socketPath string) (*Source, error) {
 
 	jwtSource, err := workloadapi.NewJWTSource(ctx, clientOpts)
 	if err != nil {
-		x509Source.Close()
+		if closeErr := x509Source.Close(); closeErr != nil {
+			log.Warnf("Failed to close X509Source during cleanup: %v", closeErr)
+		}
 		return nil, fmt.Errorf("failed to create SPIRE JWTSource: %w", err)
 	}
 

--- a/internal/spire/source.go
+++ b/internal/spire/source.go
@@ -1,0 +1,125 @@
+// Copyright 2026 The argocd-agent Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spire
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+
+	"github.com/argoproj-labs/argocd-agent/internal/logging"
+	"github.com/spiffe/go-spiffe/v2/spiffetls/tlsconfig"
+	"github.com/spiffe/go-spiffe/v2/svid/jwtsvid"
+	"github.com/spiffe/go-spiffe/v2/workloadapi"
+)
+
+var log = logging.GetDefaultLogger().ComponentLogger("spire")
+
+// Source wraps SPIRE Workload API sources. It connects to the local SPIRE Agent
+// and provides access to X.509 SVIDs (for server TLS) and JWT-SVIDs (for client auth).
+type Source struct {
+	x509Source *workloadapi.X509Source
+	jwtSource  *workloadapi.JWTSource
+	socketPath string
+}
+
+// New connects to the SPIRE Agent at the given socket path and returns a Source.
+// The socketPath should be a URI like "unix:///run/spire/sockets/agent.sock".
+func New(ctx context.Context, socketPath string) (*Source, error) {
+	log.Infof("Connecting to SPIRE Agent at %s", socketPath)
+
+	clientOpts := workloadapi.WithClientOptions(workloadapi.WithAddr(socketPath))
+
+	x509Source, err := workloadapi.NewX509Source(ctx, clientOpts)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create SPIRE X509Source: %w", err)
+	}
+
+	jwtSource, err := workloadapi.NewJWTSource(ctx, clientOpts)
+	if err != nil {
+		x509Source.Close()
+		return nil, fmt.Errorf("failed to create SPIRE JWTSource: %w", err)
+	}
+
+	log.Infof("Connected to SPIRE Agent, X.509 and JWT sources ready")
+	return &Source{
+		x509Source: x509Source,
+		jwtSource:  jwtSource,
+		socketPath: socketPath,
+	}, nil
+}
+
+// GetCertificate returns a server-side callback for tls.Config.GetCertificate.
+func (s *Source) GetCertificate() func(*tls.ClientHelloInfo) (*tls.Certificate, error) {
+	return tlsconfig.GetCertificate(s.x509Source)
+}
+
+// TrustBundle returns the X.509 trust bundle for the local trust domain.
+func (s *Source) TrustBundle() (*x509.CertPool, error) {
+	svid, err := s.x509Source.GetX509SVID()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get SVID for trust domain: %w", err)
+	}
+	bundle, err := s.x509Source.GetX509BundleForTrustDomain(svid.ID.TrustDomain())
+	if err != nil {
+		return nil, fmt.Errorf("failed to get trust bundle: %w", err)
+	}
+	pool := x509.NewCertPool()
+	for _, cert := range bundle.X509Authorities() {
+		pool.AddCert(cert)
+	}
+	return pool, nil
+}
+
+// FetchJWTSVID fetches a JWT-SVID from the local SPIRE Agent for the given audience.
+// The returned token string can be sent as a bearer token in gRPC metadata.
+func (s *Source) FetchJWTSVID(ctx context.Context, audience string) (string, error) {
+	svid, err := s.jwtSource.FetchJWTSVID(ctx, jwtsvid.Params{
+		Audience: audience,
+	})
+	if err != nil {
+		return "", fmt.Errorf("failed to fetch JWT-SVID: %w", err)
+	}
+	log.Debugf("Fetched JWT-SVID for audience %q, SPIFFE ID: %s, expires: %s",
+		audience, svid.ID, svid.Expiry)
+	return svid.Marshal(), nil
+}
+
+// JWTSource returns the underlying JWTSource for use in JWT bundle validation.
+func (s *Source) JWTSource() *workloadapi.JWTSource {
+	return s.jwtSource
+}
+
+// X509Source returns the underlying X509Source.
+func (s *Source) X509Source() *workloadapi.X509Source {
+	return s.x509Source
+}
+
+// Close releases all connections to the SPIRE Agent.
+func (s *Source) Close() error {
+	var firstErr error
+	if s.jwtSource != nil {
+		if err := s.jwtSource.Close(); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+	if s.x509Source != nil {
+		if err := s.x509Source.Close(); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+	return firstErr
+}

--- a/internal/spire/source_test.go
+++ b/internal/spire/source_test.go
@@ -1,0 +1,131 @@
+// Copyright 2026 The argocd-agent Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spire
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	fakespire "github.com/argoproj-labs/argocd-agent/test/fake/spire"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const testSpiffeID = "spiffe://example.org/test-workload"
+
+func startFakeSpire(t *testing.T) string {
+	t.Helper()
+	srv, err := fakespire.New(testSpiffeID, nil, nil, nil)
+	require.NoError(t, err)
+
+	socketPath := filepath.Join(t.TempDir(), "agent.sock")
+	require.NoError(t, srv.Listen(socketPath))
+
+	go func() { _ = srv.Serve() }()
+	t.Cleanup(func() { srv.Stop() })
+
+	return socketPath
+}
+
+func TestNew_ConnectsToFakeSPIRE(t *testing.T) {
+	socketPath := startFakeSpire(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	source, err := New(ctx, "unix://"+socketPath)
+	require.NoError(t, err)
+	require.NotNil(t, source)
+	defer source.Close()
+
+	assert.NotNil(t, source.X509Source())
+	assert.NotNil(t, source.JWTSource())
+}
+
+func TestNew_FailsWithInvalidSocket(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	_, err := New(ctx, "unix:///nonexistent/path/agent.sock")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to create SPIRE X509Source")
+}
+
+func TestSource_GetCertificate(t *testing.T) {
+	socketPath := startFakeSpire(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	source, err := New(ctx, "unix://"+socketPath)
+	require.NoError(t, err)
+	defer source.Close()
+
+	cb := source.GetCertificate()
+	require.NotNil(t, cb)
+}
+
+func TestSource_TrustBundle(t *testing.T) {
+	socketPath := startFakeSpire(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	source, err := New(ctx, "unix://"+socketPath)
+	require.NoError(t, err)
+	defer source.Close()
+
+	pool, err := source.TrustBundle()
+	require.NoError(t, err)
+	require.NotNil(t, pool)
+	//nolint:staticcheck
+	assert.NotEmpty(t, pool.Subjects(), "trust bundle should contain at least one CA")
+}
+
+func TestSource_FetchJWTSVID(t *testing.T) {
+	socketPath := startFakeSpire(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	source, err := New(ctx, "unix://"+socketPath)
+	require.NoError(t, err)
+	defer source.Close()
+
+	token, err := source.FetchJWTSVID(ctx, "test-audience")
+	require.NoError(t, err)
+	assert.NotEmpty(t, token, "JWT-SVID token should not be empty")
+}
+
+func TestSource_Close_NilSources(t *testing.T) {
+	s := &Source{x509Source: nil, jwtSource: nil}
+	err := s.Close()
+	assert.NoError(t, err)
+}
+
+func TestSource_Close(t *testing.T) {
+	socketPath := startFakeSpire(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	source, err := New(ctx, "unix://"+socketPath)
+	require.NoError(t, err)
+
+	err = source.Close()
+	assert.NoError(t, err)
+}

--- a/pkg/client/remote.go
+++ b/pkg/client/remote.go
@@ -677,10 +677,10 @@ func (r *Remote) Connect(ctx context.Context, forceReauth bool) error {
 			creds := r.creds
 			// When SPIRE is configured with JWT authentication,
 			// fetch the JWT-SVID and include it in the credentials.
-			if r.spireSource != nil && r.authMethod == "spiffe-jwt" {
+			if r.spireSource != nil && r.authMethod == auth.MethodSPIFFEJWT {
 				jwtToken, jwtErr := r.spireSource.FetchJWTSVID(ctx, config.SPIREJWTAudience)
 				if jwtErr != nil {
-					logrus.Warnf("Failed to fetch JWT-SVID: %v (retrying in %v)", jwtErr, cBackoff.Step())
+					logrus.Errorf("Failed to fetch JWT-SVID: %v (retrying in %v)", jwtErr, cBackoff.Step())
 					return jwtErr
 				}
 				creds = auth.Credentials{"token": jwtToken}

--- a/pkg/client/remote.go
+++ b/pkg/client/remote.go
@@ -28,8 +28,10 @@ import (
 	grpcprom "github.com/grpc-ecosystem/go-grpc-middleware/providers/prometheus"
 
 	"github.com/argoproj-labs/argocd-agent/internal/auth"
+	"github.com/argoproj-labs/argocd-agent/internal/config"
 	"github.com/argoproj-labs/argocd-agent/internal/grpcutil"
 	"github.com/argoproj-labs/argocd-agent/internal/logging"
+	"github.com/argoproj-labs/argocd-agent/internal/spire"
 	"github.com/argoproj-labs/argocd-agent/internal/tlsutil"
 	"github.com/argoproj-labs/argocd-agent/internal/version"
 	"github.com/argoproj-labs/argocd-agent/pkg/api/grpc/authapi"
@@ -37,6 +39,7 @@ import (
 	"github.com/argoproj-labs/argocd-agent/pkg/types"
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/sirupsen/logrus"
+	"github.com/spiffe/go-spiffe/v2/spiffetls/tlsconfig"
 	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
 	grpchttp1client "golang.stackrox.io/grpc-http1/client"
 	"google.golang.org/grpc"
@@ -110,6 +113,9 @@ type Remote struct {
 
 	// agentNamespace is the namespace where the agent is running.
 	agentNamespace string
+
+	// spireSource provides JWT-SVIDs for SPIFFE authentication
+	spireSource *spire.Source
 
 	// grpcClientMetrics holds gRPC client-side Prometheus metrics
 	grpcClientMetrics *grpcprom.ClientMetrics
@@ -189,6 +195,23 @@ func WithTLSClientCertFromSecret(kube kubernetes.Interface, namespace, name stri
 			return fmt.Errorf("unable to read TLS client from secret: %w", err)
 		}
 		r.tlsConfig.Certificates = append(r.tlsConfig.Certificates, c)
+		return nil
+	}
+}
+
+// WithSPIRE configures the Remote to use SPIRE for TLS and authentication.
+// When useMTLS is true, the agent presents its X.509-SVID as a client certificate
+// for mTLS authentication. When false, only server verification is configured
+// and JWT-SVIDs are used for authentication instead.
+func WithSPIRE(source *spire.Source, useMTLS bool) RemoteOption {
+	return func(r *Remote) error {
+		r.spireSource = source
+		spiffeTLS := tlsconfig.TLSClientConfig(source.X509Source(), tlsconfig.AuthorizeAny())
+		r.tlsConfig.InsecureSkipVerify = spiffeTLS.InsecureSkipVerify
+		r.tlsConfig.VerifyPeerCertificate = spiffeTLS.VerifyPeerCertificate
+		if useMTLS {
+			r.tlsConfig.GetClientCertificate = tlsconfig.GetClientCertificate(source.X509Source())
+		}
 		return nil
 	}
 }
@@ -651,9 +674,21 @@ func (r *Remote) Connect(ctx context.Context, forceReauth bool) error {
 			}
 			authC := authapi.NewAuthenticationClient(conn)
 
+			creds := r.creds
+			// When SPIRE is configured, fetch a fresh JWT-SVID and include it
+			// in the credentials for the authentication.
+			if r.spireSource != nil {
+				jwtToken, jwtErr := r.spireSource.FetchJWTSVID(ctx, config.SPIREJWTAudience)
+				if jwtErr != nil {
+					logrus.Warnf("Failed to fetch JWT-SVID: %v (retrying in %v)", jwtErr, cBackoff.Step())
+					return jwtErr
+				}
+				creds = auth.Credentials{"token": jwtToken}
+			}
+
 			authReq := &authapi.AuthRequest{
 				Method:         r.authMethod,
-				Credentials:    r.creds,
+				Credentials:    creds,
 				Mode:           r.clientMode.String(),
 				Version:        r.agentVersion,
 				AgentNamespace: r.agentNamespace,

--- a/pkg/client/remote.go
+++ b/pkg/client/remote.go
@@ -675,9 +675,9 @@ func (r *Remote) Connect(ctx context.Context, forceReauth bool) error {
 			authC := authapi.NewAuthenticationClient(conn)
 
 			creds := r.creds
-			// When SPIRE is configured, fetch a fresh JWT-SVID and include it
-			// in the credentials for the authentication.
-			if r.spireSource != nil {
+			// When SPIRE is configured with JWT authentication,
+			// fetch the JWT-SVID and include it in the credentials.
+			if r.spireSource != nil && r.authMethod == "spiffe-jwt" {
 				jwtToken, jwtErr := r.spireSource.FetchJWTSVID(ctx, config.SPIREJWTAudience)
 				if jwtErr != nil {
 					logrus.Warnf("Failed to fetch JWT-SVID: %v (retrying in %v)", jwtErr, cBackoff.Step())

--- a/principal/options.go
+++ b/principal/options.go
@@ -34,6 +34,7 @@ import (
 	"github.com/argoproj-labs/argocd-agent/internal/auth"
 	"github.com/argoproj-labs/argocd-agent/internal/grpcutil"
 	"github.com/argoproj-labs/argocd-agent/internal/logging"
+	"github.com/argoproj-labs/argocd-agent/internal/spire"
 	"github.com/argoproj-labs/argocd-agent/internal/tlsutil"
 	"github.com/argoproj-labs/argocd-agent/pkg/ha"
 	cacheutil "github.com/argoproj/argo-cd/v3/util/cache"
@@ -105,6 +106,9 @@ type ServerOptions struct {
 	redisTLSCA                  *x509.CertPool
 	redisTLSCAPath              string
 	redisTLSInsecure            bool
+
+	// SPIRE configuration
+	spireSource *spire.Source
 
 	// haOptions contains HA configuration options
 	haOptions []ha.Option
@@ -270,6 +274,14 @@ func WithTLSRootCaFromSecret(kube kubernetes.Interface, namespace, name string, 
 func WithRequireClientCerts(require bool) ServerOption {
 	return func(o *Server) error {
 		o.options.requireClientCerts = require
+		return nil
+	}
+}
+
+// WithSPIRESource configures the server to use SPIRE-issued SVIDs and trust bundles for TLS.
+func WithSPIRESource(source *spire.Source) ServerOption {
+	return func(o *Server) error {
+		o.options.spireSource = source
 		return nil
 	}
 }

--- a/principal/options.go
+++ b/principal/options.go
@@ -35,6 +35,7 @@ import (
 	"github.com/argoproj-labs/argocd-agent/internal/blocklist"
 	"github.com/argoproj-labs/argocd-agent/internal/grpcutil"
 	"github.com/argoproj-labs/argocd-agent/internal/logging"
+	"github.com/argoproj-labs/argocd-agent/internal/spire"
 	"github.com/argoproj-labs/argocd-agent/internal/tlsutil"
 	"github.com/argoproj-labs/argocd-agent/pkg/ha"
 	cacheutil "github.com/argoproj/argo-cd/v3/util/cache"
@@ -106,6 +107,9 @@ type ServerOptions struct {
 	redisTLSCA                  *x509.CertPool
 	redisTLSCAPath              string
 	redisTLSInsecure            bool
+
+	// SPIRE configuration
+	spireSource *spire.Source
 
 	// haOptions contains HA configuration options
 	haOptions []ha.Option
@@ -271,6 +275,14 @@ func WithTLSRootCaFromSecret(kube kubernetes.Interface, namespace, name string, 
 func WithRequireClientCerts(require bool) ServerOption {
 	return func(o *Server) error {
 		o.options.requireClientCerts = require
+		return nil
+	}
+}
+
+// WithSPIRESource configures the server to use SPIRE-issued SVIDs and trust bundles for TLS.
+func WithSPIRESource(source *spire.Source) ServerOption {
+	return func(o *Server) error {
+		o.options.spireSource = source
 		return nil
 	}
 }

--- a/principal/options_test.go
+++ b/principal/options_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/argoproj-labs/argocd-agent/internal/spire"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -157,4 +158,14 @@ func Test_WithRedisProxyDisabled(t *testing.T) {
 	err := WithRedisProxyDisabled()(s)
 	assert.NoError(t, err)
 	assert.True(t, s.options.redisProxyDisabled)
+}
+
+func Test_WithSPIRESource(t *testing.T) {
+	t.Run("Sets SPIRE source on server options", func(t *testing.T) {
+		s := &Server{options: &ServerOptions{}}
+		source := &spire.Source{}
+		err := WithSPIRESource(source)(s)
+		assert.NoError(t, err)
+		assert.Equal(t, source, s.options.spireSource)
+	})
 }

--- a/principal/server.go
+++ b/principal/server.go
@@ -1194,6 +1194,29 @@ func (s *Server) loadTLSConfig() (*tls.Config, error) {
 		return nil, nil
 	}
 
+	// When SPIRE is configured, use SPIRE SVID instead of TLS certificate and key
+	if s.options.spireSource != nil {
+		log().Infof("Using SPIRE for server TLS credentials")
+		tlsConfig := &tls.Config{
+			GetCertificate: s.options.spireSource.GetCertificate(),
+			ClientAuth:     tls.NoClientCert,
+			MinVersion:     s.options.tlsMinVersion,
+			MaxVersion:     s.options.tlsMaxVersion,
+			CipherSuites:   s.options.tlsCiphers,
+		}
+		// When mTLS is used with SPIRE, require client certs verified against the SPIRE trust bundle
+		if s.options.requireClientCerts {
+			log().Infof("SPIRE mTLS: requiring client certificates verified against SPIRE trust bundle")
+			trustBundle, err := s.options.spireSource.TrustBundle()
+			if err != nil {
+				return nil, fmt.Errorf("failed to get SPIRE trust bundle for client verification: %w", err)
+			}
+			tlsConfig.ClientAuth = tls.RequireAndVerifyClientCert
+			tlsConfig.ClientCAs = trustBundle
+		}
+		return tlsConfig, nil
+	}
+
 	var cert tls.Certificate
 	var err error
 

--- a/principal/server.go
+++ b/principal/server.go
@@ -1236,6 +1236,29 @@ func (s *Server) loadTLSConfig() (*tls.Config, error) {
 		return nil, nil
 	}
 
+	// When SPIRE is configured, use SPIRE SVID instead of TLS certificate and key
+	if s.options.spireSource != nil {
+		log().Infof("Using SPIRE for server TLS credentials")
+		tlsConfig := &tls.Config{
+			GetCertificate: s.options.spireSource.GetCertificate(),
+			ClientAuth:     tls.NoClientCert,
+			MinVersion:     s.options.tlsMinVersion,
+			MaxVersion:     s.options.tlsMaxVersion,
+			CipherSuites:   s.options.tlsCiphers,
+		}
+		// When mTLS is used with SPIRE, require client certs verified against the SPIRE trust bundle
+		if s.options.requireClientCerts {
+			log().Infof("SPIRE mTLS: requiring client certificates verified against SPIRE trust bundle")
+			trustBundle, err := s.options.spireSource.TrustBundle()
+			if err != nil {
+				return nil, fmt.Errorf("failed to get SPIRE trust bundle for client verification: %w", err)
+			}
+			tlsConfig.ClientAuth = tls.RequireAndVerifyClientCert
+			tlsConfig.ClientCAs = trustBundle
+		}
+		return tlsConfig, nil
+	}
+
 	var cert tls.Certificate
 	var err error
 

--- a/principal/server.go
+++ b/principal/server.go
@@ -1239,22 +1239,22 @@ func (s *Server) loadTLSConfig() (*tls.Config, error) {
 	// When SPIRE is configured, use SPIRE SVID instead of TLS certificate and key
 	if s.options.spireSource != nil {
 		log().Infof("Using SPIRE for server TLS credentials")
+		trustBundle, err := s.options.spireSource.TrustBundle()
+		if err != nil {
+			return nil, fmt.Errorf("failed to get SPIRE trust bundle for client verification: %w", err)
+		}
+		clientAuth := tls.VerifyClientCertIfGiven
+		if s.options.requireClientCerts {
+			log().Infof("SPIRE mTLS: requiring client certificates verified against SPIRE trust bundle")
+			clientAuth = tls.RequireAndVerifyClientCert
+		}
 		tlsConfig := &tls.Config{
 			GetCertificate: s.options.spireSource.GetCertificate(),
-			ClientAuth:     tls.NoClientCert,
+			ClientAuth:     clientAuth,
+			ClientCAs:      trustBundle,
 			MinVersion:     s.options.tlsMinVersion,
 			MaxVersion:     s.options.tlsMaxVersion,
 			CipherSuites:   s.options.tlsCiphers,
-		}
-		// When mTLS is used with SPIRE, require client certs verified against the SPIRE trust bundle
-		if s.options.requireClientCerts {
-			log().Infof("SPIRE mTLS: requiring client certificates verified against SPIRE trust bundle")
-			trustBundle, err := s.options.spireSource.TrustBundle()
-			if err != nil {
-				return nil, fmt.Errorf("failed to get SPIRE trust bundle for client verification: %w", err)
-			}
-			tlsConfig.ClientAuth = tls.RequireAndVerifyClientCert
-			tlsConfig.ClientCAs = trustBundle
 		}
 		return tlsConfig, nil
 	}

--- a/test/e2e/application_test.go
+++ b/test/e2e/application_test.go
@@ -70,11 +70,11 @@ func (s *ApplicationTestSuite) Test_ApplicationManagementAPI() {
 	requires.Eventually(func() bool {
 		createdApp, createErr = s.argoClient.CreateApplication(app)
 		if createErr != nil && strings.Contains(createErr.Error(), "project does not exist") {
-			s.T().Logf("Project does not exist in informer cache, retrying...")
+			s.T().Logf("Project does not exist in informer cache, retrying... (error: %v)", createErr)
 			return false
 		}
 		return true
-	}, 60*time.Second, 2*time.Second)
+	}, 120*time.Second, 2*time.Second)
 	requires.NoError(createErr, "failed to create application")
 	asserts.Equal(appName, createdApp.Name)
 

--- a/test/e2e/fixture/goreman.go
+++ b/test/e2e/fixture/goreman.go
@@ -3,8 +3,13 @@ package fixture
 import (
 	"bufio"
 	"bytes"
+	"os"
 	"os/exec"
+	"strings"
 	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
 )
 
 // StopProcess stops the named process managed by goreman
@@ -58,4 +63,23 @@ func IsProcessRunning(processName string, t *testing.T) bool {
 	}
 	// process not found
 	return false
+}
+
+// VerifyProcessLogs checks if expected messages are present in process logs.
+func VerifyProcessLogs(t testing.TB, processName string, requiredMessages []string) {
+	t.Helper()
+	require.Eventually(t, func() bool {
+		content, err := os.ReadFile("/tmp/argocd-agent-e2e-process-output.log")
+		if err != nil {
+			t.Logf("reading process log for %s: %v", processName, err)
+			return false
+		}
+		for _, msg := range requiredMessages {
+			if !strings.Contains(string(content), msg) {
+				t.Logf("expected log not found for %s: %q", processName, msg)
+				return false
+			}
+		}
+		return true
+	}, 120*time.Second, 5*time.Second, "process %s logs should contain required messages", processName)
 }

--- a/test/e2e/fixture/goreman.go
+++ b/test/e2e/fixture/goreman.go
@@ -68,14 +68,23 @@ func IsProcessRunning(processName string, t *testing.T) bool {
 // VerifyProcessLogs checks if expected messages are present in process logs.
 func VerifyProcessLogs(t testing.TB, processName string, requiredMessages []string) {
 	t.Helper()
+	prefix := processName + " | "
 	require.Eventually(t, func() bool {
 		content, err := os.ReadFile("/tmp/argocd-agent-e2e-process-output.log")
 		if err != nil {
 			t.Logf("reading process log for %s: %v", processName, err)
 			return false
 		}
+		lines := strings.Split(string(content), "\n")
 		for _, msg := range requiredMessages {
-			if !strings.Contains(string(content), msg) {
+			found := false
+			for _, line := range lines {
+				if strings.Contains(line, prefix) && strings.Contains(line, msg) {
+					found = true
+					break
+				}
+			}
+			if !found {
 				t.Logf("expected log not found for %s: %q", processName, msg)
 				return false
 			}

--- a/test/e2e/fixture/spire.go
+++ b/test/e2e/fixture/spire.go
@@ -85,11 +85,18 @@ func BackupAndDeleteStaticTLSSecrets(ctx context.Context, principalClient, manag
 		*spec.backup = secret
 	}
 
+	var deleted []spireSecretSpec
 	for _, spec := range specs {
 		if err := deleteSecret(ctx, spec.client, spec.name, spec.namespace); err != nil {
-			// Return backups even on error so callers can still restore
+			// Roll back already-deleted secrets before returning
+			for _, d := range deleted {
+				if restoreErr := restoreSecret(ctx, d.client, *d.backup); restoreErr != nil {
+					fmt.Printf("WARNING: rollback restore %s/%s failed: %v\n", d.namespace, d.name, restoreErr)
+				}
+			}
 			return backups, fmt.Errorf("delete secret %s/%s: %w", spec.namespace, spec.name, err)
 		}
+		deleted = append(deleted, spec)
 	}
 
 	return backups, nil

--- a/test/e2e/fixture/spire.go
+++ b/test/e2e/fixture/spire.go
@@ -87,7 +87,8 @@ func BackupAndDeleteStaticTLSSecrets(ctx context.Context, principalClient, manag
 
 	for _, spec := range specs {
 		if err := deleteSecret(ctx, spec.client, spec.name, spec.namespace); err != nil {
-			return nil, fmt.Errorf("delete secret %s/%s: %w", spec.namespace, spec.name, err)
+			// Return backups even on error so callers can still restore
+			return backups, fmt.Errorf("delete secret %s/%s: %w", spec.namespace, spec.name, err)
 		}
 	}
 

--- a/test/e2e/fixture/spire.go
+++ b/test/e2e/fixture/spire.go
@@ -1,0 +1,272 @@
+// Copyright 2026 The argocd-agent Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fixture
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/argoproj-labs/argocd-agent/internal/config"
+	fakespire "github.com/argoproj-labs/argocd-agent/test/fake/spire"
+	argoapp "github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+const (
+	SpirePrincipalSocket       = "/tmp/fake-spire-principal.sock"
+	SpireManagedAgentSocket    = "/tmp/fake-spire-agent-managed.sock"
+	SpireAutonomousAgentSocket = "/tmp/fake-spire-agent-autonomous.sock"
+
+	spirePrincipalID       = "spiffe://e2e.test/principal"
+	spireManagedAgentID    = "spiffe://e2e.test/agent-managed"
+	spireAutonomousAgentID = "spiffe://e2e.test/agent-autonomous"
+)
+
+// StaticTLSSecretBackups holds copies of static TLS secrets removed during
+// SPIRE e2e tests so they can be restored afterward.
+type StaticTLSSecretBackups struct {
+	PrincipalTLS          *corev1.Secret
+	ManagedAgentClient    *corev1.Secret
+	ManagedAgentCA        *corev1.Secret
+	AutonomousAgentClient *corev1.Secret
+	AutonomousAgentCA     *corev1.Secret
+}
+
+type spireSecretSpec struct {
+	client    KubeClient
+	name      string
+	namespace string
+	backup    **corev1.Secret
+}
+
+// FakeSpireEnvironment runs fake SPIRE Workload API servers for SPIRE e2e tests.
+type FakeSpireEnvironment struct {
+	Principal       *fakespire.Server
+	ManagedAgent    *fakespire.Server
+	AutonomousAgent *fakespire.Server
+}
+
+// BackupAndDeleteStaticTLSSecrets copies the static TLS secrets that SPIRE
+// replaces for SPIRE e2e tests.
+func BackupAndDeleteStaticTLSSecrets(ctx context.Context, principalClient, managedAgentClient, autonomousAgentClient KubeClient) (*StaticTLSSecretBackups, error) {
+	backups := &StaticTLSSecretBackups{}
+	specs := []spireSecretSpec{
+		{principalClient, config.SecretNamePrincipalTLS, PrincipalNamespace, &backups.PrincipalTLS},
+		{managedAgentClient, config.SecretNameAgentClientCert, ManagedAgentNamespace, &backups.ManagedAgentClient},
+		{managedAgentClient, config.SecretNameAgentCA, ManagedAgentNamespace, &backups.ManagedAgentCA},
+		{autonomousAgentClient, config.SecretNameAgentClientCert, AutonomousAgentNamespace, &backups.AutonomousAgentClient},
+		{autonomousAgentClient, config.SecretNameAgentCA, AutonomousAgentNamespace, &backups.AutonomousAgentCA},
+	}
+
+	for _, spec := range specs {
+		secret, err := backupSecret(ctx, spec.client, spec.name, spec.namespace)
+		if err != nil {
+			return nil, fmt.Errorf("backup secret %s/%s: %w", spec.namespace, spec.name, err)
+		}
+		*spec.backup = secret
+	}
+
+	for _, spec := range specs {
+		if err := deleteSecret(ctx, spec.client, spec.name, spec.namespace); err != nil {
+			return nil, fmt.Errorf("delete secret %s/%s: %w", spec.namespace, spec.name, err)
+		}
+	}
+
+	return backups, nil
+}
+
+// RestoreStaticTLSSecrets restores static TLS secrets after SPIRE e2e tests.
+func RestoreStaticTLSSecrets(ctx context.Context, principalClient, managedAgentClient, autonomousAgentClient KubeClient, backups *StaticTLSSecretBackups) error {
+	if backups == nil {
+		return nil
+	}
+
+	restores := []struct {
+		client KubeClient
+		secret *corev1.Secret
+	}{
+		{principalClient, backups.PrincipalTLS},
+		{managedAgentClient, backups.ManagedAgentClient},
+		{managedAgentClient, backups.ManagedAgentCA},
+		{autonomousAgentClient, backups.AutonomousAgentClient},
+		{autonomousAgentClient, backups.AutonomousAgentCA},
+	}
+
+	for _, item := range restores {
+		if err := restoreSecret(ctx, item.client, item.secret); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// NewFakeSpireEnvironment creates fake SPIRE servers for the principal and both
+// agents, all sharing the same trust root and JWT signing key.
+func NewFakeSpireEnvironment() (*FakeSpireEnvironment, error) {
+	principal, err := fakespire.New(spirePrincipalID, nil, nil, nil)
+	if err != nil {
+		return nil, fmt.Errorf("create principal fake SPIRE server: %w", err)
+	}
+
+	caCert := principal.CACert()
+	caKey := principal.CAKey()
+	jwtKey := principal.JWTSignKey()
+
+	managed, err := fakespire.New(spireManagedAgentID, caCert, caKey, jwtKey)
+	if err != nil {
+		return nil, fmt.Errorf("create managed agent fake SPIRE server: %w", err)
+	}
+
+	autonomous, err := fakespire.New(spireAutonomousAgentID, caCert, caKey, jwtKey)
+	if err != nil {
+		return nil, fmt.Errorf("create autonomous agent fake SPIRE server: %w", err)
+	}
+
+	return &FakeSpireEnvironment{
+		Principal:       principal,
+		ManagedAgent:    managed,
+		AutonomousAgent: autonomous,
+	}, nil
+}
+
+// Start listens on all fake SPIRE sockets synchronously, then serves in the
+// background. It returns when all sockets are ready to accept connections.
+func (env *FakeSpireEnvironment) Start() error {
+	servers := []struct {
+		server *fakespire.Server
+		socket string
+	}{
+		{env.Principal, SpirePrincipalSocket},
+		{env.ManagedAgent, SpireManagedAgentSocket},
+		{env.AutonomousAgent, SpireAutonomousAgentSocket},
+	}
+
+	for _, s := range servers {
+		if err := s.server.Listen(s.socket); err != nil {
+			return fmt.Errorf("listen on %s: %w", s.socket, err)
+		}
+	}
+
+	for _, s := range servers {
+		go serveFakeSpire(s.server)
+	}
+	return nil
+}
+
+// Stop stops all fake SPIRE servers and removes their socket files.
+func (env *FakeSpireEnvironment) Stop() {
+	stopFakeSpire(env.Principal)
+	stopFakeSpire(env.ManagedAgent)
+	stopFakeSpire(env.AutonomousAgent)
+
+	for _, path := range []string{
+		SpirePrincipalSocket,
+		SpireManagedAgentSocket,
+		SpireAutonomousAgentSocket,
+	} {
+		_ = os.Remove(path)
+	}
+}
+
+// WriteEnvVars writes SPIRE socket paths and auth method for e2e goreman processes.
+func (env *FakeSpireEnvironment) WriteEnvVars() error {
+	return env.WriteEnvVarsWithAuthMethod("jwt")
+}
+
+// WriteEnvVarsWithAuthMethod writes SPIRE socket paths and the specified auth method
+// ("jwt" or "mtls") for e2e goreman processes.
+func (env *FakeSpireEnvironment) WriteEnvVarsWithAuthMethod(authMethod string) error {
+	return WriteEnvVarsToFile(map[string]string{
+		"ARGOCD_PRINCIPAL_SPIRE_AGENT_SOCKET":        "unix://" + SpirePrincipalSocket,
+		"ARGOCD_AGENT_SPIRE_AGENT_SOCKET":            "unix://" + SpireManagedAgentSocket,
+		"ARGOCD_AUTONOMOUS_AGENT_SPIRE_AGENT_SOCKET": "unix://" + SpireAutonomousAgentSocket,
+		"ARGOCD_PRINCIPAL_SPIRE_AUTH_METHOD":         authMethod,
+		"ARGOCD_AGENT_SPIRE_AUTH_METHOD":             authMethod,
+	})
+}
+
+// VerifyAgentConnected waits until the given agent reports a successful connection to the principal.
+func VerifyAgentConnected(t testing.TB, agentName string, clusterDetails *ClusterDetails, msgAndArgs ...interface{}) {
+	t.Helper()
+	require.Eventually(t, func() bool {
+		return HasConnectionStatus(agentName, argoapp.ConnectionState{
+			Status:  argoapp.ConnectionStatusSuccessful,
+			Message: fmt.Sprintf("Agent: '%s' is %s with principal", agentName, "connected"),
+		}, clusterDetails)
+	}, 60*time.Second, 1*time.Second, msgAndArgs...)
+}
+
+func serveFakeSpire(server *fakespire.Server) {
+	if err := server.Serve(); err != nil {
+		fmt.Printf("fake SPIRE server stopped: %v\n", err)
+	}
+}
+
+func stopFakeSpire(server *fakespire.Server) {
+	if server != nil {
+		server.Stop()
+	}
+}
+
+func backupSecret(ctx context.Context, client KubeClient, name, namespace string) (*corev1.Secret, error) {
+	secret := &corev1.Secret{}
+	key := types.NamespacedName{Name: name, Namespace: namespace}
+	if err := client.Get(ctx, key, secret, metav1.GetOptions{}); err != nil {
+		return nil, err
+	}
+	return secret.DeepCopy(), nil
+}
+
+func deleteSecret(ctx context.Context, client KubeClient, name, namespace string) error {
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+	}
+	err := client.Delete(ctx, secret, metav1.DeleteOptions{})
+	if errors.IsNotFound(err) {
+		return nil
+	}
+	return err
+}
+
+func restoreSecret(ctx context.Context, client KubeClient, backup *corev1.Secret) error {
+	if backup == nil {
+		return nil
+	}
+
+	newSecret := backup.DeepCopy()
+	newSecret.ResourceVersion = ""
+	newSecret.UID = ""
+	newSecret.ManagedFields = nil
+
+	err := client.Create(ctx, newSecret, metav1.CreateOptions{})
+	if errors.IsAlreadyExists(err) {
+		if err := deleteSecret(ctx, client, backup.Name, backup.Namespace); err != nil {
+			return fmt.Errorf("delete existing secret %s/%s before restore: %w", backup.Namespace, backup.Name, err)
+		}
+		return client.Create(ctx, newSecret, metav1.CreateOptions{})
+	}
+	return err
+}

--- a/test/e2e/spire_test.go
+++ b/test/e2e/spire_test.go
@@ -89,15 +89,10 @@ func (suite *SpireTestSuite) initExpectedLogs() {
 		suite.expectedPrincipalLogs = append(commonPrincipalLogs,
 			"SPIRE mTLS: requiring client certificates verified against SPIRE trust bundle",
 			"Using mTLS authentication (source: uri",
-		)
-		suite.expectedManagedAgentLogs = append(
-			commonAgentLogs(fixture.SpireManagedAgentSocket),
 			"Extracted agent identity from client certificate",
 		)
-		suite.expectedAutonomousAgentLogs = append(
-			commonAgentLogs(fixture.SpireAutonomousAgentSocket),
-			"Extracted agent identity from client certificate",
-		)
+		suite.expectedManagedAgentLogs = commonAgentLogs(fixture.SpireManagedAgentSocket)
+		suite.expectedAutonomousAgentLogs = commonAgentLogs(fixture.SpireAutonomousAgentSocket)
 	case "jwt":
 		suite.expectedPrincipalLogs = append(commonPrincipalLogs,
 			"Using SPIFFE JWT authentication",

--- a/test/e2e/spire_test.go
+++ b/test/e2e/spire_test.go
@@ -1,0 +1,249 @@
+// Copyright 2026 The argocd-agent Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package e2e
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/argoproj-labs/argocd-agent/test/e2e/fixture"
+	argoapp "github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
+	"github.com/stretchr/testify/suite"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+type SpireTestSuite struct {
+	fixture.BaseSuite
+
+	authMethod string
+	spireEnv   *fixture.FakeSpireEnvironment
+	tlsBackups *fixture.StaticTLSSecretBackups
+
+	expectedPrincipalLogs       []string
+	expectedManagedAgentLogs    []string
+	expectedAutonomousAgentLogs []string
+}
+
+func (suite *SpireTestSuite) SetupSuite() {
+	suite.BaseSuite.SetupSuite()
+
+	requires := suite.Require()
+	fixture.SkipIfAgentInClusterEnvVarIsSet(suite.T())
+
+	suite.initExpectedLogs()
+
+	// Backup static TLS secrets
+	var err error
+	suite.tlsBackups, err = fixture.BackupAndDeleteStaticTLSSecrets(
+		suite.Ctx, suite.PrincipalClient, suite.ManagedAgentClient, suite.AutonomousAgentClient)
+	requires.NoError(err)
+
+	// Create fake SPIRE environment
+	suite.spireEnv, err = fixture.NewFakeSpireEnvironment()
+	requires.NoError(err)
+	requires.NoError(suite.spireEnv.Start())
+	requires.NoError(suite.spireEnv.WriteEnvVarsWithAuthMethod(suite.authMethod))
+
+	// Restart agents to pick up new SPIRE environment variables
+	fixture.RestartAgent(suite.T(), fixture.PrincipalName)
+	fixture.CheckReadiness(suite.T(), fixture.PrincipalName)
+
+	fixture.RestartAgent(suite.T(), fixture.AgentManagedName)
+	fixture.CheckReadiness(suite.T(), fixture.AgentManagedName)
+
+	fixture.RestartAgent(suite.T(), fixture.AgentAutonomousName)
+	fixture.CheckReadiness(suite.T(), fixture.AgentAutonomousName)
+}
+
+func (suite *SpireTestSuite) initExpectedLogs() {
+	commonPrincipalLogs := []string{
+		fmt.Sprintf("Using SPIRE for TLS credentials (socket: unix://%s)", fixture.SpirePrincipalSocket),
+		fmt.Sprintf("Connecting to SPIRE Agent at unix://%s", fixture.SpirePrincipalSocket),
+		"Connected to SPIRE Agent, X.509 and JWT sources ready",
+		"Using SPIRE for server TLS credentials",
+		"Now listening on [::]:8443",
+	}
+	commonAgentLogs := func(socket string) []string {
+		return []string{
+			fmt.Sprintf("Connecting to SPIRE Agent at unix://%s", socket),
+			"Connected to SPIRE Agent, X.509 and JWT sources ready",
+		}
+	}
+
+	switch suite.authMethod {
+	case "mtls":
+		suite.expectedPrincipalLogs = append(commonPrincipalLogs,
+			"SPIRE mTLS: requiring client certificates verified against SPIRE trust bundle",
+			"Using mTLS authentication (source: uri",
+		)
+		suite.expectedManagedAgentLogs = append(
+			commonAgentLogs(fixture.SpireManagedAgentSocket),
+			"Extracted agent identity from client certificate",
+		)
+		suite.expectedAutonomousAgentLogs = append(
+			commonAgentLogs(fixture.SpireAutonomousAgentSocket),
+			"Extracted agent identity from client certificate",
+		)
+	case "jwt":
+		suite.expectedPrincipalLogs = append(commonPrincipalLogs,
+			"Using SPIFFE JWT authentication",
+		)
+		suite.expectedManagedAgentLogs = append(
+			commonAgentLogs(fixture.SpireManagedAgentSocket),
+			"Fetched JWT-SVID for audience",
+		)
+		suite.expectedAutonomousAgentLogs = append(
+			commonAgentLogs(fixture.SpireAutonomousAgentSocket),
+			"Fetched JWT-SVID for audience",
+		)
+	}
+}
+
+func (suite *SpireTestSuite) Test_AgentsConnectWhenSPIREIsEnabled() {
+	requires := suite.Require()
+
+	suite.T().Logf("Verifying agents connected via SPIRE (auth-method: %s)", suite.authMethod)
+
+	fixture.VerifyAgentConnected(suite.T(), fixture.AgentManagedName, suite.ClusterDetails)
+	fixture.VerifyAgentConnected(suite.T(), fixture.AgentAutonomousName, suite.ClusterDetails)
+
+	suite.T().Log("Verifying principal and agent logs to ensure SPIRE is used for authentication")
+
+	fixture.VerifyProcessLogs(suite.T(), fixture.PrincipalName, suite.expectedPrincipalLogs)
+	fixture.VerifyProcessLogs(suite.T(), fixture.AgentManagedName, suite.expectedManagedAgentLogs)
+	fixture.VerifyProcessLogs(suite.T(), fixture.AgentAutonomousName, suite.expectedAutonomousAgentLogs)
+
+	suite.T().Log("Creating managed application")
+
+	managedApp := newSpireGuestbookApplication(
+		fixture.ManagedPrincipalAppNamespace(),
+		"managed",
+	)
+	requires.NoError(suite.PrincipalClient.Create(suite.Ctx, &managedApp, metav1.CreateOptions{}))
+
+	suite.T().Log("Verifying managed app is propagated to managed agent")
+
+	managedAgentKey := types.NamespacedName{Name: managedApp.Name, Namespace: fixture.ManagedAgentAppNamespace()}
+	requires.Eventually(func() bool {
+		app := argoapp.Application{}
+		err := suite.ManagedAgentClient.Get(suite.Ctx, managedAgentKey, &app, metav1.GetOptions{})
+		return err == nil
+	}, 30*time.Second, 1*time.Second, "managed application should replicate to agent via SPIRE")
+
+	suite.T().Log("Verifying managed app is Synced and healthy")
+
+	requires.Eventually(func() bool {
+		app := argoapp.Application{}
+		err := suite.ManagedAgentClient.Get(suite.Ctx, managedAgentKey, &app, metav1.GetOptions{})
+		if err != nil {
+			return false
+		}
+		return app.Status.Sync.Status == "Synced" && app.Status.Health.Status == "Healthy"
+	}, 60*time.Second, 2*time.Second, "app should become Synced and Healthy")
+
+	suite.T().Log("Creating autonomous application")
+
+	autonomousApp := newSpireGuestbookApplication(
+		fixture.AutonomousAgentNamespace,
+		"autonomous",
+	)
+	requires.NoError(suite.AutonomousAgentClient.Create(suite.Ctx, &autonomousApp, metav1.CreateOptions{}))
+
+	suite.T().Log("Verifying autonomous app is propagated to principal")
+
+	principalKey := types.NamespacedName{Name: autonomousApp.Name, Namespace: "agent-autonomous"}
+	requires.Eventually(func() bool {
+		app := argoapp.Application{}
+		err := suite.PrincipalClient.Get(suite.Ctx, principalKey, &app, metav1.GetOptions{})
+		return err == nil
+	}, 30*time.Second, 1*time.Second, "autonomous application should replicate to principal via SPIRE")
+
+	suite.T().Log("Verifying autonomous app is Synced and healthy")
+
+	requires.Eventually(func() bool {
+		app := argoapp.Application{}
+		err := suite.PrincipalClient.Get(suite.Ctx, principalKey, &app, metav1.GetOptions{})
+		if err != nil {
+			return false
+		}
+		return app.Status.Sync.Status == "Synced" && app.Status.Health.Status == "Healthy"
+	}, 60*time.Second, 2*time.Second, "app should become Synced and Healthy")
+}
+
+func (suite *SpireTestSuite) TearDownSuite() {
+	if suite.spireEnv != nil {
+		suite.spireEnv.Stop()
+	}
+
+	fixture.ClearEnvVarsFile()
+	if err := fixture.RestoreStaticTLSSecrets(
+		suite.Ctx, suite.PrincipalClient, suite.ManagedAgentClient, suite.AutonomousAgentClient, suite.tlsBackups); err != nil {
+		suite.T().Logf("Warning: failed to restore static TLS secrets: %v", err)
+	}
+
+	// Restart agents
+	fixture.RestartAgent(suite.T(), fixture.PrincipalName)
+	fixture.CheckReadiness(suite.T(), fixture.PrincipalName)
+
+	fixture.RestartAgent(suite.T(), fixture.AgentManagedName)
+	fixture.CheckReadiness(suite.T(), fixture.AgentManagedName)
+
+	fixture.RestartAgent(suite.T(), fixture.AgentAutonomousName)
+	fixture.CheckReadiness(suite.T(), fixture.AgentAutonomousName)
+}
+
+func TestSpireJWTTestSuite(t *testing.T) {
+	suite.Run(t, &SpireTestSuite{authMethod: "jwt"})
+}
+
+func TestSpireMTLSTestSuite(t *testing.T) {
+	suite.Run(t, &SpireTestSuite{authMethod: "mtls"})
+}
+
+func newSpireGuestbookApplication(namespace string, mode string) argoapp.Application {
+	app := argoapp.Application{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "spire-guestbook",
+			Namespace: namespace,
+		},
+		Spec: argoapp.ApplicationSpec{
+			Project: "default",
+			Source: &argoapp.ApplicationSource{
+				RepoURL:        "https://github.com/argoproj/argocd-example-apps",
+				TargetRevision: "HEAD",
+				Path:           "kustomize-guestbook",
+			},
+			SyncPolicy: &argoapp.SyncPolicy{
+				SyncOptions: argoapp.SyncOptions{
+					"CreateNamespace=true",
+				},
+				Automated: &argoapp.SyncPolicyAutomated{},
+			},
+		},
+	}
+
+	if mode == "managed" {
+		app.Spec.Destination = fixture.ManagedDestination("guestbook")
+	} else {
+		app.Spec.Destination = argoapp.ApplicationDestination{
+			Server:    "https://kubernetes.default.svc",
+			Namespace: "guestbook",
+		}
+	}
+
+	return app
+}

--- a/test/e2e/spire_test.go
+++ b/test/e2e/spire_test.go
@@ -132,6 +132,7 @@ func (suite *SpireTestSuite) Test_AgentsConnectWhenSPIREIsEnabled() {
 	managedApp := newSpireGuestbookApplication(
 		fixture.ManagedPrincipalAppNamespace(),
 		"managed",
+		suite.authMethod,
 	)
 	requires.NoError(suite.PrincipalClient.Create(suite.Ctx, &managedApp, metav1.CreateOptions{}))
 
@@ -160,6 +161,7 @@ func (suite *SpireTestSuite) Test_AgentsConnectWhenSPIREIsEnabled() {
 	autonomousApp := newSpireGuestbookApplication(
 		fixture.AutonomousAgentNamespace,
 		"autonomous",
+		suite.authMethod,
 	)
 	requires.NoError(suite.AutonomousAgentClient.Create(suite.Ctx, &autonomousApp, metav1.CreateOptions{}))
 
@@ -214,10 +216,10 @@ func TestSpireMTLSTestSuite(t *testing.T) {
 	suite.Run(t, &SpireTestSuite{authMethod: "mtls"})
 }
 
-func newSpireGuestbookApplication(namespace string, mode string) argoapp.Application {
+func newSpireGuestbookApplication(namespace string, mode string, authMethod string) argoapp.Application {
 	app := argoapp.Application{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "spire-guestbook",
+			Name:      fmt.Sprintf("spire-%s-guestbook", authMethod),
 			Namespace: namespace,
 		},
 		Spec: argoapp.ApplicationSpec{

--- a/test/e2e/terminal_test.go
+++ b/test/e2e/terminal_test.go
@@ -204,6 +204,53 @@ func (suite *TerminalStreamingTestSuite) Test_SelfRegisteredSecret_Terminal() {
 	suite.validateTerminalStreaming()
 }
 
+// Test_SPIRE_Terminal tests terminal streaming when SPIRE is used for
+// agent-to-principal authentication, verifying the resource proxy path is unaffected.
+func (suite *TerminalStreamingTestSuite) Test_SPIRE_Terminal() {
+	requires := suite.Require()
+	fixture.SkipIfAgentInClusterEnvVarIsSet(suite.T())
+
+	// Backup static TLS secrets
+	tlsBackups, err := fixture.BackupAndDeleteStaticTLSSecrets(
+		suite.Ctx, suite.PrincipalClient, suite.ManagedAgentClient, suite.AutonomousAgentClient)
+	requires.NoError(err)
+
+	suite.T().Log("Creating fake SPIRE environment")
+	spireEnv, err := fixture.NewFakeSpireEnvironment()
+	requires.NoError(err)
+	requires.NoError(spireEnv.Start())
+	requires.NoError(spireEnv.WriteEnvVars())
+
+	// Restore static TLS secrets after test
+	defer func() {
+		spireEnv.Stop()
+		fixture.ClearEnvVarsFile()
+		_ = fixture.RestoreStaticTLSSecrets(
+			suite.Ctx, suite.PrincipalClient, suite.ManagedAgentClient, suite.AutonomousAgentClient, tlsBackups)
+
+		fixture.RestartAgent(suite.T(), fixture.PrincipalName)
+		fixture.CheckReadiness(suite.T(), fixture.PrincipalName)
+		fixture.RestartAgent(suite.T(), fixture.AgentManagedName)
+		fixture.CheckReadiness(suite.T(), fixture.AgentManagedName)
+		fixture.RestartAgent(suite.T(), fixture.AgentAutonomousName)
+		fixture.CheckReadiness(suite.T(), fixture.AgentAutonomousName)
+	}()
+
+	// Restart processes to pick up SPIRE configuration
+	fixture.RestartAgent(suite.T(), fixture.PrincipalName)
+	fixture.CheckReadiness(suite.T(), fixture.PrincipalName)
+	fixture.RestartAgent(suite.T(), fixture.AgentManagedName)
+	fixture.CheckReadiness(suite.T(), fixture.AgentManagedName)
+	fixture.RestartAgent(suite.T(), fixture.AgentAutonomousName)
+	fixture.CheckReadiness(suite.T(), fixture.AgentAutonomousName)
+
+	suite.T().Log("Verifying agents connected via SPIRE before testing terminal")
+	fixture.VerifyAgentConnected(suite.T(), fixture.AgentManagedName, suite.ClusterDetails)
+
+	suite.T().Log("SPIRE environment active, testing terminal streaming")
+	suite.validateTerminalStreaming()
+}
+
 func TestTerminalStreamingTestSuite(t *testing.T) {
 	t.Run("terminal_streaming", func(t *testing.T) {
 		suite.Run(t, new(TerminalStreamingTestSuite))

--- a/test/fake/spire/spire.go
+++ b/test/fake/spire/spire.go
@@ -1,0 +1,322 @@
+// Copyright 2026 The argocd-agent Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spire
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/json"
+	"math/big"
+	"net"
+	"net/url"
+	"os"
+	"time"
+
+	"github.com/go-jose/go-jose/v4"
+	josejwt "github.com/go-jose/go-jose/v4/jwt"
+	workloadPB "github.com/spiffe/go-spiffe/v2/proto/spiffe/workload"
+	"google.golang.org/grpc"
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+// Server is a fake SPIFFE Workload API gRPC server that issues SVIDs from an in-memory CA.
+type Server struct {
+	workloadPB.UnimplementedSpiffeWorkloadAPIServer
+	grpcServer  *grpc.Server
+	listener    net.Listener
+	caCert      *x509.Certificate
+	caKey       *ecdsa.PrivateKey
+	svidCertDER []byte
+	svidKeyDER  []byte
+	spiffeID    string
+	trustDomain string
+	jwtSignKey  *ecdsa.PrivateKey
+}
+
+// New creates a fake Workload API server that issues SVIDs for the given spiffeID.
+func New(spiffeID string, caCert *x509.Certificate, caKey *ecdsa.PrivateKey, jwtSignKey *ecdsa.PrivateKey) (*Server, error) {
+	trustDomain, err := trustDomainFromID(spiffeID)
+	if err != nil {
+		return nil, err
+	}
+
+	s := &Server{
+		spiffeID:    spiffeID,
+		trustDomain: trustDomain,
+		caCert:      caCert,
+		caKey:       caKey,
+		jwtSignKey:  jwtSignKey,
+	}
+
+	if s.caCert == nil || s.caKey == nil {
+		if err := s.generateCA(); err != nil {
+			return nil, err
+		}
+	}
+	if err := s.generateSVID(); err != nil {
+		return nil, err
+	}
+
+	if s.jwtSignKey == nil {
+		jwtKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+		if err != nil {
+			return nil, err
+		}
+		s.jwtSignKey = jwtKey
+	}
+
+	return s, nil
+}
+
+// CACert returns the server's CA certificate.
+func (s *Server) CACert() *x509.Certificate {
+	return s.caCert
+}
+
+// CAKey returns the server's CA private key.
+func (s *Server) CAKey() *ecdsa.PrivateKey {
+	return s.caKey
+}
+
+// JWTSignKey returns the server's JWT signing key.
+func (s *Server) JWTSignKey() *ecdsa.PrivateKey {
+	return s.jwtSignKey
+}
+
+// Listen creates a Unix domain socket at the given path and starts accepting connections.
+func (s *Server) Listen(socketPath string) error {
+	_ = os.Remove(socketPath)
+
+	lis, err := net.Listen("unix", socketPath)
+	if err != nil {
+		return err
+	}
+	s.listener = lis
+
+	s.grpcServer = grpc.NewServer()
+	workloadPB.RegisterSpiffeWorkloadAPIServer(s.grpcServer, s)
+	return nil
+}
+
+// Serve starts accepting connections on the listener created by Listen.
+// It blocks until the server is stopped.
+func (s *Server) Serve() error {
+	return s.grpcServer.Serve(s.listener)
+}
+
+// Stop stops the gRPC server.
+func (s *Server) Stop() {
+	if s.grpcServer != nil {
+		s.grpcServer.Stop()
+	}
+}
+
+// FetchX509SVID implements the streaming Workload API method.
+// It sends one response containing the SVID and then blocks until the client
+// disconnects, matching real SPIRE Agent behavior.
+func (s *Server) FetchX509SVID(_ *workloadPB.X509SVIDRequest, stream grpc.ServerStreamingServer[workloadPB.X509SVIDResponse]) error {
+	resp := &workloadPB.X509SVIDResponse{
+		Svids: []*workloadPB.X509SVID{
+			{
+				SpiffeId:    s.spiffeID,
+				X509Svid:    s.svidCertDER,
+				X509SvidKey: s.svidKeyDER,
+				Bundle:      s.caCert.Raw,
+			},
+		},
+	}
+
+	if err := stream.Send(resp); err != nil {
+		return err
+	}
+
+	// Block until the client disconnects
+	<-stream.Context().Done()
+	return nil
+}
+
+// FetchX509Bundles implements the streaming Workload API method.
+func (s *Server) FetchX509Bundles(_ *workloadPB.X509BundlesRequest, stream grpc.ServerStreamingServer[workloadPB.X509BundlesResponse]) error {
+	resp := &workloadPB.X509BundlesResponse{
+		Bundles: map[string][]byte{
+			s.trustDomain: s.caCert.Raw,
+		},
+	}
+
+	if err := stream.Send(resp); err != nil {
+		return err
+	}
+
+	<-stream.Context().Done()
+	return nil
+}
+
+// FetchJWTSVID implements the unary Workload API method for JWT-SVIDs.
+func (s *Server) FetchJWTSVID(_ context.Context, req *workloadPB.JWTSVIDRequest) (*workloadPB.JWTSVIDResponse, error) {
+	signer, err := jose.NewSigner(
+		jose.SigningKey{Algorithm: jose.ES256, Key: s.jwtSignKey},
+		(&jose.SignerOptions{}).WithType("JWT").WithHeader("kid", "fake-key-1"),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	now := time.Now()
+	claims := josejwt.Claims{
+		Subject:  s.spiffeID,
+		Audience: req.Audience,
+		IssuedAt: josejwt.NewNumericDate(now),
+		Expiry:   josejwt.NewNumericDate(now.Add(1 * time.Hour)),
+	}
+
+	token, err := josejwt.Signed(signer).Claims(claims).Serialize()
+	if err != nil {
+		return nil, err
+	}
+
+	return &workloadPB.JWTSVIDResponse{
+		Svids: []*workloadPB.JWTSVID{
+			{
+				SpiffeId: s.spiffeID,
+				Svid:     token,
+			},
+		},
+	}, nil
+}
+
+// FetchJWTBundles implements the streaming Workload API method for JWT bundles.
+func (s *Server) FetchJWTBundles(_ *workloadPB.JWTBundlesRequest, stream grpc.ServerStreamingServer[workloadPB.JWTBundlesResponse]) error {
+	jwk := jose.JSONWebKey{
+		Key:       &s.jwtSignKey.PublicKey,
+		KeyID:     "fake-key-1",
+		Algorithm: string(jose.ES256),
+		Use:       "sig",
+	}
+	jwks := jose.JSONWebKeySet{Keys: []jose.JSONWebKey{jwk}}
+	jwksBytes, err := json.Marshal(jwks)
+	if err != nil {
+		return err
+	}
+
+	bundleStruct := &structpb.Struct{}
+	if err := json.Unmarshal(jwksBytes, bundleStruct); err != nil {
+		return err
+	}
+
+	resp := &workloadPB.JWTBundlesResponse{
+		Bundles: map[string][]byte{
+			s.trustDomain: jwksBytes,
+		},
+	}
+
+	if err := stream.Send(resp); err != nil {
+		return err
+	}
+
+	<-stream.Context().Done()
+	return nil
+}
+
+// generateCA generates a new CA certificate and key.
+func (s *Server) generateCA() error {
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return err
+	}
+
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject: pkix.Name{
+			CommonName: "Fake SPIRE CA",
+		},
+		URIs:                  []*url.URL{mustParseURL(s.trustDomain)},
+		NotBefore:             time.Now().Add(-1 * time.Hour),
+		NotAfter:              time.Now().Add(24 * time.Hour),
+		IsCA:                  true,
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+		BasicConstraintsValid: true,
+	}
+
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		return err
+	}
+
+	cert, err := x509.ParseCertificate(der)
+	if err != nil {
+		return err
+	}
+
+	s.caCert = cert
+	s.caKey = key
+	return nil
+}
+
+// generateSVID generates a new SVID certificate and key.
+func (s *Server) generateSVID() error {
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return err
+	}
+
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(2),
+		Subject: pkix.Name{
+			CommonName: "SVID",
+		},
+		URIs:                  []*url.URL{mustParseURL(s.spiffeID)},
+		NotBefore:             time.Now().Add(-1 * time.Hour),
+		NotAfter:              time.Now().Add(24 * time.Hour),
+		KeyUsage:              x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth},
+		BasicConstraintsValid: true,
+	}
+
+	certDER, err := x509.CreateCertificate(rand.Reader, tmpl, s.caCert, &key.PublicKey, s.caKey)
+	if err != nil {
+		return err
+	}
+
+	keyDER, err := x509.MarshalPKCS8PrivateKey(key)
+	if err != nil {
+		return err
+	}
+
+	s.svidCertDER = certDER
+	s.svidKeyDER = keyDER
+	return nil
+}
+
+// trustDomainFromID extracts the trust domain from a spiffeID.
+func trustDomainFromID(spiffeID string) (string, error) {
+	u, err := url.Parse(spiffeID)
+	if err != nil {
+		return "", err
+	}
+	return "spiffe://" + u.Host, nil
+}
+
+// mustParseURL parses a URL and panics if it fails.
+func mustParseURL(raw string) *url.URL {
+	u, err := url.Parse(raw)
+	if err != nil {
+		panic(err)
+	}
+	return u
+}

--- a/test/fake/spire/spire_test.go
+++ b/test/fake/spire/spire_test.go
@@ -1,0 +1,244 @@
+// Copyright 2026 The argocd-agent Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spire
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"math/big"
+	"net/url"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	workloadPB "github.com/spiffe/go-spiffe/v2/proto/spiffe/workload"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+)
+
+const testSpiffeID = "spiffe://example.org/test-workload"
+
+func Test_New_GeneratesCA(t *testing.T) {
+	srv, err := New(testSpiffeID, nil, nil, nil)
+	require.NoError(t, err)
+	require.NotNil(t, srv)
+
+	assert.NotNil(t, srv.CACert())
+	assert.NotNil(t, srv.CAKey())
+	assert.True(t, srv.CACert().IsCA)
+	assert.Equal(t, testSpiffeID, srv.spiffeID)
+	assert.Equal(t, "spiffe://example.org", srv.trustDomain)
+}
+
+func Test_New_WithProvidedCA(t *testing.T) {
+	caKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	caTmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(100),
+		Subject:               pkix.Name{CommonName: "Test CA"},
+		URIs:                  []*url.URL{mustParseURL("spiffe://example.org")},
+		NotBefore:             time.Now().Add(-1 * time.Hour),
+		NotAfter:              time.Now().Add(24 * time.Hour),
+		IsCA:                  true,
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+		BasicConstraintsValid: true,
+	}
+	caDER, err := x509.CreateCertificate(rand.Reader, caTmpl, caTmpl, &caKey.PublicKey, caKey)
+	require.NoError(t, err)
+	caCert, err := x509.ParseCertificate(caDER)
+	require.NoError(t, err)
+
+	srv, err := New(testSpiffeID, caCert, caKey, nil)
+	require.NoError(t, err)
+	require.NotNil(t, srv)
+
+	assert.Equal(t, caCert, srv.CACert())
+	assert.Equal(t, caKey, srv.CAKey())
+}
+
+func Test_New_InvalidSpiffeID(t *testing.T) {
+	_, err := New("://invalid", nil, nil, nil)
+	require.Error(t, err)
+}
+
+func Test_ListenServeStop(t *testing.T) {
+	srv, err := New(testSpiffeID, nil, nil, nil)
+	require.NoError(t, err)
+
+	socketPath := filepath.Join(t.TempDir(), "test.sock")
+
+	err = srv.Listen(socketPath)
+	require.NoError(t, err)
+
+	// Verify socket file was created
+	_, err = os.Stat(socketPath)
+	require.NoError(t, err)
+
+	// Start serving in background
+	serveDone := make(chan error, 1)
+	go func() {
+		serveDone <- srv.Serve()
+	}()
+
+	// Connect a client to verify the server is serving
+	conn, err := grpc.NewClient(
+		"unix://"+socketPath,
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	require.NoError(t, err)
+	defer conn.Close()
+
+	client := workloadPB.NewSpiffeWorkloadAPIClient(conn)
+
+	// Test FetchX509SVID
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	svidStream, err := client.FetchX509SVID(ctx, &workloadPB.X509SVIDRequest{})
+	require.NoError(t, err)
+
+	svidResp, err := svidStream.Recv()
+	require.NoError(t, err)
+	require.Len(t, svidResp.Svids, 1)
+	assert.Equal(t, testSpiffeID, svidResp.Svids[0].SpiffeId)
+	assert.NotEmpty(t, svidResp.Svids[0].X509Svid)
+	assert.NotEmpty(t, svidResp.Svids[0].X509SvidKey)
+	assert.NotEmpty(t, svidResp.Svids[0].Bundle)
+
+	// Verify the SVID certificate is valid
+	svidCert, err := x509.ParseCertificate(svidResp.Svids[0].X509Svid)
+	require.NoError(t, err)
+	require.Len(t, svidCert.URIs, 1)
+	assert.Equal(t, testSpiffeID, svidCert.URIs[0].String())
+
+	// Test FetchX509Bundles
+	bundleCtx, bundleCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer bundleCancel()
+
+	bundleStream, err := client.FetchX509Bundles(bundleCtx, &workloadPB.X509BundlesRequest{})
+	require.NoError(t, err)
+
+	bundleResp, err := bundleStream.Recv()
+	require.NoError(t, err)
+	require.Contains(t, bundleResp.Bundles, "spiffe://example.org")
+	assert.NotEmpty(t, bundleResp.Bundles["spiffe://example.org"])
+
+	// Stop the server
+	srv.Stop()
+
+	// Wait for Serve to return
+	select {
+	case serveErr := <-serveDone:
+		assert.NoError(t, serveErr)
+	case <-time.After(5 * time.Second):
+		t.Fatal("server did not stop in time")
+	}
+}
+
+func Test_Stop_NilServer(t *testing.T) {
+	srv, err := New(testSpiffeID, nil, nil, nil)
+	require.NoError(t, err)
+
+	// Stop without Listen/Serve should not panic
+	assert.NotPanics(t, func() {
+		srv.Stop()
+	})
+}
+
+func Test_trustDomainFromID(t *testing.T) {
+	tests := []struct {
+		name       string
+		spiffeID   string
+		wantDomain string
+		wantErr    bool
+	}{
+		{
+			name:       "valid SPIFFE ID",
+			spiffeID:   "spiffe://example.org/workload",
+			wantDomain: "spiffe://example.org",
+		},
+		{
+			name:       "SPIFFE ID with nested path",
+			spiffeID:   "spiffe://cluster.local/ns/default/sa/myapp",
+			wantDomain: "spiffe://cluster.local",
+		},
+		{
+			name:       "trust domain only",
+			spiffeID:   "spiffe://example.org",
+			wantDomain: "spiffe://example.org",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := trustDomainFromID(tt.spiffeID)
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.wantDomain, got)
+			}
+		})
+	}
+}
+
+func Test_SharedCA_TwoServers(t *testing.T) {
+	srv1, err := New("spiffe://example.org/principal", nil, nil, nil)
+	require.NoError(t, err)
+
+	srv2, err := New("spiffe://example.org/agent", srv1.CACert(), srv1.CAKey(), srv1.JWTSignKey())
+	require.NoError(t, err)
+
+	// Both servers should share the same CA
+	assert.Equal(t, srv1.CACert().Raw, srv2.CACert().Raw)
+
+	// Parse their SVIDs and verify they were signed by the same CA
+	svid1, err := x509.ParseCertificate(srv1.svidCertDER)
+	require.NoError(t, err)
+	svid2, err := x509.ParseCertificate(srv2.svidCertDER)
+	require.NoError(t, err)
+
+	// Both SVIDs should be verifiable by the shared CA
+	pool := x509.NewCertPool()
+	pool.AddCert(srv1.CACert())
+
+	_, err = svid1.Verify(x509.VerifyOptions{
+		Roots:     pool,
+		KeyUsages: []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+	})
+	assert.NoError(t, err)
+
+	_, err = svid2.Verify(x509.VerifyOptions{
+		Roots:     pool,
+		KeyUsages: []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+	})
+	assert.NoError(t, err)
+
+	// Different SPIFFE IDs
+	assert.NotEqual(t, svid1.URIs[0].String(), svid2.URIs[0].String())
+
+	// Both servers should share the same JWT signing key
+	assert.Equal(t, srv1.JWTSignKey(), srv2.JWTSignKey())
+	assert.Equal(t, "spiffe://example.org/principal", svid1.URIs[0].String())
+	assert.Equal(t, "spiffe://example.org/agent", svid2.URIs[0].String())
+}


### PR DESCRIPTION
This PR is to add support for SPIFFE/SPIRE-based workload identity for authentication between principal and agent. 
This eliminates need to manually create certificates and secrets for each agent. Users can choose the authentication method via --spire-auth-method flag, supported values for are jwt (separate SPIRE Server per cluster, separate trust domains) and mtls (single SPIRE Server, shared trust domain). It is recommended to use this feature with self agent registration enabled, then it will be completely automated process from agent registration to authentication.

Few blogs/docs for reference
- https://www.redhat.com/en/topics/security/spiffe-and-spire#overview
- https://spiffe.io/docs/latest/planning/scaling_spire/
- https://github.com/spiffe/spire
- https://www.redhat.com/en/technologies/cloud-computing/openshift/zero-trust-workload-identity-manager

Assisted by: Cursor


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional SPIRE-based authentication and automatic TLS credential provisioning through mTLS or SPIFFE JWT.
  * Added Helm configuration for SPIRE sockets, authentication methods, and socket mounting.
  * Added shared client certificate issuance for principal self-registration.
  * Added SPIFFE JWT identity and audience validation.
* **Bug Fixes**
  * Improved TLS CA fallback when client secrets omit a CA certificate.
* **Documentation**
  * Added SPIRE setup, authentication, certificate management, and deployment guidance.
* **Tests**
  * Added end-to-end coverage for SPIRE authentication, connectivity, and terminal streaming.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->