### PR TITLE
chore: add sync-consistency-util to dependabot ignore list

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+hack/sync-consistency-util/* linguist-vendored


### PR DESCRIPTION
**What does this PR do / why we need it**:
- Dependabot is flagging `hack/sync-consistency-util/go.mod` for vulnerabilities, despite the fact it is only a standalone test utility, and thus not exploitable under any circumstances without our threat model.
- Thus lets add it to `.gitattributes` with `linguist-vendored`, which will, quote:
    - _linguist-vendored is a custom attribute used in .gitattributes files to instruct GitHub's language detection library ([Linguist](https://www.google.com/search?q=https://github.com/github/linguist)) to treat designated files or directories as third-party dependency code rather than primary project code._
    - (and which is apparently likewise used by Dependabot for this purpose)

**How to test changes / Special notes to the reviewer**:


**Checklist**

* [ ] Documentation update is required by this PR (and has been updated) OR no documentation update is required.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Marked consistency utility files as vendored for repository language and code statistics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->