### PR TITLE
fix(redisproxy): send RESP null bulk string on cache miss

### DIFF
--- a/principal/redisproxy/redisproxy.go
+++ b/principal/redisproxy/redisproxy.go
@@ -556,7 +556,11 @@ func (rp *RedisProxy) handleAgentGet(connState *connectionState, key string, arg
 
 		// Cache miss: no data for that key in agent redis
 
-		response := "-\r\n" // Cache miss is a simple redis null
+		// A cache miss must be reported as a RESP null bulk string. The '-' prefix
+		// is the RESP simple error type, which Redis clients surface as an error
+		// (with an empty message) rather than as a missing key, preventing Argo CD
+		// from recognizing the miss and refreshing the cache.
+		response := "$-1\r\n"
 
 		logCtx.Tracef("Wrote GET response to argo cd: '%s'", response)
 

--- a/principal/redisproxy/redisproxy_test.go
+++ b/principal/redisproxy/redisproxy_test.go
@@ -214,6 +214,9 @@ func (m *mockSendSynchronousMessageToAgentFunc) call(agentName string, connectio
 	return m.responseToReturn
 }
 
+// Test_handleAgentGet verifies that handleAgentGet translates each agent
+// response into the correct RESP reply to Argo CD: a bulk string on a cache
+// hit, a null bulk string on a cache miss, and an error on a failed get.
 func Test_handleAgentGet(t *testing.T) {
 	t.Run("successful get with cache hit", func(t *testing.T) {
 		// Setup mocks
@@ -352,7 +355,8 @@ func Test_handleAgentGet(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, 1, mockSendFunc.callCount)
 		require.True(t, mockWriter.writeToArgoCDRedisSocketCalled)
-		expectedResponse := "-\r\n"
+		// RESP null bulk string: signals a missing key, rather than an error
+		expectedResponse := "$-1\r\n"
 		require.Equal(t, expectedResponse, string(mockWriter.writtenBytes))
 	})
 


### PR DESCRIPTION
Fixes #1107

## What

On a Redis cache miss, the principal's resource proxy replied to Argo CD with `"-\r\n"`, intended as a "redis null". In RESP, `-` is the **simple error** prefix (`-Error message\r\n`), so this is an *error reply with an empty message*, not a null. The RESP2 null bulk string is `$-1\r\n`.

## Why it matters

Redis clients surface `"-\r\n"` as a non-nil error whose message is the empty string — neither `redis.Nil` nor Argo CD's `ErrCacheMiss`. Argo CD's `getCachedAppState` only recovers (trigger refresh, retry) when the error `errors.Is` an `ErrCacheMiss`, so the miss is never recognised and the error is returned to the client verbatim:

```
level=error msg="finished call" grpc.code=Unknown grpc.component=server \
  grpc.error="error getting cached app managed resources: " \
  grpc.method=ManagedResources grpc.service=application.ApplicationService
```

The empty string after the colon is the empty RESP error message. In the UI this shows up as the **Logs** and **Diff / Live Manifest** tabs failing for apps on agent-managed clusters, intermittently — only in the window where that key has expired on the agent — with no error message to go on.

Verified against `go-redis/v9` with a fake Redis server returning each payload for a `GET`:

```
argocd-agent cache miss      payload="-\r\n"    err=true  Error()=""            isRedisNil=false
correct RESP2 null bulk      payload="$-1\r\n"  err=true  Error()="redis: nil"   isRedisNil=true
```

The full reproducer is in #1107.

## Change

```diff
-		response := "-\r\n" // Cache miss is a simple redis null
+		// A cache miss must be reported as a RESP null bulk string. The '-' prefix
+		// is the RESP simple error type, which Redis clients surface as an error
+		// (with an empty message) rather than as a missing key, preventing Argo CD
+		// from recognizing the miss and refreshing the cache.
+		response := "$-1\r\n"
```

The existing test `cache miss returns 'CacheHit: false', with empty error string` asserted the old byte sequence, so its expectation is updated to `$-1\r\n` in the same commit.

## Testing

- `go build ./principal/...` — clean
- `go test ./principal/redisproxy/...` — `ok github.com/argoproj-labs/argocd-agent/principal/redisproxy`
- `gofmt -l principal/redisproxy/` — clean

Only the miss path is affected; cache hits already wrote a correct bulk string (`$<len>\r\n<bytes>\r\n`) and are untouched.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected cache-miss handling so Redis clients and Argo CD recognize missing keys properly instead of treating them as errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->