### PR TITLE
fix: process Delete event for app already deleted on the agent

### DIFF
--- a/agent/inbound.go
+++ b/agent/inbound.go
@@ -872,10 +872,24 @@ func (a *Agent) deleteApplication(app *v1alpha1.Application) error {
 	}
 
 	// Fetch the source UID of the existing app to mark it as expected deletion.
-	app, err := a.appManager.Get(a.context, app.Name, app.Namespace)
+	existing, err := a.appManager.Get(a.context, app.Name, app.Namespace)
 	if err != nil {
+		if apierrors.IsNotFound(err) {
+			// The app is already gone, e.g. because it was deleted on the agent
+			// at the same time it was deleted on the principal. Still mark the
+			// deletion as expected and drop the source cache entry, otherwise
+			// the agent recreates the app from stale state and the recreated
+			// app can never be deleted again.
+			logCtx.Debug("application is not found, perhaps it is already deleted")
+			a.deletions.MarkExpected(sourceUIDForApp(app))
+			if a.mode == types.AgentModeManaged {
+				a.sourceCache.Application.Delete(sourceUIDForApp(app))
+			}
+			return nil
+		}
 		return err
 	}
+	app = existing
 
 	sourceUID := app.Annotations[manager.SourceUIDAnnotation]
 	a.deletions.MarkExpected(ktypes.UID(sourceUID))

--- a/agent/inbound_test.go
+++ b/agent/inbound_test.go
@@ -379,6 +379,41 @@ func Test_ProcessIncomingAppWithUIDMismatch(t *testing.T) {
 		require.False(t, a.appManager.IsManaged(incomingApp.QualifiedName()))
 	})
 
