### PR TITLE
fix: preserve notifications state on the principal across agent updates

### DIFF
--- a/internal/manager/application/application.go
+++ b/internal/manager/application/application.go
@@ -474,6 +474,23 @@ func (m *ApplicationManager) CompareSourceUID(ctx context.Context, incoming *v1a
 	return result.Exists, result.SourceUIDMatch, nil
 }
 
+// preservePrincipalAnnotations carries principal-owned annotations from the
+// existing application over to the incoming one before the incoming
+// annotation set is applied. State written on the principal's copy of the
+// application (the source UID mapping, the notifications engine's delivery
+// tracking) is unknown to the agent, so an update inherited verbatim from
+// the agent would otherwise delete it.
+func preservePrincipalAnnotations(existing, incoming *v1alpha1.Application) {
+	for _, key := range []string{manager.SourceUIDAnnotation, manager.NotifiedAnnotation} {
+		if v, ok := existing.Annotations[key]; ok {
+			if incoming.Annotations == nil {
+				incoming.Annotations = make(map[string]string)
+			}
+			incoming.Annotations[key] = v
+		}
+	}
+}
+
 // UpdateAutonomousApp updates the Application resource on the control plane side
 // when the agent is in autonomous mode. It will update changes to .spec and
 // .status fields along with syncing labels and annotations.
