### PR TITLE
fix: prevent unbounded growth in workqueue Add

### DIFF
--- a/internal/queue/queue.go
+++ b/internal/queue/queue.go
@@ -68,7 +68,7 @@ func newBoundedQueue(maxSize int, name string) *boundedQueue {
 
 func (bq *boundedQueue) Add(item *event.Event) {
 	// We pop the oldest item if the size is going to exceed maxSize.
-	if bq.Len() == bq.maxSize {
+	if bq.Len() >= bq.maxSize {
 		old, _ := bq.Get()
 		bq.Done(old)
 	}

--- a/internal/queue/queue_test.go
+++ b/internal/queue/queue_test.go
@@ -81,6 +81,31 @@ func Test_Queue(t *testing.T) {
 		assert.Equal(t, "2", front.ID())
 	})
 
+	t.Run("Bound self-heals when the queue exceeds maxSize", func(t *testing.T) {
+		q := NewSendRecvQueues()
+		err := q.Create("agent1")
+		assert.NoError(t, err)
+		bq, ok := q.RecvQ("agent1").(*boundedQueue)
+		assert.True(t, ok)
+
+		const overshoot = 5
+		for i := 0; i < defaultMaxQueueSize+overshoot; i++ {
+			ev := event.New()
+			ev.SetID(strconv.Itoa(i))
+			bq.TypedRateLimitingInterface.Add(&ev)
+		}
+		assert.Equal(t, defaultMaxQueueSize+overshoot, bq.Len())
+
+		// Every further Add must evict before inserting, so the length never
+		// grows.
+		for i := 0; i < 100; i++ {
+			ev := event.New()
+			ev.SetID("new-" + strconv.Itoa(i))
+			bq.Add(&ev)
+			assert.LessOrEqual(t, bq.Len(), defaultMaxQueueSize+overshoot)
+		}
+	})
+
 	t.Run("Ensure that the queue sizes can be configured via environment variable", func(t *testing.T) {
 		queueSize := 100
 		t.Setenv(config.EnvRecvQueueSize, strconv.Itoa(queueSize))


### PR DESCRIPTION
**What does this PR do / why we need it**:

Currently, the queue length check and the Get() calls in the bounded queue Add() method are not atomic. So, there is a tiny window where the queue size can grow beyond the max size. Since Add() uses a hard equals `==`, the checks can fail, and the queue can grow without bound. In this PR, we use `>=` so eviction activates again once the queue is at or above the limit, making the bound self-healing

**Which issue(s) this PR fixes**:

Fixes https://github.com/argoproj-labs/argocd-agent/issues/1053

**How to test changes / Special notes to the reviewer**:


**Checklist**

* [ ] Documentation update is required by this PR (and has been updated) OR no documentation update is required.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Bounded queues now consistently evict the oldest items when adding entries after exceeding their configured capacity.
  * Queue length remains controlled during subsequent additions, even if the capacity was previously overshot.

* **Tests**
  * Added coverage to verify queue behavior after capacity overshoot.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->