### PR TITLE
chore: Fix the source object on which update actions are diffed, when full detail logging

### DIFF
--- a/internal/manager/application/application.go
+++ b/internal/manager/application/application.go
@@ -214,17 +214,19 @@ func (m *ApplicationManager) Upsert(ctx context.Context, app *v1alpha1.Applicati
 	if !errors.IsAlreadyExists(err) {
 		return nil, err
 	}
+	var originalOnCluster *v1alpha1.Application
 	var updated *v1alpha1.Application
 	err = retry.RetryOnConflict(retry.DefaultBackoff, func() error {
-		existing, ierr := m.applicationBackend.Get(ctx, app.Name, app.Namespace)
+		var ierr error
+		originalOnCluster, ierr = m.applicationBackend.Get(ctx, app.Name, app.Namespace)
 		if ierr != nil {
 			return fmt.Errorf("get existing application for upsert: %w", ierr)
 		}
 		// UID must match the replica's existing object — the primary and replica
 		// assign different UIDs to the same-named resource. Without this, etcd
 		// rejects the update with a storage precondition error (Code 4).
-		app.ResourceVersion = existing.ResourceVersion
-		app.UID = existing.UID
+		app.ResourceVersion = originalOnCluster.ResourceVersion
+		app.UID = originalOnCluster.UID
 		// Do NOT preserve the existing source-uid here. Create() already stamped
 		// source-uid = primary's UID before the AlreadyExists error. Preserving
 		// the existing value would allow a stale/wrong source-uid (e.g. from a
@@ -240,7 +242,7 @@ func (m *ApplicationManager) Upsert(ctx context.Context, app *v1alpha1.Applicati
 	if err != nil {
 		return nil, err
 	}
-	logging.LogActionUpdate(log().WithField("application", updated.QualifiedName()), "application", app, updated)
+	logging.LogActionUpdate(log().WithField("application", updated.QualifiedName()), "application", originalOnCluster, updated)
 	if err := m.IgnoreChange(updated.QualifiedName(), updated.ResourceVersion); err != nil {
 		log().Warnf("Could not ignore change %s for app %s: %v", updated.ResourceVersion, updated.QualifiedName(), err)
 	}
@@ -310,9 +312,6 @@ func (m *ApplicationManager) UpdateManagedApp(ctx context.Context, incoming *v1a
 		"resourceVersion": incoming.ResourceVersion,
 	})
 
-	var updated *v1alpha1.Application
-	var err error
-
 	if !m.destinationBasedMapping {
 		incoming.SetNamespace(m.namespace)
 	}
@@ -323,7 +322,7 @@ func (m *ApplicationManager) UpdateManagedApp(ctx context.Context, incoming *v1a
 
 	deletionTimestampChanged := false
 
-	updated, err = m.update(ctx, m.allowUpsert, incoming, func(existing, incoming *v1alpha1.Application) {
+	updated, originalOnCluster, err := m.update(ctx, m.allowUpsert, incoming, func(existing, incoming *v1alpha1.Application) {
 		applyManagedIdentity(existing, incoming, identity)
 		existing.Annotations = incoming.Annotations
 		existing.Labels = incoming.Labels
@@ -367,7 +366,7 @@ func (m *ApplicationManager) UpdateManagedApp(ctx context.Context, incoming *v1a
 	})
 	if err == nil {
 		if updated.Generation > 1 {
-			logging.LogActionUpdate(logCtx, "application", incoming, updated)
+			logging.LogActionUpdate(logCtx, "application", originalOnCluster, updated)
 		}
 		if err := m.IgnoreChange(updated.QualifiedName(), updated.ResourceVersion); err != nil {
 			logCtx.Warnf("Couldn't unignore change %s for app %s: %v", updated.ResourceVersion, updated.QualifiedName(), err)
@@ -461,19 +460,6 @@ func (m *ApplicationManager) CompareIdentity(ctx context.Context, incoming *v1al
 	return result, nil
 }
 
-// CompareSourceUID checks for an existing app with the same name/namespace and compare its source UID with the incoming app.
-// Deprecated: Use CompareIdentity for principal-transition-aware comparisons.
-func (m *ApplicationManager) CompareSourceUID(ctx context.Context, incoming *v1alpha1.Application) (bool, bool, error) {
-	result, err := m.CompareIdentity(ctx, incoming, "")
-	if err != nil {
-		return result != nil && result.Exists, false, err
-	}
-	if result.ExistingMissingSourceUID {
-		return result != nil && result.Exists, false, fmt.Errorf("source UID Annotation is not found for app: %s", incoming.Name)
-	}
-	return result.Exists, result.SourceUIDMatch, nil
-}
-
 // principalOwnedAnnotations lists the annotations that are written on the
 // principal's copy of an application and are unknown to the agent. They are
 // retained across updates received from the agent.
@@ -512,8 +498,6 @@ func (m *ApplicationManager) UpdateAutonomousApp(ctx context.Context, namespace 
 		"resourceVersion": incoming.ResourceVersion,
 	})
 
-	var updated *v1alpha1.Application
-	var err error
 	incoming.SetNamespace(namespace)
 	if m.role == manager.ManagerRolePrincipal {
 		stampLastUpdated(incoming)
@@ -521,7 +505,7 @@ func (m *ApplicationManager) UpdateAutonomousApp(ctx context.Context, namespace 
 		return nil, fmt.Errorf("UpdateAutonomousApp should only be called from principal")
 	}
 
-	updated, err = m.update(ctx, true, incoming, func(existing, incoming *v1alpha1.Application) {
+	updated, originalOnCluster, err := m.update(ctx, true, incoming, func(existing, incoming *v1alpha1.Application) {
 		preservePrincipalAnnotations(existing, incoming)
 
 		existing.Annotations = incoming.Annotations
@@ -574,7 +558,7 @@ func (m *ApplicationManager) UpdateAutonomousApp(ctx context.Context, namespace 
 		if err := m.IgnoreChange(updated.QualifiedName(), updated.ResourceVersion); err != nil {
 			logCtx.Warnf("Could not unignore change %s for app %s: %v", updated.ResourceVersion, updated.QualifiedName(), err)
 		}
-		logging.LogActionUpdate(logCtx.WithField(logfields.NewResourceVersion, updated.ResourceVersion), "application", incoming, updated)
+		logging.LogActionUpdate(logCtx.WithField(logfields.NewResourceVersion, updated.ResourceVersion), "application", originalOnCluster, updated)
 	}
 	return updated, err
 }
@@ -593,8 +577,6 @@ func (m *ApplicationManager) UpdateStatus(ctx context.Context, namespace string,
 		"resourceVersion": incoming.ResourceVersion,
 	})
 
-	var updated *v1alpha1.Application
-	var err error
 	if !m.destinationBasedMapping {
 		incoming.SetNamespace(namespace)
 	}
@@ -604,7 +586,7 @@ func (m *ApplicationManager) UpdateStatus(ctx context.Context, namespace string,
 		return nil, fmt.Errorf("UpdateStatus should only be called on principal")
 	}
 
-	updated, err = m.update(ctx, false, incoming, func(existing, incoming *v1alpha1.Application) {
+	updated, originalOnCluster, err := m.update(ctx, false, incoming, func(existing, incoming *v1alpha1.Application) {
 		preservePrincipalAnnotations(existing, incoming)
 		existing.Annotations = incoming.Annotations
 		existing.Labels = incoming.Labels
@@ -648,7 +630,7 @@ func (m *ApplicationManager) UpdateStatus(ctx context.Context, namespace string,
 		if err := m.IgnoreChange(updated.QualifiedName(), updated.ResourceVersion); err != nil {
 			logCtx.Warnf("Could not ignore change %s for app %s: %v", updated.ResourceVersion, updated.QualifiedName(), err)
 		}
-		logging.LogActionUpdate(logCtx, "application", incoming, updated)
+		logging.LogActionUpdate(logCtx, "application", originalOnCluster, updated)
 	}
 	return updated, err
 }
@@ -668,14 +650,11 @@ func (m *ApplicationManager) UpdateOperation(ctx context.Context, incoming *v1al
 		"resourceVersion": incoming.ResourceVersion,
 	})
 
-	var updated *v1alpha1.Application
-	var err error
-
 	if !m.role.IsAgent() || !m.mode.IsAutonomous() {
 		return nil, fmt.Errorf("UpdateOperation should only be called by an agent in autonomous mode: %v %v", m.role, m.mode)
 	}
 
-	updated, err = m.update(ctx, false, incoming, func(existing, incoming *v1alpha1.Application) {
+	updated, originalOnCluster, err := m.update(ctx, false, incoming, func(existing, incoming *v1alpha1.Application) {
 		existing.Annotations = incoming.Annotations
 		existing.Labels = incoming.Labels
 		existing.Operation = operationToUse(existing, incoming)
@@ -706,7 +685,7 @@ func (m *ApplicationManager) UpdateOperation(ctx context.Context, incoming *v1al
 		if err := m.IgnoreChange(updated.QualifiedName(), updated.ResourceVersion); err != nil {
 			logCtx.Warnf("Could not ignore change %s for app %s: %v", updated.ResourceVersion, updated.QualifiedName(), err)
 		}
-		logging.LogActionUpdate(logCtx, "application", incoming, updated)
+		logging.LogActionUpdate(logCtx, "application", originalOnCluster, updated)
 	}
 	return updated, err
 }
@@ -727,7 +706,7 @@ func (m *ApplicationManager) SetOperation(ctx context.Context, incoming *v1alpha
 		incoming.SetNamespace(m.namespace)
 	}
 
-	updated, err := m.update(ctx, false, incoming, func(existing, incoming *v1alpha1.Application) {
+	updated, originalOnCluster, err := m.update(ctx, false, incoming, func(existing, incoming *v1alpha1.Application) {
 		existing.Operation = operationToUse(existing, incoming)
 	}, func(existing, incoming *v1alpha1.Application) (jsondiff.Patch, error) {
 		target := &v1alpha1.Application{
@@ -742,7 +721,7 @@ func (m *ApplicationManager) SetOperation(ctx context.Context, incoming *v1alpha
 		if err := m.IgnoreChange(updated.QualifiedName(), updated.ResourceVersion); err != nil {
 			logCtx.Warnf("Could not ignore change %s for app %s: %v", updated.ResourceVersion, updated.QualifiedName(), err)
 		}
-		logging.LogActionUpdate(logCtx, "application", incoming, updated)
+		logging.LogActionUpdate(logCtx, "application", originalOnCluster, updated)
 	}
 	return updated, err
 }
@@ -824,11 +803,9 @@ func (m *ApplicationManager) Delete(ctx context.Context, namespace string, incom
 	if m.role.IsPrincipal() {
 		removeFinalizer = true
 	}
-	var err error
-	var updated *v1alpha1.Application
 
 	if removeFinalizer {
-		updated, err = m.RemoveFinalizers(ctx, incoming)
+		updated, err := m.RemoveFinalizers(ctx, incoming)
 		if err == nil {
 			logCtx.Debugf("Removed finalizer for app %s", updated.QualifiedName())
 		} else {
@@ -836,7 +813,7 @@ func (m *ApplicationManager) Delete(ctx context.Context, namespace string, incom
 		}
 	}
 
-	err = m.applicationBackend.Delete(ctx, incoming.Name, incoming.Namespace, deletionPropagation)
+	err := m.applicationBackend.Delete(ctx, incoming.Name, incoming.Namespace, deletionPropagation)
 	if err == nil {
 		logging.LogActionDelete(logCtx, "application", incoming.Namespace, incoming.Name)
 	}
@@ -856,7 +833,7 @@ func (m *ApplicationManager) Delete(ctx context.Context, namespace string, incom
 //
 // The updated application will be returned on success, otherwise an error will
 // be returned.
-func (m *ApplicationManager) update(ctx context.Context, upsert bool, incoming *v1alpha1.Application, updateFn updateTransformer, patchFn patchTransformer) (*v1alpha1.Application, error) {
+func (m *ApplicationManager) update(ctx context.Context, upsert bool, incoming *v1alpha1.Application, updateFn updateTransformer, patchFn patchTransformer) (*v1alpha1.Application, *v1alpha1.Application, error) {
 	var updated *v1alpha1.Application
 
 	if ctx == nil {
@@ -864,6 +841,7 @@ func (m *ApplicationManager) update(ctx context.Context, upsert bool, incoming *
 	}
 	ctxForUpdate := context.WithValue(ctx, backend.ForUpdateContextKey, true)
 
+	var originalOnCluster *v1alpha1.Application
 	err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
 		existing, ierr := m.applicationBackend.Get(ctxForUpdate, incoming.Name, incoming.Namespace)
 		if ierr != nil {
@@ -874,6 +852,7 @@ func (m *ApplicationManager) update(ctx context.Context, upsert bool, incoming *
 				return fmt.Errorf("error updating application %s: %w", incoming.QualifiedName(), ierr)
 			}
 		} else {
+			originalOnCluster = existing.DeepCopy()
 			if m.applicationBackend.SupportsPatch() && patchFn != nil {
 				patch, err := patchFn(existing, incoming)
 				if err != nil {
@@ -893,14 +872,14 @@ func (m *ApplicationManager) update(ctx context.Context, upsert bool, incoming *
 		}
 		return ierr
 	})
-	return updated, err
+	return updated, originalOnCluster, err
 }
 
 // RemoveFinalizers will remove finalizers on an existing application
 func (m *ApplicationManager) RemoveFinalizers(ctx context.Context, incoming *v1alpha1.Application) (*v1alpha1.Application, error) {
-	updated, err := m.update(ctx, false, incoming, func(existing, incoming *v1alpha1.Application) {
+	updated, originalOnCluster, err := m.update(ctx, false, incoming, func(existing, _ *v1alpha1.Application) {
 		existing.Finalizers = nil
-	}, func(existing, incoming *v1alpha1.Application) (jsondiff.Patch, error) {
+	}, func(existing, _ *v1alpha1.Application) (jsondiff.Patch, error) {
 		var err error
 		var patch jsondiff.Patch
 		target := &v1alpha1.Application{
@@ -917,7 +896,7 @@ func (m *ApplicationManager) RemoveFinalizers(ctx context.Context, incoming *v1a
 		return patch, err
 	})
 	if err == nil {
-		logging.LogActionUpdate(log().WithField("application", incoming.QualifiedName()), "application", incoming, updated)
+		logging.LogActionUpdate(log().WithField("application", incoming.QualifiedName()), "application", originalOnCluster, updated)
 	}
 	return updated, err
 }
@@ -932,13 +911,19 @@ func (m *ApplicationManager) ClearOperationState(ctx context.Context, app *v1alp
 		"component":   "ClearOperationState",
 		"application": app.Namespace + "/" + app.Name,
 	})
+	// Retrieve the current contents of the existing app, so we can log (roughly) what we are patching against. This is not used for the patch.
+	origApp, err := m.applicationBackend.Get(ctx, app.Name, app.Namespace)
+	if err != nil {
+		logging.LogActionError(logCtx, "application", "clear-operation-state", app, err)
+		return err
+	}
 	updated, err := m.applicationBackend.Patch(ctx, app.Name, app.Namespace,
 		[]byte(`[{"op":"replace","path":"/status/operationState","value":null}]`))
 	if err != nil {
 		logging.LogActionError(logCtx, "application", "clear-operation-state", app, err)
 		return err
 	}
-	logging.LogActionUpdate(logCtx, "application", app, updated)
+	logging.LogActionUpdate(logCtx, "application", origApp, updated)
 	return nil
 }
 

--- a/internal/manager/application/application.go
+++ b/internal/manager/application/application.go
@@ -914,8 +914,8 @@ func (m *ApplicationManager) ClearOperationState(ctx context.Context, app *v1alp
 	// Retrieve the current contents of the existing app, so we can log (roughly) what we are patching against. This is not used for the patch.
 	origApp, err := m.applicationBackend.Get(ctx, app.Name, app.Namespace)
 	if err != nil {
+		// Log the error, but continue: this Get is optional, and there is no need to block the Patch
 		logging.LogActionError(logCtx, "application", "clear-operation-state", app, err)
-		return err
 	}
 	updated, err := m.applicationBackend.Patch(ctx, app.Name, app.Namespace,
 		[]byte(`[{"op":"replace","path":"/status/operationState","value":null}]`))

--- a/internal/manager/application/application_test.go
+++ b/internal/manager/application/application_test.go
@@ -438,6 +438,8 @@ func Test_ManagerUpdateStatus(t *testing.T) {
 		require.Contains(t, updated.Labels, "bar")
 		require.Contains(t, updated.Labels, "some")
 		require.Equal(t, updated.Spec.Source.Path, ".")
+		require.NotNil(t, updated.Operation)
+		require.Equal(t, incoming.Operation, updated.Operation)
 	})
 
 	t.Run("Retain principal-owned annotations across an agent status update", func(t *testing.T) {

--- a/internal/manager/application/application_test.go
+++ b/internal/manager/application/application_test.go
@@ -438,8 +438,6 @@ func Test_ManagerUpdateStatus(t *testing.T) {
 		require.Contains(t, updated.Labels, "bar")
 		require.Contains(t, updated.Labels, "some")
 		require.Equal(t, updated.Spec.Source.Path, ".")
-		require.NotNil(t, updated.Operation)
-		require.Equal(t, incoming.Operation, updated.Operation)
 	})
 
 	t.Run("Retain principal-owned annotations across an agent status update", func(t *testing.T) {
@@ -1001,117 +999,6 @@ func Test_stampLastUpdated(t *testing.T) {
 	})
 }
 
-func Test_CompareSourceUIDForApp(t *testing.T) {
-	oldApp := &v1alpha1.Application{
-		ObjectMeta: v1.ObjectMeta{
-			Name:      "test",
-			Namespace: "argocd",
-			Annotations: map[string]string{
-				manager.SourceUIDAnnotation: "old_uid",
-			},
-		},
-	}
-
-	mockedBackend := appmock.NewApplication(t)
-	getMock := mockedBackend.On("Get", mock.Anything, mock.Anything, mock.Anything).Return(oldApp, nil)
-	m, err := NewApplicationManager(mockedBackend, "")
-	require.Nil(t, err)
-	ctx := context.Background()
-
-	t.Cleanup(func() {
-		getMock.Unset()
-	})
-
-	t.Run("should return true if the UID matches", func(t *testing.T) {
-		incoming := oldApp.DeepCopy()
-		incoming.UID = ktypes.UID("old_uid")
-
-		exists, uidMatch, err := m.CompareSourceUID(ctx, incoming)
-		require.True(t, exists)
-		require.Nil(t, err)
-		require.True(t, uidMatch)
-	})
-
-	t.Run("should return false if the UID doesn't match", func(t *testing.T) {
-		incoming := oldApp.DeepCopy()
-		// Clear source-uid so comparison falls back to incoming.UID (normal operation path)
-		delete(incoming.Annotations, manager.SourceUIDAnnotation)
-		incoming.UID = ktypes.UID("new_uid")
-
-		exists, uidMatch, err := m.CompareSourceUID(ctx, incoming)
-		require.True(t, exists)
-		require.Nil(t, err)
-		require.False(t, uidMatch)
-	})
-
-	t.Run("should return true if incoming has matching source-uid annotation", func(t *testing.T) {
-		incoming := oldApp.DeepCopy()
-		incoming.UID = ktypes.UID("agent_uid")
-		incoming.Annotations[manager.SourceUIDAnnotation] = "old_uid"
-
-		exists, uidMatch, err := m.CompareSourceUID(ctx, incoming)
-		require.True(t, exists)
-		require.Nil(t, err)
-		require.True(t, uidMatch)
-	})
-
-	t.Run("should return an error if there is no UID annotation", func(t *testing.T) {
-		oldApp.Annotations = map[string]string{}
-		mockedBackend.On("Get", mock.Anything, mock.Anything, mock.Anything).Return(oldApp, nil)
-		m, err := NewApplicationManager(mockedBackend, "")
-		require.Nil(t, err)
-		ctx := context.Background()
-
-		incoming := oldApp.DeepCopy()
-		incoming.UID = ktypes.UID("new_uid")
-
-		exists, uidMatch, err := m.CompareSourceUID(ctx, incoming)
-		require.True(t, exists)
-		require.NotNil(t, err)
-		require.EqualError(t, err, "source UID Annotation is not found for app: test")
-		require.False(t, uidMatch)
-	})
-
-	t.Run("should return False if the app doesn't exist", func(t *testing.T) {
-		expectedErr := errors.NewNotFound(schema.GroupResource{Group: "argoproj.io", Resource: "application"},
-			oldApp.Name)
-		getMock.Unset()
-		getMock = mockedBackend.On("Get", mock.Anything, mock.Anything, mock.Anything).Return(nil, expectedErr)
-		m, err := NewApplicationManager(mockedBackend, "")
-		require.Nil(t, err)
-		ctx := context.Background()
-
-		app, err := m.applicationBackend.Get(ctx, oldApp.Name, oldApp.Namespace)
-		require.Nil(t, app)
-		require.True(t, errors.IsNotFound(err))
-
-		incoming := oldApp.DeepCopy()
-		incoming.UID = ktypes.UID("new_uid")
-		exists, uidMatch, err := m.CompareSourceUID(ctx, incoming)
-		require.False(t, exists)
-		require.False(t, uidMatch)
-		require.Nil(t, err)
-	})
-
-	t.Run("should override incoming namespace", func(t *testing.T) {
-		oldApp.Annotations = map[string]string{manager.SourceUIDAnnotation: "old_uid"}
-		getMock.Unset()
-		getMock = mockedBackend.On("Get", mock.Anything, mock.Anything, "argocd").Return(oldApp, nil)
-		m, err := NewApplicationManager(mockedBackend, oldApp.Namespace)
-		require.Nil(t, err)
-		ctx := context.Background()
-
-		incoming := oldApp.DeepCopy()
-		incoming.Namespace = "foobar"
-		incoming.UID = ktypes.UID("old_uid")
-
-		exists, uidMatch, err := m.CompareSourceUID(ctx, incoming)
-		require.True(t, exists)
-		require.Nil(t, err)
-		require.True(t, uidMatch)
-	})
-}
-
 func Test_CompareIdentity(t *testing.T) {
 	existingApp := &v1alpha1.Application{
 		ObjectMeta: v1.ObjectMeta{
@@ -1351,6 +1238,7 @@ func Test_ClearOperationState(t *testing.T) {
 		}
 
 		mockedBackend := appmock.NewApplication(t)
+		mockedBackend.On("Get", mock.Anything, "guestbook", "argocd").Return(app, nil)
 		mockedBackend.On("Patch", mock.Anything, "guestbook", "argocd", []byte(`[{"op":"replace","path":"/status/operationState","value":null}]`)).Return(updatedApp, nil)
 
 		m, err := NewApplicationManager(mockedBackend, "argocd")
@@ -1370,6 +1258,7 @@ func Test_ClearOperationState(t *testing.T) {
 		}
 
 		mockedBackend := appmock.NewApplication(t)
+		mockedBackend.On("Get", mock.Anything, "guestbook", "argocd").Return(app, nil)
 		mockedBackend.On("Patch", mock.Anything, "guestbook", "argocd", []byte(`[{"op":"replace","path":"/status/operationState","value":null}]`)).Return(nil, fmt.Errorf("patch failed"))
 
 		m, err := NewApplicationManager(mockedBackend, "argocd")


### PR DESCRIPTION
**What does this PR do / why we need it**:
- At present, when full detail logging is enabled (via e.g. `ARGOCD_AGENT_FULL_DETAIL`), the object patch/update diff is not being logged correctly.
    - This is because the diff (generated via `cmp.Diff`) is being generated from  _the incoming object from peer agent_, rather than from the existing object on the same cluster.
    - This was leading to strange log messages where, for example, the resource uid was changing (impossible) and/or resource version was jumping around wildly (also impossible). (Because we were comparing with the wrong object: the UID and resource version are from the object on the other cluster)
- Fix is just to make a copy of the local cluster object (which is being patched/updated), BEFORE we modify it, and then pass that to log statement.
- This PR only affects logging of update actions; it doesn't make any functional changes.
- (I also removed `CompareSourceUID` which is dead code, while I was at it)


**Checklist**

* [ ] Documentation update is required by this PR (and has been updated) OR no documentation update is required.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved update and operation logging to accurately reflect application state before changes.
  * Ensured operation-state clearing uses the latest available application state before applying updates.
  * Improved application deletion and update handling for more reliable state transitions.
  * Preserved operation details when updating application status.

* **Tests**
  * Expanded coverage for retrieving current application state and preserving operation details during updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->