### PR TITLE
fix: skip mapping an app to an agent that isn't actually connected

### DIFF
--- a/principal/callbacks.go
+++ b/principal/callbacks.go
@@ -1073,9 +1073,12 @@ func (s *Server) handleAppAgentChange(ctx context.Context, old, new *v1alpha1.Ap
 	}
 
 	if newAgentName != "" {
-		// Add mapping for the new agent
-		s.trackAppToAgent(new, newAgentName)
-		s.resources.Add(newAgentName, resources.NewResourceKeyFromApp(new))
+		// Only map to the new agent if it's actually a connected agent, otherwise we'd
+		// poison the Redis proxy routing for an app that isn't agent-managed.
+		if s.clusterMgr == nil || s.clusterMgr.HasMapping(newAgentName) {
+			s.trackAppToAgent(new, newAgentName)
+			s.resources.Add(newAgentName, resources.NewResourceKeyFromApp(new))
+		}
 	}
 }
 

--- a/principal/callbacks_test.go
+++ b/principal/callbacks_test.go
@@ -33,8 +33,10 @@ import (
 	"github.com/argoproj-labs/argocd-agent/internal/resources"
 	"github.com/argoproj-labs/argocd-agent/pkg/replication"
 	"github.com/argoproj-labs/argocd-agent/pkg/types"
+	fakekube "github.com/argoproj-labs/argocd-agent/test/fake/kube"
 	synccommon "github.com/argoproj/argo-cd/gitops-engine/pkg/sync/common"
 	"github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
+	cacheutil "github.com/argoproj/argo-cd/v3/util/cache"
 	cloudevents "github.com/cloudevents/sdk-go/v2"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
@@ -2292,11 +2294,19 @@ func TestServer_updateAppCallback(t *testing.T) {
 	})
 }
 
+func newTestClusterManager(t *testing.T) *cluster.Manager {
+	t.Helper()
+	m, err := cluster.NewManager(context.Background(), "default", "", "", cacheutil.RedisCompressionGZip, fakekube.NewFakeKubeClient("default"), nil)
+	require.NoError(t, err)
+	return m
+}
+
 func TestServer_handleAppAgentChange(t *testing.T) {
 	tests := []struct {
 		name                    string
 		destinationBasedMapping bool
 		namespaceMap            map[string]types.AgentMode
+		clusterMgr              *cluster.Manager
 		oldApp                  *v1alpha1.Application
 		newApp                  *v1alpha1.Application
 		expectedDeleteAgent     string
@@ -2488,10 +2498,76 @@ func TestServer_handleAppAgentChange(t *testing.T) {
 			expectedAddAgent:    "",
 			shouldTrackApp:      false,
 		},
+		{
+			name:                    "new agent has no cluster mapping - does not poison appToAgent",
+			destinationBasedMapping: true,
+			clusterMgr:              newTestClusterManager(t),
+			oldApp: &v1alpha1.Application{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-app",
+					Namespace: "default",
+				},
+				Spec: v1alpha1.ApplicationSpec{
+					Destination: v1alpha1.ApplicationDestination{
+						Name: "old-agent",
+					},
+				},
+			},
+			newApp: &v1alpha1.Application{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-app",
+					Namespace: "default",
+				},
+				Spec: v1alpha1.ApplicationSpec{
+					Destination: v1alpha1.ApplicationDestination{
+						Name: "local-cluster",
+					},
+				},
+			},
+			expectedDeleteAgent: "old-agent",
+			expectedDeleteEvent: true,
+			expectedAddAgent:    "",
+			shouldTrackApp:      false,
+		},
+		{
+			name:                    "new agent has a live cluster mapping - tracks normally",
+			destinationBasedMapping: true,
+			clusterMgr:              newTestClusterManager(t),
+			oldApp: &v1alpha1.Application{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-app",
+					Namespace: "default",
+				},
+				Spec: v1alpha1.ApplicationSpec{
+					Destination: v1alpha1.ApplicationDestination{
+						Name: "old-agent",
+					},
+				},
+			},
+			newApp: &v1alpha1.Application{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-app",
+					Namespace: "default",
+				},
+				Spec: v1alpha1.ApplicationSpec{
+					Destination: v1alpha1.ApplicationDestination{
+						Name: "new-agent",
+					},
+				},
+			},
+			expectedDeleteAgent: "old-agent",
+			expectedDeleteEvent: true,
+			expectedAddAgent:    "new-agent",
+			shouldTrackApp:      true,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			if tt.clusterMgr != nil && tt.expectedAddAgent != "" && tt.shouldTrackApp {
+				require.NoError(t, tt.clusterMgr.MapCluster(tt.expectedAddAgent, &v1alpha1.Cluster{Name: tt.expectedAddAgent}))
+			}
+
 			s := &Server{
 				ctx:                     context.Background(),
 				queues:                  queue.NewSendRecvQueues(),
@@ -2500,6 +2576,7 @@ func TestServer_handleAppAgentChange(t *testing.T) {
 				appToAgent:              newConcurrentStringMap(),
 				destinationBasedMapping: tt.destinationBasedMapping,
 				namespaceMap:            tt.namespaceMap,
+				clusterMgr:              tt.clusterMgr,
 			}
 
 			// Create queues for agents involved


### PR DESCRIPTION
**What does this PR do / why we need it**:

handleAppAgentChange tracked an app to its new destination agent unconditionally on every destination change, even if that agent was never connected. This poisoned the Redis proxy's routing table and broke resource-tree/manifest reads for that app. Now it checks HasMapping first, same as the rest of this file already does.

Assisted by: Cursor

**Which issue(s) this PR fixes**:

Fixes #1060 

**How to test changes / Special notes to the reviewer**:
See #1060 for more details

**Checklist**

* [ ] Documentation update is required by this PR (and has been updated) OR no documentation update is required.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved application routing when moving to a new destination agent.
  * Applications moving to agents without a valid cluster mapping are removed without creating invalid routing or resource mappings.
  * Applications moving to properly mapped agents continue to be tracked normally.

* **Tests**
  * Added coverage for mapped and unmapped destination-agent scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->