### PR TITLE
fix: adopt pre-installed AppProject in-place instead of delete and recreate

### DIFF
--- a/agent/inbound.go
+++ b/agent/inbound.go
@@ -519,12 +519,16 @@ func (a *Agent) resolveAppProjectSourceUIDMismatch(logCtx *logrus.Entry, incomin
 	// Adopt the existing AppProject in-place to avoid this issue.
 	if !hasSourceUID || !a.projectManager.IsManaged(incoming.Name) {
 		logCtx.Info("Adopting existing AppProject (missing source-UID or not managed)")
-		return a.adoptAppProject(incoming)
+		stampSourceUID(&incoming.ObjectMeta, string(incoming.UID))
+		_, err = a.updateAppProject(incoming)
+		return err
 	}
 
 	if a.effectiveMismatchPolicy(incoming) == manager.MismatchPolicyUpsert {
 		logCtx.Info("AppProject source UID mismatch, upsert policy: updating in-place")
-		return a.adoptAppProject(incoming)
+		stampSourceUID(&incoming.ObjectMeta, string(incoming.UID))
+		_, err = a.updateAppProject(incoming)
+		return err
 	}
 
 	logCtx.Debug("Source UID mismatch between the incoming and existing appProject. Deleting the existing appProject")
@@ -537,19 +541,6 @@ func (a *Agent) resolveAppProjectSourceUIDMismatch(logCtx *logrus.Entry, incomin
 		return fmt.Errorf("could not create incoming appProject after deleting existing appProject: %w", err)
 	}
 	return nil
-}
-
-// adoptAppProject stamps the principal source-UID onto an existing AppProject,
-// marks it managed, and updates it in-place.
-func (a *Agent) adoptAppProject(incoming *v1alpha1.AppProject) error {
-	stampSourceUID(&incoming.ObjectMeta, string(incoming.UID))
-	if !a.projectManager.IsManaged(incoming.Name) {
-		if err := a.projectManager.Manage(incoming.Name); err != nil {
-			return fmt.Errorf("could not manage adopted appProject: %w", err)
-		}
-	}
-	_, err := a.updateAppProject(incoming)
-	return err
 }
 
 func (a *Agent) processIncomingRepository(ev *event.Event) error {
@@ -965,6 +956,7 @@ func (a *Agent) updateAppProject(incoming *v1alpha1.AppProject) (*v1alpha1.AppPr
 		"resourceVersion": incoming.ResourceVersion,
 	})
 