@@ -497,12 +514,7 @@ func (m *ApplicationManager) UpdateAutonomousApp(ctx context.Context, namespace 
 	}
 
 	updated, err = m.update(ctx, true, incoming, func(existing, incoming *v1alpha1.Application) {
-		if v, ok := existing.Annotations[manager.SourceUIDAnnotation]; ok {
-			if incoming.Annotations == nil {
-				incoming.Annotations = make(map[string]string)
-			}
-			incoming.Annotations[manager.SourceUIDAnnotation] = v
-		}
+		preservePrincipalAnnotations(existing, incoming)
 
 		existing.Annotations = incoming.Annotations
 		existing.Labels = incoming.Labels
@@ -518,12 +530,7 @@ func (m *ApplicationManager) UpdateAutonomousApp(ctx context.Context, namespace 
 		existing.Operation = incoming.Operation.DeepCopy()
 		logCtx.Infof("Updating")
 	}, func(existing, incoming *v1alpha1.Application) (jsondiff.Patch, error) {
-		if v, ok := existing.Annotations[manager.SourceUIDAnnotation]; ok {
-			if incoming.Annotations == nil {
-				incoming.Annotations = make(map[string]string)
-			}
-			incoming.Annotations[manager.SourceUIDAnnotation] = v
-		}
+		preservePrincipalAnnotations(existing, incoming)
 
 		target := &v1alpha1.Application{
 			ObjectMeta: v1.ObjectMeta{
@@ -590,6 +597,7 @@ func (m *ApplicationManager) UpdateStatus(ctx context.Context, namespace string,
 	}
 
 	updated, err = m.update(ctx, false, incoming, func(existing, incoming *v1alpha1.Application) {
+		preservePrincipalAnnotations(existing, incoming)
 		existing.Annotations = incoming.Annotations
 		existing.Labels = incoming.Labels
 		existing.Status = *incoming.Status.DeepCopy()

--- a/internal/manager/application/application.go
+++ b/internal/manager/application/application.go
@@ -474,6 +474,14 @@ func (m *ApplicationManager) CompareSourceUID(ctx context.Context, incoming *v1a
 	return result.Exists, result.SourceUIDMatch, nil
 }
 
+// principalOwnedAnnotations lists the annotations that are written on the
+// principal's copy of an application and are unknown to the agent. They are
+// retained across updates received from the agent.
+var principalOwnedAnnotations = []string{
+	manager.SourceUIDAnnotation,
+	manager.NotifiedAnnotation,
+}
+
 // preservePrincipalAnnotations carries principal-owned annotations from the
 // existing application over to the incoming one before the incoming
 // annotation set is applied. State written on the principal's copy of the
@@ -481,7 +489,7 @@ func (m *ApplicationManager) CompareSourceUID(ctx context.Context, incoming *v1a
 // tracking) is unknown to the agent, so an update inherited verbatim from
 // the agent would otherwise delete it.
 func preservePrincipalAnnotations(existing, incoming *v1alpha1.Application) {
-	for _, key := range []string{manager.SourceUIDAnnotation, manager.NotifiedAnnotation} {
+	for _, key := range principalOwnedAnnotations {
 		if v, ok := existing.Annotations[key]; ok {
 			if incoming.Annotations == nil {
 				incoming.Annotations = make(map[string]string)

--- a/internal/manager/application/application_test.go
+++ b/internal/manager/application/application_test.go
@@ -510,6 +510,66 @@ func Test_ManagerUpdateAutonomous(t *testing.T) {
 		require.NotContains(t, updated.ObjectMeta.Annotations, "argocd.argoproj.io/refresh")
 		require.Equal(t, map[string]string{"foo": "bar"}, updated.Labels)
 	})
+	t.Run("Retain principal-owned annotations across an agent update", func(t *testing.T) {
+		incoming := &v1alpha1.Application{
+			ObjectMeta: v1.ObjectMeta{
+				Name:      "foobar",
+				Namespace: "argocd",
+				Annotations: map[string]string{
+					"bar": "foo",
+				},
+			},
+			Spec: v1alpha1.ApplicationSpec{
+				Source: &v1alpha1.ApplicationSource{
+					RepoURL:        "github.com",
+					TargetRevision: "HEAD",
+					Path:           ".",
+				},
+				Destination: v1alpha1.ApplicationDestination{
+					Server:    "in-cluster",
+					Namespace: "guestbook",
+				},
+			},
+		}
+		existing := &v1alpha1.Application{
+			ObjectMeta: v1.ObjectMeta{
+				Name:      "foobar",
+				Namespace: "cluster-1",
+				Annotations: map[string]string{
+					// State written on the principal's copy only: the agent's
+					// incoming application does not carry these annotations.
+					manager.SourceUIDAnnotation: "12345",
+					manager.NotifiedAnnotation:  `{"cd6b8a91cf6b8a4b1e0b4d0e:app-deployed":{"state":"delivered"}}`,
+					// A stale value the agent has since changed: the incoming
+					// value must win for annotations the agent owns.
+					"bar": "baz",
+				},
+			},
+			Spec: v1alpha1.ApplicationSpec{
+				Source: &v1alpha1.ApplicationSource{
+					RepoURL:        "github.com",
+					TargetRevision: "HEAD",
+					Path:           ".",
+				},
+				Destination: v1alpha1.ApplicationDestination{
+					Server:    "in-cluster",
+					Namespace: "guestbook",
+				},
+			},
+		}
+
+		appC, ai := fakeInformer(t, "", existing)
+		be := application.NewKubernetesBackend(appC, "", ai, true)
+		mgr, err := NewApplicationManager(be, "argocd")
+		require.NoError(t, err)
+		mgr.role = manager.ManagerRolePrincipal
+		updated, err := mgr.UpdateAutonomousApp(context.TODO(), "cluster-1", incoming)
+		require.NoError(t, err)
+		require.NotNil(t, updated)
+		assert.Equal(t, "12345", updated.Annotations[manager.SourceUIDAnnotation])
+		assert.Equal(t, `{"cd6b8a91cf6b8a4b1e0b4d0e:app-deployed":{"state":"delivered"}}`, updated.Annotations[manager.NotifiedAnnotation])
+		assert.Equal(t, "foo", updated.Annotations["bar"])
+	})
 }
 
 func Test_ManagerUpdateOperation(t *testing.T) {

--- a/internal/manager/application/application_test.go
+++ b/internal/manager/application/application_test.go
@@ -440,6 +440,71 @@ func Test_ManagerUpdateStatus(t *testing.T) {
 		require.NotNil(t, updated.Operation)
 		require.Equal(t, incoming.Operation, updated.Operation)
 	})
+
+	t.Run("Retain principal-owned annotations across an agent status update", func(t *testing.T) {
+		incoming := &v1alpha1.Application{
+			ObjectMeta: v1.ObjectMeta{
+				Name:      "foobar",
+				Namespace: "argocd",
+				Annotations: map[string]string{
+					"bar": "foo",
+				},
+			},
+			Spec: v1alpha1.ApplicationSpec{
+				Source: &v1alpha1.ApplicationSource{
+					RepoURL:        "github.com",
+					TargetRevision: "HEAD",
+					Path:           ".",
+				},
+				Destination: v1alpha1.ApplicationDestination{
+					Server:    "in-cluster",
+					Namespace: "guestbook",
+				},
+			},
+		}
+		existing := &v1alpha1.Application{
+			ObjectMeta: v1.ObjectMeta{
+				Name:      "foobar",
+				Namespace: "cluster-1",
+				Annotations: map[string]string{
+					// State written on the principal's copy only: the agent's
+					// incoming application does not carry these annotations.
+					manager.SourceUIDAnnotation: "12345",
+					manager.NotifiedAnnotation:  `{"cd6b8a91cf6b8a4b1e0b4d0e:app-deployed":{"state":"delivered"}}`,
+					// A stale value the agent has since changed: the incoming
+					// value must win for annotations the agent owns.
+					"bar": "baz",
+				},
+			},
+			Spec: v1alpha1.ApplicationSpec{
+				Source: &v1alpha1.ApplicationSource{
+					RepoURL:        "github.com",
+					TargetRevision: "HEAD",
+					Path:           ".",
+				},
+				Destination: v1alpha1.ApplicationDestination{
+					Server:    "in-cluster",
+					Namespace: "guestbook",
+				},
+			},
+		}
+
+		appC, ai := fakeInformer(t, "", existing)
+		// usePatch=false exercises the update path, which inherits the
+		// incoming annotation set and is where preservation must happen; the
+		// patch path never touches annotations except the refresh marker.
+		be := application.NewKubernetesBackend(appC, "", ai, false)
+		mgr, err := NewApplicationManager(be, "argocd")
+		require.NoError(t, err)
+		mgr.mode = manager.ManagerModeManaged
+		mgr.role = manager.ManagerRolePrincipal
+		updated, err := mgr.UpdateStatus(context.Background(), "cluster-1", incoming)
+		require.NoError(t, err)
+		require.NotNil(t, updated)
+		assert.Equal(t, "12345", updated.Annotations[manager.SourceUIDAnnotation])
+		assert.Equal(t, `{"cd6b8a91cf6b8a4b1e0b4d0e:app-deployed":{"state":"delivered"}}`, updated.Annotations[manager.NotifiedAnnotation])
+		assert.Equal(t, "foo", updated.Annotations["bar"])
+	})
 }
 
 func Test_ManagerUpdateAutonomous(t *testing.T) {

--- a/internal/manager/application/application_test.go
+++ b/internal/manager/application/application_test.go
@@ -635,6 +635,61 @@ func Test_ManagerUpdateAutonomous(t *testing.T) {
 		assert.Equal(t, `{"cd6b8a91cf6b8a4b1e0b4d0e:app-deployed":{"state":"delivered"}}`, updated.Annotations[manager.NotifiedAnnotation])
 		assert.Equal(t, "foo", updated.Annotations["bar"])
 	})
+
+	t.Run("Retain principal-owned annotations without patch support", func(t *testing.T) {
+		// The non-patch update path inherits the incoming annotation set the
+		// same way; the incoming application carries no annotations at all,
+		// which also exercises the nil-map initialization.
+		incoming := &v1alpha1.Application{
+			ObjectMeta: v1.ObjectMeta{
+				Name:      "foobar",
+				Namespace: "argocd",
+			},
+			Spec: v1alpha1.ApplicationSpec{
+				Source: &v1alpha1.ApplicationSource{
+					RepoURL:        "github.com",
+					TargetRevision: "HEAD",
+					Path:           ".",
+				},
+				Destination: v1alpha1.ApplicationDestination{
+					Server:    "in-cluster",
+					Namespace: "guestbook",
+				},
+			},
+		}
+		existing := &v1alpha1.Application{
+			ObjectMeta: v1.ObjectMeta{
+				Name:      "foobar",
+				Namespace: "cluster-1",
+				Annotations: map[string]string{
+					manager.SourceUIDAnnotation: "12345",
+					manager.NotifiedAnnotation:  `{"cd6b8a91cf6b8a4b1e0b4d0e:app-deployed":{"state":"delivered"}}`,
+				},
+			},
+			Spec: v1alpha1.ApplicationSpec{
+				Source: &v1alpha1.ApplicationSource{
+					RepoURL:        "github.com",
+					TargetRevision: "HEAD",
+					Path:           ".",
+				},
+				Destination: v1alpha1.ApplicationDestination{
+					Server:    "in-cluster",
+					Namespace: "guestbook",
+				},
+			},
+		}
+
+		appC, ai := fakeInformer(t, "", existing)
+		be := application.NewKubernetesBackend(appC, "", ai, false)
+		mgr, err := NewApplicationManager(be, "argocd")
+		require.NoError(t, err)
+		mgr.role = manager.ManagerRolePrincipal
+		updated, err := mgr.UpdateAutonomousApp(context.TODO(), "cluster-1", incoming)
+		require.NoError(t, err)
+		require.NotNil(t, updated)
+		assert.Equal(t, "12345", updated.Annotations[manager.SourceUIDAnnotation])
+		assert.Equal(t, `{"cd6b8a91cf6b8a4b1e0b4d0e:app-deployed":{"state":"delivered"}}`, updated.Annotations[manager.NotifiedAnnotation])
+	})
 }
 
 func Test_ManagerUpdateOperation(t *testing.T) {

--- a/internal/manager/manager.go
+++ b/internal/manager/manager.go
@@ -45,6 +45,16 @@ const (
 	// It is added to the resources managed on the target.
 	SourceUIDAnnotation = "argocd.argoproj.io/source-uid"
 
+	// NotifiedAnnotation is the annotation used by Argo CD's notifications
+	// engine to track which notifications have already been delivered for an
+	// application. When a notifications controller runs on the principal, it
+	// stores this state on the principal's copy of the application, and it
+	// must survive updates that mirror the application from the agent: the
+	// agent's copy never carries this annotation, so inheriting the agent's
+	// annotation set verbatim deletes the delivery state on every update and
+	// makes the notifications controller re-send every matching notification.
+	NotifiedAnnotation = "notified.notifications.argoproj.io"
+
 	// PrincipalUIDAnnotation is an annotation stamped by the agent on managed resources
 	// to track which principal identity last wrote the resource. This survives
 	// principal failovers and allows the agent to distinguish a true source-uid


### PR DESCRIPTION
**What does this PR do / why we need it**:

When a notifications controller runs on the principal, it records what it has already delivered in the `notified.notifications.argoproj.io` annotation on the principal's copy of the Application. The agent's copy never carries this annotation, so `UpdateAutonomousApp` inheriting the agent's annotation set verbatim deletes the delivery state on every update — the controller then re-sends every notification whose trigger condition holds, on every agent sync. The non-patch path of `UpdateStatus` has the same shape for managed agents.

This PR carries principal-owned annotations (the existing `argocd.argoproj.io/source-uid` mapping, plus the notifications state) from the existing resource over to the incoming one before the incoming annotation set is applied, via a shared helper used by both the update and the jsondiff patch paths. Annotations the agent's side owns keep inheriting the incoming value; only state the agent cannot know about is retained.

**Which issue(s) this PR fixes**:

Fixes #1058

**How to test changes / Special notes to the reviewer**:

Unit test included: `Test_ManagerUpdateAutonomous/Retain_principal-owned_annotations_across_an_agent_update` sets up an existing principal-side application carrying `source-uid`, the notifications annotation, and a stale agent-owned annotation, then applies an incoming agent update. Against current main the test fails with the notifications annotation coming back empty (while `source-uid` survives, since it is already special-cased); with this change both principal-owned annotations survive and the agent-owned annotation inherits the incoming value.

Manual reproduction: principal + autonomous agent + argocd-notifications on the control plane with any trigger matching the mirrored app; watch the `notified.notifications.argoproj.io` annotation get written after delivery and wiped by the next status update from the agent.

**Checklist**

* [x] Documentation update is required by this PR (and has been updated) OR no documentation update is required.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Application updates now preserve system-managed source and notification metadata instead of unintentionally overwriting it.
  * Incoming application changes continue to update agent-managed metadata as expected.
  * Standard status updates retain notification delivery information.

* **Improvements**
  * Notification delivery state is tracked consistently across application updates, patches, and status changes.
  * Application metadata remains reliable when changes originate from multiple management processes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->