### PR TITLE
docs: expand destination-based mapping documentation across all sections

### DIFF
--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -91,6 +91,9 @@ This section is organized by task to help you find what you need:
 | [Reference: Principal](reference/principal.md) | Complete principal parameter reference |
 | [Reference: Agent](reference/agent.md) | Complete agent parameter reference |
 
+!!! tip "Mapping Mode Configuration"
+    argocd-agent supports two mapping modes: **namespace-based** (default) and **destination-based**. If you plan to use destination-based mapping, both principal and agent must have `--destination-based-mapping` enabled. See [Agent Mapping Modes](../concepts/agent-mapping.md) for a conceptual overview, or the [Principal](reference/principal.md#destination-based-mapping) and [Agent](reference/agent.md#destination-based-mapping) reference pages for configuration details.
+
 ## Quick Start
 
 ### Minimal Principal Configuration

--- a/docs/configuration/namespaces.md
+++ b/docs/configuration/namespaces.md
@@ -1,4 +1,4 @@
-# Namespaces
+# Namespaces (namespace-based mapping)
 
 This document explains how the principal handles namespaces, how to configure namespace access control, and how to enable automatic namespace creation for autonomous agents.
 

--- a/docs/configuration/reference/agent.md
+++ b/docs/configuration/reference/agent.md
@@ -60,6 +60,62 @@ Mode of operation for the agent.
 
 Namespace to manage applications in.
 
+### Destination-Based Mapping
+
+| | |
+|---|---|
+| **CLI Flag** | `--destination-based-mapping` |
+| **Environment Variable** | `ARGOCD_AGENT_DESTINATION_BASED_MAPPING` |
+| **ConfigMap Entry** | `agent.destination-based-mapping` |
+| **Type** | Boolean |
+| **Default** | `false` |
+
+Enable destination-based mapping mode. When enabled, the agent creates Applications in their original namespace (preserving the namespace from the principal) instead of the agent's configured namespace. The agent also watches for Applications in all allowed namespaces rather than only its own namespace.
+
+Both the principal and agent must have this flag enabled for destination-based mapping to work correctly.
+
+See [Agent Mapping Modes](../../concepts/agent-mapping.md) for a detailed comparison of namespace-based and destination-based mapping.
+
+**Example:**
+
+```bash
+argocd-agent agent --destination-based-mapping
+```
+
+### Create Namespace
+
+| | |
+|---|---|
+| **CLI Flag** | `--create-namespace` |
+| **Environment Variable** | `ARGOCD_AGENT_CREATE_NAMESPACE` |
+| **ConfigMap Entry** | N/A |
+| **Type** | Boolean |
+| **Default** | `false` |
+
+Automatically create target namespaces on the agent cluster when they do not exist. This is used with destination-based mapping to ensure that namespaces referenced by Applications exist before the Application is created.
+
+Without this flag, Applications targeting non-existent namespaces will fail to be created on the agent.
+
+**Example:**
+
+```bash
+argocd-agent agent --destination-based-mapping --create-namespace
+```
+
+### Allowed Namespaces
+
+| | |
+|---|---|
+| **CLI Flag** | `--allowed-namespaces` |
+| **Environment Variable** | `ARGOCD_AGENT_ALLOWED_NAMESPACES` |
+| **ConfigMap Entry** | `agent.allowed-namespaces` |
+| **Type** | String slice (comma-separated) |
+| **Default** | `[]` (empty - all namespaces allowed) |
+
+List of namespaces the agent is allowed to operate in. Supports shell-style wildcards.
+
+**Example:** `argocd,team-a-*,team-b-*`
+
 ### Credentials
 
 | | |

--- a/docs/configuration/reference/agent.md
+++ b/docs/configuration/reference/agent.md
@@ -88,7 +88,7 @@ argocd-agent agent --destination-based-mapping
 |---|---|
 | **CLI Flag** | `--create-namespace` |
 | **Environment Variable** | `ARGOCD_AGENT_CREATE_NAMESPACE` |
-| **ConfigMap Entry** | N/A |
+| **ConfigMap Entry** | `agent.create-namespace` |
 | **Type** | Boolean |
 | **Default** | `false` |
 

--- a/docs/configuration/reference/principal.md
+++ b/docs/configuration/reference/principal.md
@@ -97,6 +97,30 @@ Labels to apply to auto-created namespaces.
 
 **Example:** `managed-by=argocd-agent,environment=production`
 
+## Agent Mapping
+
+### Destination-Based Mapping
+
+| | |
+|---|---|
+| **CLI Flag** | `--destination-based-mapping` |
+| **Environment Variable** | `ARGOCD_PRINCIPAL_DESTINATION_BASED_MAPPING` |
+| **ConfigMap Entry** | `principal.destination-based-mapping` |
+| **Type** | Boolean |
+| **Default** | `false` |
+
+Enable destination-based mapping mode. When enabled, the principal routes Applications to agents based on `spec.destination.name` instead of the Application's namespace. This allows applications from multiple namespaces to be synced to the same agent.
+
+Both the principal and agent must have this flag enabled for destination-based mapping to work correctly.
+
+See [Agent Mapping Modes](../../concepts/agent-mapping.md) for a detailed comparison of namespace-based and destination-based mapping.
+
+**Example:**
+
+```bash
+argocd-agent principal --destination-based-mapping
+```
+
 ## Resource Filtering
 
 ### Label Selector

--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -28,6 +28,12 @@ argocd-agent transforms traditional multi-cluster Argo CD deployments by inverti
 
 **[OpenTelemetry Tracing](../operations/tracing.md)**: Distributed tracing support using OpenTelemetry with OTLP export. Provides visibility into gRPC communication, resource synchronization, event processing, and Kubernetes operations across the distributed architecture.
 
+### Mapping Modes
+
+**[Namespace-Based Mapping](../concepts/agent-mapping.md#namespace-based-mapping-default)** (default): Applications are routed to agents based on their namespace on the control plane. Each agent has a dedicated namespace, and any Application placed in that namespace is synced to the corresponding agent. Simple to configure with no additional flags required.
+
+**[Destination-Based Mapping](../concepts/agent-mapping.md#destination-based-mapping)**: Applications are routed to agents based on `spec.destination.name`, matching the same targeting model that traditional Argo CD uses with cluster secrets. Multiple namespaces can target the same agent, enabling multi-tenancy and team-based namespace isolation.
+
 ### Resource Management
 
 **Application Synchronization**: Full lifecycle management of Argo CD Applications, including creation, updates, deletion, and status reporting across the distributed architecture.

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -35,6 +35,18 @@ It's perfectly fine to run a mixed-mode scenario, where some of the agents run i
 
 If in doubt, it's recommended to start using the [managed mode](../concepts/agent-modes/managed.md) for your agents.
 
+## Choosing the agent mapping mode
+
+In addition to the operational mode, you must choose how Applications are routed to managed agents. argocd-agent supports two [mapping modes](../concepts/agent-mapping.md):
+
+* **Namespace-based mapping** (default): Each agent has a dedicated namespace on the control plane. Applications placed in that namespace are routed to the agent. Simple to set up but limited multi-tenancy.
+
+* **Destination-based mapping**: Applications use `spec.destination.name` to specify the target agent, regardless of their namespace. Provides better multi-tenancy support and matches traditional Argo CD's routing model.
+
+If you are migrating from a traditional multi-cluster Argo CD setup, destination-based mapping provides the most familiar experience since it uses the same `spec.destination.name` field.
+
+See [Agent Mapping Modes](../concepts/agent-mapping.md) for a detailed comparison.
+
 ## Argo CD Component Placement
 
 The *argocd-agent* architecture requires specific Argo CD components to be deployed on different clusters. Understanding this placement is crucial for a successful setup.

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -24,7 +24,7 @@ When choosing a name, consider the following:
 
 * Naming rules for an agent are equal to [naming rules for Kubernetes namespaces](https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-label-names), and must follow the [DNS label standard](https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-label-names).
 * The name of an agent should clearly identify the agent, and the cluster it is running on. The name of an agent will be visible as the destination cluster in Argo CD.
-* For each agent, a namespace with the same name will be created on the control plane cluster. These namespaces must be accessible by the Argo CD API server on the control plane through apps-in-any-namespace configuration.
+* With namespace-based mapping (the default), a namespace with the same name as the agent will be created on the control plane cluster. These namespaces must be accessible by the Argo CD API server on the control plane through apps-in-any-namespace configuration. With destination-based mapping, per-agent namespaces are not required.
 * The name of the agent must be part of its TLS client certificate's subject
 
 ## Choosing the right operational mode for each agent

--- a/docs/getting-started/kubernetes/index.md
+++ b/docs/getting-started/kubernetes/index.md
@@ -477,7 +477,26 @@ kubectl rollout restart deployment argocd-agent-agent -n argocd --context <workl
 
 ### Test Application Synchronization (Destination-Based Mapping)
 
-With destination-based mapping, create a test application that uses `spec.destination.name` to target the agent:
+With destination-based mapping, Applications can live in any namespace. Before creating the test Application, prepare the namespace and ensure the principal is allowed to operate in it:
+
+```bash
+# Create the namespace for the test Application on the control plane
+kubectl create namespace team-ns --context <control-plane-context>
+
+# Allow the principal to operate in team-ns (in addition to the agent namespace)
+kubectl patch configmap argocd-agent-params -n argocd --context <control-plane-context> \
+  --patch '{"data":{
+    "principal.allowed-namespaces":"my-first-agent,team-ns"
+  }}'
+
+# Restart the principal to apply the updated allowed-namespaces
+kubectl rollout restart deployment argocd-agent-principal -n argocd --context <control-plane-context>
+```
+
+!!! tip
+    The `default` AppProject was already patched with `sourceNamespaces: ["*"]` in [Step 6.4](#64-test-application-synchronization-managed-mode), so it already permits Applications from `team-ns`.
+
+Now create a test application that uses `spec.destination.name` to target the agent:
 
 ```bash
 cat <<EOF | kubectl apply -f - --context <control-plane-context>

--- a/docs/getting-started/kubernetes/index.md
+++ b/docs/getting-started/kubernetes/index.md
@@ -316,11 +316,14 @@ kubectl get secret argocd-agent-ca -n argocd --context <workload-cluster-context
 
 ### 5.5 Create Agent Namespace on Principal
 
-For managed agents, create a namespace on the principal where the agent's Applications will be created and managed:
+For managed agents using **namespace-based mapping** (the default), create a namespace on the principal where the agent's Applications will be created and managed:
 
 ```bash
 kubectl create namespace my-first-agent --context <control-plane-context>
 ```
+
+!!! tip "Using Destination-Based Mapping Instead?"
+    If you plan to use **destination-based mapping**, you can skip this step. Destination-based mapping routes Applications to agents via `spec.destination.name` and does not require per-agent namespaces. Continue to [Step 5.6](#56-deploy-agent) and see [Configuring Destination-Based Mapping](#configuring-destination-based-mapping) below for the additional configuration needed.
 
 ### 5.6 Deploy Agent
 
@@ -434,6 +437,82 @@ kubectl get applications -n argocd --context <workload-cluster-context>
 ```
 
 Access the Argo CD UI to see your agent and its applications!
+
+## Configuring Destination-Based Mapping
+
+If you prefer to use destination-based mapping instead of the default namespace-based mapping, follow these additional steps after completing the basic setup above.
+
+### Why Use Destination-Based Mapping?
+
+- Multiple teams can share an agent without needing separate namespaces per team
+- Applications can live in any namespace on the principal
+- Familiar to users of traditional Argo CD's `destination.name` cluster targeting
+- Recommended for ApplicationSets that target multiple agents from a single resource
+- Better multi-tenancy support
+
+### Enable on Principal
+
+```bash
+kubectl patch configmap argocd-agent-params -n argocd --context <control-plane-context> \
+  --patch '{"data":{
+    "principal.destination-based-mapping":"true"
+  }}'
+
+# Restart the principal to apply changes
+kubectl rollout restart deployment argocd-agent-principal -n argocd --context <control-plane-context>
+```
+
+### Enable on Agent
+
+```bash
+kubectl patch configmap argocd-agent-params -n argocd --context <workload-cluster-context> \
+  --patch '{"data":{
+    "agent.destination-based-mapping":"true",
+    "agent.create-namespace":"true"
+  }}'
+
+# Restart the agent to apply changes
+kubectl rollout restart deployment argocd-agent-agent -n argocd --context <workload-cluster-context>
+```
+
+### Test Application Synchronization (Destination-Based Mapping)
+
+With destination-based mapping, create a test application that uses `spec.destination.name` to target the agent:
+
+```bash
+cat <<EOF | kubectl apply -f - --context <control-plane-context>
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: test-app-dbm
+  namespace: team-ns  # Applications can live in any namespace
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/argoproj/argocd-example-apps
+    targetRevision: HEAD
+    path: guestbook
+  destination:
+    name: my-first-agent  # Routes to agent by name
+    namespace: guestbook
+  syncPolicy:
+    syncOptions:
+    - CreateNamespace=true
+EOF
+```
+
+Verify the application is synchronized to the agent:
+
+```bash
+# Check that the application exists on the principal
+kubectl get applications -n team-ns --context <control-plane-context>
+
+# Check that the application appears on the workload cluster (in its original namespace)
+kubectl get applications -n team-ns --context <workload-cluster-context>
+```
+
+!!! note "Namespace Preservation"
+    With destination-based mapping, the Application's namespace from the principal is preserved on the agent side. If your Application is in namespace `team-ns` on the principal, it will also be in namespace `team-ns` on the agent (unlike namespace-based mapping where it's always placed in the agent's configured namespace).
 
 ## Next Steps
 

--- a/docs/getting-started/openshift/index.md
+++ b/docs/getting-started/openshift/index.md
@@ -97,7 +97,7 @@ argocd-agent supports two mapping modes for routing Applications to managed agen
 - **Namespace-based mapping** (default): Each agent has a dedicated namespace on the control plane. Applications placed in that namespace are routed to the agent. No additional configuration required.
 - **Destination-based mapping**: Applications use `spec.destination.name` to target an agent, regardless of their namespace. Better multi-tenancy support and familiar to traditional Argo CD users.
 
-To enable destination-based mapping, set the corresponding fields in the ArgoCD CR on both clusters. Both sides must have it enabled.
+To enable destination-based mapping, set the corresponding fields in the ArgoCD CR on both clusters. Both sides must have it enabled. These CR fields require **argocd-operator v0.18.0** or later.
 
 **Hub cluster** — add `destinationBasedMapping: true` under the principal spec:
 

--- a/docs/getting-started/openshift/index.md
+++ b/docs/getting-started/openshift/index.md
@@ -90,6 +90,48 @@ Create argocd-redis secret, because principal looks for it to fetch redis authen
 oc create secret generic argocd-redis -n argocd --from-literal=auth="$(oc get secret argocd-redis-initial-password -n argocd -o jsonpath='{.data.admin\.password}' | base64 -d)"
 ```
 
+### Choose a Mapping Mode
+
+argocd-agent supports two mapping modes for routing Applications to managed agents:
+
+- **Namespace-based mapping** (default): Each agent has a dedicated namespace on the control plane. Applications placed in that namespace are routed to the agent. No additional configuration required.
+- **Destination-based mapping**: Applications use `spec.destination.name` to target an agent, regardless of their namespace. Better multi-tenancy support and familiar to traditional Argo CD users.
+
+To enable destination-based mapping, set the corresponding fields in the ArgoCD CR on both clusters. Both sides must have it enabled.
+
+**Hub cluster** — add `destinationBasedMapping: true` under the principal spec:
+
+```yaml
+apiVersion: argoproj.io/v1beta1
+kind: ArgoCD
+metadata:
+  name: argocd
+spec:
+  argoCDAgent:
+    principal:
+      enabled: true
+      destinationBasedMapping: true
+      # ... other principal settings
+```
+
+**Agent cluster** — add a `destinationBasedMapping` block under the agent spec:
+
+```yaml
+apiVersion: argoproj.io/v1beta1
+kind: ArgoCD
+metadata:
+  name: argocd
+spec:
+  argoCDAgent:
+    agent:
+      destinationBasedMapping:
+        enabled: true
+        createNamespace: true
+      # ... other agent settings
+```
+
+With this configuration, Applications use `spec.destination.name` to route to agents and do not require a per-agent namespace on the hub cluster. See [Agent Mapping Modes](../../concepts/agent-mapping.md) for a detailed comparison.
+
 ## Setting up agent workload cluster
 
 ### Configure Argo CD for Agent
@@ -155,8 +197,6 @@ Update the configMap with name `argocd-agent-params`  with parameters related to
   agent.tls.secret-name: argocd-agent-client-tls
 ```
 Also Update RBAC, rolebinding/clusterrolebinding with `workload-namespace`, if pod is facing rbac issues.
-
-
 
 ### Configure Agent in Autonomous mode
 

--- a/docs/user-guide/adding-agents.md
+++ b/docs/user-guide/adding-agents.md
@@ -114,12 +114,15 @@ This command:
 Create the required namespace for the agent on the principal cluster:
 
 ```bash
-# Create namespace for managed agents
+# Create namespace for managed agents (namespace-based mapping)
 kubectl create namespace <agent-name> --context <control-plane-context>
 
 # For autonomous agents, the namespace is typically created automatically
 # but you can create it manually if needed
 ```
+
+!!! tip "Destination-Based Mapping"
+    If you are using **destination-based mapping**, you do not need to create a namespace per agent on the principal. Applications can live in any namespace. Skip this step and instead ensure `--destination-based-mapping` is enabled on both the principal and agent. See [Agent Mapping Modes](../concepts/agent-mapping.md) for details.
 
 ## Step 5: Deploy Agent to Workload Cluster
 
@@ -193,6 +196,28 @@ data:
   # Logging
   agent.log.level: "info"
 ```
+
+### Destination-Based Mapping Configuration
+
+If you are using destination-based mapping instead of the default namespace-based mapping, add the following to the agent's ConfigMap:
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: argocd-agent-params
+  namespace: argocd
+data:
+  # ... connection and auth settings as above ...
+  
+  # Destination-based mapping settings
+  agent.destination-based-mapping: "true"
+  agent.create-namespace: "true"  # Recommended: auto-create target namespaces
+  agent.allowed-namespaces: "argocd,team-*"  # Optional: restrict managed namespaces
+```
+
+!!! important "Both Sides Must Match"
+    Destination-based mapping must be enabled on **both** the principal and agent. Ensure the principal also has `--destination-based-mapping` set. See the [Configuration Reference](../configuration/reference/principal.md#destination-based-mapping) for principal-side configuration.
 
 ### Authentication Methods
 
@@ -358,12 +383,13 @@ kubectl delete -n argocd \
 
 After successfully adding agents:
 
-1. **Configure Applications**: Create Applications in the appropriate namespaces
+1. **Configure Applications**: Create Applications in the appropriate namespaces (or with `destination.name` for DBM)
 2. **Set up AppProjects**: Define project boundaries and access controls
 3. **Monitor Resources**: Use the live resources feature to view cluster state
 4. **Implement GitOps**: Configure your deployment pipelines
 
 For more information, refer to:
+- [Agent Mapping Modes](../concepts/agent-mapping.md) - Namespace-based vs destination-based mapping
 - [Application Synchronization](./applications.md)
 - [AppProject Synchronization](./appprojects.md)
 - [Live Resources](./live-resources.md) 

--- a/docs/user-guide/applications.md
+++ b/docs/user-guide/applications.md
@@ -149,16 +149,16 @@ If an Application is modified directly on the managed agent cluster (outside of 
 
 ### Lifecycle Management
 
-- **Creation**: Create Applications on the principal in the agent's namespace
+- **Creation**: Create Applications on the principal — in the agent's namespace (namespace-based mapping) or with `spec.destination.name` set to the agent (destination-based mapping)
 - **Updates**: Modify Applications on the principal; changes are automatically propagated
 - **Deletion**: Delete Applications on the principal; they're automatically removed from the agent
-- **Agent Connection**: When an agent connects, it receives all Applications in its namespace
+- **Agent Connection**: When an agent connects, it receives all Applications that are mapped to it
 
 ## Autonomous Agent Mode
 
 ### Creating Applications
 
-In autonomous mode, Applications are created directly on the **agent cluster**. The agent then synchronizes these Applications to the principal, where they appear in a namespace named after the agent.
+In autonomous mode, Applications are created directly on the **agent cluster**. The agent then synchronizes these Applications to the principal, where they appear in a dedicated namespace named after the agent on the control plane.
 
 ### Example: Creating an Application on an Autonomous Agent
 
@@ -402,7 +402,7 @@ This Application will remain only on the autonomous agent cluster and will not b
 
 2. **Label Removal**: If you remove the skip sync label from an existing Application, it will begin synchronizing according to the normal rules for your agent mode.
 
-3. **Namespace Rules Still Apply**: The skip sync label doesn't override namespace-based filtering. Applications must still be in allowed namespaces to be processed.
+3. **Routing Rules Still Apply**: The skip sync label doesn't override the normal mapping mode rules. Applications must still be in allowed namespaces to be processed.
 
 ### Use Cases
 

--- a/docs/user-guide/applications.md
+++ b/docs/user-guide/applications.md
@@ -4,27 +4,38 @@ This document explains how Argo CD `Applications` are synchronized between the p
 
 ## Overview
 
-Application synchronization in argocd-agent follows a fundamentally different pattern than AppProjects. Applications are mapped to agents using **namespaces**, where each namespace on the principal corresponds to a specific agent. This provides a clear and scalable way to manage Applications across multiple clusters.
+Application synchronization in argocd-agent supports two mapping modes that determine how Applications are routed to agents:
 
-The synchronization mechanism varies depending on the agent mode:
+- **Namespace-based mapping** (default): Applications are mapped to agents using **namespaces**, where each namespace on the principal corresponds to a specific agent.
+- **Destination-based mapping**: Applications are mapped to agents using `spec.destination.name`, allowing multiple namespaces to route to the same agent.
+
+The synchronization mechanism also varies depending on the agent mode:
 
 - **Managed agents**: Applications are created on the principal and distributed to agents; agents send status updates back
 - **Autonomous agents**: Applications are created on the agent and synchronized to the principal; principal acts as a read-only mirror for specifications but can still perform sync, refresh, and resource actions
+
+!!! tip "Choosing a Mapping Mode"
+    If you are unsure which mode to use, see [Agent Mapping Modes](../concepts/agent-mapping.md) for a detailed comparison. Destination-based mapping is recommended for multi-tenant environments and when using ApplicationSets targeting multiple agents.
 
 ## Managed Agent Mode
 
 ### Creating Applications
 
-In managed mode, Applications must be created in the **agent's corresponding namespace** on the **principal cluster** (control plane). The principal determines which agent should receive an Application based on the namespace where it's created.
+In managed mode, Applications are created on the **principal cluster** (control plane). The principal determines which agent should receive an Application based on the active mapping mode:
 
-### Namespace to Agent Mapping
+- **Namespace-based mapping** (default): The Application's namespace determines the target agent
+- **Destination-based mapping**: The Application's `spec.destination.name` determines the target agent
+
+### Namespace-Based Mapping (Default)
+
+#### Namespace to Agent Mapping
 
 Applications are mapped to agents through a simple naming convention:
 
 - **Namespace name on principal** = **Agent name**
 - Example: Applications in namespace `production-cluster` are sent to the agent named `production-cluster`
 
-### Example: Creating an Application for a Managed Agent
+#### Example: Creating an Application (Namespace-Based)
 
 ```yaml
 apiVersion: argoproj.io/v1alpha1
@@ -48,9 +59,9 @@ spec:
 
 When this Application is created in namespace `production-cluster` on the principal, it will be automatically sent to the managed agent named `production-cluster`.
 
-### Agent-Side Transformation
+#### Agent-Side Transformation (Namespace-Based)
 
-When an Application is sent to a managed agent, it undergoes transformation to make it agent-specific:
+When an Application is sent to a managed agent using namespace-based mapping, it undergoes transformation:
 
 1. **Destination Server**: Transformed to point to the local cluster:
 ```yaml
@@ -67,6 +78,61 @@ When an Application is sent to a managed agent, it undergoes transformation to m
 ```
 
 3. **Source UID Annotation**: Added to track the original source for synchronization purposes
+
+### Destination-Based Mapping
+
+#### How Routing Works
+
+With destination-based mapping enabled, the principal routes Applications to agents based on `spec.destination.name`. The Application's namespace is preserved rather than being used as a routing key.
+
+- Applications can live in any namespace on the principal
+- Multiple teams can share a namespace while targeting different agents
+- Applications from multiple namespaces can route to the same agent
+
+#### Example: Creating an Application (Destination-Based)
+
+```yaml
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: my-app
+  namespace: argocd  # Can be any namespace
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/argoproj/argocd-example-apps
+    targetRevision: HEAD
+    path: guestbook
+  destination:
+    name: production-cluster  # This determines the target agent
+    namespace: guestbook
+  syncPolicy:
+    syncOptions:
+    - CreateNamespace=true
+```
+
+When this Application is created on the principal with `destination.name: production-cluster`, it will be routed to the managed agent named `production-cluster` regardless of the Application's namespace.
+
+#### Agent-Side Transformation (Destination-Based)
+
+When an Application is sent to a managed agent using destination-based mapping, the transformation differs from namespace-based mapping:
+
+1. **Destination Server**: Transformed to point to the local cluster:
+```yaml
+   destination:
+     server: ""
+     name: "in-cluster"
+     namespace: "guestbook"
+```
+
+2. **Namespace**: The Application's **original namespace is preserved** on the agent:
+```yaml
+   metadata:
+     namespace: team-a  # Preserved from the principal
+```
+
+!!! note "Namespace Creation"
+    With destination-based mapping, the agent must create Applications in namespaces that may not exist yet. Use the `--create-namespace` flag on the agent to automatically create namespaces when needed.
 
 ### Status Synchronization
 
@@ -151,7 +217,7 @@ The principal serves as a centralized view of all Applications across autonomous
 
 ## Best Practices
 
-### For Managed Agents
+### For Managed Agents (Namespace-Based Mapping)
 
 1. **Namespace Organization**: Use clear, descriptive namespace names that match your agent names:
 ```
@@ -172,6 +238,29 @@ The principal serves as a centralized view of all Applications across autonomous
 
 4. **Avoid Direct Changes**: Never modify Applications directly on agent clusters; always use the principal
 
+### For Managed Agents (Destination-Based Mapping)
+
+1. **Use Consistent destination.name**: Ensure `spec.destination.name` exactly matches the agent name:
+```yaml
+   spec:
+     destination:
+       name: production-east  # Must match agent name
+       namespace: my-app
+```
+
+2. **Organize by Team or Project**: Since Applications are not bound to agent-specific namespaces, organize them by team, project, or environment instead:
+```yaml
+   metadata:
+     name: frontend-prod
+     namespace: team-platform  # Need not match agent
+```
+
+3. **Enable Namespace Creation**: Use `--create-namespace` on agents to handle namespaces that may not exist yet
+
+4. **Configure Allowed Namespaces**: Restrict which namespaces the agent and principal can operate in using `--allowed-namespaces` with glob patterns for security
+
+5. **AppProject sourceNamespaces**: Ensure your AppProjects have `sourceNamespaces` configured to allow Applications from the namespaces you use
+
 ### For Autonomous Agents
 
 1. **Project Management**: Be mindful of project names as they may be prefixed on the principal:
@@ -188,10 +277,12 @@ The principal serves as a centralized view of all Applications across autonomous
 
 ### Application Not Appearing on Agent (Managed Mode)
 
-1. **Check Namespace**: Verify the Application is created in the correct namespace on the principal
-2. **Verify Agent Connection**: Ensure the agent is connected and the namespace name matches the agent name
-3. **Review Logs**: Check principal logs for distribution events and agent logs for reception
-4. **Check Source UID**: Look for source UID annotations to verify proper synchronization
+1. **Check Namespace** (namespace-based mapping): Verify the Application is created in the correct namespace on the principal
+2. **Check destination.name** (destination-based mapping): Verify `spec.destination.name` matches the agent name exactly and both principal and agent have `--destination-based-mapping` enabled
+3. **Verify Agent Connection**: Ensure the agent is connected and the namespace name matches the agent name
+4. **Review Logs**: Check principal logs for distribution events and agent logs for reception
+5. **Check Source UID**: Look for source UID annotations to verify proper synchronization
+6. **Check Allowed Namespaces** (destination-based mapping): Verify the Application's namespace is included in `--allowed-namespaces` on both principal and agent
 
 ### Application Not Appearing on Principal (Autonomous Mode)
 

--- a/docs/user-guide/migration.md
+++ b/docs/user-guide/migration.md
@@ -258,7 +258,7 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   name: my-app
-  namespace: argocd  # Can be any namespace
+  namespace: argocd  # Or another namespace if apps-in-any-namespace, allowed-namespaces, and AppProject sourceNamespaces are configured
 spec:
   # ... application specification
   destination:

--- a/docs/user-guide/migration.md
+++ b/docs/user-guide/migration.md
@@ -87,6 +87,26 @@ For each workload cluster, decide on the operational mode:
 !!! tip "Mixed Modes"
     You can run different agents in different modes. For example, development clusters in managed mode and production clusters in autonomous mode.
 
+### Choose Agent Mapping Mode
+
+For managed agents, decide on the mapping mode:
+
+**Namespace-Based Mapping** (default) - Choose when:
+
+- You have a simple one-agent-per-namespace setup
+- Backward compatibility with existing argocd-agent deployments is required
+- You don't need multi-tenant isolation within a single agent
+
+**[Destination-Based Mapping](../concepts/agent-mapping.md)** - Choose when:
+
+- You are migrating from traditional Argo CD (same `destination.name` model)
+- Multiple teams share agents but need namespace isolation
+- You plan to use ApplicationSets targeting multiple agents
+- You want to organize Applications by team/project rather than by agent
+
+!!! tip "Familiar Model"
+    If you are migrating from traditional multi-cluster Argo CD, destination-based mapping will feel the most natural since it uses the same `spec.destination.name` routing model that traditional Argo CD uses with its cluster secrets.
+
 ### Plan Network Architecture
 
 **For the Control Plane:**
@@ -208,7 +228,7 @@ argocd cluster list --context <control-plane-context>
 
 ### 4.1 Migration Strategy by Mode
 
-#### Managed Mode Applications
+#### Managed Mode Applications (Namespace-Based Mapping)
 
 1. **Create Applications on Control Plane**: Applications are created in namespaces named after the target agent
 ```bash
@@ -227,6 +247,30 @@ EOF
 ```
 
 2. **Verify Synchronization**: Check that applications appear and sync on workload clusters
+
+#### Managed Mode Applications (Destination-Based Mapping)
+
+1. **Create Applications on Control Plane**: Applications use `spec.destination.name` for routing
+```bash
+# Application routes to agent via destination.name, not namespace
+kubectl apply -f - <<EOF
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: my-app
+  namespace: argocd  # Can be any namespace
+spec:
+  # ... application specification
+  destination:
+    name: my-workload-cluster  # Routes to agent by name
+    namespace: my-app-ns
+EOF
+```
+
+2. **Verify Synchronization**: Check that applications appear and sync on workload clusters
+
+!!! tip "Easier Migration with Destination-Based Mapping"
+    If you are migrating from traditional multi-cluster Argo CD, destination-based mapping requires the least changes to your existing Application manifests since traditional Argo CD already uses `spec.destination.name` to target clusters. You may only need to update the destination name to match your agent names.
 
 #### Autonomous Mode Applications
 
@@ -563,5 +607,6 @@ For migration support:
 ## Additional Resources
 
 - [Architecture Overview](../concepts/architecture.md) - Understanding the technical foundations
-- [Agent Modes](../concepts/agent-modes/index.md) - Detailed mode comparisons  
+- [Agent Modes](../concepts/agent-modes/index.md) - Detailed mode comparisons
+- [Agent Mapping Modes](../concepts/agent-mapping.md) - Namespace-based vs destination-based mapping
 - [Configuration Guide](../configuration/index.md) - Advanced configuration options

--- a/docs/user-guide/repository.md
+++ b/docs/user-guide/repository.md
@@ -41,9 +41,18 @@ Requirements for a repository secret to be reconciled by the principal:
 The principal distributes a repository secret to a managed agent using a **two-step matching process**:
 
 1. **Project Association**: Repository must include a `project` field referencing an existing AppProject
-2. **Pattern Matching**: Agent name must match **both**:
+2. **Pattern Matching**: The matching logic depends on the active mapping mode:
+
+**Namespace-based mapping** (default): Agent name must match **both**:
+
    - At least one destination pattern via `.spec.destinations` (either `name` or a `server` URL that includes `?agentName=<pattern>`; `*` is allowed)  
    - At least one pattern in the AppProject's `.spec.sourceNamespaces` fields
+
+**Destination-based mapping**: Agent name must match:
+
+   - At least one destination pattern via `.spec.destinations` (either `name` or a `server` URL that includes `?agentName=<pattern>`; `*` is allowed)
+
+   `.spec.sourceNamespaces` is not consulted for routing in destination-based mapping mode.
 
 Learn more about AppProject matching logic in the [AppProjects guide](./appprojects.md).
 
@@ -285,7 +294,8 @@ kubectl get appproject my-project -n argocd -o yaml
 Verify that:
 
 - The AppProject referenced by the secret exists
-- Agent names match patterns in both `.spec.destinations` (either `name` or `server` with `?agentName=`) and `.spec.sourceNamespaces`
+- **Namespace-based mapping**: Agent names match patterns in both `.spec.destinations` (either `name` or `server` with `?agentName=`) and `.spec.sourceNamespaces`
+- **Destination-based mapping**: Agent names match patterns in `.spec.destinations` (either `name` or `server` with `?agentName=`); `.spec.sourceNamespaces` is not used for routing
 - Patterns use correct glob syntax, including any deny patterns (`!pattern`) you intend
 
 #### Check Principal Logs


### PR DESCRIPTION
**What does this PR do / why we need it**:

Currently, the destination-based mapping topic is confined to a [single page](https://argocd-agent.readthedocs.io/latest/concepts/agent-mapping/#destination-based-mapping). The agent documentation only uses the default namespaced approach in every section: guides, examples, etc and doesn't mention the alternative. In this PR, we broaden the coverage to other sections of the docs as well. DBM provides a better user experience that aligns with the existing argocd workflow. So, we must document it (guide, examples, etc) alongside the default namespace-based mapping.


Assisted-by: Cursor

**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:


**Checklist**

* [✅ ] Documentation update is required by this PR (and has been updated) OR no documentation update is required.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance for namespace-based and destination-based agent mapping modes.
  * Documented destination-based routing configuration, including required matching settings, namespace creation behavior, and allowed-namespace restrictions.
  * Expanded setup, application management, migration, repository distribution, best-practice, and troubleshooting guidance for both modes.
  * Added examples and tips for enabling destination-based mapping and routing Applications using `spec.destination.name`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->