+	newlyManaged := false
 	if !a.projectManager.IsManaged(incoming.Name) {
 		// Prefer update+manage over create when the resource may already exist
 		// locally (e.g. Argo CD's pre-installed default AppProject).
@@ -972,6 +964,7 @@ func (a *Agent) updateAppProject(incoming *v1alpha1.AppProject) (*v1alpha1.AppPr
 		if err := a.projectManager.Manage(incoming.Name); err != nil {
 			return nil, fmt.Errorf("could not manage appProject prior to update: %w", err)
 		}
+		newlyManaged = true
 	}
 
 	if a.projectManager.IsChangeIgnored(incoming.Name, incoming.ResourceVersion) {
@@ -984,7 +977,16 @@ func (a *Agent) updateAppProject(incoming *v1alpha1.AppProject) (*v1alpha1.AppPr
 	a.sourceCache.AppProject.Set(incoming.UID, incoming.Spec)
 
 	logCtx.Tracef("Calling update spec for this event")
-	return a.projectManager.UpdateAppProject(a.context, incoming)
+	updated, err := a.projectManager.UpdateAppProject(a.context, incoming)
+	if err != nil {
+		if newlyManaged {
+			if errUnmanage := a.projectManager.Unmanage(incoming.Name); errUnmanage != nil {
+				logCtx.Errorf("Could not unmanage appProject %s: %v", incoming.Name, errUnmanage)
+			}
+		}
+		return nil, err
+	}
+	return updated, nil
 }
 
 func (a *Agent) deleteAppProject(project *v1alpha1.AppProject) error {

--- a/agent/inbound.go
+++ b/agent/inbound.go
@@ -469,18 +469,8 @@ func (a *Agent) processIncomingAppProject(ev *event.Event) error {
 					return fmt.Errorf("could not update the existing appProject: %w", err)
 				}
 				return nil
-			} else {
-				if a.effectiveMismatchPolicy(incomingAppProject) == manager.MismatchPolicyUpsert {
-					logCtx.Info("AppProject source UID mismatch, upsert policy: updating in-place")
-					stampSourceUID(&incomingAppProject.ObjectMeta, string(incomingAppProject.UID))
-					_, err := a.updateAppProject(incomingAppProject)
-					return err
-				}
-				logCtx.Debug("An appProject already exists with a different source UID. Deleting the existing appProject")
-				if err := a.deleteAppProject(incomingAppProject); err != nil {
-					return fmt.Errorf("could not delete existing appProject prior to creation: %w", err)
-				}
 			}
+			return a.resolveAppProjectSourceUIDMismatch(logCtx, incomingAppProject)
 		}
 
 		_, err = a.createAppProject(incomingAppProject)
@@ -497,21 +487,7 @@ func (a *Agent) processIncomingAppProject(ev *event.Event) error {
 		}
 
 		if !sourceUIDMatch {
-			if a.effectiveMismatchPolicy(incomingAppProject) == manager.MismatchPolicyUpsert {
-				logCtx.Info("AppProject source UID mismatch, upsert policy: updating in-place")
-				stampSourceUID(&incomingAppProject.ObjectMeta, string(incomingAppProject.UID))
-				_, err := a.updateAppProject(incomingAppProject)
-				return err
-			}
-			logCtx.Debug("Source UID mismatch between the incoming and existing appProject. Deleting the existing appProject")
-			if err := a.deleteAppProject(incomingAppProject); err != nil {
-				return fmt.Errorf("could not delete existing appProject prior to creation: %w", err)
-			}
-			logCtx.Debug("Creating the incoming appProject after deleting the existing appProject")
-			if _, err := a.createAppProject(incomingAppProject); err != nil {
-				return fmt.Errorf("could not create incoming appProject after deleting existing appProject: %w", err)
-			}
-			return nil
+			return a.resolveAppProjectSourceUIDMismatch(logCtx, incomingAppProject)
 		}
 
 		_, err = a.updateAppProject(incomingAppProject)
@@ -527,6 +503,52 @@ func (a *Agent) processIncomingAppProject(ev *event.Event) error {
 		logCtx.Warnf("Received an unknown event: %s. Protocol mismatch?", ev.Type())
 	}
 
+	return err
+}
+
+// resolveAppProjectSourceUIDMismatch handles Create/SpecUpdate when an AppProject
+// already exists locally with a missing or different source-UID.
+func (a *Agent) resolveAppProjectSourceUIDMismatch(logCtx *logrus.Entry, incoming *v1alpha1.AppProject) error {
+	existing, err := a.projectManager.Get(a.context, incoming.Name, incoming.Namespace)
+	if err != nil {
+		return fmt.Errorf("failed to get existing appProject for source-UID mismatch: %w", err)
+	}
+
+	_, hasSourceUID := existing.Annotations[manager.SourceUIDAnnotation]
+	// Pre-installed AppProjects may not have source-UID annotation and the deletion may fail with "is not managed" error.
+	// Adopt the existing AppProject in-place to avoid this issue.
+	if !hasSourceUID || !a.projectManager.IsManaged(incoming.Name) {
+		logCtx.Info("Adopting existing AppProject (missing source-UID or not managed)")
+		return a.adoptAppProject(incoming)
+	}
+
+	if a.effectiveMismatchPolicy(incoming) == manager.MismatchPolicyUpsert {
+		logCtx.Info("AppProject source UID mismatch, upsert policy: updating in-place")
+		return a.adoptAppProject(incoming)
+	}
+
+	logCtx.Debug("Source UID mismatch between the incoming and existing appProject. Deleting the existing appProject")
+	if err := a.deleteAppProject(incoming); err != nil {
+		return fmt.Errorf("could not delete existing appProject prior to creation: %w", err)
+	}
+
+	logCtx.Debug("Creating the incoming appProject after deleting the existing appProject")
+	if _, err := a.createAppProject(incoming); err != nil {
+		return fmt.Errorf("could not create incoming appProject after deleting existing appProject: %w", err)
+	}
+	return nil
+}
+
+// adoptAppProject stamps the principal source-UID onto an existing AppProject,
+// marks it managed, and updates it in-place.
+func (a *Agent) adoptAppProject(incoming *v1alpha1.AppProject) error {
+	stampSourceUID(&incoming.ObjectMeta, string(incoming.UID))
+	if !a.projectManager.IsManaged(incoming.Name) {
+		if err := a.projectManager.Manage(incoming.Name); err != nil {
+			return fmt.Errorf("could not manage adopted appProject: %w", err)
+		}
+	}
+	_, err := a.updateAppProject(incoming)
 	return err
 }
 