+	t.Run("Delete: App already deleted on the agent must not be recreated", func(t *testing.T) {
+		configureManager(t, manager.ManagerModeManaged)
+		defer unsetMocks(t)
+		a.appManager.Manage(oldApp.QualifiedName())
+		defer a.appManager.ClearManaged()
+
+		// The app was deleted on the agent at the same time it was deleted on
+		// the principal, so it is gone from the cluster before the Delete event
+		// from the principal is processed.
+		getMock.Unset()
+		notFoundError := kerrors.NewNotFound(schema.GroupResource{
+			Group: "argoproj.io", Resource: "application",
+		}, incomingApp.Name)
+		getMock = be.On("Get", mock.Anything, mock.Anything, mock.Anything).Return(nil, notFoundError)
+
+		a.sourceCache.Application.Set(incomingApp.UID, incomingApp.Spec)
+
+		ev := event.New(evs.ApplicationEvent(event.Delete, incomingApp), targets.Application)
+		err := a.processIncomingApplication(ev)
+		require.NoError(t, err)
+
+		// Identity check and lookup of the existing app, but no Delete or Create
+		expectedCalls := []string{"Get", "Get"}
+		gotCalls := []string{}
+		for _, call := range be.Calls {
+			gotCalls = append(gotCalls, call.Method)
+		}
+		require.Equal(t, expectedCalls, gotCalls)
+
+		// The stale source cache entry must be dropped and the deletion marked
+		// as expected, so the agent does not recreate the app.
+		require.False(t, a.sourceCache.Application.Contains(incomingApp.UID))
+		require.True(t, a.deletions.RemoveExpected(incomingApp.UID))
+	})
+
 	t.Run("SpecUpdate: upsert policy skips delete and updates in-place", func(t *testing.T) {
 		configureManager(t, manager.ManagerModeManaged)
 		defer unsetMocks(t)


### PR DESCRIPTION
**What does this PR do / why we need it**:

## Problem

When an Application is deleted on the principal and, at about the same time, by a user on the managed agent, the Delete event from the principal reaches the agent after the Application is already gone from the workload cluster. The agent fails to process that event, so it never learns that the deletion was legitimate. The concurrent local deletion is then treated as an unauthorized deletion and the Application is recreated; every further attempt to delete it is reverted the same way. The Application no longer exists on the principal, so nothing can ever remove it again until the agent is restarted.

## Root cause

`agent/inbound.go:875` (`deleteApplication`): the lookup of the existing Application via `a.appManager.Get` returns the NotFound error straight to the caller. Everything that tells the agent the deletion is expected runs only after that lookup succeeds: `a.deletions.MarkExpected(...)` and `a.sourceCache.Application.Delete(...)`. As a result the source UID of the deleted Application is never marked as an expected deletion and the stale source cache entry is kept, and `addAppDeletionToQueue` in `agent/outbound.go` recreates the Application through `RevertUserInitiatedDeletion`.

The NotFound case is already handled when `Delete` itself reports NotFound a few lines further down; only the `Get` path was missing it.

## Fix

The Delete event path now goes through a new `deleteApplicationFromEvent`. It calls `deleteApplication` and, if that returns NotFound from `Get`, marks the deletion as expected for the source UID carried by the incoming event (`sourceUIDForApp(app)`, which is the principal side UID and therefore the value of the `source-uid` annotation on the agent side copy), drops the stale source cache entry in managed mode, unmanages the app, logs at debug level and returns nil. Errors other than NotFound are still returned unchanged.

`deleteApplication` itself keeps returning NotFound from `Get`. It is also called on a source UID mismatch, where the incoming app is the new application; marking its source UID as expected there would let a later user-initiated deletion of the recreated app go unreverted (pointed out in review). That path therefore behaves as on main. Per review, the app is now also unmanaged in both NotFound cases.

**Which issue(s) this PR fixes**:

Fixes #1056

**How to test changes / Special notes to the reviewer**:

## How tested

Added the unit test `Delete: App already deleted on the agent must not be recreated` to `Test_ProcessIncomingAppWithUIDMismatch` in `agent/inbound_test.go`. It seeds the source cache with the incoming UID, makes the backend `Get` return NotFound, sends a Delete event through `processIncomingApplication`, and asserts that no error is returned, that no `Delete`/`Create` backend call is made, that the source cache entry is gone and that the deletion is marked as expected.

Added `Create: Old app gone before delete on UID mismatch must not mark the new UID as expected` to the same test: the identity check sees the old app, the second `Get` returns NotFound, and it asserts the error is surfaced, no `Delete`/`Create` is made and neither the new nor the old source UID is marked as an expected deletion.

Before the fix:

```
--- FAIL: Test_ProcessIncomingAppWithUIDMismatch (0.00s)
    --- FAIL: Test_ProcessIncomingAppWithUIDMismatch/Delete:_App_already_deleted_on_the_agent_must_not_be_recreated (0.00s)
        inbound_test.go:401:
            	Error:      	Received unexpected error:
            	            	application.argoproj.io "test" not found
FAIL	github.com/argoproj-labs/argocd-agent/agent	0.059s
```

After the fix:

```
--- PASS: Test_ProcessIncomingAppWithUIDMismatch (0.01s)
    --- PASS: Test_ProcessIncomingAppWithUIDMismatch/Delete:_App_already_deleted_on_the_agent_must_not_be_recreated (0.00s)
ok  	github.com/argoproj-labs/argocd-agent/agent	0.055s
```

`go test ./agent/`, `go vet ./agent/` and `go build ./...` pass.

## Links

- https://github.com/argoproj-labs/argocd-agent/issues/1056

**Checklist**

* [x] Documentation update is required by this PR (and has been updated) OR no documentation update is required.

This change was prepared with an AI agent operated by KR-Ravindra, who reviewed and tested it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of application deletion events when the application has already been removed.
  * Prevented unnecessary delete or recreate operations in this scenario.
  * Removed stale application state and correctly recorded the deletion as expected.
  * Improved handling of create events when an existing application disappears during processing, ensuring the operation reports an error without incorrectly recording a deletion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
