### PR TITLE
docs: clarify hybrid architecture enables app-of-apps in managed mode

### DIFF
--- a/docs/concepts/agent-modes/managed.md
+++ b/docs/concepts/agent-modes/managed.md
@@ -28,9 +28,12 @@ Changes to `Application` resources on the workload cluster that are not originat
 
 ## Why not chose this mode
 
-* Very limited support for the app-of-apps pattern
 * In the case the control plane cluster is compromised, it may affect workload clusters in managed mode, too
 * As noted [previously](#architectural-considerations), the control plane cluster might become a SPoF
+
+## Enabling App-of-Apps in Managed Mode
+
+See the [Hybrid Architecture](../../user-guide/hybrid-architecture.md) guide to run an *application-controller* on the control plane cluster as well. This lets the parent app-of-apps `Application` target the control plane cluster directly, so its children are created there and distributed to agents like any other managed `Application`.
 
 ## Pre-existing Applications
 

--- a/docs/user-guide/hybrid-architecture.md
+++ b/docs/user-guide/hybrid-architecture.md
@@ -5,6 +5,9 @@ This guide explains how to run argocd-agent (principal + agent) alongside a pre-
 !!! tip "Who is this for?"
     This guide is for teams that already have a working Argo CD installation managing applications and want to adopt argocd-agent incrementally. If you are setting up argocd-agent from scratch, see the [Getting Started](../getting-started/index.md) guide instead.
 
+!!! tip "Using this for app-of-apps in managed mode"
+    This architecture is also how to get proper app-of-apps support in [managed mode](../concepts/agent-modes/managed.md). Since the hub gains its own *application-controller*, a parent app-of-apps `Application` can target the hub cluster directly, and its labeled children are routed to agents via `spec.destination.name` like any other managed `Application`.
+
 ## Overview
 
 In a hybrid architecture, the traditional Argo CD components (server, application controller, repository server, Redis) continue to operate on the hub cluster. The argocd-agent principal is installed alongside them. Both systems share the same Argo CD UI and API, but each manages a distinct set of applications:


### PR DESCRIPTION
**What does this PR do / why we need it**:

Thanks to hybrid mode which enables the application controller on the hub cluster, managed mode can now support the popular app of apps pattern.

**Which issue(s) this PR fixes**:

Fixes NA

**How to test changes / Special notes to the reviewer**:


**Checklist**

* [x] Documentation update is required by this PR (and has been updated) OR no documentation update is required.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated managed mode guidance to explain how to enable app-of-apps deployments.
  * Added hybrid architecture guidance covering parent applications on the control plane and child application distribution to agents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->