@@ -944,8 +966,12 @@ func (a *Agent) updateAppProject(incoming *v1alpha1.AppProject) (*v1alpha1.AppPr
 	})
 
 	if !a.projectManager.IsManaged(incoming.Name) {
-		logCtx.Trace("AppProject is not managed on this agent. Creating the new AppProject")
-		return a.createAppProject(incoming)
+		// Prefer update+manage over create when the resource may already exist
+		// locally (e.g. Argo CD's pre-installed default AppProject).
+		logCtx.Trace("AppProject is not managed on this agent. Managing and updating")
+		if err := a.projectManager.Manage(incoming.Name); err != nil {
+			return nil, fmt.Errorf("could not manage appProject prior to update: %w", err)
+		}
 	}
 
 	if a.projectManager.IsChangeIgnored(incoming.Name, incoming.ResourceVersion) {

--- a/agent/inbound_test.go
+++ b/agent/inbound_test.go
@@ -707,11 +707,10 @@ func Test_ProcessIncomingAppProjectWithUIDMismatch(t *testing.T) {
 		}
 		require.Equal(t, expectedCalls, gotCalls)
 
-		// Check if the new app has the updated source UID annotation.
-		appInterface := be.Calls[4].ReturnArguments[0]
-		latestAppProject, ok := appInterface.(*v1alpha1.AppProject)
+		// Check the AppProject argument passed to Create has the correct source UID.
+		createdArg, ok := be.Calls[4].Arguments.Get(1).(*v1alpha1.AppProject)
 		require.True(t, ok)
-		require.Equal(t, string(incomingAppProject.UID), latestAppProject.Annotations[manager.SourceUIDAnnotation])
+		require.Equal(t, string(incomingAppProject.UID), createdArg.Annotations[manager.SourceUIDAnnotation])
 	})
 
 	t.Run("Create: Old appProject with the same UID must be updated", func(t *testing.T) {
@@ -764,12 +763,10 @@ func Test_ProcessIncomingAppProjectWithUIDMismatch(t *testing.T) {
 		}
 		require.Equal(t, expectedCalls, gotCalls)
 
-		// Check if the new appProject has the updated source UID annotation.
-		appInterface := be.Calls[4].ReturnArguments[0]
-
-		latestAppProject, ok := appInterface.(*v1alpha1.AppProject)
+		// Check the AppProject argument passed to Create has the correct source UID.
+		createdArg, ok := be.Calls[4].Arguments.Get(1).(*v1alpha1.AppProject)
 		require.True(t, ok)
-		require.Equal(t, string(incomingAppProject.UID), latestAppProject.Annotations[manager.SourceUIDAnnotation])
+		require.Equal(t, string(incomingAppProject.UID), createdArg.Annotations[manager.SourceUIDAnnotation])
 	})
 
 	t.Run("Update: incoming appProject must be created if it doesn't exist while handling update event", func(t *testing.T) {

--- a/agent/inbound_test.go
+++ b/agent/inbound_test.go
@@ -667,13 +667,14 @@ func Test_ProcessIncomingAppProjectWithUIDMismatch(t *testing.T) {
 		require.NotNil(t, a)
 
 		// Get is used to retrieve the oldAppProject and compare its UID annotation.
-		getMock = be.On("Get", mock.Anything, mock.Anything, mock.Anything).Return(oldAppProject, nil)
+		// DeepCopy so updateFn mutations don't pollute later subtests.
+		getMock = be.On("Get", mock.Anything, mock.Anything, mock.Anything).Return(oldAppProject.DeepCopy(), nil)
 
 		// Create is used to create the latest version of the appProject on the agent.
 		createMock = be.On("Create", mock.Anything, mock.Anything).Return(createdAppProject, nil)
 
 		supportsPatchMock = be.On("SupportsPatch").Return(false)
-		updateMock = be.On("Update", mock.Anything, mock.Anything).Return(oldAppProject, nil)
+		updateMock = be.On("Update", mock.Anything, mock.Anything).Return(oldAppProject.DeepCopy(), nil)
 
 		// Delete is used to delete the oldAppProject from the agent.
 		deleteMock = be.On("Delete", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
@@ -698,9 +699,8 @@ func Test_ProcessIncomingAppProjectWithUIDMismatch(t *testing.T) {
 		err := a.processIncomingAppProject(ev)
 		require.Nil(t, err)
 
-		// Check if the API calls were made in the same order:
-		// compare the UID, delete old appProject, and create a new appProject.
-		expectedCalls := []string{"Get", "Get", "Delete", "Create"}
+		// compare UID, re-get for mismatch resolution, delete old, create new
+		expectedCalls := []string{"Get", "Get", "Get", "Delete", "Create"}
 		gotCalls := []string{}
 		for _, call := range be.Calls {
 			gotCalls = append(gotCalls, call.Method)
@@ -708,7 +708,7 @@ func Test_ProcessIncomingAppProjectWithUIDMismatch(t *testing.T) {
 		require.Equal(t, expectedCalls, gotCalls)
 
 		// Check if the new app has the updated source UID annotation.
-		appInterface := be.Calls[3].ReturnArguments[0]
+		appInterface := be.Calls[4].ReturnArguments[0]
 		latestAppProject, ok := appInterface.(*v1alpha1.AppProject)
 		require.True(t, ok)
 		require.Equal(t, string(incomingAppProject.UID), latestAppProject.Annotations[manager.SourceUIDAnnotation])
@@ -739,10 +739,10 @@ func Test_ProcessIncomingAppProjectWithUIDMismatch(t *testing.T) {
 		}
 		require.Equal(t, expectedCalls, gotCalls)
 
-		appInterface := be.Calls[3].ReturnArguments[0]
-		latestAppProject, ok := appInterface.(*v1alpha1.AppProject)
+		// Assert against the object passed to Update (after updateFn applied labels).
+		updatedArg, ok := be.Calls[3].Arguments.Get(1).(*v1alpha1.AppProject)
 		require.True(t, ok)
-		require.Equal(t, newAppProject.Labels, latestAppProject.Labels)
+		require.Equal(t, newAppProject.Labels, updatedArg.Labels)
 	})
 
 	t.Run("Update: Old appProject with diff UID must be deleted and a new appProject must be created", func(t *testing.T) {
@@ -756,9 +756,8 @@ func Test_ProcessIncomingAppProjectWithUIDMismatch(t *testing.T) {
 		err := a.processIncomingAppProject(ev)
 		require.Nil(t, err)
 
-		// Check if the API calls were made in the same order:
-		// compare the UID, delete old appProject, and create a new appProject.
-		expectedCalls := []string{"Get", "Get", "Delete", "Create"}
+		// compare UID, re-get for mismatch resolution, delete old, create new
+		expectedCalls := []string{"Get", "Get", "Get", "Delete", "Create"}
 		gotCalls := []string{}
 		for _, call := range be.Calls {
 			gotCalls = append(gotCalls, call.Method)
@@ -766,7 +765,7 @@ func Test_ProcessIncomingAppProjectWithUIDMismatch(t *testing.T) {
 		require.Equal(t, expectedCalls, gotCalls)
 
 		// Check if the new appProject has the updated source UID annotation.
-		appInterface := be.Calls[3].ReturnArguments[0]
+		appInterface := be.Calls[4].ReturnArguments[0]
 
 		latestAppProject, ok := appInterface.(*v1alpha1.AppProject)
 		require.True(t, ok)
@@ -833,15 +832,12 @@ func Test_ProcessIncomingAppProjectWithUIDMismatch(t *testing.T) {
 		require.False(t, a.appManager.IsManaged(incomingAppProject.Name))
 	})
 
-	// Missing Source UID Annotation scenarios - when existing AppProject lacks the source UID annotation
-	t.Run("Create: Existing AppProject without source UID annotation should be deleted and recreated", func(t *testing.T) {
-		// Setup separate backend for this test to avoid mock conflicts
+	t.Run("Create: Existing AppProject without source UID annotation should be adopted", func(t *testing.T) {
 		beMissing := backend_mocks.NewAppProject(t)
 		var err error
 		a.projectManager, err = appproject.NewAppProjectManager(beMissing, "argocd", appproject.WithAllowUpsert(true))
 		require.NoError(t, err)
 
-		// Setup for missing source UID scenario
 		existingAppProject := &v1alpha1.AppProject{
 			ObjectMeta: v1.ObjectMeta{
 				Name:      "test",
@@ -850,49 +846,35 @@ func Test_ProcessIncomingAppProjectWithUIDMismatch(t *testing.T) {
 			},
 		}
 
-		// Configure separate backend
 		getMockMissing := beMissing.On("Get", mock.Anything, mock.Anything, mock.Anything).Return(existingAppProject, nil)
-		createMockMissing := beMissing.On("Create", mock.Anything, mock.Anything).Return(createdAppProject, nil)
-		deleteMockMissing := beMissing.On("Delete", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+		beMissing.On("SupportsPatch").Return(false)
+		updateMockMissing := beMissing.On("Update", mock.Anything, mock.Anything).Return(createdAppProject, nil)
 
 		defer func() {
 			getMockMissing.Unset()
-			createMockMissing.Unset()
-			deleteMockMissing.Unset()
+			updateMockMissing.Unset()
 		}()
 
-		a.projectManager.Manage(existingAppProject.Name)
-		defer a.projectManager.ClearManaged()
-
+		// Not managed — matches the pre-installed default AppProject failure mode
 		ev := event.New(evs.AppProjectEvent(event.Create, incomingAppProject), targets.AppProject)
 		err = a.processIncomingAppProject(ev)
-
-		// The process should succeed after deleting the existing AppProject and creating the new one
 		require.NoError(t, err)
+		require.True(t, a.projectManager.IsManaged(existingAppProject.Name))
 
-		// Verify the sequence: Get (to compare UID), Delete (existing), Create (new)
-		expectedCalls := []string{"Get", "Get", "Delete", "Create"}
+		expectedCalls := []string{"Get", "Get", "Get", "SupportsPatch", "Update"}
 		gotCalls := []string{}
 		for _, call := range beMissing.Calls {
 			gotCalls = append(gotCalls, call.Method)
 		}
 		require.Equal(t, expectedCalls, gotCalls)
-
-		// Verify the created AppProject has the correct source UID annotation
-		appInterface := beMissing.Calls[3].ReturnArguments[0]
-		latestAppProject, ok := appInterface.(*v1alpha1.AppProject)
-		require.True(t, ok)
-		require.Equal(t, string(incomingAppProject.UID), latestAppProject.Annotations[manager.SourceUIDAnnotation])
 	})
 
-	t.Run("Update: Existing AppProject without source UID annotation should be deleted and recreated", func(t *testing.T) {
-		// Setup separate backend for this test to avoid mock conflicts
+	t.Run("Update: Existing AppProject without source UID annotation should be adopted", func(t *testing.T) {
 		beMissing := backend_mocks.NewAppProject(t)
 		var err error
 		a.projectManager, err = appproject.NewAppProjectManager(beMissing, "argocd", appproject.WithAllowUpsert(true))
 		require.NoError(t, err)
 
-		// Setup for missing source UID scenario
 		existingAppProject := &v1alpha1.AppProject{
 			ObjectMeta: v1.ObjectMeta{
 				Name:      "test",
@@ -901,39 +883,26 @@ func Test_ProcessIncomingAppProjectWithUIDMismatch(t *testing.T) {
 			},
 		}
 
-		// Configure separate backend
 		getMockMissing := beMissing.On("Get", mock.Anything, mock.Anything, mock.Anything).Return(existingAppProject, nil)
-		createMockMissing := beMissing.On("Create", mock.Anything, mock.Anything).Return(createdAppProject, nil)
-		deleteMockMissing := beMissing.On("Delete", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+		beMissing.On("SupportsPatch").Return(false)
+		updateMockMissing := beMissing.On("Update", mock.Anything, mock.Anything).Return(createdAppProject, nil)
 
 		defer func() {
 			getMockMissing.Unset()
-			createMockMissing.Unset()
-			deleteMockMissing.Unset()
+			updateMockMissing.Unset()
 		}()
-
-		a.projectManager.Manage(existingAppProject.Name)
-		defer a.projectManager.ClearManaged()
 
 		ev := event.New(evs.AppProjectEvent(event.SpecUpdate, incomingAppProject), targets.AppProject)
 		err = a.processIncomingAppProject(ev)
-
-		// The process should succeed after deleting the existing AppProject and creating the new one
 		require.NoError(t, err)
+		require.True(t, a.projectManager.IsManaged(existingAppProject.Name))
 
-		// Verify the sequence: Get (to compare UID), Delete (existing), Create (new)
-		expectedCalls := []string{"Get", "Get", "Delete", "Create"}
+		expectedCalls := []string{"Get", "Get", "Get", "SupportsPatch", "Update"}
 		gotCalls := []string{}
 		for _, call := range beMissing.Calls {
 			gotCalls = append(gotCalls, call.Method)
 		}
 		require.Equal(t, expectedCalls, gotCalls)
-
-		// Verify the created AppProject has the correct source UID annotation
-		appInterface := beMissing.Calls[3].ReturnArguments[0]
-		latestAppProject, ok := appInterface.(*v1alpha1.AppProject)
-		require.True(t, ok)
-		require.Equal(t, string(incomingAppProject.UID), latestAppProject.Annotations[manager.SourceUIDAnnotation])
 	})
 
 	t.Run("Delete: Existing AppProject without source UID annotation should be deleted", func(t *testing.T) {
@@ -979,6 +948,41 @@ func Test_ProcessIncomingAppProjectWithUIDMismatch(t *testing.T) {
 		require.Equal(t, expectedCalls, gotCalls)
 	})
 
+	t.Run("Create: unmanaged AppProject with mismatched source UID should be adopted", func(t *testing.T) {
+		beUnmanaged := backend_mocks.NewAppProject(t)
+		var err error
+		a.projectManager, err = appproject.NewAppProjectManager(beUnmanaged, "argocd", appproject.WithAllowUpsert(true))
+		require.NoError(t, err)
+
+		existingAppProject := &v1alpha1.AppProject{
+			ObjectMeta: v1.ObjectMeta{
+				Name:      "default",
+				Namespace: "argocd",
+				UID:       ktypes.UID("local_uid"),
+				Annotations: map[string]string{
+					manager.SourceUIDAnnotation: "stale_uid",
+				},
+			},
+		}
+
+		getMock := beUnmanaged.On("Get", mock.Anything, mock.Anything, mock.Anything).Return(existingAppProject, nil)
+		beUnmanaged.On("SupportsPatch").Return(false)
+		updateMock := beUnmanaged.On("Update", mock.Anything, mock.Anything).Return(createdAppProject, nil)
+		defer func() {
+			getMock.Unset()
+			updateMock.Unset()
+		}()
+
+		incomingDefault := incomingAppProject.DeepCopy()
+		incomingDefault.Name = "default"
+		incomingDefault.UID = ktypes.UID("principal_uid")
+
+		ev := event.New(evs.AppProjectEvent(event.SpecUpdate, incomingDefault), targets.AppProject)
+		err = a.processIncomingAppProject(ev)
+		require.NoError(t, err)
+		require.True(t, a.projectManager.IsManaged("default"))
+	})
+
 	t.Run("Create: upsert policy skips delete and updates in-place", func(t *testing.T) {
 		configureManager(t)
 		defer unsetMocks(t)
@@ -992,7 +996,7 @@ func Test_ProcessIncomingAppProjectWithUIDMismatch(t *testing.T) {
 		err := a.processIncomingAppProject(ev)
 		require.Nil(t, err)
 
-		expectedCalls := []string{"Get", "Get", "SupportsPatch", "Update"}
+		expectedCalls := []string{"Get", "Get", "Get", "SupportsPatch", "Update"}
 		gotCalls := []string{}
 		for _, call := range be.Calls {
 			gotCalls = append(gotCalls, call.Method)
@@ -1013,7 +1017,7 @@ func Test_ProcessIncomingAppProjectWithUIDMismatch(t *testing.T) {
 		err := a.processIncomingAppProject(ev)
 		require.Nil(t, err)
 
-		expectedCalls := []string{"Get", "Get", "SupportsPatch", "Update"}
+		expectedCalls := []string{"Get", "Get", "Get", "SupportsPatch", "Update"}
 		gotCalls := []string{}
 		for _, call := range be.Calls {
 			gotCalls = append(gotCalls, call.Method)
@@ -1254,12 +1258,18 @@ func Test_UpdateAppProject(t *testing.T) {
 	t.Run("Create the appproject if it doesn't exist", func(t *testing.T) {
 		a.mode = types.AgentModeManaged
 		a.projectManager, err = appproject.NewAppProjectManager(be, "argocd", appproject.WithAllowUpsert(true), appproject.WithMode(manager.ManagerModeManaged), appproject.WithRole(manager.ManagerRoleAgent))
+		notFoundError := kerrors.NewNotFound(schema.GroupResource{
+			Group: "argoproj.io", Resource: "appproject",
+		}, project.Name)
+		getMock := be.On("Get", mock.Anything, mock.Anything, mock.Anything).Return(nil, notFoundError)
+		defer getMock.Unset()
 		createMock := be.On("Create", mock.Anything, mock.Anything).Return(&v1alpha1.AppProject{}, nil)
 		defer createMock.Unset()
 		napp, err := a.updateAppProject(project)
 		require.NoError(t, err)
 		require.NotNil(t, napp)
 		require.Empty(t, napp.OwnerReferences, "OwnerReferences should not be applied on managed app project")
+		require.True(t, a.projectManager.IsManaged(project.Name))
 	})
 
 	// Namespace handling tests

--- a/internal/manager/appproject/appproject.go
+++ b/internal/manager/appproject/appproject.go
@@ -230,12 +230,10 @@ func (m *AppProjectManager) UpdateAppProject(ctx context.Context, incoming *v1al
 	var err error
 
 	updated, err = m.update(ctx, m.allowUpsert, incoming, func(existing, incoming *v1alpha1.AppProject) {
-		if v, ok := existing.Annotations[manager.SourceUIDAnnotation]; ok {
-			if incoming.Annotations == nil {
-				incoming.Annotations = make(map[string]string)
-			}
-			incoming.Annotations[manager.SourceUIDAnnotation] = v
-		}
+		// Keep the existing source-UID unless the caller explicitly stamped a
+		// new one (adopt/upsert). Always overwriting would block adoption of
+		// pre-installed AppProjects such as "default".
+		preserveSourceUIDIfUnset(existing, incoming)
 
 		existing.Annotations = incoming.Annotations
 		existing.Labels = incoming.Labels
@@ -243,12 +241,7 @@ func (m *AppProjectManager) UpdateAppProject(ctx context.Context, incoming *v1al
 		existing.Spec = *incoming.Spec.DeepCopy()
 		existing.Status = *incoming.Status.DeepCopy()
 	}, func(existing, incoming *v1alpha1.AppProject) (jsondiff.Patch, error) {
-		if v, ok := existing.Annotations[manager.SourceUIDAnnotation]; ok {
-			if incoming.Annotations == nil {
-				incoming.Annotations = make(map[string]string)
-			}
-			incoming.Annotations[manager.SourceUIDAnnotation] = v
-		}
+		preserveSourceUIDIfUnset(existing, incoming)
 
 		target := &v1alpha1.AppProject{
 			ObjectMeta: v1.ObjectMeta{
@@ -394,6 +387,21 @@ func (m *AppProjectManager) RemoveFinalizers(ctx context.Context, incoming *v1al
 // timeout has been reached (which will return an error)
 func (m *AppProjectManager) EnsureSynced(duration time.Duration) error {
 	return m.appprojectBackend.EnsureSynced(duration)
+}
+
+// preserveSourceUIDIfUnset copies the existing source-UID onto incoming when
+// incoming does not already carry one. Callers that intentionally adopt or
+// upsert must stamp the new source-UID before UpdateAppProject.
+func preserveSourceUIDIfUnset(existing, incoming *v1alpha1.AppProject) {
+	if incoming.Annotations != nil && incoming.Annotations[manager.SourceUIDAnnotation] != "" {
+		return
+	}
+	if v, ok := existing.Annotations[manager.SourceUIDAnnotation]; ok {
+		if incoming.Annotations == nil {
+			incoming.Annotations = make(map[string]string)
+		}
+		incoming.Annotations[manager.SourceUIDAnnotation] = v
+	}
 }
 
 // CompareSourceUID checks for an existing appProject with the same name/namespace and compare its source UID with the incoming appProject.


### PR DESCRIPTION
**What does this PR do / why we need it**:

The principal may send a `specUpdate` for an AppProject before the agent's informers have reconciled the local AppProject.    These AppProjects are not marked as managed yet. If the default AppProject is already installed on the agent, it will not have a sourceUID annotation. When the principal sends the specUpdate for the default project, the agent tries to delete and recreate the project. Since this project is not managed yet, the deletion fails with "is not managed" error. Adopt AppProjects with missing sourceUID annotation instead of deleting and recreating. This was noticed in one of the CI fails: https://github.com/argoproj-labs/argocd-agent/actions/runs/31574580668/job/94043789514#step:16:725

Assisted-by: Cursor

**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:


**Checklist**

* [ ] Documentation update is required by this PR (and has been updated) OR no documentation update is required.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Existing AppProjects with missing or unmanaged source information are now adopted and updated in place.
  - AppProjects with mismatched source identifiers follow consistent resolution behavior, preserving existing resources when appropriate.
  - Unmanaged AppProjects are managed before updates, preventing unnecessary creation attempts.
  - Updates preserve an existing source identifier when no replacement is provided, while allowing explicitly supplied identifiers to take effect.
- **Tests**
  - Expanded coverage for adoption, updates, and source-identifier mismatch scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->